### PR TITLE
docs(select): atualização serviço do sample

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.component.html
@@ -40,7 +40,7 @@
     >
       <ng-template p-select-option-template let-option>
         <div class="sample-select-option-template-container">
-          <po-avatar p-size="xs" p-src="https://thf.totvs.com.br/sample/api/static/assets/{{ option.value }}.png">
+          <po-avatar p-size="xs" p-src="https://po-sample-api.herokuapp.com/api/v1/sampleSelect/{{ option.value }}.png">
           </po-avatar>
 
           <div class="sample-select-option-template-margin">

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.component.ts
@@ -107,15 +107,17 @@ export class SamplePoSelectCustomerRegistrationComponent implements OnDestroy, O
   }
 
   private getCitiesByState(state: string) {
-    this.citiesSubscription = this.sampleService.getCitiesByState(state).subscribe((cities: Array<PoSelectOption>) => {
-      this.cityOptions = cities;
-      this.city = this.cityOptions[0].value as number;
-    });
+    this.citiesSubscription = this.sampleService
+      .getCitiesByState(state)
+      .subscribe((cities: { items: Array<PoSelectOption> }) => {
+        this.cityOptions = cities.items;
+        this.city = this.cityOptions[0].value as number;
+      });
   }
 
   private getStates() {
-    this.statesSubscription = this.sampleService.getStates().subscribe((states: Array<PoSelectOption>) => {
-      this.stateOptions = states;
+    this.statesSubscription = this.sampleService.getStates().subscribe((states: { items: Array<PoSelectOption> }) => {
+      this.stateOptions = states.items;
       this.state = 'sp';
 
       this.getCitiesByState(this.state);

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class SamplePoSelectCustomerRegistrationService {
-  private url: string = 'https://thf.totvs.com.br/sample/api/sampleSelect/';
+  private url: string = 'https://po-sample-api.herokuapp.com/api/v1/sampleSelect';
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
**PO SELECT**

**DTHFUI-2685**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
Os samples não estavam funcionando corretamente no portal

**Qual o novo comportamento?**
Atualização da url dos serviços dos samples para poder funcionar
de forma mais didática no portal.

**Simulação**
Subir o back-end da PR do po-sample-api -> npm start.
Substituir localmente no Sample Po Select Customer Registration "https://po-sample-api.herokuapp.com/v1/sampleSelect" por "http://localhost:3000/v1/sampleSelect", tanto no service quanto no html e Buildar os samples no portal.