### PR TITLE
build: habilita tslint no travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,6 @@ cache:
 script:
   - commitlint-travis
   - npm run format:check
+  - npm run lint
   - npm run build:lite
   - npm run test

--- a/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.spec.ts
+++ b/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.spec.ts
@@ -1,6 +1,6 @@
-import { Directive } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { HttpResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { Observable, of, Subscriber } from 'rxjs';
@@ -24,14 +24,14 @@ import { PoSyncSchema } from './../po-sync/interfaces/po-sync-schema.interface';
 
 const EVENT_SOURCING_NAME: string = PoEventSourcingService['event_sourcing_name'];
 
-@Directive()
+@Injectable()
 class StorageServiceMock extends PoStorageService {
   constructor() {
     super();
   }
 }
 
-@Directive()
+@Injectable()
 class PoDataTransformMock extends PoDataTransform {
   getDateFieldName(): string {
     return undefined;

--- a/projects/sync/src/lib/services/po-schema/po-schema-definition/po-schema-definition.service.spec.ts
+++ b/projects/sync/src/lib/services/po-schema/po-schema-definition/po-schema-definition.service.spec.ts
@@ -1,4 +1,4 @@
-import { Directive } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { PoStorageService } from '@po-ui/ng-storage';
@@ -7,7 +7,7 @@ import { PoSchemaDefinitionService } from './po-schema-definition.service';
 import { PoSchemaUtil } from './../po-schema-util/po-schema-util.model';
 import { PoSyncSchema } from './../../po-sync/interfaces/po-sync-schema.interface';
 
-@Directive()
+@Injectable()
 class PoStorageServiceMock extends PoStorageService {
   constructor() {
     super();

--- a/projects/sync/src/lib/services/po-schema/po-schema.service.spec.ts
+++ b/projects/sync/src/lib/services/po-schema/po-schema.service.spec.ts
@@ -1,4 +1,4 @@
-import { Directive } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { PoStorageService } from '@po-ui/ng-storage';
@@ -8,14 +8,14 @@ import { PoSchemaService } from './po-schema.service';
 import { PoSchemaUtil } from './po-schema-util/po-schema-util.model';
 import { PoSyncSchema } from './../po-sync/interfaces/po-sync-schema.interface';
 
-@Directive()
+@Injectable()
 class PoStorageServiceMock extends PoStorageService {
   constructor() {
     super();
   }
 }
 
-@Directive()
+@Injectable()
 class PoSchemaDefinitionServiceMock extends PoSchemaDefinitionService {}
 
 describe('PoSchemaService:', () => {

--- a/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-dynamic-type.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-dynamic-type.component.ts
@@ -9,6 +9,7 @@ import { PoPieChartSeries } from './po-chart-pie/po-chart-pie-series.interface';
 
 const Padding: number = 24;
 
+/* tslint:disable:directive-class-suffix */
 @Directive()
 export abstract class PoChartDynamicTypeComponent {
   protected windowResizeListener: () => void;

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -3,6 +3,7 @@ import { AbstractControl } from '@angular/forms';
 
 import { PoInputBaseComponent } from '../po-input/po-input-base.component';
 
+/* tslint:disable:directive-class-suffix */
 @Directive()
 export abstract class PoInputGeneric extends PoInputBaseComponent implements AfterViewInit {
   @ViewChild('inp', { read: ElementRef, static: true }) inputEl: ElementRef;

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,7 @@
     "no-empty-destructuring": false,
     "no-commented-code": false,
     "no-duplicated-branches": false,
-    "max-union-size": false
+    "max-union-size": false,
+    "directive-class-suffix": [true, "Directive", "BaseComponent"]
   }
 }


### PR DESCRIPTION
**TSLINT**

**DTHFUI-3254**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A execução do tslint no travis estava desabilitada.

O problema ocorreu provavelmente apos v9 que adicionou @Directive nos BaseComponents,
com isso o lint estava quebrando.

**Qual o novo comportamento?**
Habilita a execução do tslint no travis.

Adiciona o suffixo customizado "BaseComponent" na regra "directive-class-suffix" e desabilta a regra em casos excepcionais.

**Simulação**
- Avaliar se o build no travis passou;
-  no projeto po-angular, executar: npm install && npm run lint