### PR TITLE
feat(schematics): implementa ng update para v2

### DIFF
--- a/docs/guides/migration-poui-v2.md
+++ b/docs/guides/migration-poui-v2.md
@@ -1,0 +1,139 @@
+[comment]: # (@label Migração do PO UI para V2)
+[comment]: # (@link guides/migration-poui-v2)
+
+Este guia contém informações sobre a migração do seu projeto para a versão 2 do PO UI.
+
+## Atualizando o projeto com Angular
+
+Antes de atualizar a versão do PO UI, é importante que você tenha atualizado o seu projeto para
+o Angular 9, executando o comando abaixo:
+
+``` ng update @angular/cli @angular/core ```
+
+> Para realizar a migração completa e avaliar se não precisa fazer alguma alteração veja o [**Guia de Upgrade do Angular**](https://update.angular.io/).
+
+## Atualizando o PO UI
+
+Para facilitar a migração do seu projeto para o PO UI v2, implementamos o `ng update`.
+
+Para poder utilizar o comando e realizar a migração, execute os comandos abaixo:
+
+``` npm i --save @po-ui/ng-components ```
+
+``` ng update @po-ui/ng-components --from 1 --migrate-only ```
+
+O `ng update` fará as alterações necessárias para seu projeto seguir atualizado, que são elas:
+  - Alterar todo conteúdo relacionado ao **BREAKING CHANGES** no seu projeto;
+  - Atualizar as versões dos pacotes `@po-ui`.
+
+### Breaking Changes
+
+Nesta nova versão o nome dos pacotes foram alterados, de acordo com a tabela abaixo:
+
+| Pacotes                                                 | Subistituído por                     |
+| --------------------------------------------------------| ------------------------------------ |
+| `@portinari/portinari-ui`                               | `@po-ui/ng-components`               |
+| `@portinari/portinari-templates`                        | `@po-ui/ng-templates`                |
+| `@portinari/portinari-code-editor`                      | `@po-ui/ng-code-editor`              |
+| `@portinari/portinari-sync`                             | `@po-ui/ng-sync`                     |
+| `@portinari/portinari-storage`                          | `@po-ui/ng-storage`                  |
+| `@portinari/tslint`                                     | `@po-ui/ng-tslint`                      |
+| `@portinari/style`                                      | `@po-ui/style`                       |
+
+Também foi realizado remoções das propriedades, onde passam a valer as novas definições, veja a tabela abaixo:
+
+| Componentes                                             | Anteriormente                            | Subistituido por             |
+| --------------------------------------------------------| -----------------------------------------| -----------------------------|
+| `PoFieldModule`                                         | `[p-focus]`                              | `[p-auto-focus]`             |
+| `PoHttpResquestInterceptor`                             | `X-Portinari-Screen-Lock`                | `X-PO-Screen-Lock`           |
+| `PoHttpResquestInterceptor`                             | `X-Portinari-No-Count-Pending-Requests`  | `X-PO-No-Message`            |
+| `PoHttpInterceptor`                                     | `X-Portinari-No-Message`                 | `X-PO-No-Message`            |
+| `PoPageEdit`                                            | Possuir a ação `cancel() {}` no TS       | `(p-cancel)`                 |
+| `PoPageEdit`                                            | Possuir a ação `save() {}` no TS         | `(p-save)`                   |
+| `PoPageEdit`                                            | Possuir a ação `saveNew() {}` no TS      | `(p-save-new)`               |
+| `PoPageDetail`                                          | Possuir a ação `back() {}` no TS         | `(p-back)`                   |
+| `PoPageDetail`                                          | Possuir a ação `edit() {}` no TS         | `(p-edit)`                   |
+| `PoPageDetail`                                          | Possuir a ação `remove() {}` no TS       | `(p-remove)`                 |
+
+
+### Depreciação
+
+Nas versões `1.x.x` era possível passar funções para nossas propriedades sem informar o `.bind(this)`,
+pois capturávamos o componente pai e conseguíamos acessar o contexto corrente. Porém depreciamos este comportamento,
+agora necessita passar a referência da função utilizando o `.bind(this)` para que o mesmo execute 
+a função no contexto invocado, tanto em funções dentro de *arrays* quanto em funções via *property bind*.
+
+Os componentes que sofrerão esta depreciação, são:
+- [**PageChangePassword**](http://po-ui.io/documentation/po-page-change-password)
+- [**ButtonGroup**](http://po-ui.io/documentation/po-button-group)
+- [**Menu**](http://po-ui.io/documentation/po-menu)
+- [**MenuPanel**](http://po-ui.io/documentation/po-menu-panel)
+- [**Navbar**](http://po-ui.io/documentation/po-navbar)
+- [**PageList**](http://po-ui.io/documentation/po-page-list)
+- [**PageDefault**](http://po-ui.io/documentation/po-page-default)
+- [**Popup**](http://po-ui.io/documentation/po-popup)
+- [**Stepper**](http://po-ui.io/documentation/po-step)
+- [**Table**](http://po-ui.io/documentation/po-table)
+- [**Toolbar**](http://po-ui.io/documentation/po-toolbar)
+
+Abaixo listamos dois exemplos comparativos com essas depreciações em alguns componentes.
+
+Exemplo via funções dentro de arrays:
+- Antes:
+
+```
+<po-page-default p-title="Página" [p-actions]="actions">
+   ...
+</po-page-default>
+```
+
+```
+export class ExampleFunction () {
+
+  actions: Array<PoPageAction> = [
+    { label: 'Adicionar', action: this.add }
+  ]
+
+  add() {
+    ...
+  }
+}
+```
+
+- Agora:
+
+```
+<po-page-default p-title="Página" [p-actions]="actions">
+   ...
+</po-page-default>
+```
+
+```
+export class ExampleFunction () {
+
+  actions: Array<PoPageAction> = [
+    { label: 'Adicionar', action: this.add.bind(this) }
+  ]
+
+  add() {
+    ...
+  }
+}
+```
+
+Exemplo funções via *property bind*
+- Antes:
+```
+<po-stepper>
+  <po-step p-label="Personal" [p-can-active-next-step]="canActiveNextStep">
+  </po-step>
+</po-stepper>
+```
+
+- Agora:
+```
+<po-stepper>
+  <po-step p-label="Personal" [p-can-active-next-step]="canActiveNextStep.bind(this)">
+  </po-step>
+</po-stepper>
+```

--- a/docs/guides/migration-poui-v2.md
+++ b/docs/guides/migration-poui-v2.md
@@ -22,9 +22,11 @@ Para poder utilizar o comando e realizar a migração, execute os comandos abaix
 
 ``` ng update @po-ui/ng-components --from 1 --migrate-only ```
 
-O `ng update` fará as alterações necessárias para seu projeto seguir atualizado, que são elas:
-  - Alterar todo conteúdo relacionado ao **BREAKING CHANGES** no seu projeto;
+O `ng update` ajudará nas alterações necessárias para seu projeto seguir atualizado, que são elas:
+  - Alterar maioria dos conteúdos relacionado ao **BREAKING CHANGES** no seu projeto;
   - Atualizar as versões dos pacotes `@po-ui`.
+
+Mas é importante conhecer os **BREAKING CHANGES** e **Depreciações** para realizar as alterações manualmente caso necessaário.
 
 ### Breaking Changes
 
@@ -37,12 +39,12 @@ Nesta nova versão o nome dos pacotes foram alterados, de acordo com a tabela ab
 | `@portinari/portinari-code-editor`                      | `@po-ui/ng-code-editor`              |
 | `@portinari/portinari-sync`                             | `@po-ui/ng-sync`                     |
 | `@portinari/portinari-storage`                          | `@po-ui/ng-storage`                  |
-| `@portinari/tslint`                                     | `@po-ui/ng-tslint`                      |
+| `@portinari/tslint`                                     | `@po-ui/ng-tslint`                   |
 | `@portinari/style`                                      | `@po-ui/style`                       |
 
 Também foi realizado remoções das propriedades, onde passam a valer as novas definições, veja a tabela abaixo:
 
-| Componentes                                             | Anteriormente                            | Subistituido por             |
+| Componentes                                             | Anteriormente                            | Subistituído por             |
 | --------------------------------------------------------| -----------------------------------------| -----------------------------|
 | `PoFieldModule`                                         | `[p-focus]`                              | `[p-auto-focus]`             |
 | `PoHttpResquestInterceptor`                             | `X-Portinari-Screen-Lock`                | `X-PO-Screen-Lock`           |

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ const distFolder = path.resolve(rootFolder, './dist');
 const uiFolder = path.resolve(rootFolder, './projects/ui');
 
 const schematicsFolder = path.resolve(uiFolder, './schematics');
-const distSchematicsFolder = path.resolve(rootFolder, './dist/portinari-ui/schematics');
+const distSchematicsFolder = path.resolve(rootFolder, './dist/ng-components/schematics');
 
 /** REPLACE VERSION: replace version of dist package.json to repo version */
 const replaceVersion = () =>
@@ -26,6 +26,8 @@ const copyFiles = () =>
   src([`${schematicsFolder}/ng-generate/*/files/**`]).pipe(dest(`${distSchematicsFolder}/ng-generate`));
 
 const copyCollection = () => src([`${schematicsFolder}/collection.json`]).pipe(dest(distSchematicsFolder));
+
+const copyMigrations = () => src([`${schematicsFolder}/migrations.json`]).pipe(dest(distSchematicsFolder));
 
 /** SONAR */
 const sonarqube = task('sonarqube', function(callback) {
@@ -50,4 +52,4 @@ const sonarqube = task('sonarqube', function(callback) {
 /** Exported Functions */
 exports.sonarqube = sonarqube;
 exports.replaceVersion = replaceVersion;
-exports.schematics = series(buildSchematics, parallel(copyCollection, copySchemas, copyFiles));
+exports.schematics = series(buildSchematics, parallel(copyCollection, copyMigrations, copySchemas, copyFiles));

--- a/package.json
+++ b/package.json
@@ -42,7 +42,12 @@
     "format:fix": "pretty-quick --staged",
     "format:check": "prettier --check --loglevel error \"**/*{.ts,.js,.json,.css,.scss,.html}\"",
     "format:all": "prettier --write \"**/*{.ts,.js,.json,.css,.scss,.html}\"",
-    "publish:ui:local": "npm publish dist/ng-components --registry http://localhost:4873"
+    "publish:ui:local": "npm publish dist/ng-components --registry http://localhost:4873",
+    "publish:templates:local": "npm publish dist/ng-templates --registry http://localhost:4873",
+    "publish:sync:local": "npm publish dist/ng-sync --registry http://localhost:4873",
+    "publish:storage:local": "npm publish dist/ng-storage --registry http://localhost:4873",
+    "publish:code-editor:local": "npm publish dist/ng-code-editor --registry http://localhost:4873",
+    "publish:local": "npm run publish:ui:local && npm run publish:templates:local && npm run publish:code-editor:local && npm run publish:sync:local && npm run publish:storage:local"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "po-ui-sources",
-  "version": "1.28.0",
+  "version": "2.0.0-beta.1",
   "description": "PO UI",
   "homepage": "https://po-ui.io",
   "license": "MIT",
@@ -30,18 +30,19 @@
     "test:code-editor:browse": "ng test code-editor --code-coverage --browsers=Chrome --source-map",
     "test:dev": "ng test --browsers=ChromeHeadless",
     "build:schematics": "npm run tsc -- -p ./projects/ui/tsconfig.schematics.json",
-    "build:ui": "ng build ui --prod && gulp schematics && gulp replaceVersion && cd dist/portinari-ui && npm pack",
-    "build:code-editor": "ng build code-editor --prod && gulp replaceVersion && cd dist/portinari-code-editor && npm pack",
-    "build:templates": "ng build templates --prod && gulp replaceVersion && cd dist/portinari-templates && npm pack",
-    "build:storage": "ng build storage --prod && gulp replaceVersion && cd dist/portinari-storage && npm pack",
-    "build:sync": "ng build sync --prod && gulp replaceVersion && cd dist/portinari-sync && npm pack",
+    "build:ui": "ng build ui --prod && gulp schematics && gulp replaceVersion && cd dist/ng-components && npm pack",
+    "build:code-editor": "ng build code-editor --prod && gulp replaceVersion && cd dist/ng-code-editor && npm pack",
+    "build:templates": "ng build templates --prod && gulp replaceVersion && cd dist/ng-templates && npm pack",
+    "build:storage": "ng build storage --prod && gulp replaceVersion && cd dist/ng-storage && npm pack",
+    "build:sync": "ng build sync --prod && gulp replaceVersion && cd dist/ng-sync && npm pack",
     "build": "npm run build:ui && npm run build:templates && npm run build:storage && npm run build:sync && npm run build:code-editor",
     "build:lite": "ng build ui && ng build storage && ng build sync && ng build templates && ng build code-editor",
     "release": "standard-version",
     "sonarqube": "gulp sonarqube",
     "format:fix": "pretty-quick --staged",
     "format:check": "prettier --check --loglevel error \"**/*{.ts,.js,.json,.css,.scss,.html}\"",
-    "format:all": "prettier --write \"**/*{.ts,.js,.json,.css,.scss,.html}\""
+    "format:all": "prettier --write \"**/*{.ts,.js,.json,.css,.scss,.html}\"",
+    "publish:ui:local": "npm publish dist/ng-components --registry http://localhost:4873"
   },
   "private": true,
   "dependencies": {

--- a/projects/code-editor/ng-package.json
+++ b/projects/code-editor/ng-package.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "../../dist/portinari-code-editor",
+  "dest": "../../dist/ng-code-editor",
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "whitelistedNonPeerDependencies": ["@portinari/portinari-ui", "monaco-editor", "core-js", "intl", "uuid"]
+  "whitelistedNonPeerDependencies": ["@po-ui/ng-components", "monaco-editor", "core-js", "intl", "uuid"]
 }

--- a/projects/code-editor/package.json
+++ b/projects/code-editor/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@portinari/portinari-code-editor",
+  "name": "@po-ui/ng-code-editor",
   "version": "0.0.0-PLACEHOLDER",
   "tag": "dev",
-  "description": "PORTINARI HTML Framework - Code Editor",
+  "description": "PO UI - Code Editor",
   "author": "Portinari",
   "license": "MIT",
-  "homepage": "https://portinari.io",
+  "homepage": "https://po-ui.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/portinariui/portinari-angular"
+    "url": "https://github.com/po-ui/po-angular"
   },
   "dependencies": {
-    "@portinari/portinari-ui": "0.0.0-PLACEHOLDER",
+    "@po-ui/ng-components": "0.0.0-PLACEHOLDER",
     "monaco-editor": "0.15.6",
     "core-js": "^3.6.4",
     "intl": "^1.2.5",
@@ -21,7 +21,7 @@
     "@angular/common": "~9.0.4",
     "@angular/core": "~9.0.4",
     "@angular/forms": "~9.0.4",
-    "@portinari/portinari-ui": "0.0.0-PLACEHOLDER",
+    "@po-ui/ng-components": "0.0.0-PLACEHOLDER",
     "monaco-editor": "0.15.6",
     "zone.js": "~0.10.2"
   }

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.ts
@@ -20,10 +20,10 @@ const PO_CODE_EDITOR_THEME_DEFAULT = 'vs';
  * O [(ngModel)] deve ser usado para manipular o conteúdo do po-code-editor, ou seja, tanto para incluir um conteúdo quanto
  * para recuperar o conteúdo do po-code-editor, utiliza-se uma variável passada por [(ngModel)].
  *
- * > Não esqueça de fazer a instalação do pacote `@portinari/portinari-code-editor` em sua aplicação.
+ * > Não esqueça de fazer a instalação do pacote `@po-ui/ng-code-editor` em sua aplicação.
  * >
  * > ```
- * > npm i --save @portinari/portinari-code-editor
+ * > npm i --save @po-ui/ng-code-editor
  * > ```
  * >
  * > Adicionar o módulo `PoCodeEditorModule` em seu projeto:
@@ -32,7 +32,7 @@ const PO_CODE_EDITOR_THEME_DEFAULT = 'vs';
  * > // app.module.ts
  * > ...
  * > import { PoModule } from '@portinari/portinari-ui';
- * > import { PoCodeEditorModule } from '@portinari/portinari-code-editor';
+ * > import { PoCodeEditorModule } from '@po-ui/ng-code-editor';
  * > ...
  * > @NgModule({
  * >   imports: [

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-register.service.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-register.service.ts
@@ -15,7 +15,7 @@ import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-reg
  *
  * Exemplo de configuração:
  * ```
- * import { PoCodeEditorModule, PoCodeEditorRegisterable } from '@portinari/portinari-code-editor';
+ * import { PoCodeEditorModule, PoCodeEditorRegisterable } from '@po-ui/ng-code-editor';
  *
  * const customEditor: PoCodeEditorRegisterable = {
  *   language: 'terraform',

--- a/projects/storage/ng-package.json
+++ b/projects/storage/ng-package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "../../dist/portinari-storage",
+  "dest": "../../dist/ng-storage",
   "lib": {
     "entryFile": "src/public-api.ts"
   },

--- a/projects/storage/package.json
+++ b/projects/storage/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@portinari/portinari-storage",
+  "name": "@po-ui/ng-storage",
   "version": "0.0.0-PLACEHOLDER",
   "tag": "dev",
-  "description": "PORTINARI HTML Framework - Storage",
-  "author": "Portinari",
+  "description": "PO UI - Storage",
+  "author": "PO",
   "license": "MIT",
-  "homepage": "https://portinari.io",
+  "homepage": "https://po-ui.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/portinariui/portinari-angular"
+    "url": "https://github.com/po-ui/po-angular"
   },
   "dependencies": {
     "custom-idle-queue": "2.1.2",

--- a/projects/sync/ng-package.json
+++ b/projects/sync/ng-package.json
@@ -1,11 +1,11 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "../../dist/portinari-sync",
+  "dest": "../../dist/ng-sync",
   "lib": {
     "entryFile": "src/public-api.ts"
   },
   "whitelistedNonPeerDependencies": [
-    "@portinari/portinari-storage",
+    "@po-ui/ng-storage",
     "@ionic-native/core",
     "@ionic-native/network",
     "http-status-codes"

--- a/projects/sync/package.json
+++ b/projects/sync/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "@portinari/portinari-sync",
+  "name": "@po-ui/ng-sync",
   "version": "0.0.0-PLACEHOLDER",
   "tag": "dev",
-  "description": "PORTINARI HTML Framework - Sync",
-  "author": "Portinari",
+  "description": "PO UI - Sync",
+  "author": "PO",
   "license": "MIT",
-  "homepage": "https://portinari.io",
+  "homepage": "https://po-ui.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/portinariui/portinari-angular"
+    "url": "https://github.com/po-ui/po-angular"
   },
   "dependencies": {
     "@ionic-native/core": "5.21.5",
     "@ionic-native/network": "5.21.5",
-    "@portinari/portinari-storage": "0.0.0-PLACEHOLDER",
+    "@po-ui/ng-storage": "0.0.0-PLACEHOLDER",
     "http-status-codes": "^1.4.0"
   },
   "peerDependencies": {
     "@angular/core": "~9.0.4",
     "@ionic-native/core": "5.21.5",
     "@ionic-native/network": "5.21.5",
-    "@portinari/portinari-storage": "0.0.0-PLACEHOLDER",
+    "@po-ui/ng-storage": "0.0.0-PLACEHOLDER",
     "http-status-codes": "^1.4.0",
     "rxjs": "~6.5.4",
     "rxjs-compat": "~6.5.4",

--- a/projects/sync/src/lib/models/po-entity/po-entity.model.spec.ts
+++ b/projects/sync/src/lib/models/po-entity/po-entity.model.spec.ts
@@ -1,4 +1,4 @@
-import { PoStorageService } from '@portinari/portinari-storage';
+import { PoStorageService } from '@po-ui/ng-storage';
 import * as utilsFunctions from '../../utils/utils';
 
 import { PoEntity } from './po-entity.model';

--- a/projects/sync/src/lib/models/po-query-builder/po-query-builder.model.spec.ts
+++ b/projects/sync/src/lib/models/po-query-builder/po-query-builder.model.spec.ts
@@ -1,4 +1,4 @@
-import { PoStorageService } from '@portinari/portinari-storage';
+import { PoStorageService } from '@po-ui/ng-storage';
 import * as utilsFunctions from '../../utils/utils';
 
 import { PoQueryBuilder } from './po-query-builder.model';

--- a/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.spec.ts
+++ b/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.spec.ts
@@ -4,7 +4,7 @@ import { HttpResponse } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 
 import { Observable, of, Subscriber } from 'rxjs';
-import { PoStorageService } from '@portinari/portinari-storage';
+import { PoStorageService } from '@po-ui/ng-storage';
 
 import { PoDataMessage, PoDataTransform } from '../../models';
 import { PoEventSourcingErrorResponse } from '../../models/po-event-sourcing-error-response.model';

--- a/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.ts
+++ b/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.ts
@@ -5,7 +5,7 @@ import * as HttpStatus from 'http-status-codes';
 import { Observable, of, Subject } from 'rxjs';
 import { expand, map, reduce } from 'rxjs/operators';
 
-import { PoStorageService } from '@portinari/portinari-storage';
+import { PoStorageService } from '@po-ui/ng-storage';
 
 import { PoEventSourcingErrorResponse } from '../../models/po-event-sourcing-error-response.model';
 import { PoEventSourcingItem } from './interfaces/po-event-sourcing-item.interface';

--- a/projects/sync/src/lib/services/po-schema/po-schema-definition/po-schema-definition.service.spec.ts
+++ b/projects/sync/src/lib/services/po-schema/po-schema-definition/po-schema-definition.service.spec.ts
@@ -1,7 +1,7 @@
 import { Directive } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { PoStorageService } from '@portinari/portinari-storage';
+import { PoStorageService } from '@po-ui/ng-storage';
 
 import { PoSchemaDefinitionService } from './po-schema-definition.service';
 import { PoSchemaUtil } from './../po-schema-util/po-schema-util.model';

--- a/projects/sync/src/lib/services/po-schema/po-schema-definition/po-schema-definition.service.ts
+++ b/projects/sync/src/lib/services/po-schema/po-schema-definition/po-schema-definition.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { PoStorageService } from '@portinari/portinari-storage';
+import { PoStorageService } from '@po-ui/ng-storage';
 
 import { PoSchemaUtil } from './../po-schema-util/po-schema-util.model';
 import { PoSyncSchema } from './../../po-sync/interfaces/po-sync-schema.interface';

--- a/projects/sync/src/lib/services/po-schema/po-schema.service.spec.ts
+++ b/projects/sync/src/lib/services/po-schema/po-schema.service.spec.ts
@@ -1,7 +1,7 @@
 import { Directive } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { PoStorageService } from '@portinari/portinari-storage';
+import { PoStorageService } from '@po-ui/ng-storage';
 
 import { PoSchemaDefinitionService } from './po-schema-definition/po-schema-definition.service';
 import { PoSchemaService } from './po-schema.service';

--- a/projects/sync/src/lib/services/po-schema/po-schema.service.ts
+++ b/projects/sync/src/lib/services/po-schema/po-schema.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { PoStorageService } from '@portinari/portinari-storage';
+import { PoStorageService } from '@po-ui/ng-storage';
 
 import { PoSchemaDefinitionService } from './po-schema-definition/po-schema-definition.service';
 import { PoSchemaUtil } from './po-schema-util/po-schema-util.model';

--- a/projects/templates/ng-package.json
+++ b/projects/templates/ng-package.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "../../dist/portinari-templates",
+  "dest": "../../dist/ng-templates",
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "whitelistedNonPeerDependencies": ["@portinari/portinari-ui"]
+  "whitelistedNonPeerDependencies": ["@po-ui/ng-components"]
 }

--- a/projects/templates/package.json
+++ b/projects/templates/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@portinari/portinari-templates",
+  "name": "@po-ui/ng-templates",
   "version": "0.0.0-PLACEHOLDER",
   "tag": "dev",
-  "description": "PORTINARI HTML Framework - Templates",
-  "author": "Portinari",
+  "description": "PO UI - Templates",
+  "author": "PO",
   "license": "MIT",
-  "homepage": "https://portinari.io",
+  "homepage": "https://po-ui.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/portinariui/portinari-angular"
+    "url": "https://github.com/po-ui/po-angular"
   },
   "dependencies": {
-    "@portinari/portinari-ui": "0.0.0-PLACEHOLDER"
+    "@po-ui/ng-components": "0.0.0-PLACEHOLDER"
   },
   "peerDependencies": {
     "@angular/animations": "~9.0.4",
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "~9.0.4",
     "@angular/platform-browser-dynamic": "~9.0.4",
     "@angular/router": "~9.0.4",
-    "@portinari/portinari-ui": "0.0.0-PLACEHOLDER",
+    "@po-ui/ng-components": "0.0.0-PLACEHOLDER",
     "rxjs": "~6.5.4",
     "zone.js": "~0.10.2"
   }

--- a/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.spec.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.spec.ts
@@ -5,7 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { throwError } from 'rxjs';
 
-import { PoFieldModule, PoI18nPipe, PoModalModule } from '@portinari/portinari-ui';
+import { PoFieldModule, PoI18nPipe, PoModalModule } from '@po-ui/ng-components';
 
 import * as utilsFunctions from './../../utils/util';
 import { configureTestSuite, getObservable } from './../../util-test/util-expect.spec';

--- a/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 import { isExternalLink } from '../../utils/util';
-import { PoI18nPipe, PoModalAction, PoModalComponent, PoRadioGroupOption } from '@portinari/portinari-ui';
+import { PoI18nPipe, PoModalAction, PoModalComponent, PoRadioGroupOption } from '@po-ui/ng-components';
 
 import { PoModalPasswordRecovery } from './interfaces/po-modal-password-recovery.interface';
 import { PoModalPasswordRecoveryBaseComponent } from './po-modal-password-recovery-base.component';

--- a/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.module.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { PoFieldModule, PoI18nPipe, PoModalModule } from '@portinari/portinari-ui';
+import { PoFieldModule, PoI18nPipe, PoModalModule } from '@po-ui/ng-components';
 
 import { PoModalPasswordRecoveryComponent } from './po-modal-password-recovery.component';
 import { PoModalPasswordRecoveryErrorMessageComponent } from './po-modal-password-recovery-error-message/po-modal-password-recovery-error-message.component';

--- a/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 import { browserLanguage, convertToBoolean, isTypeof } from './../../utils/util';
-import { PoSelectOption } from '@portinari/portinari-ui';
+import { PoSelectOption } from '@po-ui/ng-components';
 
 @Component({
   selector: 'po-page-background',

--- a/projects/templates/src/lib/components/po-page-background/po-page-background.module.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoDividerModule, PoFieldModule } from '@portinari/portinari-ui';
+import { PoDividerModule, PoFieldModule } from '@po-ui/ng-components';
 
 import { PoPageBackgroundComponent } from './po-page-background.component';
 

--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user.module.ts
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoModule } from '@portinari/portinari-ui';
+import { PoModule } from '@po-ui/ng-components';
 
 import { PoPageBackgroundModule } from '../po-page-background/index';
 import { PoPageBlockedUserComponent } from './po-page-blocked-user.component';

--- a/projects/templates/src/lib/components/po-page-change-password/po-page-change-password-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-change-password/po-page-change-password-base.component.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { PoModalAction } from '@portinari/portinari-ui';
+import { PoModalAction } from '@po-ui/ng-components';
 
 import { convertToBoolean, isExternalLink, isTypeof } from '../../utils/util';
 

--- a/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.ts
+++ b/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { Subscription } from 'rxjs';
 
-import { PoComponentInjectorService, PoModalAction, PoModalComponent } from '@portinari/portinari-ui';
+import { PoComponentInjectorService, PoModalAction, PoModalComponent } from '@po-ui/ng-components';
 
 import { browserLanguage, isExternalLink, isTypeof, poLocaleDefault } from '../../utils/util';
 

--- a/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.module.ts
+++ b/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoModule } from '@portinari/portinari-ui';
+import { PoModule } from '@po-ui/ng-components';
 
 import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/po-modal-password-recovery.component';
 import { PoPageBackgroundModule } from '../po-page-background/index';

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-field.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-field.interface.ts
@@ -1,4 +1,4 @@
-import { PoDynamicViewField } from '@portinari/portinari-ui';
+import { PoDynamicViewField } from '@po-ui/ng-components';
 
 /**
  * @usedBy PoPageDynamicDetailComponent

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-options.interface.ts
@@ -1,4 +1,4 @@
-import { PoBreadcrumb } from '@portinari/portinari-ui';
+import { PoBreadcrumb } from '@po-ui/ng-components';
 
 import { PoPageDynamicDetailActions } from './po-page-dynamic-detail-actions.interface';
 import { PoPageDynamicDetailField } from './po-page-dynamic-detail-field.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { throwError, of } from 'rxjs';
 
-import { PoDialogService } from '@portinari/portinari-ui';
+import { PoDialogService } from '@po-ui/ng-components';
 
 import * as util from '../../utils/util';
 import { configureTestSuite, expectPropertiesValues } from '../../util-test/util-expect.spec';

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
@@ -11,7 +11,7 @@ import {
   PoDialogService,
   PoDialogConfirmOptions,
   PoNotificationService
-} from '@portinari/portinari-ui';
+} from '@po-ui/ng-components';
 
 import { PoPageDynamicDetailActions } from './interfaces/po-page-dynamic-detail-actions.interface';
 import { PoPageDynamicDetailField } from './interfaces/po-page-dynamic-detail-field.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.module.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoDynamicModule, PoModalModule, PoPageModule, PoWidgetModule } from '@portinari/portinari-ui';
+import { PoDynamicModule, PoModalModule, PoPageModule, PoWidgetModule } from '@po-ui/ng-components';
 
 import { PoPageDynamicDetailComponent } from './po-page-dynamic-detail.component';
 import { PoPageDynamicModule } from '../../services/po-page-dynamic/po-page-dynamic.module';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-field.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-field.interface.ts
@@ -1,4 +1,4 @@
-import { PoDynamicFormField } from '@portinari/portinari-ui';
+import { PoDynamicFormField } from '@po-ui/ng-components';
 
 /**
  * @usedBy PoPageDynamicEditComponent

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-options.interface.ts
@@ -1,4 +1,4 @@
-import { PoBreadcrumb } from '@portinari/portinari-ui';
+import { PoBreadcrumb } from '@po-ui/ng-components';
 
 import { PoPageDynamicEditField } from './po-page-dynamic-edit-field.interface';
 import { PoPageDynamicEditActions } from './po-page-dynamic-edit-actions.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { throwError, of, EMPTY } from 'rxjs';
 
-import { PoDialogModule } from '@portinari/portinari-ui';
+import { PoDialogModule } from '@po-ui/ng-components';
 
 import * as util from './../../utils/util';
 import { configureTestSuite, expectPropertiesValues } from './../../util-test/util-expect.spec';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -12,7 +12,7 @@ import {
   PoGridRowActions,
   PoNotificationService,
   PoPageAction
-} from '@portinari/portinari-ui';
+} from '@po-ui/ng-components';
 
 import * as util from './../../utils/util';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.module.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.module.ts
@@ -10,7 +10,7 @@ import {
   PoGridModule,
   PoPageModule,
   PoWidgetModule
-} from '@portinari/portinari-ui';
+} from '@po-ui/ng-components';
 
 import { PoPageDynamicEditComponent } from './po-page-dynamic-edit.component';
 import { PoPageDynamicModule } from '../../services/po-page-dynamic/po-page-dynamic.module';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/test/po-dynamic-form-stub-component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/test/po-dynamic-form-stub-component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { NgForm } from '@angular/forms';
-import { PoDynamicFormComponent } from '@portinari/portinari-ui';
+import { PoDynamicFormComponent } from '@po-ui/ng-components';
 
 @Component({
   selector: 'po-dynamic-form',

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, Input, Output, ViewChild, Directive } from '@angular/core';
 
-import { PoDynamicFormField, PoLanguageService, PoModalAction, PoModalComponent } from '@portinari/portinari-ui';
+import { PoDynamicFormField, PoLanguageService, PoModalAction, PoModalComponent } from '@po-ui/ng-components';
 
 import { poLocaleDefault } from '../../../utils/util';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
-import { PoDynamicModule, PoFieldModule, PoModalModule } from '@portinari/portinari-ui';
+import { PoDynamicModule, PoFieldModule, PoModalModule } from '@po-ui/ng-components';
 
 import { configureTestSuite } from './../../../util-test/util-expect.spec';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
 
-import { PoDynamicFormComponent, PoLanguageService } from '@portinari/portinari-ui';
+import { PoDynamicFormComponent, PoLanguageService } from '@po-ui/ng-components';
 
 import { PoAdvancedFilterBaseComponent } from './po-advanced-filter-base.component';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { PoBreadcrumb, PoDynamicFormField, PoLanguageService, PoPageAction } from '@portinari/portinari-ui';
+import { PoBreadcrumb, PoDynamicFormField, PoLanguageService, PoPageAction } from '@po-ui/ng-components';
 
 import { poLocaleDefault } from '../../utils/util';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-options.interface.ts
@@ -1,4 +1,4 @@
-import { PoDynamicFormField, PoBreadcrumb, PoPageAction } from '@portinari/portinari-ui';
+import { PoDynamicFormField, PoBreadcrumb, PoPageAction } from '@po-ui/ng-components';
 
 /**
  * @usedBy PoPageDynamicSearchComponent

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -5,7 +5,7 @@ import { Routes } from '@angular/router';
 import { TitleCasePipe } from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
-import { PoDynamicFieldType } from '@portinari/portinari-ui';
+import { PoDynamicFieldType } from '@po-ui/ng-components';
 
 import { PoPageDynamicSearchComponent } from './po-page-dynamic-search.component';
 import { PoAdvancedFilterComponent } from './po-advanced-filter/po-advanced-filter.component';

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -7,7 +7,7 @@ import {
   PoDynamicFormField,
   PoLanguageService,
   PoPageFilter
-} from '@portinari/portinari-ui';
+} from '@po-ui/ng-components';
 
 import { capitalizeFirstLetter, getBrowserLanguage } from '../../utils/util';
 import { PoPageCustomizationService } from '../../services/po-page-customization/po-page-customization.service';

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.interface.ts
@@ -1,4 +1,4 @@
-import { PoDynamicFormField, PoPageDefault } from '@portinari/portinari-ui';
+import { PoDynamicFormField, PoPageDefault } from '@po-ui/ng-components';
 
 /**
  * @docsPrivate

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.module.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoDynamicModule, PoLanguageModule, PoModalModule, PoPageModule } from '@portinari/portinari-ui';
+import { PoDynamicModule, PoLanguageModule, PoModalModule, PoPageModule } from '@po-ui/ng-components';
 
 import { PoPageCustomizationModule } from '../../services/po-page-customization/po-page-customization.module';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-field.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-field.interface.ts
@@ -1,4 +1,4 @@
-import { PoDynamicFormField } from '@portinari/portinari-ui';
+import { PoDynamicFormField } from '@po-ui/ng-components';
 
 /**
  * @usedBy PoPageDynamicTableComponent

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
@@ -1,4 +1,4 @@
-import { PoBreadcrumb } from '@portinari/portinari-ui';
+import { PoBreadcrumb } from '@po-ui/ng-components';
 
 import { PoPageDynamicTableField } from './po-page-dynamic-table-field.interface';
 import { PoPageDynamicTableActions } from './po-page-dynamic-table-actions.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
@@ -1,6 +1,6 @@
 import { Input, Directive } from '@angular/core';
 
-import { PoBreadcrumb } from '@portinari/portinari-ui';
+import { PoBreadcrumb } from '@po-ui/ng-components';
 
 import { convertToBoolean } from '../../utils/util';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -6,12 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { of, EMPTY } from 'rxjs';
 
-import {
-  PoDialogModule,
-  PoNotificationModule,
-  PoTableColumnSort,
-  PoTableColumnSortType
-} from '@portinari/portinari-ui';
+import { PoDialogModule, PoNotificationModule, PoTableColumnSort, PoTableColumnSortType } from '@po-ui/ng-components';
 
 import * as utilsFunctions from '../../utils/util';
 import { configureTestSuite, expectPropertiesValues } from '../../util-test/util-expect.spec';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -12,7 +12,7 @@ import {
   PoTableAction,
   PoTableColumnSort,
   PoTableColumnSortType
-} from '@portinari/portinari-ui';
+} from '@po-ui/ng-components';
 
 import * as util from '../../utils/util';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.module.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoTableModule } from '@portinari/portinari-ui';
+import { PoTableModule } from '@po-ui/ng-components';
 
 import { PoPageDynamicSearchModule } from '../po-page-dynamic-search/po-page-dynamic-search.module';
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-base.component.ts
@@ -1,7 +1,7 @@
 import { AbstractControl } from '@angular/forms';
 import { Input, Directive } from '@angular/core';
 
-import { PoBreadcrumb } from '@portinari/portinari-ui';
+import { PoBreadcrumb } from '@po-ui/ng-components';
 
 import { PoJobSchedulerInternal } from './interfaces/po-job-scheduler-internal.interface';
 import { PoPageJobSchedulerInternal } from './po-page-job-scheduler-internal';

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-execution/po-page-job-scheduler-execution.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-execution/po-page-job-scheduler-execution.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 
-import { PoCheckboxGroupOption, PoRadioGroupOption } from '@portinari/portinari-ui';
+import { PoCheckboxGroupOption, PoRadioGroupOption } from '@po-ui/ng-components';
 
 import { isTypeof } from '../../../utils/util';
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-lookup.service.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-lookup.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
-import { PoLookupFilter } from '@portinari/portinari-ui';
+import { PoLookupFilter } from '@po-ui/ng-components';
 
 import { PoPageJobSchedulerService } from './po-page-job-scheduler.service';
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 
-import { PoDynamicFormField } from '@portinari/portinari-ui';
+import { PoDynamicFormField } from '@po-ui/ng-components';
 
 @Component({
   selector: 'po-page-job-scheduler-parameters',

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-summary/po-page-job-scheduler-summary.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-summary/po-page-job-scheduler-summary.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { DatePipe } from '@angular/common';
 
-import { PoDynamicViewField, PoInfoOrientation } from '@portinari/portinari-ui';
+import { PoDynamicViewField, PoInfoOrientation } from '@po-ui/ng-components';
 
 import { PoJobSchedulerInternal } from '../interfaces/po-job-scheduler-internal.interface';
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
@@ -11,7 +11,7 @@ import {
   PoPageAction,
   PoStepperItem,
   PoStepperStatus
-} from '@portinari/portinari-ui';
+} from '@po-ui/ng-components';
 
 import * as util from './../../utils/util';
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.module.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.module.ts
@@ -13,7 +13,7 @@ import {
   PoPageModule,
   PoStepperModule,
   PoWidgetModule
-} from '@portinari/portinari-ui';
+} from '@po-ui/ng-components';
 
 import { PoPageJobSchedulerComponent } from './po-page-job-scheduler.component';
 import { PoPageJobSchedulerExecutionComponent } from './po-page-job-scheduler-execution/po-page-job-scheduler-execution.component';

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { of } from 'rxjs';
 
-import { PoDynamicFormField } from '@portinari/portinari-ui';
+import { PoDynamicFormField } from '@po-ui/ng-components';
 import * as utilsFunctions from '../../utils/util';
 
 import { PoJobScheduler } from './interfaces/po-job-scheduler.interface';

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { addZero, convertDateToISOExtended } from '../../utils/util';
-import { PoDynamicFormField } from '@portinari/portinari-ui';
+import { PoDynamicFormField } from '@po-ui/ng-components';
 
 import { PoJobScheduler } from './interfaces/po-job-scheduler.interface';
 import { PoJobSchedulerInternal } from './interfaces/po-job-scheduler-internal.interface';

--- a/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-custom-field.interface.ts
+++ b/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-custom-field.interface.ts
@@ -1,4 +1,4 @@
-import { PoSelectOption } from '@portinari/portinari-ui';
+import { PoSelectOption } from '@po-ui/ng-components';
 
 /**
  * @usedBy PoPageLoginComponent

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
@@ -12,7 +12,7 @@ import {
   PoPasswordComponent,
   PoSelectComponent,
   PoSwitchComponent
-} from '@portinari/portinari-ui';
+} from '@po-ui/ng-components';
 
 import { configureTestSuite } from './../../util-test/util-expect.spec';
 import { poLocaleDefault } from './../../utils/util';

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 
 import { isExternalLink } from '../../utils/util';
-import { PoComponentInjectorService } from '@portinari/portinari-ui';
+import { PoComponentInjectorService } from '@po-ui/ng-components';
 
 import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/po-modal-password-recovery.component';
 import { PoModalPasswordRecoveryType } from '../po-modal-password-recovery/enums/po-modal-password-recovery-type.enum';

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.module.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoModule } from '@portinari/portinari-ui';
+import { PoModule } from '@po-ui/ng-components';
 
 import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/po-modal-password-recovery.component';
 import { PoPageBackgroundModule } from '../po-page-background/index';

--- a/projects/ui/ng-package.json
+++ b/projects/ui/ng-package.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "../../dist/portinari-ui",
+  "dest": "../../dist/ng-components",
   "lib": {
     "entryFile": "./src/public-api.ts"
   },
-  "whitelistedNonPeerDependencies": ["@portinari/style"]
+  "whitelistedNonPeerDependencies": ["@po-ui/style"]
 }

--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -1,18 +1,27 @@
 {
-  "name": "@portinari/portinari-ui",
+  "name": "@po-ui/ng-components",
   "version": "0.0.0-PLACEHOLDER",
   "tag": "dev",
-  "description": "PORTINARI HTML Framework - UI",
-  "author": "Portinari",
+  "description": "PO UI - Components",
+  "author": "PO",
   "license": "MIT",
-  "homepage": "https://portinari.io",
+  "homepage": "https://po-ui.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/portinariui/portinari-angular"
+    "url": "https://github.com/po-ui/po-angular"
   },
   "schematics": "./schematics/collection.json",
+  "ng-update": {
+    "migrations": "./schematics/migrations.json",
+    "packageGroup": [
+      "@po-ui/ng-components",
+      "@po-ui/ng-templates",
+      "@po-ui/ng-code-editor",
+      "@po-ui/style"
+    ]
+  },
   "dependencies": {
-    "@portinari/style": "0.0.0-PLACEHOLDER"
+    "@po-ui/style": "2.0.0-beta.1"
   },
   "peerDependencies": {
     "@angular/animations": "~9.0.4",
@@ -23,7 +32,7 @@
     "@angular/platform-browser": "~9.0.4",
     "@angular/platform-browser-dynamic": "~9.0.4",
     "@angular/router": "~9.0.4",
-    "@portinari/style": "0.0.0-PLACEHOLDER",
+    "@po-ui/style": "2.0.0-beta.1",
     "rxjs": "~6.5.4",
     "zone.js": "~0.10.2"
   }

--- a/projects/ui/schematics/README.md
+++ b/projects/ui/schematics/README.md
@@ -1,0 +1,63 @@
+# PO UI Schematics
+
+## ng update @po-ui/ng-components
+
+Esse *schematic* é executado através do Angular CLI para oferecer suporte à atualização automática do PO UI em um projeto Angular.
+
+
+### Como funciona
+
+No arquivo ```npm/@po-ui/ng-components/package.json ```, é declarado a chave `ng-update`. Isso indica ao Angular CLI que este projeto possui um conjunto de *schematics* de migração.
+
+```
+  "ng-update": {
+    "migrations": "./schematics/migration.json",
+    "packageGroup": [
+      "@po-ui/ng-components"
+    ]
+  }
+```
+
+Quando os schematics forem analisados, ele tentará determinar se algum script de migração deve ser executado com base nas definições. As definições de migração podem ser encontradas em nosso arquivo `projects/ui/schematics/src/migration.json`. A execução `ng update` procurará scripts com base nesta coleção. Veja documentação do Angular sobre [ng-update](https://github.com/angular/angular-cli/blob/master/docs/specifications/update.md).
+
+
+### Como testar
+
+Para poder testar localmente é necessário instalar [verdaccio](https://github.com/verdaccio/verdaccio), para termos um *npm registry* local,
+onde publicaremos os pacotes para realizar o teste.
+
+Após a instalação, devemos apontar o npm registry para o que inciaremos localmente.
+
+O comando abaixo subirá o npm local, no endereço http://localhost:4873.
+
+``` > verdaccio ```
+
+Em seguida, definiremos o *npm registry*, conforme o comando abaixo:
+
+``` > npm set registry http://localhost:4873 ```
+
+A partir de agora, os pacotes que publicaremos serão enviados ao nosso registry local.
+
+> Para utilizar *npm registry* global novamente, execute o comando: `npm set registry https://registry.npmjs.org/`.
+
+
+Antes de testarmos o pacotes, devemos fazer duas configurações, são elas:
+
+- Adicionar dentro do arquivo ```verdacio/config.yaml``` a configuração: `max_body_size: 200mb`;
+- Executar o comando: ``` npm adduser --registry http://localhost:4873 ```
+
+Para testarmos o pacote, devemos incrementar a versão do mesmo, ter o npm registry local em execução, confirmando essas situações, podemos rodar o script abaixo:
+
+`> npm run build:ui && npm run publish:ui:local`
+
+Por fim, execute os comandos abaixo no seu projeto Angular:
+
+`> npm i --save @po-ui/ng-components`.
+
+`> ng update @po-ui/ng-components --next --from 1 --migrate-only`
+
+> Caso testar versão beta, a versão no arquivo `migrations.json` tem que ser a mesma da publicada.
+
+Pode ser utilizado o verdaccio para publicar os pacotes locais, como `@po-ui/style`, assim não precisamos instalar local e o fluxo fica mais próximo do oficial.
+
+Se você precisar executar isso várias vezes, desfaça as alterações feitas pelo `ng update` para que o `package.json` volte ao número da versão original e execute `npm install` novamente antes de tentar outra atualização.

--- a/projects/ui/schematics/migrations.json
+++ b/projects/ui/schematics/migrations.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "migration-v2": {
+      "version": "2.0.0-beta.1",
+      "description": "Atualiza @po-ui/ng-components para v2",
+      "factory": "./ng-update/index#updateToV2"
+    }
+  }
+}

--- a/projects/ui/schematics/ng-add/index.spec.ts
+++ b/projects/ui/schematics/ng-add/index.spec.ts
@@ -2,7 +2,7 @@ import { getWorkspace } from '@schematics/angular/utility/config';
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
 import { Tree } from '@angular-devkit/schematics';
-import { WorkspaceProject } from '@angular-devkit/core/src/experimental/workspace';
+import { WorkspaceProject } from '@schematics/angular/utility/workspace-models';
 
 import * as path from 'path';
 
@@ -35,7 +35,7 @@ describe('Schematic: ng-add', () => {
   });
 
   describe('Dependencies:', () => {
-    it('should update package.json with @portinari/portinari-ui dependency and run nodePackageInstall', () => {
+    it('should update package.json with @po-ui/ng-components dependency and run nodePackageInstall', () => {
       const tree = runner.runSchematic('ng-add', componentOptions, appTree);
 
       const packageJson = JSON.parse(getFileContent(tree, '/package.json'));
@@ -43,7 +43,7 @@ describe('Schematic: ng-add', () => {
       // const angularCoreVersion = dependencies['@angular/core'];
 
       // expect(dependencies['@angular/core']).toBe(angularCoreVersion);
-      expect(dependencies['@portinari/portinari-ui']).toBeDefined();
+      expect(dependencies['@po-ui/ng-components']).toBeDefined();
       expect(Object.keys(dependencies)).toEqual(Object.keys(dependencies).sort());
       expect(runner.tasks.some(task => task.name === 'node-package')).toBe(true);
     });
@@ -61,7 +61,7 @@ describe('Schematic: ng-add', () => {
   });
 
   describe('Theme configuration:', () => {
-    const defaultThemePath = './node_modules/@portinari/style/css/po-theme-default.min.css';
+    const defaultThemePath = './node_modules/@po-ui/style/css/po-theme-default.min.css';
 
     it('should add default theme in styles of build project', () => {
       const tree = runner.runSchematic('ng-add-setup-project', componentOptions, appTree);

--- a/projects/ui/schematics/ng-add/index.ts
+++ b/projects/ui/schematics/ng-add/index.ts
@@ -20,7 +20,7 @@ export default function(options: any): Rule {
 
 function addPoPackageAndInstall(): Rule {
   return (tree: Tree, context: SchematicContext) => {
-    addPackageToPackageJson(tree, '@portinari/portinari-ui', '0.0.0-PLACEHOLDER');
+    addPackageToPackageJson(tree, '@po-ui/ng-components', '0.0.0-PLACEHOLDER');
 
     // install packages
     context.addTask(new NodePackageInstallTask());

--- a/projects/ui/schematics/ng-add/setup-project.ts
+++ b/projects/ui/schematics/ng-add/setup-project.ts
@@ -1,13 +1,13 @@
 import { chain, Rule, schematic, Tree, noop } from '@angular-devkit/schematics';
 import { getWorkspace } from '@schematics/angular/utility/config';
-import { WorkspaceSchema, WorkspaceProject } from '@angular-devkit/core/src/experimental/workspace';
+import { WorkspaceProject, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 
 import { addModuleImportToRootModule } from '../utils/module';
 import { getProjectFromWorkspace, getProjectTargetOptions } from '../utils/project';
 
 /** PO Module name that will insert in app root module */
 const poModuleName = 'PoModule';
-const poModuleSourcePath = '@portinari/portinari-ui';
+const poModuleSourcePath = '@po-ui/ng-components';
 
 /**
  * Scaffolds the basics of a Angular Material application, this includes:
@@ -30,7 +30,7 @@ function addThemeToAppStyles(options: any): (tree: Tree) => Tree {
     const project = getProjectFromWorkspace(workspace, options.project);
 
     // Path needs to be always relative to the `package.json` or workspace root.
-    const themePath = './node_modules/@portinari/style/css/po-theme-default.min.css';
+    const themePath = './node_modules/@po-ui/style/css/po-theme-default.min.css';
 
     addThemeStyleToTarget(project, 'build', tree, themePath, workspace);
     addThemeStyleToTarget(project, 'test', tree, themePath, workspace);

--- a/projects/ui/schematics/ng-generate/po-page-default/files/__path__/__name@dasherize__/__name@dasherize__.component.spec.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-default/files/__path__/__name@dasherize__/__name@dasherize__.component.spec.ts.template
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { PoPageModule } from '@portinari/portinari-ui';
+import { PoPageModule } from '@po-ui/ng-components';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 

--- a/projects/ui/schematics/ng-generate/po-page-default/files/__path__/__name@dasherize__/__name@dasherize__.component.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-default/files/__path__/__name@dasherize__/__name@dasherize__.component.ts.template
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoPageAction } from '@portinari/portinari-ui';
+import { PoPageAction } from '@po-ui/ng-components';
 
 @Component({
   selector: '<%= selector %>',

--- a/projects/ui/schematics/ng-generate/po-page-default/files/__path__/__name@dasherize__/__name@dasherize__.module.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-default/files/__path__/__name@dasherize__/__name@dasherize__.module.ts.template
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { PoModule } from '@portinari/portinari-ui';
+import { PoModule } from '@po-ui/ng-components';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';<% if (routing) { %>
 import { <%= classify(name) %>RoutingModule } from './<%= dasherize(name) %>-routing.module';<% } %>

--- a/projects/ui/schematics/ng-generate/po-page-detail/files/__path__/__name@dasherize__/__name@dasherize__.component.html.template
+++ b/projects/ui/schematics/ng-generate/po-page-detail/files/__path__/__name@dasherize__/__name@dasherize__.component.html.template
@@ -1,4 +1,8 @@
-<po-page-detail p-title="<%= classify(name) %>">
+<po-page-detail
+  p-title="<%= classify(name) %>"
+  (p-back)="back()"
+  (p-edit)="edit()"
+  (p-remove)="remove()">
 
   <!-- BUILD YOUR DATA VIEW HERE -->
 </po-page-detail>

--- a/projects/ui/schematics/ng-generate/po-page-detail/files/__path__/__name@dasherize__/__name@dasherize__.component.spec.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-detail/files/__path__/__name@dasherize__/__name@dasherize__.component.spec.ts.template
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { PoPageModule } from '@portinari/portinari-ui';
+import { PoPageModule } from '@po-ui/ng-components';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 

--- a/projects/ui/schematics/ng-generate/po-page-detail/files/__path__/__name@dasherize__/__name@dasherize__.module.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-detail/files/__path__/__name@dasherize__/__name@dasherize__.module.ts.template
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { PoModule } from '@portinari/portinari-ui';
+import { PoModule } from '@po-ui/ng-components';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';<% if (routing) { %>
 import { <%= classify(name) %>RoutingModule } from './<%= dasherize(name) %>-routing.module';<% } %>

--- a/projects/ui/schematics/ng-generate/po-page-edit/files/__path__/__name@dasherize__/__name@dasherize__.component.html.template
+++ b/projects/ui/schematics/ng-generate/po-page-edit/files/__path__/__name@dasherize__/__name@dasherize__.component.html.template
@@ -1,4 +1,8 @@
-<po-page-edit p-title="<%= classify(name) %>">
+<po-page-edit
+  p-title="<%= classify(name) %>"
+  (p-cancel)="cancel()"
+  (p-save)="save()"
+  (p-save-new)="saveNew()">
 
   <!-- BUILD YOUR FORM HERE -->
 </po-page-edit>

--- a/projects/ui/schematics/ng-generate/po-page-edit/files/__path__/__name@dasherize__/__name@dasherize__.component.spec.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-edit/files/__path__/__name@dasherize__/__name@dasherize__.component.spec.ts.template
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { PoPageModule } from '@portinari/portinari-ui';
+import { PoPageModule } from '@po-ui/ng-components';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 

--- a/projects/ui/schematics/ng-generate/po-page-edit/files/__path__/__name@dasherize__/__name@dasherize__.module.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-edit/files/__path__/__name@dasherize__/__name@dasherize__.module.ts.template
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { PoModule } from '@portinari/portinari-ui';
+import { PoModule } from '@po-ui/ng-components';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';<% if (routing) { %>
 import { <%= classify(name) %>RoutingModule } from './<%= dasherize(name) %>-routing.module';<% } %>

--- a/projects/ui/schematics/ng-generate/po-page-list/files/__path__/__name@dasherize__/__name@dasherize__.component.spec.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-list/files/__path__/__name@dasherize__/__name@dasherize__.component.spec.ts.template
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { PoPageModule, PoInfoModule<% if(dataView === 'table') { %>, PoTableModule <% } else { %>, PoListViewModule <% } %>} from '@portinari/portinari-ui';
+import { PoPageModule, PoInfoModule<% if(dataView === 'table') { %>, PoTableModule <% } else { %>, PoListViewModule <% } %>} from '@po-ui/ng-components';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 

--- a/projects/ui/schematics/ng-generate/po-page-list/files/__path__/__name@dasherize__/__name@dasherize__.component.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-list/files/__path__/__name@dasherize__/__name@dasherize__.component.ts.template
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoPageAction<% if(dataView === 'table') { %>, PoTableColumn<%} %> } from '@portinari/portinari-ui';
+import { PoPageAction<% if(dataView === 'table') { %>, PoTableColumn<%} %> } from '@po-ui/ng-components';
 
 @Component({
   selector: '<%= selector %>',

--- a/projects/ui/schematics/ng-generate/po-page-list/files/__path__/__name@dasherize__/__name@dasherize__.module.ts.template
+++ b/projects/ui/schematics/ng-generate/po-page-list/files/__path__/__name@dasherize__/__name@dasherize__.module.ts.template
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { PoModule } from '@portinari/portinari-ui';
+import { PoModule } from '@po-ui/ng-components';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';<% if (routing) { %>
 import { <%= classify(name) %>RoutingModule } from './<%= dasherize(name) %>-routing.module';<% } %>

--- a/projects/ui/schematics/ng-generate/sidemenu/files/app.component.spec.ts.template
+++ b/projects/ui/schematics/ng-generate/sidemenu/files/app.component.spec.ts.template
@@ -1,7 +1,7 @@
 import { async, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { PoMenuModule, PoPageModule, PoToolbarModule } from '@portinari/portinari-ui';
+import { PoMenuModule, PoPageModule, PoToolbarModule } from '@po-ui/ng-components';
 
 import { AppComponent } from './app.component';
 

--- a/projects/ui/schematics/ng-generate/sidemenu/files/app.component.ts.template
+++ b/projects/ui/schematics/ng-generate/sidemenu/files/app.component.ts.template
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { PoMenuItem } from '@portinari/portinari-ui';
+import { PoMenuItem } from '@po-ui/ng-components';
 
 @Component({
   selector: 'app-root',

--- a/projects/ui/schematics/ng-update/changes.ts
+++ b/projects/ui/schematics/ng-update/changes.ts
@@ -1,0 +1,37 @@
+export interface ReplaceChanges {
+  replace: string;
+  replaceWith: string;
+}
+
+export const replaceChanges: Array<ReplaceChanges> = [
+  {
+    replace: 'p-focus',
+    replaceWith: 'p-auto-focus'
+  },
+  {
+    replace: 'X-Portinari',
+    replaceWith: 'X-PO'
+  }
+];
+
+export const changesComponents = [
+  { component: 'po-page-edit', actions: ['cancel', 'save', 'saveNew'] },
+  { component: 'po-page-detail', actions: ['edit', 'remove', 'back'] }
+];
+
+export const regexPackages = new RegExp(
+  [
+    '@portinari/(portinari-)?((ui)|', // @po-ui/ng-components
+    '(storage)|', // @po-ui/ng-storage
+    '(templates)|', // @po-ui/ng-templates
+    '(sync)|', // @po-ui/ng-sync
+    '(code-editor)|', // @po-ui/ng-code-editor
+    '(style))' // @po-ui/style
+  ].join(''),
+  'g'
+);
+
+export const tsLint: ReplaceChanges = {
+  replace: '@portinari/tslint',
+  replaceWith: '@po-ui/ng-tslint'
+};

--- a/projects/ui/schematics/ng-update/index.ts
+++ b/projects/ui/schematics/ng-update/index.ts
@@ -1,0 +1,188 @@
+import { chain, Tree, SchematicContext } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { strings } from '@angular-devkit/core';
+
+import { getWorkspaceConfigGracefully } from '../utils/project';
+import { updatePackageJson } from '../utils/package-config';
+
+import { replaceChanges, ReplaceChanges, tsLint, regexPackages, changesComponents } from './changes';
+
+export function updateToV2() {
+  return chain([
+    updatePackageJson('0.0.0-PLACEHOLDER'),
+    replaceTsLint(),
+    replaceAgularJson(),
+    createUpgradeRule(),
+    postUpdate()
+  ]);
+}
+
+function postUpdate() {
+  return (_: Tree, context: SchematicContext) => {
+    context.addTask(new NodePackageInstallTask());
+  };
+}
+
+function replaceTsLint() {
+  return (tree: Tree) => {
+    const file = 'tslint.json';
+
+    if (tree.exists(file)) {
+      const sourceText = tree.read(file)!.toString('utf-8');
+      let updated = sourceText;
+
+      if (updated) {
+        updated = updated.replace(tsLint.replace, tsLint.replaceWith);
+      }
+
+      if (updated !== sourceText) {
+        tree.overwrite(file, updated);
+      }
+    }
+    return tree;
+  };
+}
+
+function replaceAgularJson() {
+  return (tree: Tree) => {
+    const file = 'angular.json';
+
+    if (tree.exists(file)) {
+      const sourceText = tree.read(file)!.toString('utf-8');
+      let updated = sourceText;
+
+      if (updated) {
+        updated = updated.replace(regexPackages, replacePackages).replace(/portinari\-theme/g, 'po-theme');
+      }
+
+      if (updated !== sourceText) {
+        tree.overwrite(file, updated);
+      }
+    }
+    return tree;
+  };
+}
+
+function createUpgradeRule() {
+  return (tree: Tree, context: SchematicContext) => {
+    const logger = context.logger;
+    const workspace = getWorkspaceConfigGracefully(tree);
+
+    if (workspace === null) {
+      logger.error('Não foi possível encontrar o arquivo de configuração de workspace.');
+      return;
+    }
+
+    const projectNames = Object.keys(workspace.projects);
+    for (const projectName of projectNames) {
+      const project = workspace.projects[projectName];
+      const entryFolderProject = project.projectType === 'library' ? 'lib' : 'app';
+      const sourceDir = `${project.sourceRoot}/${entryFolderProject}`;
+
+      applyUpdateInContent(tree, sourceDir);
+    }
+  };
+}
+
+function applyUpdateInContent(tree: Tree, path: string) {
+  const directory = tree.getDir(path);
+  if (directory.subfiles.length) {
+    directory.subfiles.forEach(file => {
+      const filePath = path + '/' + file;
+      const content = tree.read(filePath)!.toString('utf-8');
+      if (!content) {
+        return;
+      }
+
+      let updated = content;
+
+      if (file.endsWith('.ts')) {
+        updated = updated.replace(regexPackages, replacePackages);
+      }
+
+      if (file.endsWith('.html') || file.endsWith('.ts')) {
+        updated = addFunctionsOnPage(file, filePath, tree, updated);
+        updated = replaceWithChanges(replaceChanges, updated);
+
+        if (updated !== content) {
+          tree.overwrite(filePath, updated);
+        }
+      }
+    });
+  }
+
+  if (directory.subdirs.length) {
+    directory.subdirs.forEach(subDir => {
+      applyUpdateInContent(tree, path + '/' + subDir);
+    });
+  }
+}
+
+function getUsedFunctions(content: string, searchActions) {
+  const foundUsedFunctions: Array<string> = [];
+
+  if (!content) {
+    return foundUsedFunctions;
+  }
+
+  searchActions.forEach((searchContent: string) => {
+    const regex = new RegExp(`${searchContent}\\(`);
+    if (content.search(regex) > -1) {
+      foundUsedFunctions.push(searchContent);
+    }
+  });
+
+  return foundUsedFunctions;
+}
+
+function addFunctionsOnPage(file, filePath, tree, content) {
+  let tsSource;
+
+  changesComponents.forEach(({ component, actions }) => {
+    const isHTML = file.endsWith('.html');
+    const searchTagComponent = `<${component}`;
+    const foundComponentPosition = content.search(searchTagComponent);
+
+    if (foundComponentPosition > -1) {
+      if (isHTML) {
+        const typeScriptFileName = filePath.substring(0, filePath.lastIndexOf('.'));
+        tsSource = tree.read(`${typeScriptFileName}.ts`)!.toString('utf-8');
+      }
+
+      const usedFunctions = getUsedFunctions(isHTML ? tsSource : content, actions);
+
+      usedFunctions.forEach(usedFunction => {
+        const dasherizeFunction = strings.dasherize(usedFunction);
+
+        content =
+          content.slice(0, foundComponentPosition + searchTagComponent.length) +
+          ` (p-${dasherizeFunction})="${usedFunction}()"` +
+          content.slice(foundComponentPosition + searchTagComponent.length);
+      });
+    }
+  });
+
+  return content;
+}
+
+function replaceWithChanges(replaces: Array<ReplaceChanges>, content: string = '') {
+  replaces.forEach(({ replace, replaceWith }) => {
+    content = content.replace(replace, replaceWith);
+  });
+
+  return content;
+}
+
+function replacePackages(foundString: string, _, pkg: string) {
+  const org = '@po-ui';
+
+  if (pkg === 'ui') {
+    return `${org}/ng-components`;
+  } else if (pkg === 'style') {
+    return `${org}/style`;
+  } else if (pkg) {
+    return `${org}/ng-${pkg}`;
+  }
+
+  return foundString;
+}

--- a/projects/ui/schematics/utils/package-config.ts
+++ b/projects/ui/schematics/utils/package-config.ts
@@ -1,5 +1,18 @@
 import { Tree } from '@angular-devkit/schematics';
 
+import { tsLint } from '../ng-update/changes';
+
+const dependeciesChanges = {
+  '@portinari/portinari-ui': '@po-ui/ng-components',
+  '@portinari/portinari-sync': '@po-ui/ng-sync',
+  '@portinari/portinari-storage': '@po-ui/ng-storage',
+  '@portinari/portinari-style': '@po-ui/style',
+  '@portinari/portinari-templates': '@po-ui/ng-templates',
+  '@portinari/portinari-code-editor': '@po-ui/ng-code-editor',
+
+  '@totvs/portinari-theme': '@totvs/po-theme'
+};
+
 /**
  * Sorts the keys of the given object.
  * @returns A new object instance with sorted keys
@@ -29,6 +42,48 @@ export function addPackageToPackageJson(host: Tree, pkg: string, version: string
   }
 
   return host;
+}
+
+export function updatePackageJson(version: string) {
+  return (tree: Tree): Tree => {
+    if (tree.exists('package.json')) {
+      const sourceText = tree.read('package.json')!.toString('utf-8');
+      const json = JSON.parse(sourceText);
+
+      if (!json.dependencies) {
+        json.dependencies = {};
+      }
+
+      // necessario apenas quando migrar para @po-ui/ng-components
+      if (json.dependencies['@po-ui/ng-components']) {
+        delete json.dependencies['@po-ui/ng-components'];
+      }
+
+      Object.keys(dependeciesChanges).forEach(pkg => {
+        const previousPackage = pkg;
+        const newPackage = dependeciesChanges[pkg];
+
+        if (json.dependencies[previousPackage]) {
+          json.dependencies[newPackage] = version;
+
+          delete json.dependencies[previousPackage];
+        }
+      });
+
+      if (json.devDependencies[tsLint.replace]) {
+        json.devDependencies[tsLint.replaceWith] = '2.0.0';
+
+        delete json.devDependencies[tsLint.replace];
+      }
+
+      json.dependencies = sortObjectByKeys(json.dependencies);
+      json.devDependencies = sortObjectByKeys(json.devDependencies);
+
+      tree.overwrite('package.json', JSON.stringify(json, null, 2));
+    }
+
+    return tree;
+  };
 }
 
 /** Gets the version of the specified package by looking at the package.json in the given tree. */

--- a/projects/ui/schematics/utils/project.ts
+++ b/projects/ui/schematics/utils/project.ts
@@ -1,5 +1,26 @@
-import { SchematicsException } from '@angular-devkit/schematics';
-import { WorkspaceSchema, WorkspaceProject } from '@angular-devkit/core/src/experimental/workspace';
+import { parseJson, JsonParseMode } from '@angular-devkit/core';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import { WorkspaceProject, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
+
+/** Name of the default Angular CLI workspace configuration files. */
+const defaultWorkspaceConfigPaths = ['/angular.json', '/.angular.json'];
+
+export function getWorkspaceConfigGracefully(tree: Tree): null | WorkspaceSchema {
+  const path = defaultWorkspaceConfigPaths.find(filePath => tree.exists(filePath));
+  const configBuffer = tree.read(path!);
+
+  if (!path || !configBuffer) {
+    return null;
+  }
+
+  try {
+    // Parse the workspace file as JSON5 which is also supported for CLI
+    // workspace configurations.
+    return (parseJson(configBuffer.toString(), JsonParseMode.Json5) as unknown) as WorkspaceSchema;
+  } catch (e) {
+    return null;
+  }
+}
 
 export function getProjectFromWorkspace(workspace: WorkspaceSchema, projectName?: string): WorkspaceProject {
   const project = workspace.projects[projectName || workspace.defaultProject!];

--- a/projects/ui/tsconfig.schematics.json
+++ b/projects/ui/tsconfig.schematics.json
@@ -12,7 +12,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "rootDir": "schematics",
-    "outDir": "../../dist/portinari-ui/schematics",
+    "outDir": "../../dist/ng-components/schematics",
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,16 +14,16 @@
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"],
     "paths": {
-      "@portinari/portinari-ui": ["./dist/portinari-ui"],
-      "@portinari/portinari-ui/*": ["./dist/portinari-ui/*"],
-      "@portinari/portinari-storage": ["./dist/portinari-storage"],
-      "@portinari/portinari-storage/*": ["./dist/portinari-storage/*"],
-      "@portinari/portinari-sync": ["./dist/portinari-sync"],
-      "@portinari/portinari-sync/*": ["./dist/portinari-sync/*"],
-      "@portinari/portinari-templates": ["./dist/portinari-templates"],
-      "@portinari/portinari-templates/*": ["./dist/portinari-templates/*"],
-      "@portinari/portinari-code-editor": ["dist/portinari-code-editor"],
-      "@portinari/portinari-code-editor/*": ["dist/portinari-code-editor/*"]
+      "@po-ui/ng-components": ["./dist/ng-components"],
+      "@po-ui/ng-components/*": ["./dist/ng-components/*"],
+      "@po-ui/ng-storage": ["./dist/ng-storage"],
+      "@po-ui/ng-storage/*": ["./dist/ng-storage/*"],
+      "@po-ui/ng-sync": ["./dist/ng-sync"],
+      "@po-ui/ng-sync/*": ["./dist/ng-sync/*"],
+      "@po-ui/ng-templates": ["./dist/ng-templates"],
+      "@po-ui/ng-templates/*": ["./dist/ng-templates/*"],
+      "@po-ui/ng-code-editor": ["dist/ng-code-editor"],
+      "@po-ui/ng-code-editor/*": ["dist/ng-code-editor/*"]
     }
   }
 }


### PR DESCRIPTION
**Schematics Update**

**DTHFUI-3089**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
N/A

**Qual o novo comportamento?**

Os nomes dos pacotes foram alterados para a seguinte nomenclatura:

`@portinari/portinari-ui` ==> `@po-ui/ng-components`
`@portinari/portinari-templates` ==> `@po-ui/ng-templates`
`@portinari/portinari-code-editor` ==> `@po-ui/ng-code-editor`
`@portinari/portinari-storage` ==> `@po-ui/ng-storage`
`@portinari/portinari-sync` ==> `@po-ui/ng-sync`


Implementa ng update que realizará todas alterações relacionadas a breaking changes, depreciações. Podendo verificar o documento migration-poui-v2.

E também cria o documento de migração para versão 2, onde possui informações de como executar o ng update, os breaking changes e depreciações que ocorreram.

**Simulação**
Para poder testar o ng update, veja o documento projects/ui/schematics/README.md, 
Também devemos instalar os pacotes locais.

Podemos usar o Portal para executa-lo e tbm alguma outra aplicação que possuímos para realizar os testes.

1. Pode utilizar o verdaccio para publicar os pacotes locais, para realizar o teste mais proximo do "oficial", ex: publicar o @po-ui/style@2.0.0-beta.1 para a instalação do @po-ui/ng-components funcionar normalmente. (ou alterar para apontar local). 
Caso não publicar todos os pacotes (ng-templates/ng-code-editor), pode comentar o `postUpdate` no ng-update/index, para que não instale os pacotes no final.

2. npm run build:ui && npm run publish:ui:local (IMPORTANTE TER O VERDACCIO RODANDO)

3. No projeto angular (portal ou outro), executar:
      - npm i @po-ui/ng-components

      - ng update @po-ui/ng-components --next --from 1 --migrate-only

Caso na ultima opção reclamar do repositório sujo, pode-se utilizar --allow-dirty

