### PR TITLE
feat(page-dynamic-table): adiciona propriedade beforeNew na actions

### DIFF
--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -102,7 +102,7 @@ GET https://example.com.br/api/users/10
     country: "US",
     _messages: [{
       code: "INFO",
-      type: "information"
+      type: "information",
       message: "Esta é uma mensagem informativa",
       detailedMessage: "Mais detalhes sobre esta mensagem podem ser vistos aqui."
     }]

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
@@ -54,7 +54,7 @@ export interface PoPageDynamicTableActions {
   /**
    * @description
    *
-   * Rota criar um novo recurso, caso seja preenchida sera exibido uma ação no topo da página.
+   * Rota ou função para criar um novo recurso, caso seja preenchida sera exibido uma ação no topo da página.
    *
    * ```
    * actions = {
@@ -62,11 +62,57 @@ export interface PoPageDynamicTableActions {
    * };
    * ```
    */
-  new?: string;
+  new?: string | Function;
 
   /** Habilita a ação de exclusão na tabela. */
   remove?: boolean;
 
   /** Habilita a ação de exclusão em lote na página. */
   removeAll?: boolean;
+
+  /**
+   * @description
+   *
+   *  Método/URL que deve ser chamado antes da ação de inclusão
+   *  A URL será chamada via POST.
+   *
+   * Tanto a função como a API devem retornar um objeto com a seguinte definição:
+   *
+   * ```
+   *  newUrl: string com nova rota para inserção, deve substituir a função ou rota definida anteriormente,
+   *  allowAction: boolean que define se deve ou não executar a ação de inserção (new)
+   * ```
+   *
+   * ```
+   * // exemplo de retorno
+   * {
+   *  newUrl: '/other-new-route',
+   *  allowAction: true
+   * }
+   * ```
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeNew**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   *
+   */
+  beforeNew?: string | (() => PoPageDynamicTableBeforeNew);
+}
+
+/**
+ * @usedBy PoPageDynamicTableActions
+ *
+ * @description
+ *
+ * Interface para o retorno da função beforeNew
+ */
+export interface PoPageDynamicTableBeforeNew {
+  /**
+   * Nova rota para inserção, deve substituir a função ou rota definida anteriormente
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de inserção (new)
+   */
+  allowAction?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PoPageDynamicTableActionsService } from './po-page-dynamic-table-actions.service';
+
+describe('PoPageDynamicTableActionsService:', () => {
+  let service: PoPageDynamicTableActionsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PoPageDynamicTableActionsService]
+    });
+
+    service = TestBed.inject(PoPageDynamicTableActionsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service instanceof PoPageDynamicTableActionsService).toBeTruthy();
+  });
+
+  describe('Methods: ', () => {
+    describe('beforeNew:', () => {
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeNew('/teste/new').subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/teste/new');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({});
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = () => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+
+        service.beforeNew(testFn).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        tick();
+      }));
+
+      it('should not get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeNew(testFn).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
+  });
+});

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
@@ -1,0 +1,28 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import {
+  PoPageDynamicTableActions,
+  PoPageDynamicTableBeforeNew
+} from './interfaces/po-page-dynamic-table-actions.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PoPageDynamicTableActionsService {
+  readonly headers: HttpHeaders = new HttpHeaders({
+    'X-PO-SCREEN-LOCK': 'true'
+  });
+
+  constructor(private http: HttpClient) {}
+
+  beforeNew(action?: PoPageDynamicTableActions['beforeNew']): Observable<PoPageDynamicTableBeforeNew> {
+    if (action) {
+      if (typeof action === 'string') {
+        return this.http.post<PoPageDynamicTableBeforeNew>(action, {}, { headers: this.headers });
+      }
+      return of(action());
+    }
+    return of({});
+  }
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -164,9 +164,6 @@ describe('PoPageDynamicTableComponent:', () => {
         expect(component.breadcrumb).toEqual({
           items: [{ label: 'Test' }, { label: 'Test2' }]
         });
-
-        component['subscriptions'] = null;
-        component.ngOnDestroy();
       }));
 
       it('should configure properties based on the return of onload route', fakeAsync(() => {
@@ -537,15 +534,123 @@ describe('PoPageDynamicTableComponent:', () => {
       // expect(component['navigateTo']).toHaveBeenCalledWith({ path, url, component: PoPageDynamicEditComponent });
     });
 
-    it('openNew: should call `navigateTo` with object that contains path and component properties. ', () => {
-      const path = '/people/:id';
+    describe('openNew:', () => {
+      it('should call `navigateTo` with object that contains path and component properties. ', () => {
+        const path = '/people/:id';
 
-      spyOn(component, <any>'navigateTo');
+        const spyNavigate = spyOn(component, <any>'navigateTo');
 
-      component['openNew'](path);
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeNew').and.returnValue(of({}));
+        component['openNew'](path);
 
-      expect(component['navigateTo']).toHaveBeenCalledWith({ path });
-      // expect(component['navigateTo']).toHaveBeenCalledWith({ path, component: PoPageDynamicEditComponent });
+        expect(spyNavigate).toHaveBeenCalledWith({ path });
+      });
+
+      it('should call the function in the actions.new property ', () => {
+        const testObj = {
+          fn: () => {}
+        };
+
+        const spy = spyOn(testObj, 'fn');
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeNew').and.returnValue(of({}));
+        component['openNew'](testObj.fn);
+
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('should call `navigateTo` with a new url if actions.beforeNew is valid', () => {
+        const path = '/people/:id';
+        const newUrl = '/newUrl';
+
+        component.actions.beforeNew = '/test';
+
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeNew').and.returnValue(of({ newUrl }));
+        const spyNavigate = spyOn(component, <any>'navigateTo');
+
+        component['openNew'](path);
+
+        expect(spyNavigate).toHaveBeenCalledWith({ path: newUrl });
+      });
+
+      it('should not call `navigateTo` with a new url if allowAction is false', () => {
+        const path = '/people/:id';
+        const newUrl = '/newUrl';
+        const allowAction = false;
+
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeNew').and.returnValue(of({ allowAction, newUrl }));
+        const spyNavigate = spyOn(component, <any>'navigateTo');
+
+        component.actions.beforeNew = '/test';
+        component['openNew'](path);
+
+        expect(spyNavigate).not.toHaveBeenCalled();
+      });
+
+      it('should call `navigateTo` with a new url if allowAction is null', () => {
+        const path = '/people/:id';
+        const newUrl = '/newUrl';
+        const allowAction = null;
+
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeNew').and.returnValue(of({ allowAction, newUrl }));
+        const spyNavigate = spyOn(component, <any>'navigateTo');
+
+        component.actions.beforeNew = '/test';
+        component['openNew'](path);
+
+        expect(spyNavigate).toHaveBeenCalledWith({ path: newUrl });
+      });
+
+      it('should call `navigateTo` with a new url if allowAction is undefined', () => {
+        const path = '/people/:id';
+        const newUrl = '/newUrl';
+
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeNew').and.returnValue(of({ newUrl }));
+        const spyNavigate = spyOn(component, <any>'navigateTo');
+
+        component.actions.beforeNew = '/test';
+        component['openNew'](path);
+
+        expect(spyNavigate).toHaveBeenCalledWith({ path: newUrl });
+      });
+
+      it('should call `navigateTo` with a new url if beforeNew is null', () => {
+        const path = '/people/:id';
+
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeNew').and.returnValue(of(null));
+        const spyNavigate = spyOn(component, <any>'navigateTo');
+
+        component.actions.beforeNew = '/test';
+        component['openNew'](path);
+
+        expect(spyNavigate).toHaveBeenCalledWith({ path });
+      });
+
+      it('should call `navigateTo` with a new url if beforeNew is invalid', () => {
+        const path = '/people/:id';
+        const obj: any = { teste: 'test' };
+
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeNew').and.returnValue(of(obj));
+        const spyNavigate = spyOn(component, <any>'navigateTo');
+
+        component.actions.beforeNew = '/test';
+        component['openNew'](path);
+
+        expect(spyNavigate).toHaveBeenCalledWith({ path });
+      });
+
+      it('should call `navigateTo` with a new url if allowAction is number', () => {
+        const path = '/people/:id';
+        const newUrl = '/newUrl';
+        const allowAction: any = 0;
+
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeNew').and.returnValue(of({ allowAction, newUrl }));
+        const spyNavigate = spyOn(component, <any>'navigateTo');
+
+        component.actions.beforeNew = '/test';
+        component['openNew'](path);
+
+        expect(spyNavigate).toHaveBeenCalledWith({ path: newUrl });
+      });
     });
 
     it('remove: should call `poNotification.success` on `deleteResource` passing `uniqueKey`', fakeAsync(() => {


### PR DESCRIPTION
**page-dynamic-table**

**DTHFUI-2624**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Samples
- [x] Documentação

**Qual o comportamento atual?**
A ação new vai imediatamente para a rota indicada.

**Qual o novo comportamento?**
Adicionada propriedade beforeNew para que o desenvolvedor possa executar uma função antes da função de new.

**Simulação**
[Anexada aplicação simples] [projeto_dynamic_templates.zip](https://github.com/po-ui/po-angular/files/4581192/projeto_dynamic_templates.zip)


As realizadas foram:
-**new** com string
-**new** com func;

-**beforeNew** com string
-**beforeNew** com func
-**beforeNew** newURL undefined
-**beforeNew** com allowAction false

Pode subir a api com https://github.com/po-ui/po-sample-api/pull/12


