### PR TITLE
feat(table): add customizable table column

### DIFF
--- a/projects/ui/src/lib/components/po-table/index.ts
+++ b/projects/ui/src/lib/components/po-table/index.ts
@@ -6,6 +6,7 @@ export * from './interfaces/po-table-column-sort.interface';
 export * from './interfaces/po-table-literals.interface';
 export * from './po-table-column-icon/po-table-column-icon.interface';
 export * from './po-table-column-label/po-table-column-label.interface';
+export * from './po-table-column-template/po-table-column-template.directive';
 export * from './po-table-detail/po-table-detail-column.interface';
 export * from './po-table-detail/po-table-detail.interface';
 export * from './po-table-row-template/po-table-row-template.directive';

--- a/projects/ui/src/lib/components/po-table/po-table-column-template/po-table-column-template.directive.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-template/po-table-column-template.directive.spec.ts
@@ -1,0 +1,10 @@
+import { PoTableColumnTemplateDirective } from './po-table-column-template.directive';
+
+describe('PoTableColumnTemplateDirective', () => {
+  const component = new PoTableColumnTemplateDirective(null);
+
+  it('should be created', () => {
+
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ui/src/lib/components/po-table/po-table-column-template/po-table-column-template.directive.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-template/po-table-column-template.directive.ts
@@ -1,0 +1,70 @@
+import { Directive, Input, TemplateRef } from '@angular/core';
+
+/**
+ * @usedBy PoTableComponent
+ *
+ * @description
+ *
+ * Esta diretiva permite que a utilização de colunas com layout customizado, dando uma maior flexibilidade ao componente.
+ *
+ * ```
+ * ...
+ * <po-table
+ *   [p-columns]="columns"
+ *   [p-items]="items">
+ *     <ng-template p-table-column-template p-column="columnName" let-row="row">
+ *       {{ row.column }}
+ *     </ng-template>
+ * ...
+ * ```
+ *
+ * ```
+ * ...
+ * @Component({
+ *    selector: 'app-root',
+ *    templateUrl: `
+ *      ...
+ *      <po-table
+ *        [p-columns]="columns"
+ *        [p-items]="items">
+ *          <ng-template p-table-column-template p-column="product" let-row="row">
+ *            <span class="po-font-text-bold">{{ row.product }}</span>
+ *          </ng-template>
+ *
+ *      ...
+ *    `
+ * })
+ * export class AppComponent {
+ *    public dataTable = [{
+ *      code: 1200,
+ *      product: 'Rice',
+ *      costumer: 'Supermarket 1',
+ *      quantity: 3,
+ *      status: 'delivered',
+ *      license_plate: 'MDJD9191',
+ *      batch_product: 18041822,
+ *      driver: 'José Oliveira'
+ *    }, {
+ *      code: 1355,
+ *      product: 'Bean',
+ *      costumer: 'Supermarket 2',
+ *      quantity: 1,
+ *      status: 'transport',
+ *      license_plate: 'XXA5454',
+ *      batch_product: 18041821,
+ *      driver: 'Francisco Pereira'
+ *    }];
+ * }
+ * ```
+ */
+@Directive({
+  selector: '[p-table-column-template]'
+})
+export class PoTableColumnTemplateDirective {
+
+  @Input('p-column') column: string;
+
+  // Necessário manter templateRef para o funcionamento do row template.
+  constructor(public templateRef: TemplateRef<any>) { }
+
+}

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -200,6 +200,12 @@
               <span *ngSwitchCase="'label'">
                 <po-table-column-label [p-value]="getColumnLabel(row, column)"></po-table-column-label>
               </span>
+              <span *ngSwitchCase="'raw'">
+                <ng-container
+                  [ngTemplateOutlet]="getTemplate(row, column)"
+                  [ngTemplateOutletContext]="{ row: row }">
+                </ng-container>
+              </span>
               <span *ngSwitchDefault>{{ row[column.property] }}</span>
             </div>
           </td>

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -1,6 +1,7 @@
 import {
-  AfterViewInit, ChangeDetectorRef, Component, ContentChild, DoCheck, ElementRef, IterableDiffers,
-  OnDestroy, QueryList, Renderer2, ViewChild, ViewChildren, ViewContainerRef } from '@angular/core';
+  AfterViewInit, ChangeDetectorRef, Component, ContentChild, ContentChildren, DoCheck, ElementRef, IterableDiffers,
+  OnDestroy, QueryList, Renderer2, ViewChild, ViewChildren, ViewContainerRef
+} from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { Router } from '@angular/router';
 
@@ -14,6 +15,7 @@ import { PoTableColumn } from './interfaces/po-table-column.interface';
 import { PoTableColumnLabel } from './po-table-column-label/po-table-column-label.interface';
 import { PoTableRowTemplateDirective } from './po-table-row-template/po-table-row-template.directive';
 import { PoTableSubtitleColumn } from './po-table-subtitle-footer/po-table-subtitle-column.interface';
+import { PoTableColumnTemplateDirective } from './po-table-column-template/po-table-column-template.directive';
 
 /**
  * @docsExtends PoTableBaseComponent
@@ -57,6 +59,9 @@ import { PoTableSubtitleColumn } from './po-table-subtitle-footer/po-table-subti
   providers: [PoDateService]
 })
 export class PoTableComponent extends PoTableBaseComponent implements AfterViewInit, DoCheck, OnDestroy {
+
+  @ContentChildren(PoTableColumnTemplateDirective)
+  tableColumnTemplate: QueryList<PoTableColumnTemplateDirective>;
 
   private _columnManagerTarget: ElementRef;
 
@@ -172,7 +177,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   get validColumns() {
-    const typesValid = ['string', 'number', 'boolean', 'date', 'time', 'dateTime', 'currency', 'subtitle', 'link', 'label', 'icon'];
+    const typesValid = ['string', 'number', 'boolean', 'date', 'time', 'dateTime', 'currency', 'subtitle', 'link', 'label', 'icon', 'raw'];
     return this.columns.filter(col => !col.type || typesValid.includes(col.type));
   }
 
@@ -372,6 +377,19 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     } else {
       return tableAction.disabled;
     }
+  }
+
+  getTemplate(row: any, column: PoTableColumn) {
+    const template = this.tableColumnTemplate
+      .toArray()
+      .find(t => t.column === column.property);
+
+    if (!template) {
+      console.warn(`Couldn't find a template for column: ${column.property}`);
+      return null;
+    }
+
+    return template.templateRef;
   }
 
   protected showContainer(container: string) {

--- a/projects/ui/src/lib/components/po-table/po-table.module.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.module.ts
@@ -17,6 +17,7 @@ import { PoTableColumnIconComponent } from './po-table-column-icon/po-table-colu
 import { PoTableColumnLabelComponent } from './po-table-column-label/po-table-column-label.component';
 import { PoTableColumnLinkComponent } from './po-table-column-link/po-table-column-link.component';
 import { PoTableColumnManagerComponent } from './po-table-column-manager/po-table-column-manager.component';
+import { PoTableColumnTemplateDirective } from './po-table-column-template/po-table-column-template.directive';
 import { PoTableComponent } from './po-table.component';
 import { PoTableDetailComponent } from './po-table-detail/po-table-detail.component';
 import { PoTableIconComponent } from './po-table-icon/po-table-icon.component';
@@ -55,10 +56,12 @@ import { PoTableSubtitleFooterComponent } from './po-table-subtitle-footer/po-ta
     PoTableRowTemplateDirective,
     PoTableShowSubtitleComponent,
     PoTableSubtitleCircleComponent,
-    PoTableSubtitleFooterComponent
+    PoTableSubtitleFooterComponent,
+    PoTableColumnTemplateDirective
   ],
   exports: [
     PoTableComponent,
+    PoTableColumnTemplateDirective,
     PoTableRowTemplateDirective
   ],
   providers: [DecimalPipe]


### PR DESCRIPTION
**Table**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente não é possível personalizar o conteúdo das colunas, sendo limitado somente aos templates predefinidos.

**Qual o novo comportamento?**
Criação do tipo de coluna `raw`, que permite a utilização de templates personalizados usando a diretiva `p-table-column-template`

**Simulação**
Simular no sample do portal.

Fixes #97 