### PR TITLE
refactor(samples): utiliza .bind(this) na passagem de função

### DIFF
--- a/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-attendance/sample-po-button-group-attendance.component.ts
+++ b/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-attendance/sample-po-button-group-attendance.component.ts
@@ -8,9 +8,9 @@ import { PoButtonGroupItem, PoNotificationService } from '@portinari/portinari-u
 })
 export class SamplePoButtonGroupAttendanceComponent {
   attendances: Array<PoButtonGroupItem> = [
-    { label: 'Appointment', icon: 'po-icon-calendar', action: this.getPassword },
-    { label: 'Emergency', icon: 'po-icon-injector', action: this.getPassword },
-    { label: 'Exams', icon: 'po-icon-exam', action: this.getPassword }
+    { label: 'Appointment', icon: 'po-icon-calendar', action: this.getPassword.bind(this) },
+    { label: 'Emergency', icon: 'po-icon-injector', action: this.getPassword.bind(this) },
+    { label: 'Exams', icon: 'po-icon-exam', action: this.getPassword.bind(this) }
   ];
 
   constructor(private poNotification: PoNotificationService) {}

--- a/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-basic/sample-po-button-group-basic.component.ts
+++ b/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-basic/sample-po-button-group-basic.component.ts
@@ -8,8 +8,8 @@ import { PoButtonGroupItem } from '@portinari/portinari-ui';
 })
 export class SamplePoButtonGroupBasicComponent {
   buttons: Array<PoButtonGroupItem> = [
-    { label: 'Button 1', action: this.action },
-    { label: 'Button 2', action: this.action }
+    { label: 'Button 1', action: this.action.bind(this) },
+    { label: 'Button 2', action: this.action.bind(this) }
   ];
 
   action(button) {

--- a/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-ticket-sales/sample-po-calendar-ticket-sales.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-ticket-sales/sample-po-calendar-ticket-sales.component.ts
@@ -12,7 +12,7 @@ export class SamplePoCalendarTicketSalesComponent {
   tickets: number;
 
   readonly pageActions: Array<PoPageAction> = [
-    { label: 'Buy tickets', action: this.buyTickets, disabled: this.isdisableBuy.bind(this) }
+    { label: 'Buy tickets', action: this.buyTickets.bind(this), disabled: this.isdisableBuy.bind(this) }
   ];
 
   readonly ticketsOptions: Array<PoSelectOption> = [

--- a/projects/ui/src/lib/components/po-container/samples/sample-po-container-dashboard/sample-po-container-dashboard.component.ts
+++ b/projects/ui/src/lib/components/po-container/samples/sample-po-container-dashboard/sample-po-container-dashboard.component.ts
@@ -33,11 +33,11 @@ export class SamplePoContainerDashboardComponent implements AfterContentChecked 
   items: Array<object> = this.sampleDashboardService.getItems();
 
   public readonly actions: Array<PoPageAction> = [
-    { label: 'Share', action: this.modalOpen, icon: 'po-icon-share' },
+    { label: 'Share', action: this.modalOpen.bind(this), icon: 'po-icon-share' },
     {
       label: 'Disable notification',
       icon: 'po-icon-notification',
-      action: this.disableNotification,
+      action: this.disableNotification.bind(this),
       disabled: () => this.isSubscribed
     }
   ];

--- a/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-email-reactive-form/sample-po-textarea-email-reactive-form.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-email-reactive-form/sample-po-textarea-email-reactive-form.component.ts
@@ -36,8 +36,8 @@ export class SamplePoTextareaEmailReactiveFormComponent implements OnInit {
   getPageAction() {
     const isDisabled = this.formEmail ? !this.formEmail.valid : true;
     return [
-      { label: 'Send', action: this.send, disabled: isDisabled },
-      { label: 'Clean', action: this.reset }
+      { label: 'Send', action: this.send.bind(this), disabled: isDisabled },
+      { label: 'Clean', action: this.reset.bind(this) }
     ];
   }
 

--- a/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-email/sample-po-textarea-email.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-email/sample-po-textarea-email.component.ts
@@ -30,8 +30,8 @@ export class SamplePoTextareaEmailComponent {
   getPageAction() {
     const isDisabled = this.formEmail ? !this.formEmail['valid'] : true;
     return [
-      { label: 'Send', action: this.send, disabled: isDisabled },
-      { label: 'Clean', action: this.reset }
+      { label: 'Send', action: this.send.bind(this), disabled: isDisabled },
+      { label: 'Clean', action: this.reset.bind(this) }
     ];
   }
 

--- a/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-customer/sample-po-menu-panel-customer.component.ts
+++ b/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-customer/sample-po-menu-panel-customer.component.ts
@@ -10,11 +10,11 @@ export class SamplePoMenuPanelCustomerComponent {
   title: string = 'Customers';
 
   public readonly menuItems: Array<PoMenuPanelItem> = [
-    { label: 'Home', action: this.changeTitle, icon: 'po-icon-home' },
-    { label: 'Customers', action: this.changeTitle, icon: 'po-icon-user' },
-    { label: 'New Sale', action: this.changeTitle, icon: 'po-icon-money' },
-    { label: 'Reports', action: this.changeTitle, icon: 'po-icon-news' },
-    { label: 'Settings', action: this.changeTitle, icon: 'po-icon-settings' }
+    { label: 'Home', action: this.changeTitle.bind(this), icon: 'po-icon-home' },
+    { label: 'Customers', action: this.changeTitle.bind(this), icon: 'po-icon-user' },
+    { label: 'New Sale', action: this.changeTitle.bind(this), icon: 'po-icon-money' },
+    { label: 'Reports', action: this.changeTitle.bind(this), icon: 'po-icon-news' },
+    { label: 'Settings', action: this.changeTitle.bind(this), icon: 'po-icon-settings' }
   ];
 
   changeTitle(menu: PoMenuPanelItem) {

--- a/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-labs/sample-po-menu-panel-labs.component.ts
+++ b/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-labs/sample-po-menu-panel-labs.component.ts
@@ -25,7 +25,7 @@ export class SamplePoMenuPanelLabsComponent implements OnInit {
   }
 
   addMenuItem(menuItem: PoMenuPanelItem) {
-    const newMenuItem = Object.assign({}, menuItem, { action: this.onMenuItemSelected });
+    const newMenuItem = Object.assign({}, menuItem, { action: this.onMenuItemSelected.bind(this) });
 
     this.menuItems = [...this.menuItems, newMenuItem];
   }

--- a/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-human-resources/sample-po-menu-human-resources.component.ts
+++ b/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-human-resources/sample-po-menu-human-resources.component.ts
@@ -20,10 +20,10 @@ export class SamplePoMenuHumanResourcesComponent {
   menuItemSelected: string;
 
   menus: Array<PoMenuItem> = [
-    { label: 'Register user', action: this.printMenuAction, icon: 'po-icon-user', shortLabel: 'Register' },
+    { label: 'Register user', action: this.printMenuAction.bind(this), icon: 'po-icon-user', shortLabel: 'Register' },
     {
       label: 'Timekeeping',
-      action: this.printMenuAction,
+      action: this.printMenuAction.bind(this),
       icon: 'po-icon-clock',
       shortLabel: 'Timekeeping',
       badge: { value: 1 }
@@ -33,8 +33,8 @@ export class SamplePoMenuHumanResourcesComponent {
       icon: 'po-icon-share',
       shortLabel: 'Links',
       subItems: [
-        { label: 'Ministry of Labour', action: this.printMenuAction, link: 'http://trabalho.gov.br/' },
-        { label: 'SindPD Syndicate', action: this.printMenuAction, link: 'http://www.sindpd.com.br/' }
+        { label: 'Ministry of Labour', action: this.printMenuAction.bind(this), link: 'http://trabalho.gov.br/' },
+        { label: 'SindPD Syndicate', action: this.printMenuAction.bind(this), link: 'http://www.sindpd.com.br/' }
       ]
     },
     {
@@ -45,18 +45,18 @@ export class SamplePoMenuHumanResourcesComponent {
         {
           label: 'Meal tickets',
           subItems: [
-            { label: 'Acceptance network ', action: this.printMenuAction },
+            { label: 'Acceptance network ', action: this.printMenuAction.bind(this) },
             {
               label: 'Extracts',
-              action: this.printMenuAction,
+              action: this.printMenuAction.bind(this),
               subItems: [
-                { label: 'Monthly', action: this.printMenuAction, badge: { value: 3, color: 'color-03' } },
-                { label: 'Custom', action: this.printMenuAction }
+                { label: 'Monthly', action: this.printMenuAction.bind(this), badge: { value: 3, color: 'color-03' } },
+                { label: 'Custom', action: this.printMenuAction.bind(this) }
               ]
             }
           ]
         },
-        { label: 'Transportation tickets', action: this.printMenuAction, badge: { value: 12 } }
+        { label: 'Transportation tickets', action: this.printMenuAction.bind(this), badge: { value: 12 } }
       ]
     }
   ];

--- a/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.ts
+++ b/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.ts
@@ -30,9 +30,9 @@ export class SamplePoMenuLabsComponent implements OnInit {
   badgeColor: string;
   badgeValue: number;
   buttons: Array<PoButtonGroupItem> = [
-    { label: 'Collapse', action: this.collapse },
-    { label: 'Expand', action: this.expand },
-    { label: 'Toggle', action: this.toggle }
+    { label: 'Collapse', action: this.collapse.bind(this) },
+    { label: 'Expand', action: this.expand.bind(this) },
+    { label: 'Toggle', action: this.toggle.bind(this) }
   ];
   filter: boolean;
   icon: string;
@@ -89,7 +89,7 @@ export class SamplePoMenuLabsComponent implements OnInit {
 
     if (!this.parent) {
       this.menuItems.push({
-        action: this.changeMenuSelected,
+        action: this.changeMenuSelected.bind(this),
         icon: this.icon,
         label: this.label,
         link: this.link,
@@ -104,7 +104,7 @@ export class SamplePoMenuLabsComponent implements OnInit {
       }
 
       menuParent.subItems.push({
-        action: this.changeMenuSelected,
+        action: this.changeMenuSelected.bind(this),
         label: this.label,
         link: this.link,
         badge: { value: this.badgeValue, color: this.badgeColor }

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-dashboard/sample-po-page-default-dashboard.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-dashboard/sample-po-page-default-dashboard.component.ts
@@ -31,10 +31,10 @@ export class SamplePoPageDefaultDashboardComponent {
   items: Array<object> = this.sampleDashboardService.getItems();
 
   public readonly actions: Array<PoPageAction> = [
-    { label: 'Share', action: this.modalOpen, icon: 'po-icon-share' },
+    { label: 'Share', action: this.modalOpen.bind(this), icon: 'po-icon-share' },
     { label: 'GitHub', url: 'https://github.com/portinariui/portinari-angular' },
     { label: 'Components', url: '/documentation' },
-    { label: 'Disable notification', action: this.disableNotification, disabled: () => this.isSubscribed }
+    { label: 'Disable notification', action: this.disableNotification.bind(this), disabled: () => this.isSubscribed }
   ];
 
   public readonly breadcrumb: PoBreadcrumb = {

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.ts
@@ -29,7 +29,7 @@ export class SamplePoPageListHiringProcessesComponent implements OnInit {
   statusOptions: Array<PoCheckboxGroupOption>;
 
   public readonly actions: Array<PoPageAction> = [
-    { label: 'Hire', action: this.hireCandidate, disabled: this.disableHireButton.bind(this) },
+    { label: 'Hire', action: this.hireCandidate.bind(this), disabled: this.disableHireButton.bind(this) },
     { label: 'Legislation', url: 'https://www.usa.gov/labor-laws' }
   ];
 

--- a/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-email/sample-po-popup-email.component.ts
+++ b/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-email/sample-po-popup-email.component.ts
@@ -42,9 +42,9 @@ export class SamplePoPopupEmailComponent implements OnInit {
 
   ngOnInit() {
     this.popupActions = [
-      { icon: 'po-icon-plus', label: 'Upper Text', type: 'default', action: this.upper },
-      { icon: 'po-icon-minus', label: 'Lower Text', type: 'default', action: this.lower },
-      { icon: 'po-icon-close', label: 'Clear', type: 'danger', action: this.clear, separator: true }
+      { icon: 'po-icon-plus', label: 'Upper Text', type: 'default', action: this.upper.bind(this) },
+      { icon: 'po-icon-minus', label: 'Lower Text', type: 'default', action: this.lower.bind(this) },
+      { icon: 'po-icon-close', label: 'Clear', type: 'danger', action: this.clear.bind(this), separator: true }
     ];
 
     this.primaryAction = {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.ts
@@ -28,7 +28,7 @@ export class SamplePoTableComponentsComponent {
       ]
     },
     { property: 'component', type: 'link' },
-    { property: 'description', color: this.experimentalColor },
+    { property: 'description', color: this.experimentalColor.bind(this) },
     {
       property: 'extra',
       label: 'Extras',


### PR DESCRIPTION
**Samples**

**DTHFUI-3084**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente é possível informar a referencia da função sem passar bind, e a mesma será executada no contexto do componente que possui a função. Isto porque o parentRef é recuperado pelos componentes relacionados.

**Qual o novo comportamento?**
Todos os exemplos no samples serão com a passagem de função com bind ou arrow function, 
para indicar a maneira correta ao desenvolvedor.

O modelo anterior, passando sem bind(this), será depreciada, para que na versão 3.0.0 seja removida o parentRef.

A depreciação ocorrerá em forma de CHANGELOG, onde haverá uma descrição de como deve ser a passagem de função.

**Simulação**
Testar os samples alterados.
