### PR TITLE
fix(slide): passa métodos para OnChanges

### DIFF
--- a/projects/ui/src/lib/components/po-slide/po-slide-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-slide/po-slide-base.component.spec.ts
@@ -22,18 +22,13 @@ describe('PoSlideBaseComponent:', () => {
   });
 
   describe('Properties:', () => {
-    it('height: should update property with valid values and call `setSlideHeight`.', () => {
+    it('height: should update property with valid values.', () => {
       const validValues = [0, 1500, 500, 200, 8000];
 
-      spyOn(component, 'setSlideHeight');
-
       expectPropertiesValues(component, 'height', validValues, validValues);
-      expect(component.setSlideHeight).toHaveBeenCalledTimes(5);
     });
 
-    it('height: should update property if values are invalid and call `setSlideHeight`.', () => {
-      spyOn(component, 'setSlideHeight');
-
+    it('height: should update property if values are invalid.', () => {
       component.height = <any>'one';
       expect(component.height).toBeUndefined();
 
@@ -45,8 +40,6 @@ describe('PoSlideBaseComponent:', () => {
 
       component.height = null;
       expect(component.height).toBeUndefined();
-
-      expect(component.setSlideHeight).toHaveBeenCalledTimes(4);
     });
 
     it('interval: should update property with values greater or equal than 1000 and call `startInterval`.', () => {

--- a/projects/ui/src/lib/components/po-slide/po-slide-base.component.ts
+++ b/projects/ui/src/lib/components/po-slide/po-slide-base.component.ts
@@ -33,7 +33,6 @@ export abstract class PoSlideBaseComponent {
    */
   @Input('p-height') set height(value: number) {
     this._height = convertToInt(value);
-    this.setSlideHeight(this.height);
   }
 
   get height(): number {

--- a/projects/ui/src/lib/components/po-slide/po-slide.component.spec.ts
+++ b/projects/ui/src/lib/components/po-slide/po-slide.component.spec.ts
@@ -1,3 +1,4 @@
+import { SimpleChange } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -141,6 +142,25 @@ describe('PoSlideComponent:', () => {
         expect(component['startSlide']).not.toHaveBeenCalled();
         expect(component['setSlideItemWidth']).toHaveBeenCalled();
       });
+    });
+
+    it('ngOnChanges: should call `setSlideHeight` with `this.height` if `changes.height` is defined', () => {
+      component.height = 400;
+      const height = 400;
+
+      spyOn(component, 'setSlideHeight');
+
+      component.ngOnChanges(<any>{ height });
+
+      expect(component['setSlideHeight']).toHaveBeenCalledWith(height);
+    });
+
+    it('ngOnChanges: should`t call `setSlideHeight` if `changes.height` is not defined', () => {
+      spyOn(component, 'setSlideHeight');
+
+      component.ngOnChanges({});
+
+      expect(component['setSlideHeight']).not.toHaveBeenCalled();
     });
 
     it('goToItem: should set `currentSlideIndex` and call `animate` with `offset`', () => {
@@ -620,7 +640,9 @@ describe('PoSlideComponent:', () => {
     it(`should have style height default if component height is undefined.`, () => {
       const poSlideDefaultHeight = 336;
       component.height = undefined;
+      const simpleChangeHeight = new SimpleChange(undefined, component.height, true);
 
+      component.ngOnChanges({ height: simpleChangeHeight });
       fixture.detectChanges();
 
       const slideInnerHeight = nativeElement.querySelector('.po-slide-inner').style.height;
@@ -628,13 +650,14 @@ describe('PoSlideComponent:', () => {
     });
 
     it(`should set style height of slide to 700px.`, () => {
-      const newHeight = 700;
-      component.height = newHeight;
+      const height = 700;
+      component.height = height;
 
+      component.ngOnChanges(<any>{ height });
       fixture.detectChanges();
 
       const slideInnerHeight = nativeElement.querySelector('.po-slide-inner').style.height;
-      expect(slideInnerHeight).toBe(newHeight + `px`);
+      expect(slideInnerHeight).toBe(height + `px`);
     });
 
     it(`should have arrow left and arrow right if has more than 1 slide.`, () => {

--- a/projects/ui/src/lib/components/po-slide/po-slide.component.ts
+++ b/projects/ui/src/lib/components/po-slide/po-slide.component.ts
@@ -6,7 +6,9 @@ import {
   HostListener,
   QueryList,
   ViewChild,
-  ViewChildren
+  ViewChildren,
+  OnChanges,
+  SimpleChanges
 } from '@angular/core';
 
 import { animate, AnimationBuilder, AnimationFactory, AnimationPlayer, keyframes, style } from '@angular/animations';
@@ -49,7 +51,7 @@ const poSlideTiming = '250ms ease';
   selector: 'po-slide',
   templateUrl: './po-slide.component.html'
 })
-export class PoSlideComponent extends PoSlideBaseComponent implements DoCheck {
+export class PoSlideComponent extends PoSlideBaseComponent implements DoCheck, OnChanges {
   private isLoaded: boolean = false;
   private player: AnimationPlayer;
   private setInterval: any;
@@ -101,6 +103,12 @@ export class PoSlideComponent extends PoSlideBaseComponent implements DoCheck {
       if (this.hasSlides) {
         this.startSlide();
       }
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.height) {
+      this.setSlideHeight(this.height);
     }
   }
 


### PR DESCRIPTION
**PO-SLIDE**

**DTHFUI-3084**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Há métodos chamados dentro dos setters que estão quebrando os samples no portal.

**Qual o novo comportamento?**
Com a atualização de versão alguns métodos chamados via setter passaram a quebrar. Foi necessário deslocá-los para dentro do OnChanges.

**Simulação**
Rodar no portal.