### PR TITLE
fix(page-dynamic-table): corrige lentidão

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
@@ -41,6 +41,18 @@ describe('PoPageDynamicListBaseComponent:', () => {
       expectPropertiesValues(component, 'fields', validValues, validValues);
       expect(component['setFieldsProperties']).toHaveBeenCalled();
     });
+
+    it('columns: should return a new reference', () => {
+      const columns = [
+        { property: 'id', key: true },
+        { property: 'name', label: 'Name', filter: true, visible: true, gridColumns: 6 }
+      ];
+
+      component.columns = columns;
+
+      expect(component.columns).toEqual(columns);
+      expect(component.columns).not.toBe(columns);
+    });
   });
 
   describe('Methods:', () => {
@@ -81,13 +93,13 @@ describe('PoPageDynamicListBaseComponent:', () => {
         expect(component.filters).toEqual(filtersResult);
       });
 
-      it('should set `_columns` with all fields properties', () => {
+      it('should set `columns` with all fields properties', () => {
         component['setFieldsProperties'](fields);
 
         expect(component.columns).toEqual(fields);
       });
 
-      it('should set `_columns` with [] if fields is []', () => {
+      it('should set `columns` with [] if fields is []', () => {
         const fieldsEmpty = [];
 
         component['setFieldsProperties'](fieldsEmpty);

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
@@ -140,8 +140,12 @@ export class PoPageDynamicListBaseComponent {
   /** Título da página. */
   @Input('p-title') title: string;
 
+  set columns(value) {
+    this._columns = [...value];
+  }
+
   get columns() {
-    return [...this._columns];
+    return this._columns;
   }
 
   get duplicates() {
@@ -158,7 +162,7 @@ export class PoPageDynamicListBaseComponent {
 
   private setFieldsProperties(fields: Array<any>) {
     this._filters = fields.filter(field => field.filter === true);
-    this._columns = fields.filter(field => field.visible === undefined || field.visible === true);
+    this.columns = fields.filter(field => field.visible === undefined || field.visible === true);
     this._keys = fields.filter(field => field.key === true).map(field => field.property);
     this._duplicates = fields.filter(field => field.duplicate === true).map(field => field.property);
   }


### PR DESCRIPTION
**Po Page Dynamic Table**

**DTHFUI-2990, #260**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Lentidão ao abrir o gerenciador de colunas e não estava habilitando/desabilitando corretamente as colunas pelo gerenciador.

**Qual o novo comportamento?**
- O problema acontecia ao gerar uma nova referência no getter das colunas, pois o table acabava gerando várias detecções de mudança.
- A nova referência foi colocada no setter.

**Simulação**
- Testar o sample do portal.
- Testar com o prod do portal.
- Testar com o `p-fields`, para ver se as colunas continuam sendo colocadas corretamente.
- Testar em outros navegadores.