### PR TITLE
feat(page-dynamic): utiliza cache do metadados se servidor não responder

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
@@ -66,7 +66,10 @@ export const poPageDynamicDetailLiteralsDefault = {
  * poder especificar o endpoint dos dados e dos metadados. Exemplo de utilização:
  *
  * O componente primeiro irá carregar o metadado da rota definida na propriedade serviceMetadataApi
- * e depois irá buscar da rota definida na propriedade serviceLoadApi
+ * e depois irá buscar da rota definida na propriedade serviceLoadApi.
+ *
+ * > Caso o servidor retornar um erro ao recuperar o metadados, será repassado o metadados salvo em cache,
+ * se o cache não existe será disparado uma notificação.
  *
  * ```
  * {

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -85,6 +85,9 @@ export const poPageDynamicEditLiteralsDefault = {
  * O componente primeiro irá carregar o metadado da rota definida na propriedade serviceMetadataApi
  * e depois irá buscar da rota definida na propriedade serviceLoadApi
  *
+ * > Caso o servidor retornar um erro ao recuperar o metadados, será repassado o metadados salvo em cache,
+ * se o cache não existe será disparado uma notificação.
+ *
  * ```
  * {
  *   path: 'people',

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -1,7 +1,7 @@
 import { ActivatedRoute, Route, Router } from '@angular/router';
 import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 
-import { Subscription, Observable, EMPTY, throwError, concat } from 'rxjs';
+import { Subscription, Observable, EMPTY, concat } from 'rxjs';
 import { tap, switchMap } from 'rxjs/operators';
 
 import {
@@ -92,6 +92,9 @@ export const poPageDynamicTableLiteralsDefault = {
  *
  * O componente primeiro irá carregar o metadado da rota definida na propriedade serviceMetadataApi
  * e depois irá buscar da rota definida na propriedade serviceLoadApi
+ *
+ * > Caso o servidor retornar um erro ao recuperar o metadados, será repassado o metadados salvo em cache,
+ * se o cache não existe será disparado uma notificação.
  *
  * ```
  * {

--- a/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic-literals.interface.ts
+++ b/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic-literals.interface.ts
@@ -1,0 +1,8 @@
+// Interface para literais de tradução para os Pages Dinâmicos.
+export interface PoPageDynamicLiterals {
+  // Titulo retornado do metadados caso houver erro na requisição.
+  errorRenderPage: string;
+
+  // Mensagem exibida na notificação de erro na requisição dos metadados.
+  notPossibleLoadMetadataPage: string;
+}


### PR DESCRIPTION
**Page Dynamic**

**DTHFUI-2959**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao retornar erro do servidor na tentativa de recuperar o metadados, 
os componentes: 
- Page Dynamic Edit
- Page Dynamic Detail
- Page Dynamic Table

Não utilizavam o metadados que possuía em cache.

**Qual o novo comportamento?**
Quando houver algum erro na requisição pelo metadados
e possuir cache será utilizado o mesmo.

Caso não houver cache será disparado uma notificação
informando que não foi possível recuperar o metadados
e será repassado um titulo padrão.

**OBS:** Por enquanto será exibido as duas mensagens, do proprio interceptor e do page-dynamic.
A ideia é alterar o po-notification para aceitar detalhes, será avaliado com calma.

**Simulação**
Utilizar as rotas abaixo para simular todos os componentes.

1) Primeira rodada com servidor fora do AR, avaliar se exibe notificação e titulo default.
2) Segunda rodada rodada com o servidor no AR;
3) Terceira rodada com servidor fora novamente, para avaliar o uso do cache.

``` 
const routes: Routes = [
  {
    path: '',
    component: PoPageDynamicTableComponent,
    data: {
      serviceApi: 'http://localhost:3000/v1/people'
    }
  },
  {
    path: 'new',
    component: PoPageDynamicEditComponent,
    data: {
      serviceApi: 'http://localhost:3000/v1/people'
    }
  },
  {
    path: 'edit/:id',
    component: PoPageDynamicEditComponent,
    data: {
      serviceApi: 'http://localhost:3000/v1/people'
    }
  },
  {
    path: 'detail/:id',
    component: PoPageDynamicDetailComponent,
    data: {
      serviceApi: 'http://localhost:3000/v1/people'
    }
  }
];
```