### PR TITLE
fix(table): previne selecionar linha ao clicar em ação

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.component.html
@@ -5,6 +5,6 @@
   [p-disabled]="isDisabled(column)"
   [p-icon]="getIcon(column)"
   [p-icon-tooltip]="column.tooltip"
-  (p-click)="click(column)"
+  (p-click)="click(column, $event)"
 >
 </po-table-icon>

--- a/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.component.spec.ts
@@ -164,7 +164,10 @@ describe('PoTableColumnIconComponent:', () => {
       expect(expectedValue).toBe(expectedIcon);
     });
 
-    it('click: shouldn`t call columnIcon.action or column.action if columnIcon.disabled is true', () => {
+    it('click: shouldn`t call columnIcon.action or column.action neither `stopPropagation` if columnIcon.disabled is true', () => {
+      const fakeEvent = {
+        stopPropagation: () => {}
+      };
       const fakeRow = (component.row = {});
       const fakeColumnIcon = {
         color: 'color-08',
@@ -177,15 +180,20 @@ describe('PoTableColumnIconComponent:', () => {
       spyOn(component, 'isDisabled').and.callThrough();
       spyOn(fakeColumnIcon, 'action');
       spyOn(component.column, 'action');
+      spyOn(fakeEvent, 'stopPropagation');
 
-      component.click(fakeColumnIcon);
+      component.click(fakeColumnIcon, fakeEvent);
 
       expect(component.column.action).not.toHaveBeenCalledWith(fakeColumnIcon);
       expect(fakeColumnIcon.action).not.toHaveBeenCalledWith(fakeRow, fakeColumnIcon);
       expect(component['isDisabled']).toHaveBeenCalledWith(fakeColumnIcon);
+      expect(fakeEvent.stopPropagation).not.toHaveBeenCalled();
     });
 
-    it('click: should call columnIcon.action if isDisabled is false', () => {
+    it('click: should call `columnIcon.action` and `stopPropagation` if isDisabled is false', () => {
+      const fakeEvent = {
+        stopPropagation: () => {}
+      };
       const fakeRow = (component.row = {});
       const fakeColumnIcon = {
         color: 'color-08',
@@ -198,29 +206,60 @@ describe('PoTableColumnIconComponent:', () => {
       spyOn(component, 'isDisabled').and.callThrough();
       spyOn(component.column, 'action');
       spyOn(fakeColumnIcon, 'action');
+      spyOn(fakeEvent, 'stopPropagation');
 
-      component.click(fakeColumnIcon);
+      component.click(fakeColumnIcon, fakeEvent);
 
       expect(fakeColumnIcon.action).toHaveBeenCalledWith(fakeRow, fakeColumnIcon);
       expect(component.column.action).not.toHaveBeenCalledWith(fakeColumnIcon);
       expect(component['isDisabled']).toHaveBeenCalledWith(fakeColumnIcon);
+      expect(fakeEvent.stopPropagation).toHaveBeenCalled();
     });
 
-    it('click: should call column.action with columnIcon if isDisabled is falsy and columnIcon.action is undefined', () => {
+    it('click: should call column.action with columnIcon  and `stopPropagation` if isDisabled is falsy and columnIcon.action is undefined', () => {
+      const fakeEvent = {
+        stopPropagation: () => {}
+      };
       const fakeRow = (component.row = {});
       const fakeColumnIcon = {
         color: 'color-08',
-        value: 'po-icon-copy'
+        value: 'po-icon-copy',
+        disabled: () => false
       };
       component.column = { property: 'columnIcon', type: 'icon', action: () => {} };
 
       spyOn(component, 'isDisabled').and.callThrough();
       spyOn(component.column, 'action');
+      spyOn(fakeEvent, 'stopPropagation');
 
-      component.click(fakeColumnIcon);
+      component.click(fakeColumnIcon, fakeEvent);
 
       expect(component.column.action).toHaveBeenCalledWith(fakeRow, fakeColumnIcon);
       expect(component['isDisabled']).toHaveBeenCalledWith(fakeColumnIcon);
+      expect(fakeEvent.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('click: should call only `stopPropagation` if `columnIcon.action` and `column.action` are undefined', () => {
+      const fakeEvent = {
+        stopPropagation: () => {}
+      };
+      const fakeColumnIcon = {
+        color: 'color-08',
+        value: 'po-icon-copy',
+        action: undefined,
+        disabled: () => false
+      };
+      component.column = { property: 'columnIcon', type: 'icon' };
+
+      spyOn(component, 'isDisabled').and.callThrough();
+      spyOn(fakeEvent, 'stopPropagation');
+
+      component.click(fakeColumnIcon, fakeEvent);
+
+      expect(component['isDisabled']).toHaveBeenCalledWith(fakeColumnIcon);
+      expect(fakeEvent.stopPropagation).toHaveBeenCalled();
+      expect(component.column.action).toBeUndefined();
+      expect(fakeColumnIcon.action).toBeUndefined();
     });
 
     it('trackByFunction: should return index', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.component.ts
@@ -33,13 +33,16 @@ export class PoTableColumnIconComponent {
   /** Dados da linha da tabela. */
   @Input('p-row') row: any;
 
-  click(columnIcon: PoTableColumnIcon): void {
+  click(columnIcon: PoTableColumnIcon, event): void {
     const isAbleAction = !this.isDisabled(columnIcon);
 
-    if (columnIcon.action && isAbleAction) {
-      columnIcon.action(this.row, columnIcon);
-    } else if (this.column.action && isAbleAction) {
-      this.column.action(this.row, columnIcon);
+    if (isAbleAction) {
+      if (columnIcon.action) {
+        columnIcon.action(this.row, columnIcon);
+      } else if (this.column.action) {
+        this.column.action(this.row, columnIcon);
+      }
+      event.stopPropagation();
     }
   }
 

--- a/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.html
@@ -2,7 +2,7 @@
   class="po-icon {{ icon }} {{ disabled ? '' : color }}"
   [ngClass]="{ 'po-clickable': clickable, 'po-table-icon-disabled': disabled }"
   [p-tooltip]="tooltip"
-  (click)="onClick()"
+  (click)="onClick($event)"
   (mouseenter)="tooltipMouseEnter()"
   (mouseleave)="tooltipMouseLeave()"
 >

--- a/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.spec.ts
@@ -53,21 +53,23 @@ describe('PoTableIconComponent:', () => {
 
   describe('Methods:', () => {
     it('onClick: should call `click` and `emit` if `clickable`.', () => {
+      const event = {};
       component.clickable = true;
 
       spyOn(component.click, 'emit');
 
-      component.onClick();
+      component.onClick(event);
 
-      expect(component.click.emit).toHaveBeenCalled();
+      expect(component.click.emit).toHaveBeenCalledWith(event);
     });
 
     it('onClick: shouldn`t call `click` and `emit`.', () => {
+      const event = {};
       component.clickable = false;
 
       spyOn(component.click, 'emit');
 
-      component.onClick();
+      component.onClick(event);
 
       expect(component.click.emit).not.toHaveBeenCalled();
     });

--- a/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.ts
@@ -37,9 +37,9 @@ export class PoTableIconComponent {
     return !this.disabled && this.iconTooltip;
   }
 
-  onClick() {
+  onClick(event) {
     if (this.clickable) {
-      this.click.emit();
+      this.click.emit(event);
     }
   }
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -192,6 +192,7 @@
                 [p-link]="row[column.link]"
                 [p-row]="row"
                 [p-value]="row[column.property]"
+                (click)="onClickLink($event, row, column)"
               >
               </po-table-column-link>
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1467,6 +1467,46 @@ describe('PoTableComponent:', () => {
 
       expect(component.trackBy(index)).toBe(expectedValue);
     });
+
+    it('onClickLink: should call `stopPropagation` if link isn`t disabled', () => {
+      const fakeEvent = {
+        stopPropagation: () => {}
+      };
+      const tableRow = component.items[0];
+      const columnLink = {
+        property: 'extra',
+        label: 'Extras',
+        type: 'link',
+        action: () => {},
+        disabled: () => false
+      };
+
+      const spyStopPropagation = spyOn(fakeEvent, 'stopPropagation');
+
+      component.onClickLink(fakeEvent, tableRow, columnLink);
+
+      expect(spyStopPropagation).toHaveBeenCalled();
+    });
+
+    it('onClickLink: shouldn`t call `stopPropagation` if link is disabled', () => {
+      const fakeEvent = {
+        stopPropagation: () => {}
+      };
+      const tableRow = component.items[0];
+      const columnLink = {
+        property: 'extra',
+        label: 'Extras',
+        type: 'link',
+        action: () => {},
+        disabled: () => true
+      };
+
+      const spyStopPropagation = spyOn(fakeEvent, 'stopPropagation');
+
+      component.onClickLink(fakeEvent, tableRow, columnLink);
+
+      expect(spyStopPropagation).not.toHaveBeenCalled();
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -291,6 +291,12 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return true;
   }
 
+  onClickLink(event, row, column: PoTableColumn) {
+    if (!this.checkDisabled(row, column)) {
+      event.stopPropagation();
+    }
+  }
+
   onVisibleColumnsChange(columns: Array<PoTableColumn>) {
     this.columns = columns;
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.service.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.service.ts
@@ -23,7 +23,7 @@ export class SamplePoTableLabsService {
     return {
       text: `Text ${index}`,
       page: `Link ${index}`,
-      link: 'http://www.po-ui.com.br',
+      link: 'https://po-ui.io/',
       number: index,
       date: this.generateRandomDate(),
       time: this.generateRandomTime(),


### PR DESCRIPTION
**table**

**Fixes DTHFUI-2781**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
Ao usar uma coluna que permite uma ação (link, ícone) junto com a propriedade selected, ao executar uma ação a linha também era selecionada.

**Qual o novo comportamento?**
Se tiver a propriedade `selected` ativa e clicar sobre uma ação (link, ícone ou ações),  apenas a ação da coluna deve ser disparada, mantendo a seleção da linha inalterada. 
Exceções:
- ícones sem ação definida
- links com disabled habilitado. 
Para os casos acima a seleção de linha ainda é vigente.


**Simulação**
Validar nos samples do portal
