### PR TITLE
feat(page-dynamic-detail): adiciona action beforeBack

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-actions.interface.ts
@@ -11,6 +11,8 @@ export interface PoPageDynamicDetailActions {
    *
    * Rota de redirecionamento para ação de voltar, caso não seja especificada será usado o comando `history.back()`.
    *
+   * > Se passada uma função, é responsabilidade do desenvolvedor implementar a navegação ou outro comportamento desejado.
+   *
    * > Caso queira esconder a ação deve ser passado o valor `false`;
    *
    * ```
@@ -19,7 +21,34 @@ export interface PoPageDynamicDetailActions {
    * };
    * ```
    */
-  back?: string | boolean;
+  back?: string | boolean | Function;
+
+  /**
+   * @description
+   *
+   * Ação que é executada antes da ação `back` e que serve para realização de validações prévias.
+   * - **String**: será feita uma chamada via POST para requisição do recurso.
+   * - **Function**: função que deve ser executada;
+   *
+   * Tanto a função como a API devem retornar um objeto com a seguinte definição:
+   *
+   * ```
+   * - newUrl: string com a nova rota para navegação. Esta rota substituirá a função ou rota definida anteriormente na ação *back*,
+   * - allowAction: boolean que define se deve ou não executar a ação de voltar (*back*)
+   * ```
+   *
+   * Caso o desenvolvedor queira exibir alguma mensagem nessa ação, ele pode criá-la na função chamada pela beforeBack,
+   * ou então definir a mensagem na resposta da api através do atributo _message conforme definido em https://po-ui.io/guides/api#successMessages
+   *
+   * Exemplo de retorno
+   * ```
+   * {
+   *   newUrl: '/',
+   *   allowAction: true
+   * };
+   * ```
+   */
+  beforeBack?: string | (() => PoPageDynamicDetailBeforeBack);
 
   /**
    * @description
@@ -48,4 +77,23 @@ export interface PoPageDynamicDetailActions {
    * ```
    */
   remove?: string;
+}
+
+/**
+ * @usedBy PoPageDynamicDetailComponent
+ *
+ * @description
+ *
+ * Interface para o retorno da função beforeBack.
+ */
+export interface PoPageDynamicDetailBeforeBack {
+  /**
+   * Nova rota para navegação. Esta rota substitui a função ou rota definida anteriormente.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de voltar (*back*)
+   */
+  allowAction?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+
+import { PoPageDynamicDetailActionsService } from './po-page-dynamic-detail-actions.service';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+describe('PoPageDynamicDetailActionsService', () => {
+  let service: PoPageDynamicDetailActionsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PoPageDynamicDetailActionsService]
+    });
+
+    service = TestBed.inject(PoPageDynamicDetailActionsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service instanceof PoPageDynamicDetailActionsService).toBeTruthy();
+  });
+
+  describe('Methods', () => {
+    describe('BeforeBack', () => {
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeBack('/teste/back').subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/teste/back');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({});
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = () => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+
+        service.beforeBack(testFn).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        tick();
+      }));
+
+      it('should not get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeBack(testFn).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
+  });
+});

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.ts
@@ -1,0 +1,29 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+
+import {
+  PoPageDynamicDetailActions,
+  PoPageDynamicDetailBeforeBack
+} from './interfaces/po-page-dynamic-detail-actions.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PoPageDynamicDetailActionsService {
+  readonly headers: HttpHeaders = new HttpHeaders({
+    'X-PO-SCREEN-LOCK': 'true'
+  });
+
+  constructor(private http: HttpClient) {}
+
+  beforeBack(action?: PoPageDynamicDetailActions['beforeBack']): Observable<PoPageDynamicDetailBeforeBack> {
+    if (action) {
+      if (typeof action === 'string') {
+        return this.http.post(action, {}, { headers: this.headers });
+      }
+      return of(action());
+    }
+    return of({});
+  }
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
@@ -435,24 +435,131 @@ describe('PoPageDynamicDetailComponent:', () => {
       expect(component['poDialogService'].confirm).toHaveBeenCalled();
     });
 
-    it('goBack: should call `history.back` if the received param is a boolean type', () => {
-      spyOn(window.history, 'back');
-      spyOn(component['router'], <any>'navigate');
+    it('goBack: should call `executeBackAtion` passing `backPath` as param if beforeBack returns null', () => {
+      const backPath = '/list';
 
-      component['goBack'](true);
+      const spybeforeBack = spyOn(component['poPageDynamicDetailActionsService'], 'beforeBack').and.returnValue(
+        of(null)
+      );
+      const spyExecuteBackAction = spyOn(component, <any>'executeBackAction');
 
-      expect(window.history.back).toHaveBeenCalled();
-      expect(component['router'].navigate).not.toHaveBeenCalled();
+      component['goBack'](backPath);
+
+      expect(spybeforeBack).toHaveBeenCalled();
+      expect(spyExecuteBackAction).toHaveBeenCalledWith(backPath, undefined, undefined);
     });
 
-    it('goBack: should call `router.navigate` if the received param is a string type', () => {
-      spyOn(component['router'], <any>'navigate');
-      spyOn(window.history, 'back');
+    it('goBack: should call `executeBackAction` passing backPath, newUrl and allowAction values', () => {
+      const backPath = '/list';
+      const newUrl = '/newUrl';
+      const allowAction = false;
 
-      component['goBack']('/home');
+      const spybeforeBack = spyOn(component['poPageDynamicDetailActionsService'], 'beforeBack').and.returnValue(
+        of({ allowAction, newUrl })
+      );
+      const spyExecuteBackAction = spyOn(component, <any>'executeBackAction');
 
-      expect(component['router'].navigate).toHaveBeenCalled();
-      expect(window.history.back).not.toHaveBeenCalled();
+      component['goBack'](backPath);
+
+      expect(spybeforeBack).toHaveBeenCalled();
+      expect(spyExecuteBackAction).toHaveBeenCalledWith(backPath, allowAction, newUrl);
+    });
+
+    describe('executeBackAction', () => {
+      it('should call `history.back` if action.back is a boolean type', () => {
+        const backPath = true;
+
+        const spyHistoryBack = spyOn(window.history, 'back');
+
+        component['executeBackAction'](backPath);
+
+        expect(spyHistoryBack).toHaveBeenCalled();
+      });
+
+      it('should call `history.back` if action.back is undefined', () => {
+        const backPath = undefined;
+
+        const spyHistoryBack = spyOn(window.history, 'back');
+
+        component['executeBackAction'](backPath);
+
+        expect(spyHistoryBack).toHaveBeenCalled();
+      });
+
+      it('should call `router.navigate` if action.back is a string type', () => {
+        const backPath = '/list';
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+
+        component['executeBackAction'](backPath);
+
+        expect(spyNavigate).toHaveBeenCalledWith([backPath]);
+      });
+
+      it('should call the function of actions.new property', () => {
+        const backFn = {
+          fn: () => {}
+        };
+
+        const spyBackFn = spyOn(backFn, 'fn');
+
+        component['executeBackAction'](backFn.fn);
+
+        expect(spyBackFn).toHaveBeenCalled();
+      });
+
+      it('should call `router.navigate` passing `newUrl` value if allowAction is true', () => {
+        const backPath = '/list';
+        const newUrl = '/new-list';
+        const allowAction = true;
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+
+        component['executeBackAction'](backPath, allowAction, newUrl);
+
+        expect(spyNavigate).toHaveBeenCalledWith([newUrl]);
+      });
+
+      it('should call `router.navigate` passing `newUrl` value if allowAction is null', () => {
+        const backPath = '/list';
+        const newUrl = '/new-list';
+        const allowAction = null;
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+
+        component['executeBackAction'](backPath, allowAction, newUrl);
+
+        expect(spyNavigate).toHaveBeenCalledWith([newUrl]);
+      });
+
+      it('should call `router.navigate` passing `newUrl` value if allowAction is undefined', () => {
+        const backPath = '/list';
+        const newUrl = '/new-list';
+        const allowAction = undefined;
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+
+        component['executeBackAction'](backPath, allowAction, newUrl);
+
+        expect(spyNavigate).toHaveBeenCalledWith([newUrl]);
+      });
+
+      it('shouldn`t call any function if `allowAction` is false', () => {
+        const backFn = {
+          fn: () => {}
+        };
+        const allowAction = false;
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+        const spyHistoryBack = spyOn(window.history, 'back');
+        const spyBackFn = spyOn(backFn, 'fn');
+
+        component['executeBackAction'](backFn.fn, allowAction);
+
+        expect(spyNavigate).not.toHaveBeenCalled();
+        expect(spyHistoryBack).not.toHaveBeenCalled();
+        expect(spyBackFn).not.toHaveBeenCalled();
+      });
     });
 
     it('openEdit: should call `navigateTo` with object that contains path, url and component properties. ', () => {


### PR DESCRIPTION
**page-dynamic-detail**

**DTHFUI-2630**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A ação back retorna imediatamente para a rota indicada.

**Qual o novo comportamento?**
Adicionada propriedade beforeBack para que o desenvolvedor possa executar uma função antes da função de retorno (*back*).

**Simulação**
[Anexada aplicação simples](https://github.com/po-ui/po-angular/files/4580858/beforeBack.zip) para teste de funcionalidade. 


As realizadas foram:
-**back** com boolean;
-**back** com string
-**back** com func;
-**back** com undefined

-**beforeBack** com string
-**beforeBack** com func
-**beforeBack** newURL undefined
-**beforeBack** com allowAction false

Pode mockar a api com https://beeceptor.com/
