### PR TITLE
fix(combo): corrige HTML Injection no option.label

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -338,53 +338,6 @@ describe('PoComboComponent:', () => {
     expect(component.controlComboVisibility).not.toHaveBeenCalled();
   });
 
-  it('should get formatted label with startWith', () => {
-    component.isFiltering = true;
-    component.filterMode = PoComboFilterMode.startsWith;
-    component.safeHtml = (value: any) => value;
-    component.inputElement.nativeElement.value = 'val';
-
-    expect(component.getLabelFormatted('values')).toBe('<span class="po-font-text-large-bold">val</span>ues');
-  });
-
-  it('should get formatted label with contains', () => {
-    component.isFiltering = true;
-    component.filterMode = PoComboFilterMode.contains;
-    component.safeHtml = (value: any) => value;
-    component.inputElement.nativeElement.value = 'lue';
-
-    expect(component.getLabelFormatted('values')).toBe('va<span class="po-font-text-large-bold">lue</span>s');
-  });
-
-  it('should get formatted label with endsWith', () => {
-    component.isFiltering = true;
-    component.filterMode = PoComboFilterMode.endsWith;
-    component.safeHtml = (value: any) => value;
-    component.inputElement.nativeElement.value = 'lues';
-
-    expect(component.getLabelFormatted('values')).toBe('va<span class="po-font-text-large-bold">lues</span>');
-  });
-
-  it('should not get formatted label', () => {
-    component.isFiltering = false;
-    component.safeHtml = (value: any) => value;
-    component.inputElement.nativeElement.value = 'lues';
-
-    expect(component.getLabelFormatted('values')).toBe('values');
-  });
-
-  it('should not get formatted label when shouldMarkLetters is false', () => {
-    component.isFiltering = false;
-    component.service = component.defaultService;
-    component.shouldMarkLetters = false;
-    component.getInputValue = () => true;
-    component.compareObjects = (a, b) => false;
-    component.safeHtml = (value: any) => value;
-    component.inputElement.nativeElement.value = 'lues';
-
-    expect(component.getLabelFormatted('values')).toBe('values');
-  });
-
   it('should return a sanitized code', () => {
     const html = component.safeHtml('<b>values</b>');
     expect(html['changingThisBreaksApplicationSecurity']).toBe('<b>values</b>');
@@ -1315,6 +1268,98 @@ describe('PoComboComponent:', () => {
       component['onScroll']();
 
       expect(spyAdjustContainerPosition).toHaveBeenCalled();
+    });
+
+    it('sanitizeTagHTML: should replace < and > with &lt; and &gt; respectively', () => {
+      const expectedValue = '&lt;input&gt; Testando';
+      const value = '<input> Testando';
+
+      expect(component['sanitizeTagHTML'](value)).toBe(expectedValue);
+    });
+
+    it('sanitizeTagHTML: should return param value if it doesn`t contain < and >', () => {
+      const expectedValue = 'Testando';
+      const value = 'Testando';
+
+      expect(component['sanitizeTagHTML'](value)).toBe(expectedValue);
+    });
+
+    it('sanitizeTagHTML: should return empty value if param value is undefined', () => {
+      const expectedValue = '';
+      const value = undefined;
+
+      expect(component['sanitizeTagHTML'](value)).toBe(expectedValue);
+    });
+
+    it('getLabelFormatted: shouldn`t get formatted label with `endsWith` if inputValue isn`t found in label', () => {
+      const label = 'values';
+      const expectedValue = `<span class="po-font-text-large-bold">${label}</span>`;
+
+      component.isFiltering = true;
+      component.filterMode = PoComboFilterMode.endsWith;
+      component.safeHtml = (value: any) => value;
+      component.inputElement.nativeElement.value = 'othervalue';
+
+      expect(component.getLabelFormatted(label)).not.toBe(expectedValue);
+    });
+
+    it('getLabelFormatted: shouldn`t get formatted label with `contains` if inputValue isn`t found in label', () => {
+      const label = 'values';
+      const expectedValue = `<span class="po-font-text-large-bold">${label}</span>`;
+
+      component.isFiltering = true;
+      component.filterMode = PoComboFilterMode.contains;
+      component.safeHtml = (value: any) => value;
+      component.inputElement.nativeElement.value = 'othervalue';
+
+      expect(component.getLabelFormatted(label)).not.toBe(expectedValue);
+    });
+
+    it('getLabelFormatted: should get formatted label with startWith', () => {
+      component.isFiltering = true;
+      component.filterMode = PoComboFilterMode.startsWith;
+      component.safeHtml = (value: any) => value;
+      component.inputElement.nativeElement.value = 'val';
+
+      expect(component.getLabelFormatted('values')).toBe('<span class="po-font-text-large-bold">val</span>ues');
+    });
+
+    it('getLabelFormatted: should get formatted label with contains', () => {
+      component.isFiltering = true;
+      component.filterMode = PoComboFilterMode.contains;
+      component.safeHtml = (value: any) => value;
+      component.inputElement.nativeElement.value = 'lue';
+
+      expect(component.getLabelFormatted('values')).toBe('va<span class="po-font-text-large-bold">lue</span>s');
+    });
+
+    it('getLabelFormatted: should get formatted label with endsWith', () => {
+      component.isFiltering = true;
+      component.filterMode = PoComboFilterMode.endsWith;
+      component.safeHtml = (value: any) => value;
+      component.inputElement.nativeElement.value = 'lues';
+
+      expect(component.getLabelFormatted('values')).toBe('va<span class="po-font-text-large-bold">lues</span>');
+    });
+
+    it('getLabelFormatted: should not get formatted label', () => {
+      component.isFiltering = false;
+      component.safeHtml = (value: any) => value;
+      component.inputElement.nativeElement.value = 'lues';
+
+      expect(component.getLabelFormatted('values')).toBe('values');
+    });
+
+    it('getLabelFormatted: should not get formatted label when shouldMarkLetters is false', () => {
+      component.isFiltering = false;
+      component.service = component.defaultService;
+      component.shouldMarkLetters = false;
+      component.getInputValue = () => true;
+      component.compareObjects = (a, b) => false;
+      component.safeHtml = (value: any) => value;
+      component.inputElement.nativeElement.value = 'lues';
+
+      expect(component.getLabelFormatted('values')).toBe('values');
     });
   });
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -496,8 +496,9 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }
   }
 
-  getLabelFormatted(label): SafeHtml {
-    let format = label;
+  getLabelFormatted(label: string): SafeHtml {
+    const sanitizedLabel = this.sanitizeTagHTML(label);
+    let format: string = sanitizedLabel;
 
     if (
       this.isFiltering ||
@@ -506,8 +507,8 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
         !this.compareObjects(this.cacheOptions, this.visibleOptions) &&
         this.shouldMarkLetters)
     ) {
-      const labelInput = this.getInputValue().toString().toLowerCase();
-      const labelLowerCase = label.toLowerCase();
+      const labelInput = this.sanitizeTagHTML(this.getInputValue().toString().toLowerCase());
+      const labelLowerCase = sanitizedLabel.toLowerCase();
 
       const openTagBold = '<span class="po-font-text-large-bold">';
       const closeTagBold = '</span>';
@@ -519,20 +520,27 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
       switch (this.filterMode) {
         case PoComboFilterMode.startsWith:
         case PoComboFilterMode.contains:
-          startString = label.substring(0, labelLowerCase.indexOf(labelInput));
-          middleString = label.substring(
-            labelLowerCase.indexOf(labelInput),
-            labelLowerCase.indexOf(labelInput) + labelInput.length
-          );
-          endString = label.substring(labelLowerCase.indexOf(labelInput) + labelInput.length);
+          const indexOfLabelInput = labelLowerCase.indexOf(labelInput);
 
-          format = startString + openTagBold + middleString + closeTagBold + endString;
+          if (indexOfLabelInput > -1) {
+            startString = sanitizedLabel.substring(0, indexOfLabelInput);
+
+            middleString = sanitizedLabel.substring(indexOfLabelInput, indexOfLabelInput + labelInput.length);
+            endString = sanitizedLabel.substring(indexOfLabelInput + labelInput.length);
+
+            format = startString + openTagBold + middleString + closeTagBold + endString;
+          }
+
           break;
         case PoComboFilterMode.endsWith:
-          startString = label.substring(0, labelLowerCase.lastIndexOf(labelInput));
-          middleString = label.substring(labelLowerCase.lastIndexOf(labelInput));
+          const lastIndexOfLabelInput = labelLowerCase.lastIndexOf(labelInput);
 
-          format = startString + openTagBold + middleString + closeTagBold;
+          if (lastIndexOfLabelInput > -1) {
+            startString = sanitizedLabel.substring(0, lastIndexOfLabelInput);
+            middleString = sanitizedLabel.substring(lastIndexOfLabelInput);
+
+            format = startString + openTagBold + middleString + closeTagBold;
+          }
           break;
       }
     }
@@ -627,6 +635,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }
 
     window.removeEventListener('scroll', this.onScroll, true);
+  }
+
+  private sanitizeTagHTML(value: string = '') {
+    return value.replace(/\</gm, '&lt;').replace(/\>/g, '&gt;');
   }
 
   private setContainerPosition() {


### PR DESCRIPTION
**COMBO**

**DTHFUI-3010**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao informar option.label com elemento HTML o mesmo estava
sendo  renderizado.

**Qual o novo comportamento?**
Realizado conversão dos caracteres < e > para &lt; e &gt; respectivamente.

Para que no momento da renderização, seja exibido "<" e ">", por exemplo.

**Simulação**
Utilizar o combo labs e exemplos informados na issue.