### PR TITLE
docs(migration-thf): atualiza para a nova versão

### DIFF
--- a/docs/guides/migration-thf-to-portinari.md
+++ b/docs/guides/migration-thf-to-portinari.md
@@ -1,4 +1,4 @@
-[comment]: # (@label Migração do THF para o Portinari)
+[comment]: # (@label Migração do THF para o Portinari v1.x)
 [comment]: # (@link guides/migration-thf-to-portinari)
 
 Para facilitar a migração do seu projeto com o THF para o Portinari, disponibilizamos um pacote para fazer esta conversão. 
@@ -8,8 +8,9 @@ Este pacote, irá passar pelos arquivos do seu projeto alterando as palavras-cha
 ### Antes de iniciar a migração
 
 Antes de iniciar a migração certifique-se que:
-- Todos os arquivos estão salvos.
+- Este pacote de migração é apenas para a migração do **THF versão 4 ou superior para o Portinari versão 1.x** que é compatível com a versão 8 do Angular. 
 - As dependências do THF encontram-se na versão 4 ou superior.
+- Todos os arquivos estão salvos.
 - Se as pastas e os arquivos possuem permissão para terceiros alterá-los.
 
 ### Instalação do pacote de migração


### PR DESCRIPTION
**Documentação migration-thf-to-portinari**

**DTHFUI-3088**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Não era especificado que o pacote era apenas para a versão 1 do projeto.

**Qual o novo comportamento?**
Atualiza a documentação para fazer a migração da versão 4 do
THF para a versão 1 do projeto.


**Simulação**
Abrir a documentação no portal