### PR TITLE
fix(code-editor): corrige exibição do editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "http-status-codes": "^1.4.0",
     "localforage": "1.7.3",
     "lokijs": "1.5.8",
-    "monaco-editor": "0.15.6",
+    "monaco-editor": "0.20.0",
     "rxjs": "~6.5.4",
     "rxjs-compat": "~6.5.4",
     "tslib": "^1.11.1",

--- a/projects/code-editor/package.json
+++ b/projects/code-editor/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@po-ui/ng-components": "0.0.0-PLACEHOLDER",
-    "monaco-editor": "0.15.6",
+    "monaco-editor": "0.20.0",
     "core-js": "^3.6.4",
     "intl": "^1.2.5",
     "uuid": "^3.3.2"
@@ -22,7 +22,7 @@
     "@angular/core": "~9.1.0",
     "@angular/forms": "~9.1.0",
     "@po-ui/ng-components": "0.0.0-PLACEHOLDER",
-    "monaco-editor": "0.15.6",
+    "monaco-editor": "0.20.0",
     "zone.js": "~0.10.3"
   }
 }

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.ts
@@ -49,7 +49,7 @@ const PO_CODE_EDITOR_THEME_DEFAULT = 'vs';
  * >
  * > <pre ngNonBindable>
  * > "assets": [
- * >    { "glob": "&#8727;&#8727;/&#8727;", "input": "node_modules/monaco-editor/min", "output": "/assets/monaco/" }
+ * >    { "glob": "&#42;&#42;/&#42;", "input": "node_modules/monaco-editor/min", "output": "/assets/monaco/" }
  * >  ]
  * > </pre>
  *

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor.component.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor.component.ts
@@ -4,6 +4,10 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { PoCodeEditorBaseComponent } from './po-code-editor-base.component';
 import { PoCodeEditorRegister } from './po-code-editor-register.service';
 
+// variáveis relacionadas ao Monaco
+let loadedMonaco: boolean = false;
+let loadPromise: Promise<void>;
+
 declare const monaco: any;
 // tslint:disable-next-line
 declare const require: any;
@@ -52,8 +56,6 @@ const providers: Array<Provider> = [
 })
 export class PoCodeEditorComponent extends PoCodeEditorBaseComponent implements AfterViewInit, DoCheck {
   canLoad = false;
-  loadedMonaco = false;
-  loadPromise: Promise<void>;
 
   @ViewChild('editorContainer', { static: true }) editorContainer: ElementRef;
 
@@ -63,8 +65,8 @@ export class PoCodeEditorComponent extends PoCodeEditorBaseComponent implements 
 
   /* istanbul ignore next */
   ngAfterViewInit(): void {
-    if (this.loadedMonaco) {
-      this.loadPromise.then(() => {
+    if (loadedMonaco) {
+      loadPromise.then(() => {
         setTimeout(() => {
           if (this.el.nativeElement.offsetWidth) {
             this.registerCustomLanguage();
@@ -75,8 +77,8 @@ export class PoCodeEditorComponent extends PoCodeEditorBaseComponent implements 
         });
       });
     } else {
-      this.loadedMonaco = true;
-      this.loadPromise = new Promise<void>((resolve: any) => {
+      loadedMonaco = true;
+      loadPromise = new Promise<void>((resolve: any) => {
         const onGotAmdLoader: any = () => {
           (<any>window).require.config({ paths: { 'vs': './assets/monaco/vs' } });
           (<any>window).require(['vs/editor/editor.main'], () => {


### PR DESCRIPTION
**po-code-editor**

**DTHFUI-3311**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O portal apresentava inconsistência no carregamento dos samples do `http-interceptor` e `code-editor`.

**Qual o novo comportamento?**
- As variáveis relacionadas ao monaco-editor haviam sido atribuidas para dentro de PoCodeEditorComponent e isso estava quebrando a correta visualização do editor de texto. Agora elas foram reatribudas para fora da classe.
- Foi também atualizado o pacote do monaco-editor para sua última versão.

**Simulação**
Avaliar o componente no portal