### PR TITLE
fix(po-i18n): permite mesclar contextos adicionados em "lazy modules"

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@portinari/style": "1.28.0",
     "core-js": "3.1.4",
     "custom-idle-queue": "2.1.2",
+    "deepmerge": "^4.2.2",
     "http-status-codes": "^1.4.0",
     "localforage": "1.4.0",
     "lokijs": "1.5.7",

--- a/projects/ui/ng-package.json
+++ b/projects/ui/ng-package.json
@@ -2,7 +2,11 @@
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/portinari-ui",
   "lib": {
-    "entryFile": "./src/public-api.ts"
+    "entryFile": "./src/public-api.ts",
+    "umdModuleIds": {
+      "deepmerge": "deepmerge",
+      "uuid": "uuid"
+    }
   },
-  "whitelistedNonPeerDependencies": ["@portinari/style"]
+  "whitelistedNonPeerDependencies": ["@portinari/style", "deepmerge", "uuid"]
 }

--- a/projects/ui/src/lib/services/po-i18n/index.ts
+++ b/projects/ui/src/lib/services/po-i18n/index.ts
@@ -1,6 +1,8 @@
 export * from './interfaces/po-i18n-config.interface';
 export * from './interfaces/po-i18n-config-default.interface';
+export * from './interfaces/po-i18n-config-context.interface';
 export * from './interfaces/po-i18n-literals.interface';
+
 export * from './po-i18n.pipe';
 export * from './po-i18n.service';
 

--- a/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config-context.interface.ts
+++ b/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config-context.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * @description
+ *
+ * <a id="poI18nConfigContext"></a>
+ *
+ * Interface para a configuração dos contextos do módulo `PoI18nModule`.
+ *
+ * @usedBy PoI18nModule
+ */
+export interface PoI18nConfigContext {
+  [name: string]: { [language: string]: { [literal: string]: string } } | { url: string };
+}

--- a/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
+++ b/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
@@ -1,3 +1,4 @@
+import { PoI18nConfigContext } from './po-i18n-config-context.interface';
 import { PoI18nConfigDefault } from './po-i18n-config-default.interface';
 
 /**
@@ -10,7 +11,9 @@ import { PoI18nConfigDefault } from './po-i18n-config-default.interface';
  * @usedBy PoI18nModule
  */
 export interface PoI18nConfig {
-  /** Configurações padrões. */
+  /**
+   * Configurações padrões.
+   */
   default?: PoI18nConfigDefault;
 
   /**
@@ -20,42 +23,48 @@ export interface PoI18nConfig {
    *
    * Portanto podemos utilizar constantes, onde devemos informar o nome do contexto recebendo um objeto com os
    * idiomas suportados e o arquivo de literais, por exemplo:
-   * ```
-   *  import { generalEn } from './i18n/general-en';
-   *  import { generalPt } from './i18n/general-pt';
+   *
+   * ```typescript
+   * import { generalEn } from './i18n/general-en';
+   * import { generalPt } from './i18n/general-pt';
+   *
    * ...
-   *  general: {
-   *    pt: generalPt,
-   *    en: generalEn
-   *  }
+   * general: {
+   *   pt: generalPt,
+   *   en: generalEn
+   * }
    * ...
    * ```
    *
    * E como informado, podemos utilizar a propriedade `url` que deve receber a URL do serviço que
    * retorne as literais traduzidas, por exemplo:
-   * ```
-   *   hcm: {
-   *     url: 'http://localhost:3000/api/translations/hcm/'
-   *   }
+   *
+   * ```typescript
+   * hcm: {
+   *   url: 'http://localhost:3000/api/translations/hcm/'
+   * }
    * ```
    *
    * Ao optar por utilizar um serviço, deverá ser definida a URL específica do contexto,
    * como nos exemplos abaixo:
+   *
    * ```
-   *  http://server:port/api/translations/crm
-   *  http://server:port/api/translations/general
+   * http://server:port/api/translations/crm
+   * http://server:port/api/translations/general
    * ```
    *
    * Os idiomas e literais serão automaticamente buscados com parâmetros na própria URL:
+   *
    * - `language`: o idioma será sempre passado por parâmetro, sendo recomendado a utilização do padrão suportado
    * pelos navegadores (`pt-br`, `en-us`);
    * - `literals`: as literais serão separadas por vírgula. Caso esse parâmetro não seja informado, o
    * serviço deve retornar todas as literais do idioma.
    *
    * Exemplos de requisição:
+   *
    * ```
-   *  http://server:port/api/translations/crm?language=pt-br
-   *  http://server:port/api/translations/crm?language=pt-br&literals=add,remove,text
+   * http://server:port/api/translations/crm?language=pt-br
+   * http://server:port/api/translations/crm?language=pt-br&literals=add,remove,text
    * ```
    *
    * > Sempre que o idioma solicitado não for encontrado, será buscado por `pt-br`.
@@ -63,18 +72,19 @@ export interface PoI18nConfig {
    * Existe também a possibilidade de utilizar ambos, onde será feito a busca das literais nas constantes e depois efetua
    * a busca no serviço, com isso as constantes podem servir como *backup* caso o serviço esteja indisponível, por exemplo:
    *
-   * ```
-   *  import { generalEn } from './i18n/general-en';
-   *  import { generalPt } from './i18n/general-pt';
+   * ```typescript
+   * import { generalEn } from './i18n/general-en';
+   * import { generalPt } from './i18n/general-pt';
+   *
    * ...
-   *  general: {
-   *    pt: generalPt,
-   *    en: generalEn,
-   *    url: 'http://localhost:3000/api/translations/hcm/'
-   *  }
+   * general: {
+   *   pt: generalPt,
+   *   en: generalEn,
+   *   url: 'http://localhost:3000/api/translations/hcm/'
+   * }
    * ...
    * ```
    * > Caso a constante contenha alguma literal que o serviço não possua será utilizado a literal da constante.
    */
-  contexts: object;
+  contexts: PoI18nConfigContext;
 }

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
@@ -1,13 +1,33 @@
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HttpRequest } from '@angular/common/http';
-
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { NgModule } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import * as utils from '../../utils/util';
-
 import { PoI18nModule, PoI18nService } from '../po-i18n';
 import { PoLanguageModule } from '../po-language';
+import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
+
+const lazyConfig: PoI18nConfig = {
+  contexts: {
+    general: {
+      'pt-br': {
+        insert: 'insert'
+      }
+    },
+    special: {
+      'pt-br': {
+        delete: 'delete'
+      }
+    }
+  }
+};
+
+@NgModule({
+  imports: [PoI18nModule.forChild(lazyConfig)]
+})
+class LazyModule {}
 
 describe('PoI18nService:', () => {
   let service: PoI18nService;
@@ -42,7 +62,7 @@ describe('PoI18nService:', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, PoLanguageModule, PoI18nModule.config(config)]
+      imports: [HttpClientTestingModule, LazyModule, PoLanguageModule, PoI18nModule.config(config)]
     });
 
     service = TestBed.inject(PoI18nService);
@@ -112,6 +132,22 @@ describe('PoI18nService:', () => {
       expect(literals['text']).toBeTruthy();
       expect(literals['add']).toBeTruthy();
 
+      done();
+    });
+  });
+
+  it('should return literal merged from context added in a "lazy module"', done => {
+    service.getLiterals({ context: 'general', language: 'pt-br' }).subscribe(literals => {
+      expect(literals['insert']).toBeTruthy();
+      expect(literals['insert']).toBe(lazyConfig.contexts['general']['pt-br']['insert']);
+      done();
+    });
+  });
+
+  it('should return literal from context added in a "lazy module"', done => {
+    service.getLiterals({ context: 'special', language: 'pt-br' }).subscribe(literals => {
+      expect(literals['delete']).toBeTruthy();
+      expect(literals['delete']).toBe(lazyConfig.contexts['special']['pt-br']['delete']);
       done();
     });
   });

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
@@ -1,14 +1,12 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject } from '@angular/core';
-
 import { Observable } from 'rxjs';
 
 import { isLanguage, reloadCurrentPage } from '../../utils/util';
 import { PoLanguageService } from '../po-language/po-language.service';
-
-import { I18N_CONFIG } from './po-i18n-config-injection-token';
 import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 import { PoI18nLiterals } from './interfaces/po-i18n-literals.interface';
+import { I18N_CONFIG } from './po-i18n-config-injection-token';
 
 /**
  * @description
@@ -256,7 +254,7 @@ export class PoI18nBaseService {
     const context = options['context'] ? options['context'] : this.contextDefault;
     const literals: Array<string> = options['literals'] ? options['literals'] : [];
 
-    return new Observable(observer => {
+    return new Observable<any>(observer => {
       if (this.servicesContext[context]) {
         // Faz o processo de busca de um contexto que contém serviço
         this.getLiteralsFromContextService(language, context, literals, observer);

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-config-injection-token.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-config-injection-token.ts
@@ -2,4 +2,4 @@ import { InjectionToken } from '@angular/core';
 
 import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 
-export const I18N_CONFIG = new InjectionToken<PoI18nConfig>('I18N_CONFIG');
+export const I18N_CONFIG = new InjectionToken<Array<PoI18nConfig>>('I18N_CONFIG');

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
@@ -1,25 +1,29 @@
 import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
+import { APP_INITIALIZER, ModuleWithProviders, NgModule, Provider } from '@angular/core';
 
-import { PoLanguageService } from './../po-language/po-language.service';
-
-import { I18N_CONFIG } from './po-i18n-config-injection-token';
-import { returnPoI18nService, PoI18nService } from './po-i18n.service';
-import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 import { PoLanguageModule } from '../po-language/po-language.module';
+import { PoLanguageService } from './../po-language/po-language.service';
+import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
+import { I18N_CONFIG } from './po-i18n-config-injection-token';
+import { PoI18nService, returnPoI18nService } from './po-i18n.service';
 
 /**
  * @description
  *
  * Módulo do serviço `PoI18nService` para controle de idiomas com PO.
  *
- * Para utilização do serviço de idiomas `PoI18nService`, deve-se importar este módulo mesmo já havendo importado
- * o módulo `PoModule`. Na importação deve ser invocado o método `config`, informando um objeto que deve implementar
- * a interface [`PoI18nConfig`](documentation/po-i18n#poI18nConfig) para configuração.
+ * Para utilização do serviço de idiomas `PoI18nService`, deve-se importar este
+ * módulo mesmo já havendo importado o módulo `PoModule`.
+ *
+ * Na importação deve ser invocado o método `config`, informando um objeto que
+ * deve implementar a interface [`PoI18nConfig`](documentation/po-i18n#poI18nConfig)
+ * para configuração.
  *
  * <a id="i18n-config"></a>
- * **Exemplo de configuração do módulo do i18n:**
- * ```
+ *
+ * ## Configuração
+ *
+ * ```typescript
  * import { PoI18nConfig } from '@portinari/portinari-ui';
  *
  * import { generalEn } from './i18n/general-en';
@@ -52,31 +56,34 @@ import { PoLanguageModule } from '../po-language/po-language.module';
  * })
  * ```
  *
- * Para cada contexto é possível definir a origem das literais, que podem ser de um serviço REST ou
- * de um objeto. Exemplo:
+ * Para cada contexto é possível definir a origem das literais, que podem ser
+ * de um serviço `REST` ou de um objeto. Exemplo:
  *
- * Arquivo general-pt.ts
- * ```
+ * Arquivo `general-pt.ts`
+ *
+ * ```typescript
  * export const generalPt = {
- *  add: 'Adicionar',
- *  greeting: 'Prazer, {0} {1}',
- *  people: '{0} Pessoas,
- *  remove: 'Remover'
- * }
+ *   add: 'Adicionar',
+ *   greeting: 'Prazer, {0} {1}',
+ *   people: '{0} Pessoas,
+ *   remove: 'Remover'
+ * };
  * ```
  *
- * Arquivo general-en.ts
- * ```
+ * Arquivo `general-en.ts`
+ *
+ * ```typescript
  * export const generalEn = {
- *  add: 'Add',
- *  greeting: 'Nice to meet you, {0} {1}',
- *  people: '{0} People,
- *  remove: 'Remove'
- * }
+ *   add: 'Add',
+ *   greeting: 'Nice to meet you, {0} {1}',
+ *   people: '{0} People,
+ *   remove: 'Remove'
+ * };
  * ```
  *
- * **Exemplo de configuração de contextos usando constantes externas:**
- * ```
+ * ### Configuração de contextos utilizando constantes externas
+ *
+ * ```typescript
  * import { PoI18nConfig } from '@portinari/portinari-ui';
  *
  * import { generalEn } from './i18n/general-en';
@@ -91,24 +98,25 @@ import { PoLanguageModule } from '../po-language/po-language.module';
  *     crm: {
  *       url: 'http://10.0.0.1:3000/api/translations/crm'
  *     }
- *   },
- *   default: {}
+ *   }
  * }
  * ```
  *
- * **Exemplo de configuração de um contexto utilizando serviço:**
+ * ### Configuração de contextos utilizando serviços
  *
- * Ao optar por utilizar um serviço para configuração de contexto, deverá ser definida a URL
- * específica do contexto, como nos exemplos abaixo:
+ * Ao optar por utilizar um serviço para configuração de contexto, deverá ser
+ * definida a URL específica do contexto, como nos exemplos abaixo:
  *
  *  - http://10.0.0.1:3000/api/translations/crm
  *  - http://10.0.0.1:3000/api/translations/general
  *
- * Os idiomas e literais serão automaticamente buscados com parâmetros na própria URL:
- * - **language**: o idioma será sempre passado por parâmetro e é recomendado utilizar uma das linguagens
- * suportadas pelo PO (`pt-br`, `en-us` ou `es-es`).
- * - **literals**: as literais serão separadas por vírgula. Caso esse parâmetro não seja informado, o
- * serviço deve retornar todas as literais do idioma.
+ * Os idiomas e literais serão automaticamente buscados com parâmetros na
+ * própria URL:
+ *
+ * - **language**: o idioma será sempre passado por parâmetro e é recomendado
+ * utilizar uma das linguagens suportadas pelo PO (`pt-br`, `en-us` ou `es-es`).
+ * - **literals**: as literais serão separadas por vírgula. Caso esse parâmetro
+ * não seja informado, o serviço deve retornar todas as literais do idioma.
  *
  * Exemplos de requisição:
  *
@@ -117,75 +125,123 @@ import { PoLanguageModule } from '../po-language/po-language.module';
  *
  * > Sempre que o idioma solicitado não for encontrado, será buscado por `pt-br`.
  *
- * Além dos contextos, é possível definir as configurações *default* do sistema na configuração do
- * módulo utilizando a interface [`PoI18nConfig`](documentation/po-i18n#poI18nConfig):
+ * ### Configurações padrões
  *
- * **Exemplo de padrões definidos:**
- * ```
+ * Além dos contextos, é possível definir as configurações *default* do sistema
+ * na configuração do módulo utilizando a interface [`PoI18nConfig`](documentation/po-i18n#poI18nConfig):
+ *
+ * ```typescript
  * const i18nConfig: PoI18nConfig = {
- *   contexts: {
- *     general: { }
- *   },
  *   default: {
  *    language: 'pt-BR',
  *    context: 'general',
  *    cache: true
+ *   },
+ *   contexts: {
+ *     general: {
+ *       'en-US': generalEs,
+ *       'pt-BR': generalPt
+ *     }
  *   }
- * }
+ * };
  * ```
  *
- * **Importante:**
+ * > #### Importante
+ * >
+ * > Recomenda-se que as definições *default* sejam realizadas apenas uma vez
+ * > na aplicação, preferencialmente no módulo `AppModule`.
  *
- * Recomenda-se que as definições *default* sejam realizadas apenas uma vez na aplicação,
- * preferencialmente no módulo `AppModule`.
+ * ## `PoI18nModule` com **Lazy Loading** e **bibliotecas**
  *
- * **i18n com *Lazy loading***
+ * Para aplicações que utilizem a abordagem de módulos com carregamento *lazy
+ * loading* ou para módulos de bibliotecas que utilizam o PO, caso seja definida
+ * outra configuração do `PoI18nModule`, deve-se atentar os seguintes detalhes:
  *
- * Para aplicações que utilizem a abordagem de módulos com carregamento *lazy loading*, caso seja
- * definida outra configuração do `PoI18nModule`, deve-se atentar os seguintes detalhes:
+ * * Utilize o método **`forChild`** ao invés do método `config` e defina
+ * utilizando a interface [`PoI18nConfigWithoutDefault`](documentation/po-i18n#poI18nConfigWithoutDefault)
+ * para definir os contextos e suas respectivas literais:
  *
- * - Caso existam literais comuns na aplicação, estas devem ser reimportadas;
- * - Não defina outra *default language* para este módulo. Caso for definida, será sobreposta para
- * toda a aplicação;
- * - Caso precise de módulos carregados via *lazy loading* com linguagens diferentes, utilize o
- * método [`setLanguage()`](documentation/po-i18n#setLanguage) disponibilizado pelo `PoI18nService`
- * para definir a linguagem da aplicação e dos módulos com as linguagens diferentes.
+ * ```typescript
+ * const i18nConfig: PoI18nConfigWithoutDefault = {
+ *   contexts: {
+ *     myLib: {
+ *       'en-US': myLibEn,
+ *       'pt-BR': myLibPt
+ *     }
+ *   }
+ * };
+ *
+ * @NgModule({
+ *   declarations: [],
+ *   imports: [
+ *     CommonModule,
+ *     PoModule,
+ *     PoI18nModule.forChild(i18nConfig)
+ *   ]
+ * })
+ * ```
+ *
+ * * Caso existam literais comuns na aplicação, estas devem ser reimportadas;
+ * * Não defina outra *default language* para este módulo. Caso for definida,
+ *   será sobreposta para toda a aplicação;
+ * * Caso precise de módulos carregados via *lazy loading* com linguagens
+ *   diferentes, utilize o método [`setLanguage()`](documentation/po-i18n#setLanguage)
+ *   disponibilizado pelo `PoI18nService` para definir a linguagem da aplicação
+ *   e dos módulos com as linguagens diferentes.
  */
-
 @NgModule({
   imports: [HttpClientModule, PoLanguageModule]
 })
 export class PoI18nModule {
-  static config(config: PoI18nConfig): ModuleWithProviders<PoI18nModule> {
+  static config(config: PoI18nConfig): ModuleWithProviders {
     return {
       ngModule: PoI18nModule,
       providers: [
-        {
-          provide: I18N_CONFIG,
-          useValue: config
-        },
+        provideI18nConfig(config),
         {
           provide: APP_INITIALIZER,
           useFactory: initializeLanguageDefault,
-          multi: true,
-          deps: [I18N_CONFIG, PoLanguageService]
-        },
-        {
-          provide: PoI18nService,
-          useFactory: returnPoI18nService,
-          deps: [I18N_CONFIG, HttpClient, PoLanguageService]
+          deps: [I18N_CONFIG, PoLanguageService],
+          multi: true
         }
       ]
     };
   }
+
+  static forRoot(config: PoI18nConfig): ModuleWithProviders {
+    return PoI18nModule.config(config);
+  }
+
+  static forChild(config: PoI18nConfig): ModuleWithProviders {
+    return { ngModule: PoI18nModule, providers: [provideI18nConfig(config)] };
+  }
 }
 
-export function initializeLanguageDefault(config: PoI18nConfig, languageService: PoLanguageService) {
+export function provideI18nConfig(config: PoI18nConfig): Array<Provider> {
+  return [
+    {
+      provide: I18N_CONFIG,
+      useValue: config,
+      multi: true
+    },
+    {
+      provide: PoI18nService,
+      useFactory: returnPoI18nService,
+      deps: [I18N_CONFIG, HttpClient, PoLanguageService]
+    }
+  ];
+}
+
+export function initializeLanguageDefault(configs: Array<PoI18nConfig>, languageService: PoLanguageService) {
+  // Recupera a primeira configuração que possui "default".
+  const config = configs.find(c => c.default);
+
   // tslint:disable-next-line:prefer-immediate-return
   const setDefaultLanguage = () => {
     if (config.default.language) {
       languageService.setLanguageDefault(config.default.language);
     }
   };
+
   return setDefaultLanguage;
 }

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
@@ -1,19 +1,20 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { all as deepmergeAll } from 'deepmerge';
 
 import { PoLanguageService } from './../po-language/po-language.service';
-
-import { PoI18nBaseService } from './po-i18n-base.service';
 import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
+import { PoI18nBaseService } from './po-i18n-base.service';
 
 /**
  * @docsExtends PoI18nBaseService
  */
-
-@Injectable()
 export class PoI18nService extends PoI18nBaseService {}
 
 // Função usada para retornar instância para o módulo po-i18n.module
-export function returnPoI18nService(config: PoI18nConfig, http: HttpClient, languageService: PoLanguageService) {
-  return new PoI18nService(config, http, languageService);
+export function returnPoI18nService(
+  configs: Array<PoI18nConfig>,
+  http: HttpClient,
+  languageService: PoLanguageService
+) {
+  return new PoI18nService(deepmergeAll<PoI18nConfig>(configs), http, languageService);
 }


### PR DESCRIPTION
**PoI18nModule**

**#321**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente quando a aplicação possui como dependência outro módulo que utiliza o `PoI18nModule` (uma biblioteca Angular por exemplo), as configurações de i18n da aplicação sobrescreviam as configurações de i18n do módulo importado.

**Qual o novo comportamento?**

Foi criado o método `forChild` que permite adicionar novos contextos para o módulo de i18n do PO. Para isto alguns ajustes foram necessários:

* Agora os contextos podem ser "mesclados" (mesmo se utilizado o método `config`)
* O `provider` **I18N_CONFIG** agora é `multi`
* Ao criar o serviço para o módulo atual, os contextos são mesclados
* Foi adicionada uma biblioteca de terceiro que permite efetuar **deep merge** de objetos
* Por convenção foi criado o método `forRoot` que chama o método `config`

- Documentação e testes alterados.

**Simulação**

Executar a simulação relatada na ISSUE #321.