### PR TITLE
docs: informa a versão que as propriedades serão depreciadas no futuro

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-filter.interface.ts
@@ -12,7 +12,9 @@ import { PoLookupResponseApi } from './po-lookup-response-api.interface';
  */
 export interface PoLookupFilter {
   /**
-   * **Deprecated**
+   * ***Deprecated 3.x.x***
+   *
+   * > Este método está depreciado, deve-se utilizar a método `getFilteredItems`.
    *
    * Método responsável por enviar um filtro para o serviço e receber os dados.
    *
@@ -21,14 +23,12 @@ export interface PoLookupFilter {
    *
    * Este método deve retornar um *Observable* com a resposta da API no formato da interface `PoLookupResponseApi`.
    *
-   * > Este método está depreciado, deve-se utilizar a método `getFilteredItems`.
-   *
    * @param {any} filter Utilizado pelo serviço para filtrar os dados.
    * @param {number} page Controla a paginação dos dados e recebe valor automaticamente a cada clique no botão 'Carregar mais resultados'.
    * @param {number} pageSize Quantidade de itens retornados cada vez que o serviço é chamado, por padrão é 10.
    * @param {any} filterParams Valor informado através da propriedade `p-filter-params`.
    *
-   * @deprecated 4.x.x
+   * @deprecated 3.x.x
    *
    */
   getFilteredData?(filter: any, page: number, pageSize?: number, filterParams?: any): Observable<PoLookupResponseApi>;

--- a/projects/ui/src/lib/components/po-field/po-upload/interfaces/po-upload-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/interfaces/po-upload-literals.interface.ts
@@ -7,20 +7,22 @@
  */
 export interface PoUploadLiterals {
   /**
-   * @deprecated 3.X.X
+   * @deprecated 3.x.x
+   *
    * @description
    *
-   * **Deprecated**
+   * ***Deprecated 3.x.x***
    *
    * Texto exibido no label para cancelar o envio.
    */
   cancel?: string;
 
   /**
-   * @deprecated 3.X.X
+   * @deprecated 3.x.x
+   *
    * @description
    *
-   * **Deprecated**
+   * ***Deprecated 3.x.x***
    *
    * Texto exibido no label para excluir o arquivo.
    */
@@ -72,10 +74,11 @@ export interface PoUploadLiterals {
   startSending?: string;
 
   /**
-   * @deprecated 3.X.X
+   * @deprecated 3.x.x
+   *
    * @description
    *
-   * **Deprecated**
+   * ***Deprecated 3.x.x***
    *
    * Texto exibido no label para tentar novamente.
    */

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -292,10 +292,11 @@ export abstract class PoTableBaseComponent implements OnChanges {
   /**
    * @optional
    *
-   * @deprecated 2.X.X
+   * @deprecated 3.x.x
+   *
    * @description
    *
-   * **Deprecated**
+   * ***Deprecated 3.x.x***
    *
    * > Esta propriedade está depreciada, utilize a propriedade `p-selectable`.
    *


### PR DESCRIPTION
**DOCS**

**DTHFUI-3340**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Não exibe qual versão será feito a depreciação.

**Qual o novo comportamento?**

Componentes que tem depreciações:
- lookup
- upload
- table

**Simulação**

Atualizar o portal com as alterações.