### PR TITLE
fix(page-list) e fix(page-dynamic-search): corrige erro ao filtrar

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -69,6 +69,9 @@ describe('PoPageDynamicSearchComponent:', () => {
       beforeEach(() => {
         fakethis = {
           changeDisclaimersEnabled: true,
+          changeDetector: {
+            detectChanges: () => {}
+          },
           _disclaimerGroup: {
             disclaimers: []
           },
@@ -114,6 +117,14 @@ describe('PoPageDynamicSearchComponent:', () => {
         component.onAction.call(fakethis);
 
         expect(fakethis._disclaimerGroup.disclaimers).toEqual(result);
+      });
+
+      it('should call `ChangeDetectorRef.detectChanges`', () => {
+        spyOn(component['changeDetector'], 'detectChanges');
+
+        component.onAction();
+
+        expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
       });
     });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, OnInit, OnDestroy } from '@angular/core';
+import { Component, ViewChild, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 
 import { Observable, Subscription } from 'rxjs';
 import {
@@ -62,7 +62,11 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
 
   @ViewChild(PoAdvancedFilterComponent, { static: true }) poAdvancedFilter: PoAdvancedFilterComponent;
 
-  constructor(languageService: PoLanguageService, private poPageCustomizationService: PoPageCustomizationService) {
+  constructor(
+    languageService: PoLanguageService,
+    private poPageCustomizationService: PoPageCustomizationService,
+    private changeDetector: ChangeDetectorRef
+  ) {
     super(languageService);
   }
 
@@ -100,6 +104,8 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
     }
 
     this.quickFilter = undefined;
+
+    this.changeDetector.detectChanges();
   }
 
   onAdvancedAction() {

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
@@ -261,7 +261,10 @@ describe('PoPageListComponent - Desktop:', () => {
     const fakeThis = {
       parentRef: context,
       filter: { 'funcao': 'getName' },
-      callFunction: component.callFunction
+      callFunction: component.callFunction,
+      changeDetector: {
+        detectChanges: () => {}
+      }
     };
 
     spyOn(context, 'getName');
@@ -451,6 +454,16 @@ describe('PoPageListComponent - Desktop:', () => {
   });
 
   describe('Methods:', () => {
+    it('callActionFilter: should call `ChangeDetectorRef.detectChanges` after `callFunction`', () => {
+      const changeDetectorSpy = spyOn(component['changeDetector'], 'detectChanges');
+      const callFunctionSpy = spyOn(component, 'callFunction');
+      component.filter = { action: 'test' };
+
+      component.callActionFilter('sction');
+
+      expect(callFunctionSpy).toHaveBeenCalledBefore(changeDetectorSpy);
+    });
+
     it('callAction: should open an external URL in a new tab in the browser by calling Utils`s openExternalLink method', () => {
       const url = 'http://portinari.io';
 

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -7,7 +7,8 @@ import {
   Renderer2,
   SimpleChange,
   ViewChild,
-  ViewContainerRef
+  ViewContainerRef,
+  ChangeDetectorRef
 } from '@angular/core';
 import { Router } from '@angular/router';
 
@@ -63,7 +64,8 @@ export class PoPageListComponent extends PoPageListBaseComponent
     viewRef: ViewContainerRef,
     languageService: PoLanguageService,
     public renderer: Renderer2,
-    private router: Router
+    private router: Router,
+    private changeDetector: ChangeDetectorRef
   ) {
     super(languageService);
     this.parentRef = viewRef['_hostView'][8];
@@ -132,6 +134,7 @@ export class PoPageListComponent extends PoPageListBaseComponent
 
   callActionFilter(field: string): void {
     this.callFunction(this.filter[field], this.parentRef);
+    this.changeDetector.detectChanges();
   }
 
   onkeypress(key) {


### PR DESCRIPTION
**Page List e Page Dynamic Search**

**DTHFUI-3084**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Estava gerando erro "expressionChangedAfterItHasBeenCheckedError" ao utilizar o filtro com nenhuma string.

**Qual o novo comportamento?**
Não está mais gerando este erro em nenhum dos dois componentes. 

**Simulação**
Samples do portal