### PR TITLE
fix(page-job-scheduler): corrige validação dos parametros

### DIFF
--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.ts
@@ -8,7 +8,7 @@ import { PoDynamicFormField } from '@po-ui/ng-components';
   templateUrl: 'po-page-job-scheduler-parameters.component.html'
 })
 export class PoPageJobSchedulerParametersComponent implements AfterViewInit {
-  @ViewChild('parametersForm', { static: true }) form: NgForm;
+  @ViewChild('parametersForm') form: NgForm;
 
   @Input('p-literals') literals = <any>{};
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
@@ -367,8 +367,31 @@ describe('PoPageJobSchedulerComponent:', () => {
     }));
 
     describe('isDisabledAdvance', () => {
-      it(`should return 'true' if have 'schedulerExecution'`, () => {
+      it(`should return 'true' if 'step' is 2 and 'schedulerParameters.form.invalid' is true`, () => {
         const fakeThis = {
+          step: 2,
+          schedulerParameters: {
+            form: {
+              invalid: true
+            }
+          }
+        };
+
+        expect(component['isDisabledAdvance'].call(fakeThis)).toBe(true);
+      });
+
+      it(`should return 'false' if 'step' is 2 and 'schedulerParameters' is undefined`, () => {
+        const fakeThis = {
+          step: 2,
+          schedulerParameters: undefined
+        };
+
+        expect(component['isDisabledAdvance'].call(fakeThis)).toBe(false);
+      });
+
+      it(`should return 'true' if 'step' is 1 and 'schedulerExecution.form.invalid' is true`, () => {
+        const fakeThis = {
+          step: 1,
           schedulerExecution: {
             form: {
               invalid: true
@@ -376,19 +399,26 @@ describe('PoPageJobSchedulerComponent:', () => {
           }
         };
 
-        const functionTest = component['isDisabledAdvance'].call(fakeThis);
-
-        expect(functionTest).toBe(true);
+        expect(component['isDisabledAdvance'].call(fakeThis)).toBe(true);
       });
 
-      it(`should return 'false' if have 'schedulerExecution'`, () => {
+      it(`should return 'false' if 'step' is 1 and 'schedulerExecution' is undefined`, () => {
         const fakeThis = {
+          step: 1,
           schedulerExecution: undefined
         };
 
-        const functionTest = component['isDisabledAdvance'].call(fakeThis);
+        expect(component['isDisabledAdvance'].call(fakeThis)).toBe(false);
+      });
 
-        expect(functionTest).toBe(false);
+      it(`should return 'false' if 'step' is undefined`, () => {
+        const fakeThis = {
+          step: undefined,
+          schedulerExecution: undefined,
+          schedulerParameters: undefined
+        };
+
+        expect(component['isDisabledAdvance'].call(fakeThis)).toBe(false);
       });
     });
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
@@ -87,7 +87,7 @@ export class PoPageJobSchedulerComponent extends PoPageJobSchedulerBaseComponent
   ];
 
   @ViewChild('schedulerExecution', { static: true }) schedulerExecution: { form: NgForm };
-  @ViewChild('schedulerParameters', { static: true }) schedulerParameters: { form: NgForm };
+  @ViewChild('schedulerParameters') schedulerParameters: { form: NgForm };
 
   constructor(
     public poPageDynamicLookupService: PoPageJobSchedulerLookupService,
@@ -191,7 +191,12 @@ export class PoPageJobSchedulerComponent extends PoPageJobSchedulerBaseComponent
   }
 
   private isDisabledAdvance(): boolean {
-    return this.schedulerExecution ? this.schedulerExecution.form.invalid : false;
+    const componentByStep = {
+      1: this.schedulerExecution,
+      2: this.schedulerParameters
+    };
+
+    return componentByStep[this.step]?.form?.invalid || false;
   }
 
   private isDisabledBack(): boolean {


### PR DESCRIPTION
**PAGE JOB SCHEDULER**

**DTHFUI-3043**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O template não estava validando os campos obrigatórios que retornavam da API,
possibilitando trocar de step mesmo com o campo obrigatório.

**Qual o novo comportamento?**
Valida os parâmetros ao tentar passar de step e também foi realizado tratamento para
desabilitar o botão de "Avançar" caso o formulário dos parâmetros for invalido.

**Simulação**
Utilizar o sample do template.
Selecionar o processo "process1" que possui parâmetros obrigatórios. 