### PR TITLE
feat(combo): adiciona a propriedade p-clean

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -1386,6 +1386,21 @@ describe('PoComboBaseComponent using Service', () => {
 
     expect(component.getObjectByValue).toHaveBeenCalled();
   });
+
+  it('clear: should call `callModelChange` and `updateSelectedValue` and `updateComboList`', () => {
+    component.clean = true;
+
+    spyOn(component, 'callModelChange');
+    spyOn(component, 'updateSelectedValue');
+    spyOn(component, 'updateComboList');
+
+    component.clear('');
+
+    expect(component.callModelChange).toHaveBeenCalled();
+    expect(component.updateSelectedValue).toHaveBeenCalled();
+    expect(component.updateComboList).toHaveBeenCalled();
+    expect(component.selectedValue).toEqual(undefined);
+  });
 });
 
 function getFakeService(item): any {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -454,6 +454,9 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     return this._literals || poComboLiteralsDefault[browserLanguage()];
   }
 
+  /** Se verdadeiro, o campo receberá um botão para ser limpo. */
+  @Input('p-clean') @InputBoolean() clean?: boolean;
+
   /** Deve ser informada uma função que será disparada quando houver alterações no ngModel. */
   @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
 
@@ -710,6 +713,12 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
         }
       };
     }
+  }
+
+  clear(value) {
+    this.callModelChange(value);
+    this.updateSelectedValue(null, true, true);
+    this.updateComboList();
   }
 
   protected validateModel(model: any) {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -5,8 +5,9 @@
     </div>
 
     <input
-      #inputElement
+      #inputEl
       class="po-input po-combo-input"
+      [ngClass]="clean && inputEl.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
       [class.po-input-icon-left]="icon"
       autocomplete="off"
       type="text"
@@ -21,6 +22,13 @@
     />
 
     <div class="po-field-icon-container-right">
+      <po-clean
+        [class.po-field-icon]="!disabled"
+        [class.po-field-icon-disabled]="disabled"
+        (p-change-event)="clear($event)"
+        [p-element-ref]="inputElement"
+      >
+      </po-clean>
       <span
         #iconArrow
         class="po-icon po-field-icon {{ comboIcon }}"

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -13,6 +13,8 @@ import { PoLoadingModule } from '../../po-loading/po-loading.module';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
 
+import { PoCleanComponent } from '../po-clean/po-clean.component';
+
 import { PoComboComponent } from './po-combo.component';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
 import { PoComboFilterService } from './po-combo-filter.service';
@@ -33,7 +35,7 @@ describe('PoComboComponent:', () => {
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [PoLoadingModule],
-      declarations: [PoComboComponent, PoFieldContainerComponent, PoFieldContainerBottomComponent],
+      declarations: [PoComboComponent, PoFieldContainerComponent, PoFieldContainerBottomComponent, PoCleanComponent],
       providers: [HttpClient, HttpHandler]
     });
   });

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -116,7 +116,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   @ViewChild('containerElement', { read: ElementRef }) containerElement: ElementRef;
   @ViewChild('contentElement', { read: ElementRef }) contentElement: ElementRef;
   @ViewChild('iconArrow', { read: ElementRef, static: true }) iconElement: ElementRef;
-  @ViewChild('inputElement', { read: ElementRef, static: true }) inputElement: ElementRef;
+  @ViewChild('inputEl', { read: ElementRef, static: true }) inputElement: ElementRef;
 
   constructor(
     public element: ElementRef,

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -3,6 +3,7 @@
   name="combo"
   [(ngModel)]="combo"
   [p-change-on-enter]="properties.includes('changeOnEnter')"
+  [p-clean]="properties.includes('clean')"
   [p-debounce-time]="debounceTime"
   [p-disabled]="properties.includes('disabled')"
   [p-disabled-init-filter]="properties.includes('disableInitFilter')"

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
@@ -57,7 +57,8 @@ export class SamplePoComboLabsComponent implements OnInit {
     { value: 'optional', label: 'Optional' },
     { value: 'disabledInitFilter', label: 'Disabled Init Filter' },
     { value: 'required', label: 'Required' },
-    { value: 'sort', label: 'Sort' }
+    { value: 'sort', label: 'Sort' },
+    { value: 'clean', label: 'Clean' }
   ];
 
   ngOnInit() {


### PR DESCRIPTION
**po-combo**

**DTHFUI-2314**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Para limpar o combo, é necessário apagar todos caracteres do input.

**Qual o novo comportamento?**
Ao atribuir o valor true para a propriedade p-clean e selecionar um item no combo, será exibido um ícone X. Ao clicar neste ícone, o combo será limpo.

**Simulação**
Criar um po-combo com a propriedade p-clean, escolher alguma opção do combo e clicar no X ao lado da seta. O combo deve ser limpo e o ngModel deve ser atualizado