### PR TITLE
fix(page-dynamic-detail): corrige ação back com string

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
@@ -435,12 +435,24 @@ describe('PoPageDynamicDetailComponent:', () => {
       expect(component['poDialogService'].confirm).toHaveBeenCalled();
     });
 
-    it('goBack: should call `history.back`', () => {
+    it('goBack: should call `history.back` if the received param is a boolean type', () => {
       spyOn(window.history, 'back');
+      spyOn(component['router'], <any>'navigate');
 
-      component['goBack']();
+      component['goBack'](true);
 
       expect(window.history.back).toHaveBeenCalled();
+      expect(component['router'].navigate).not.toHaveBeenCalled();
+    });
+
+    it('goBack: should call `router.navigate` if the received param is a string type', () => {
+      spyOn(component['router'], <any>'navigate');
+      spyOn(window.history, 'back');
+
+      component['goBack']('/home');
+
+      expect(component['router'].navigate).toHaveBeenCalled();
+      expect(window.history.back).not.toHaveBeenCalled();
     });
 
     it('openEdit: should call `navigateTo` with object that contains path, url and component properties. ', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
@@ -309,8 +309,8 @@ export class PoPageDynamicDetailComponent implements OnInit, OnDestroy {
     return util.valuesFromObject(keys).join('|');
   }
 
-  private goBack() {
-    window.history.back();
+  private goBack(backAction: string | boolean) {
+    typeof backAction === 'string' ? this.router.navigate([backAction]) : window.history.back();
   }
 
   private loadData(id) {

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/samples/sample-po-page-dynamic-detail-user/sample-po-page-dynamic-detail-user.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/samples/sample-po-page-dynamic-detail-user/sample-po-page-dynamic-detail-user.component.ts
@@ -11,7 +11,7 @@ export class SamplePoPageDynamicDetailUserComponent {
   public readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
 
   public readonly actions: PoPageDynamicDetailActions = {
-    back: true
+    back: '/documentation/po-page-dynamic-table'
   };
 
   public readonly breadcrumb: PoBreadcrumb = {


### PR DESCRIPTION
**page-dynamic-detail**

**DTHFUI-3063**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
Ao adicionar uma rota no botão de ação "back", ele não está redirecionando para a rota especificada, apenas voltando para a URL do histórico anterior.

**Qual o novo comportamento?**
Tratamento para que a ação de voltar redirecione para a rota especificada em `action.back`

**Simulação**
Adicionada rota no sample `SamplePoPageDynamicDetailUserComponent`