### PR TITLE
feat(page-dynamic-edit): implementa a propriedade beforeSave

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
@@ -3,5 +3,6 @@ export * from './interfaces/po-page-dynamic-edit-actions.interface';
 export * from './interfaces/po-page-dynamic-edit-field.interface';
 export * from './interfaces/po-page-dynamic-edit-metadata.interface';
 export * from './interfaces/po-page-dynamic-edit-options.interface';
+export * from './interfaces/po-page-dynamic-edit-before-save.interface';
 
 export * from './po-page-dynamic-edit.module';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
@@ -1,3 +1,5 @@
+import { PoPageDynamicEditBeforeSave } from './po-page-dynamic-edit-before-save.interface';
+
 /**
  * @usedBy PoPageDynamicEditComponent
  *
@@ -6,6 +8,17 @@
  * Interface para as ações do componente po-page-dynamic-edit.
  */
 export interface PoPageDynamicEditActions {
+  /**
+   * @description
+   *
+   * Rota ou método que será chamado antes de salvar um recurso (save).
+   *
+   * Tanto o método como a API receberão o recurso e devem retornar um objeto com a definição de `PoPageDynamicEditBeforeSave`.
+   *
+   * > A url será chamada via POST
+   */
+  beforeSave?: string | ((resource: any) => PoPageDynamicEditBeforeSave);
+
   /**
    * @description
    *
@@ -24,7 +37,9 @@ export interface PoPageDynamicEditActions {
   /**
    * @description
    *
-   * Rota de redirecionamento que será executada após a confirmação de gravação do registro.
+   * Rota de redirecionamento ou método para executar o envio dos dados ao servidor.
+   *
+   * A rota de redirecionamento será executada após a confirmação de gravação do registro.
    *
    * > A rota pode conter um parâmetro chamando id.
    *
@@ -33,8 +48,13 @@ export interface PoPageDynamicEditActions {
    *   save: 'detail/:id'
    * };
    * ```
+   *
+   * Se for passado um método:
+   *  - receberá como parâmetro na chamada do método o recurso, por exemplo: `{ email: 'example@email.com' }`.
+   *  - é responsabilidade do desenvolvedor implementar a navegação e/ou envio dos dados
+   * para o servidor ou outro comportamento desejado.
    */
-  save?: string;
+  save?: string | Function;
 
   /**
    * @description

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-before-save.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-before-save.interface.ts
@@ -1,0 +1,45 @@
+/**
+ * @usedBy PoPageDynamicEditComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeSave`.
+ */
+export interface PoPageDynamicEditBeforeSave {
+  /**
+   * Nova rota para salvar o recurso, que substituirá a rota definida anteriormente em `save`.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação salvar (save).
+   */
+  allowAction?: boolean;
+
+  /**
+   * Recurso atualizado.
+   *
+   * Será feito uma mesclagem entre os valores existentes e esse novo objeto.
+   * Por exemplo:
+   *
+   * - recurso anterior:
+   * ```
+   * { name: 'Ane' }
+   * ```
+   *
+   * - recurso retornado no `beforeSave`:
+   * ```
+   * { age: 23 }
+   * ```
+   *
+   * - Mesclagem do recurso:
+   * ```
+   * { name: 'Ane', age: 23 }
+   * ```
+   *
+   * > Caso `allowAction` seja `false`, o recurso será atualizado apenas localmente, sem concluir
+   * a ação de salvar (save).
+   */
+  resource?: any;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.spec.ts
@@ -1,0 +1,108 @@
+import { TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { PoPageDynamicEditActionsService } from './po-page-dynamic-edit-actions.service';
+
+describe('PoPageDynamicEditActions:', () => {
+  let service: PoPageDynamicEditActionsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PoPageDynamicEditActionsService]
+    });
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PoPageDynamicEditActionsService]
+    });
+
+    service = TestBed.inject(PoPageDynamicEditActionsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service instanceof PoPageDynamicEditActionsService).toBeTruthy();
+  });
+
+  describe('Methods: ', () => {
+    describe('beforeSave:', () => {
+      const resource = { name: 'Mario' };
+
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeSave('/newSave', resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/newSave');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = resourceTest => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeSave(spyObj.testFn, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(resource);
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function if resource is null', fakeAsync(() => {
+        const testFn = resourceTest => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeSave(spyObj.testFn, null).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith({});
+        });
+
+        tick();
+      }));
+
+      it('shouldn`t get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeSave(testFn, resource).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
+  });
+});

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { of, Observable } from 'rxjs';
+
+import { PoPageDynamicEditBeforeSave } from './interfaces/po-page-dynamic-edit-before-save.interface';
+import { PoPageDynamicEditActions } from './interfaces/po-page-dynamic-edit-actions.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PoPageDynamicEditActionsService {
+  readonly headers: HttpHeaders = new HttpHeaders({
+    'X-PO-SCREEN-LOCK': 'true'
+  });
+
+  constructor(private http: HttpClient) {}
+
+  beforeSave(path: PoPageDynamicEditActions['beforeSave'], resource: any): Observable<PoPageDynamicEditBeforeSave> {
+    const resourceToPost = resource ?? {};
+
+    if (!path) {
+      return of({});
+    }
+
+    if (typeof path === 'string') {
+      return this.http.post(path, resourceToPost, { headers: this.headers });
+    }
+
+    return of(path(resourceToPost));
+  }
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -14,6 +14,7 @@ import { configureTestSuite, expectPropertiesValues } from './../../util-test/ut
 import { PoPageDynamicEditComponent } from './po-page-dynamic-edit.component';
 import { PoPageDynamicEditActions } from './interfaces/po-page-dynamic-edit-actions.interface';
 import { PoDynamicFormStubComponent } from './test/po-dynamic-form-stub-component';
+import { PoPageDynamicEditBeforeSave } from './interfaces/po-page-dynamic-edit-before-save.interface';
 
 describe('PoPageDynamicEditComponent: ', () => {
   let component: PoPageDynamicEditComponent;
@@ -655,7 +656,133 @@ describe('PoPageDynamicEditComponent: ', () => {
       expect(component['poPageDynamicService'].updateResource).toHaveBeenCalledWith(id, model);
     }));
 
-    it('save: should call `poNotification.warning` and not call `updateResource` and `createResource` if `form.invalid` is true', () => {
+    it('save: shouldn`t call executeSave if allowAction is false', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: false };
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'updateModel');
+
+      component['save']('testSave/');
+
+      expect(component['executeSave']).not.toHaveBeenCalled();
+    });
+
+    it('save: shouldn`t call executeSave if newAction is a Function', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: true };
+      const newAction = jasmine.createSpy('newAction');
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'updateModel');
+
+      component['save'](newAction);
+
+      expect(component['executeSave']).not.toHaveBeenCalled();
+      expect(newAction).toHaveBeenCalledWith(component.model);
+    });
+
+    it('save: should call executeSave if allowAction is true', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: true };
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'updateModel');
+
+      component['save']('testSave/');
+
+      expect(component['executeSave']).toHaveBeenCalled();
+    });
+
+    it('save: should call executeSave if allowAction is undefined', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: undefined };
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'updateModel');
+
+      component['save']('testSave/');
+
+      expect(component['executeSave']).toHaveBeenCalled();
+    });
+
+    it('save: should call executeSave if allowAction is null', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: null };
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'updateModel');
+
+      component['save']('testSave/');
+
+      expect(component['executeSave']).toHaveBeenCalled();
+    });
+
+    it('save: should call executeSave with newUrl if it is defined', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = { newUrl: 'newUrl' };
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'updateModel');
+
+      component['save']('testSave/');
+
+      expect(component['executeSave']).toHaveBeenCalledWith('newUrl');
+    });
+
+    it('save: should call executeSave with saveAction if newUrl is undefined', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = { newUrl: undefined };
+      const saveAction = 'testSave/';
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'updateModel');
+
+      component['save'](saveAction);
+
+      expect(component['executeSave']).toHaveBeenCalledWith(saveAction);
+    });
+
+    it('save: should call executeSave with saveAction if newUrl is null', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = { newUrl: null };
+      const saveAction = 'testSave/';
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'updateModel');
+
+      component['save'](saveAction);
+
+      expect(component['executeSave']).toHaveBeenCalledWith(saveAction);
+    });
+
+    it('save: should call executeSave with saveAction if returnBeforeSave is undefined', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = undefined;
+      const saveAction = 'testSave/';
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'updateModel');
+
+      component['save'](saveAction);
+
+      expect(component['executeSave']).toHaveBeenCalledWith(saveAction);
+    });
+
+    it('save: should call updateModel before executeSave', () => {
+      const returnBeforeSave: PoPageDynamicEditBeforeSave = undefined;
+      const saveAction = 'testSave/';
+
+      spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
+      const executeSaveSpy = spyOn(component, <any>'executeSave');
+      const updateModelSpy = spyOn(component, <any>'updateModel');
+
+      component['save'](saveAction);
+
+      expect(updateModelSpy).toHaveBeenCalledBefore(executeSaveSpy);
+    });
+
+    it('executeSave: should call `poNotification.warning` and not call `updateResource` and `createResource` if `form.invalid` is true', () => {
       const path = '';
 
       component.dynamicForm = dynamicFormInvalid;
@@ -664,14 +791,53 @@ describe('PoPageDynamicEditComponent: ', () => {
       spyOn(component['poPageDynamicService'], 'createResource');
       spyOn(component['poNotification'], 'warning');
 
-      component['save'](path);
+      component['executeSave'](path);
 
       expect(component['poNotification'].warning).toHaveBeenCalledWith(component.literals.saveNotificationWarning);
       expect(component['poPageDynamicService'].updateResource).not.toHaveBeenCalled();
       expect(component['poPageDynamicService'].createResource).not.toHaveBeenCalled();
     });
 
-    it('save: should call `updateResource`, `poNotification.success` and `navigateTo` if `params.id` is truthy', fakeAsync(() => {
+    it('updateModel: should merge the properties', () => {
+      const newResource = { prop4: 'test 4', prop5: 'test 5' };
+      component.model = { prop1: 'test 1', prop2: 'test 2' };
+      const result = { prop1: 'test 1', prop2: 'test 2', prop4: 'test 4', prop5: 'test 5' };
+
+      component.dynamicForm = <any>{
+        form: {
+          form: {
+            patchValue: () => {}
+          }
+        }
+      };
+
+      component['updateModel'](newResource);
+
+      expect(component.model).toEqual(result);
+    });
+
+    it('updateModel: should keep model if newResource is undefined', () => {
+      const newResource = undefined;
+      component.model = { prop1: 'test 1', prop2: 'test 2' };
+      const result = { prop1: 'test 1', prop2: 'test 2' };
+
+      component.dynamicForm = <any>{
+        form: {
+          form: {
+            patchValue: () => {}
+          }
+        }
+      };
+
+      const patchValueSpy = spyOn(component.dynamicForm.form.form, 'patchValue');
+
+      component['updateModel'](newResource);
+
+      expect(component.model).toEqual(result);
+      expect(patchValueSpy).toHaveBeenCalled();
+    });
+
+    it('executeSave: should call `updateResource`, `poNotification.success` and `navigateTo` if `params.id` is truthy', fakeAsync(() => {
       const path = 'people/id';
       const id = '1';
       const model = { name: 'angular' };
@@ -693,7 +859,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       spyOn(component['poPageDynamicService'], 'createResource');
       spyOn(component['poNotification'], 'warning');
 
-      component['save'](path);
+      component['executeSave'](path);
 
       tick();
 
@@ -707,7 +873,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       expect(component['poPageDynamicService'].updateResource).toHaveBeenCalledWith(id, model);
     }));
 
-    it('save: should call `createResource`, `poNotification.success` and `navigateTo` if `params.id` is truthy', fakeAsync(() => {
+    it('executeSave: should call `createResource`, `poNotification.success` and `navigateTo` if `params.id` is truthy', fakeAsync(() => {
       const path = 'people/id';
       const id = undefined;
       const model = { name: 'angular' };
@@ -729,7 +895,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       spyOn(component['poPageDynamicService'], 'updateResource');
       spyOn(component['poNotification'], 'warning');
 
-      component['save'](path);
+      component['executeSave'](path);
 
       tick();
 


### PR DESCRIPTION
**page-dynamic-edit**

**DTHFUI-2628**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O usuário não conseguia fazer uma validação antes que a ação de salvar fosse realizada.

**Qual o novo comportamento?**
Adicionada propriedade beforeSave para que o desenvolvedor possa executar uma função antes da função de salvar (*save*).

**Simulação:**
Pode estar colocando este anexo no lugar da pasta app, e verificar as rotas para iniciar os testes
com a nova propriedade:
[app.zip](https://github.com/po-ui/po-angular/files/4594842/app.zip)
