### PR TITLE
fix(page-blocked-user): corrige colunas de contatos

### DIFF
--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.html
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.html
@@ -12,7 +12,7 @@
     >
       <div class="po-page-blocked-user-contact-group-item">
         <span class="po-page-blocked-user-contact-icon po-icon po-icon-telephone po-pr-1"></span>
-        <span #phoneItem class="po-page-blocked-user-contact-text po-font-text">{{ phone }}</span>
+        <div #phoneItem class="po-page-blocked-user-contact-text po-font-text">{{ phone }}</div>
       </div>
     </a>
   </div>
@@ -29,7 +29,7 @@
     >
       <div class="po-page-blocked-user-contact-group-item">
         <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1"></span>
-        <span #mailItem class="po-page-blocked-user-contact-text po-font-text">{{ email }}</span>
+        <div #mailItem class="po-page-blocked-user-contact-text po-font-text">{{ email }}</div>
       </div>
     </a>
   </div>

--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.spec.ts
@@ -1,7 +1,7 @@
+import { ChangeDetectionStrategy, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpClient, HttpHandler } from '@angular/common/http';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { PoPageBlockedUserContactsComponent } from './po-page-blocked-user-contacts.component';
@@ -20,6 +20,10 @@ describe('PoPageBlockedUserContactsComponent: ', () => {
       providers: [HttpClient, HttpHandler],
       schemas: [NO_ERRORS_SCHEMA]
     });
+
+    TestBed.overrideComponent(PoPageBlockedUserContactsComponent, {
+      set: { changeDetection: ChangeDetectionStrategy.Default }
+    }).createComponent(PoPageBlockedUserContactsComponent);
   });
 
   beforeEach(() => {
@@ -35,52 +39,68 @@ describe('PoPageBlockedUserContactsComponent: ', () => {
     expect(component instanceof PoPageBlockedUserContactsComponent).toBeTruthy();
   });
 
+  describe('Properties', () => {
+    it('p-email: should call `checkContactItemWidth`', () => {
+      spyOn(component, <any>'checkContactItemWidth');
+
+      component.email = 'mail@test.com';
+
+      expect(component['checkContactItemWidth']).toHaveBeenCalled();
+    });
+
+    it('p-phone: should call `checkContactItemWidth`', () => {
+      spyOn(component, <any>'checkContactItemWidth');
+
+      component.phone = '999999';
+
+      expect(component['checkContactItemWidth']).toHaveBeenCalled();
+    });
+  });
+
   describe('Methods: ', () => {
-    it('ngAfterViewInit: should call `checkContactItemWidth` and `ChangeDetector.detectChanges`', () => {
-      spyOn(component, <any>'checkContactItemWidth');
-      const spyDetectChanges = spyOn(component['changeDetector'], <any>'detectChanges');
-
-      component.ngAfterViewInit();
-      expect(component['checkContactItemWidth']).toHaveBeenCalled();
-      expect(spyDetectChanges).toHaveBeenCalled();
-    });
-
-    it('ngOnChanges: shouldn`t call `checkContactItemWidth`', () => {
-      const fakeChanges = {};
-      spyOn(component, <any>'checkContactItemWidth');
-      component.ngOnChanges(fakeChanges);
-      expect(component['checkContactItemWidth']).not.toHaveBeenCalled();
-    });
-
-    it('ngOnChanges: should call `checkContactItemWidth`', () => {
-      component.phone = '55-22-98787-8787';
-
-      const changes = { phone: { firstChange: true } };
-
-      spyOn(component, <any>'checkContactItemWidth');
-
-      component.ngOnChanges(<any>changes);
-
-      expect(component['checkContactItemWidth']).toHaveBeenCalled();
-    });
-
-    it('checkContactItemWidth: should update value of `overflowItem` with valid `true`.', () => {
-      component.phone = '55-22-98787-8787';
-      const expectedValue = true;
-
-      component['checkContactItemWidth']();
-
-      expect(component.overflowItem).toBe(expectedValue);
-    });
-
-    it('checkContactItemWidth: should update value of `overflowItem` with `false`.', () => {
-      component.phone = '55-22-98787-8787';
-      component.email = 'mail@mail.com';
+    it('checkContactItemWidth: should apply `true` to `overflowItem`', () => {
       component.overflowItem = false;
 
       component['checkContactItemWidth']();
 
-      expect(component.overflowItem).toBe(false);
+      expect(component.overflowItem).toBeTruthy();
+    });
+
+    it('checkContactItemWidth: should call `detectChanges`', () => {
+      component.email = 'mail@test.com';
+      component.phone = '999999';
+
+      const spyDetectChanges = spyOn(component['changeDetector'], <any>'detectChanges');
+
+      component['checkContactItemWidth']();
+
+      expect(spyDetectChanges).toHaveBeenCalled();
+    });
+
+    it(`checkContactItemWidth: should apply 'false' to 'overflowItem' if 'phoneItem' and 'mailItem' summed measures are less than 'contactGroup' width`, () => {
+      component.email = 'mail@test.com';
+      component.phone = '999999';
+
+      spyOnProperty(component.phoneItem.nativeElement, 'offsetWidth').and.returnValue(20);
+      spyOnProperty(component.mailItem.nativeElement, 'offsetWidth').and.returnValue(20);
+      spyOnProperty(component.contactGroup.nativeElement, 'offsetWidth').and.returnValue(200);
+
+      component['checkContactItemWidth']();
+
+      expect(component.overflowItem).toBeFalsy();
+    });
+
+    it(`checkContactItemWidth: should apply 'true' to 'overflowItem' if 'phoneItem' and 'mailItem' summed measures are greater than 'contactGroup' width`, () => {
+      component.email = 'mail@test.com';
+      component.phone = '999999';
+
+      spyOnProperty(component.phoneItem.nativeElement, 'offsetWidth').and.returnValue(20);
+      spyOnProperty(component.mailItem.nativeElement, 'offsetWidth').and.returnValue(150);
+      spyOnProperty(component.contactGroup.nativeElement, 'offsetWidth').and.returnValue(200);
+
+      component['checkContactItemWidth']();
+
+      expect(component.overflowItem).toBeTruthy();
     });
   });
 

--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.ts
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.ts
@@ -1,30 +1,37 @@
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Input,
-  OnChanges,
-  SimpleChanges,
-  ViewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, ViewChild } from '@angular/core';
 
 const poPageBlockedUserContactItemMargin = 16;
 
 @Component({
   selector: 'po-page-blocked-user-contacts',
-  templateUrl: './po-page-blocked-user-contacts.component.html'
+  templateUrl: './po-page-blocked-user-contacts.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PoPageBlockedUserContactsComponent implements AfterViewInit, OnChanges {
-  literals: Object;
-  overflowItem: boolean = false;
+export class PoPageBlockedUserContactsComponent {
+  private _email: string;
+  private _phone: string;
 
-  private mailText: string;
-  private phoneText: string;
+  overflowItem: boolean = true;
 
-  @Input('p-email') email: string;
+  @Input('p-email') set email(value: string) {
+    this._email = value;
 
-  @Input('p-phone') phone: string;
+    this.checkContactItemWidth();
+  }
+
+  get email() {
+    return this._email;
+  }
+
+  @Input('p-phone') set phone(value: string) {
+    this._phone = value;
+
+    this.checkContactItemWidth();
+  }
+
+  get phone() {
+    return this._phone;
+  }
 
   @ViewChild('contactGroup', { static: true }) contactGroup: ElementRef;
 
@@ -34,31 +41,19 @@ export class PoPageBlockedUserContactsComponent implements AfterViewInit, OnChan
 
   constructor(private changeDetector: ChangeDetectorRef) {}
 
-  ngAfterViewInit() {
-    this.checkContactItemWidth();
-    this.changeDetector.detectChanges();
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes.email || changes.phone) {
-      this.checkContactItemWidth();
-    }
-  }
-
   private checkContactItemWidth() {
-    if (!this.email || !this.phone) {
-      this.overflowItem = true;
-      return;
-    } else {
-      setTimeout(() => {
-        const phoneWidth = this.phoneItem.nativeElement.offsetWidth;
-        const mailWidth = this.mailItem.nativeElement.offsetWidth;
-        const contactGroupHalfWidth = this.contactGroup.nativeElement.offsetWidth / 2;
+    this.overflowItem = true;
 
-        this.overflowItem =
-          phoneWidth > contactGroupHalfWidth || mailWidth > contactGroupHalfWidth - poPageBlockedUserContactItemMargin;
-      });
+    if (this.phone && this.email) {
+      this.changeDetector.detectChanges();
+
+      const phoneWidth = this.phoneItem.nativeElement.offsetWidth;
+      const mailWidth = this.mailItem.nativeElement.offsetWidth;
+      const contactGroupHalfWidth =
+        this.contactGroup.nativeElement.offsetWidth / 2 - poPageBlockedUserContactItemMargin;
+
+      this.overflowItem =
+        phoneWidth > contactGroupHalfWidth || mailWidth > contactGroupHalfWidth - poPageBlockedUserContactItemMargin;
     }
-    this.changeDetector.detectChanges();
   }
 }


### PR DESCRIPTION
**page-blocked-user**

**DTHFUI-3195**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Os campos de contato não estavam respeitando as definições de colunagem.

**Qual o novo comportamento?**
- Corrigido método que verifica o dimensionamento das larguras dos campos de contatos.
- Identificado também que o ellipsis não estava funcionando se um campo excedesse a largura máxima. Verificar também a [po-style](https://github.com/po-ui/po-style/pull/101)

**Simulação**
Testar no sample labs do portal