### PR TITLE
feat(dynamic-search): permite manter os filtros de busca avançada e disclaimers com a ultima busca do usuário

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -762,29 +762,15 @@ describe('PoPageDynamicEditComponent: ', () => {
     describe('save:', () => {
       let executeSaveSpy;
       let updateModelSpy;
-
       beforeEach(() => {
         executeSaveSpy = spyOn(component, <any>'executeSave').and.returnValue(of({}));
         updateModelSpy = spyOn(component, <any>'updateModel');
       });
-
-      it('save: should call `resolveUniqueKey`', () => {
-        const resolveUniqueKeySpy = spyOn(component, <any>'resolveUniqueKey');
-        component.model = { name: 'Angular' };
-        component['save']('testSave/');
-        expect(resolveUniqueKeySpy).toHaveBeenCalledWith(component.model);
-      });
-
       it('shouldn`t call executeSave if allowAction is false', () => {
-        const newAction = jasmine.createSpy('newAction');
         const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: false };
-
-        component.model = { name: 'Angular' };
-        spyOn(component, <any>'resolveUniqueKey').and.returnValue('1');
         spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
-        component['save'](newAction);
+        component['save']('testSave/');
         expect(executeSaveSpy).not.toHaveBeenCalled();
-        expect(newAction).not.toHaveBeenCalledWith(component.model, '1');
       });
 
       it('shouldn`t call executeSave if newAction is a Function', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/index.ts
@@ -2,5 +2,6 @@ export * from './po-page-dynamic-search.component';
 export * from './po-page-dynamic-search.interface';
 export * from './po-page-dynamic-search-literals.interface';
 export * from './po-page-dynamic-search-options.interface';
+export * from './po-page-dynamic-search-filters.interface';
 
 export * from './po-page-dynamic-search.module';

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.ts
@@ -1,10 +1,17 @@
 import { EventEmitter, Input, Output, ViewChild, Directive } from '@angular/core';
 
-import { PoDynamicFormField, PoLanguageService, PoModalAction, PoModalComponent } from '@po-ui/ng-components';
+import {
+  InputBoolean,
+  PoDynamicFormField,
+  PoLanguageService,
+  PoModalAction,
+  PoModalComponent
+} from '@po-ui/ng-components';
 
 import { poLocaleDefault } from '../../../utils/util';
 
 import { PoAdvancedFilterLiterals } from './po-advanced-filter-literals.interface';
+import { PoPageDynamicSearchFilters } from '../po-page-dynamic-search-filters.interface';
 
 export const poAdvancedFiltersLiteralsDefault = {
   en: <PoAdvancedFilterLiterals>{
@@ -65,16 +72,23 @@ export class PoAdvancedFilterBaseComponent {
   };
 
   /**
-   * Coleção de objetos que implementam a interface PoDynamicFormField, para definição dos campos que serão criados
+   * Coleção de objetos que implementam a interface PoPageDynamicSearchFilters, para definição dos campos que serão criados
    * dinamicamente.
    */
-  @Input('p-filters') set filters(filters: Array<PoDynamicFormField>) {
+  @Input('p-filters') set filters(filters: Array<PoPageDynamicSearchFilters>) {
     this._filters = Array.isArray(filters) ? [...filters] : [];
   }
 
-  get filters() {
+  get filters(): Array<PoPageDynamicSearchFilters> {
     return this._filters;
   }
+
+  /**
+   * Mantém na modal de busca avançada os valores preenchidos do último filtro realizado pelo usuário.
+   */
+  @InputBoolean()
+  @Input('p-keep-filters')
+  keepFilters: boolean = false;
 
   /** Objeto com as literais usadas no `po-advanced-filter`. */
   @Input('p-literals') set literals(value: PoAdvancedFilterLiterals) {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.spec.ts
@@ -40,8 +40,9 @@ describe('PoAdvancedFilterComponent', () => {
   });
 
   describe('Methods:', () => {
-    it('open: should call `poModal.open` and set `filter` with {}', () => {
+    it('open: should call `poModal.open` and set `filter` with {} if `this.keepFilters` is false', () => {
       component.filter = filters;
+      component.keepFilters = false;
 
       spyOn(component.poModal, 'open');
 
@@ -49,6 +50,37 @@ describe('PoAdvancedFilterComponent', () => {
 
       expect(component.poModal.open).toHaveBeenCalled();
       expect(component.filter).toEqual({});
+    });
+
+    it(`open: should call 'poModal.open', call 'getInitialValuesFromFilters' and set 'filter' with
+    initial values if 'this.keepFilters' is true`, () => {
+      const expectedFilters = [{ property: 'city', initValue: 'Ontario' }];
+      const expectedFilter = { city: 'Ontario' };
+
+      spyOn(component.poModal, 'open');
+      spyOn(component, <any>'getInitialValuesFromFilter').and.returnValue(expectedFilter);
+
+      component.filter = filters;
+      component.filters = expectedFilters;
+      component.keepFilters = true;
+
+      component.open();
+
+      expect(component.poModal.open).toHaveBeenCalled();
+      expect(component['getInitialValuesFromFilter']).toHaveBeenCalledWith(expectedFilters);
+      expect(component.filter).toEqual(expectedFilter);
+    });
+
+    it(`getInitialValuesFromFilters: should return initial values from filter`, () => {
+      const expectedFilters = [{ property: 'city', initValue: 'Ontario' }];
+      const expectedFilter = { city: 'Ontario' };
+
+      component.filters = expectedFilters;
+      component.keepFilters = true;
+
+      const getInitialValues = component['getInitialValuesFromFilter'](component.filters);
+
+      expect(getInitialValues).toEqual(expectedFilter);
     });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.ts
@@ -3,6 +3,7 @@ import { Component, ViewChild } from '@angular/core';
 import { PoDynamicFormComponent, PoLanguageService } from '@po-ui/ng-components';
 
 import { PoAdvancedFilterBaseComponent } from './po-advanced-filter-base.component';
+import { PoPageDynamicSearchFilters } from '../po-page-dynamic-search-filters.interface';
 
 /**
  * @docsPrivate
@@ -28,7 +29,12 @@ export class PoAdvancedFilterComponent extends PoAdvancedFilterBaseComponent {
   }
 
   open() {
-    this.filter = {};
+    this.filter = this.keepFilters ? this.getInitialValuesFromFilter(this.filters) : {};
+
     this.poModal.open();
+  }
+
+  private getInitialValuesFromFilter(filters: Array<PoPageDynamicSearchFilters>) {
+    return filters.reduce((result, item) => Object.assign(result, { [item.property]: item.initValue }), {});
   }
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
@@ -8,6 +8,17 @@ import {
   PoPageDynamicSearchBaseComponent,
   poPageDynamicSearchLiteralsDefault
 } from './po-page-dynamic-search-base.component';
+import { PoPageDynamicSearchFilters } from './po-page-dynamic-search-filters.interface';
+import { PoPageAction, PoBreadcrumb } from '@po-ui/ng-components/lib';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'mock-component',
+  template: ''
+})
+class MockComponent extends PoPageDynamicSearchBaseComponent {
+  onChangeFilters(filters: Array<PoPageDynamicSearchFilters>) {}
+}
 
 describe('PoPageDynamicSearchBaseComponent:', () => {
   let component;
@@ -15,7 +26,7 @@ describe('PoPageDynamicSearchBaseComponent:', () => {
   const languageService = new PoLanguageService();
 
   beforeEach(() => {
-    component = new PoPageDynamicSearchBaseComponent(languageService);
+    component = new MockComponent(languageService);
   });
 
   it('should be created', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-filters.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-filters.interface.ts
@@ -1,0 +1,15 @@
+import { PoDynamicFormField } from '@po-ui/ng-components';
+
+/**
+ * @usedBy PoPageDynamicSearchComponent
+ *
+ * @description
+ *
+ * Interface para a customização de uma página dinâmica que permite atribuir valores iniciais aos filtros de busca avançada.
+ */
+export interface PoPageDynamicSearchFilters extends PoDynamicFormField {
+  /**
+   * Define um valor inicial para um filtro de busca avançada.
+   */
+  initValue?: any;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-options.interface.ts
@@ -1,4 +1,5 @@
-import { PoDynamicFormField, PoBreadcrumb, PoPageAction } from '@po-ui/ng-components';
+import { PoBreadcrumb, PoPageAction } from '@po-ui/ng-components';
+import { PoPageDynamicSearchFilters } from './po-page-dynamic-search-filters.interface';
 
 /**
  * @usedBy PoPageDynamicSearchComponent
@@ -13,7 +14,7 @@ export interface PoPageDynamicSearchOptions {
    *
    * Caso precise alterar um filtro que já exista deve ser passado o atributo `property` com o mesmo conteúdo do original.
    */
-  filters?: Array<PoDynamicFormField>;
+  filters?: Array<PoPageDynamicSearchFilters>;
 
   /**
    * Lista de ações que o usuário poderá executar na página através de botões.
@@ -35,4 +36,11 @@ export interface PoPageDynamicSearchOptions {
    * Caso esse atributo seja utilizado ele sempre irá substituir o original.
    */
   title?: string;
+
+  /**
+   * Mantém na modal de busca avançada os valores preenchidos do último filtro realizado pelo usuário.
+   *
+   * Caso esse atributo seja utilizado ele sempre irá substituir o original.
+   */
+  keepFilters?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.html
@@ -7,6 +7,7 @@
 >
   <po-advanced-filter
     [p-filters]="filters"
+    [p-keep-filters]="keepFilters"
     [p-literals]="advancedFilterLiterals"
     (p-search-event)="onAdvancedSearch($event)"
   >

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -16,6 +16,7 @@ import { PoAdvancedFilterComponent } from './po-advanced-filter/po-advanced-filt
 import { PoPageDynamicSearchBaseComponent } from './po-page-dynamic-search-base.component';
 import { PoPageDynamicSearchOptions } from './po-page-dynamic-search-options.interface';
 import { PoPageDynamicOptionsSchema } from '../../services';
+import { PoPageDynamicSearchFilters } from './po-page-dynamic-search-filters.interface';
 
 type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicSearchOptions);
 
@@ -54,10 +55,6 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
     ngModel: 'quickFilter',
     placeholder: this.literals.searchPlaceholder
   };
-
-  // Flag to control when changeDisclaimerGroup should be called
-  private changeDisclaimersEnabled: boolean = false;
-
   private quickFilter;
 
   @ViewChild(PoAdvancedFilterComponent, { static: true }) poAdvancedFilter: PoAdvancedFilterComponent;
@@ -93,14 +90,29 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
     }
   }
 
+  onChangeFilters(filters: Array<PoPageDynamicSearchFilters>) {
+    const filterObjectWithValue = filters
+      .filter(filter => filter.initValue)
+      .reduce((prev, current) => {
+        return { ...prev, ...{ [current.property]: current.initValue } };
+      }, {});
+
+    if (Object.keys(filterObjectWithValue).length) {
+      this.onAdvancedSearch(filterObjectWithValue);
+    }
+  }
+
   onAction() {
-    this.changeDisclaimersEnabled = false;
     this._disclaimerGroup.disclaimers = [
       { property: 'search', label: `${this.literals.quickSearchLabel} ${this.quickFilter}`, value: this.quickFilter }
     ];
 
     if (this.quickSearch.observers && this.quickSearch.observers.length > 0) {
       this.quickSearch.emit(this.quickFilter);
+    }
+
+    if (this.keepFilters) {
+      this.filters.forEach(element => delete element.initValue);
     }
 
     this.quickFilter = undefined;
@@ -113,19 +125,40 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
   }
 
   onAdvancedSearch(filters) {
-    this.changeDisclaimersEnabled = false;
     this._disclaimerGroup.disclaimers = this.setDisclaimers(filters);
 
+    this.setFilters(filters);
+
     this.advancedSearch.emit(filters);
+  }
+
+  private setFilters(filters) {
+    const formattedFilters = this.convertToFilters(filters);
+
+    this.filters.forEach(element => {
+      const compatibleObject = formattedFilters.find(item => item.property === element.property);
+
+      if (compatibleObject) {
+        element.initValue = compatibleObject.value;
+      } else {
+        delete element.initValue;
+      }
+    });
+  }
+
+  private convertToFilters(filters) {
+    return Object.entries(filters).map(([property, value]) => ({ property, value }));
   }
 
   private applyDisclaimerLabelValue(field: any, filterValue: any) {
     const values = Array.isArray(filterValue) ? filterValue : [filterValue];
 
     const labels = values.map(value => {
-      const filteredField = field.options.find(option => option.value === value);
+      const filteredField = field.options.find(option => option.value === value || option === value);
 
-      return filteredField.label || filteredField.value;
+      if (filteredField) {
+        return filteredField.label || filteredField.value || filteredField;
+      }
     });
 
     return labels.join(', ');
@@ -139,6 +172,21 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
     return new Date(year, month - 1, day).toLocaleDateString(getBrowserLanguage());
   }
 
+  private formatsFilterValuesToUpdateDisclaimers(filters) {
+    const formattedFilters = filters.reduce(
+      (result, item) => Object.assign(result, { [item.property]: item.value || item.initValue }),
+      {}
+    );
+
+    Object.keys(formattedFilters).forEach(key => {
+      if (!formattedFilters[key]) {
+        delete formattedFilters[key];
+      }
+    });
+
+    return formattedFilters;
+  }
+
   private getFieldByProperty(fields: Array<PoDynamicFormField>, fieldName: string) {
     return fields.find((field: PoDynamicFormField) => field.property === fieldName);
   }
@@ -148,7 +196,7 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
       return this.formatDate(value);
     }
 
-    if (field.options) {
+    if (field.options && value) {
       return this.applyDisclaimerLabelValue(field, value);
     }
 
@@ -156,7 +204,21 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
   }
 
   private onChangeDisclaimerGroup(disclaimers) {
-    this.changeDisclaimersEnabled ? this.changeDisclaimers.emit(disclaimers) : (this.changeDisclaimersEnabled = true);
+    if ((!this.disclaimersEqualsFilters(disclaimers) && !this.isQuickSearch(disclaimers)) || disclaimers.length === 0) {
+      this.changeDisclaimers.emit(disclaimers);
+      this.setFilters(this.formatsFilterValuesToUpdateDisclaimers(disclaimers));
+    }
+  }
+
+  private disclaimersEqualsFilters(disclaimers) {
+    const formattedDisclaimers = this.formatsFilterValuesToUpdateDisclaimers(disclaimers);
+    const formattedFilters = this.formatsFilterValuesToUpdateDisclaimers(this.filters);
+
+    return JSON.stringify(formattedDisclaimers) === JSON.stringify(formattedFilters);
+  }
+
+  private isQuickSearch(disclaimers) {
+    return disclaimers.length > 0 && disclaimers.find(element => element.property === 'search');
   }
 
   private setDisclaimers(filters) {
@@ -168,11 +230,15 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
       const label = field.label || capitalizeFirstLetter(field.property);
       const value = filters[property];
 
-      disclaimers.push({
-        label: `${label}: ${this.getFilterValueToDisclaimer(field, value)}`,
-        property,
-        value
-      });
+      const valueDisplayedOnTheDisclaimerLabel = this.getFilterValueToDisclaimer(field, value);
+
+      if (valueDisplayedOnTheDisclaimerLabel !== '') {
+        disclaimers.push({
+          label: `${label}: ${valueDisplayedOnTheDisclaimerLabel}`,
+          property,
+          value
+        });
+      }
     });
 
     return disclaimers;
@@ -189,7 +255,8 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
       title: this.title,
       actions: this.actions,
       breadcrumb: this.breadcrumb,
-      filters: this.filters
+      filters: this.filters,
+      keepFilters: this.keepFilters
     };
 
     const pageOptionSchema: PoPageDynamicOptionsSchema<PoPageDynamicSearchOptions> = {
@@ -209,6 +276,9 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
         },
         {
           nameProp: 'title'
+        },
+        {
+          nameProp: 'keepFilters'
         }
       ]
     };

--- a/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
@@ -1,14 +1,15 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { PoPageDynamicSearchLiterals } from '@po-ui/ng-templates';
+import { PoPageDynamicSearchLiterals, PoPageDynamicSearchFilters } from '@po-ui/ng-templates';
 
 import {
   PoBreadcrumb,
   PoPageAction,
   PoDialogService,
   PoNotificationService,
-  PoTableColumn
+  PoTableColumn,
+  PoSelectOption
 } from '@po-ui/ng-components';
 
 import { SamplePoPageDynamicSearchHiringProcessesService } from './sample-po-page-dynamic-search-hiring-processes.service';
@@ -22,8 +23,8 @@ export class SamplePoPageDynamicSearchHiringProcessesComponent implements OnInit
   hiringProcesses: Array<object>;
   hiringProcessesColumns: Array<PoTableColumn>;
 
-  private jobDescriptionOptions: Array<object>;
-  private statusOptions: Array<object>;
+  private jobDescriptionOptions: Array<PoSelectOption>;
+  private statusOptions: Array<PoSelectOption>;
 
   public readonly actions: Array<PoPageAction> = [
     { label: 'Hire', action: this.hireCandidate.bind(this), disabled: this.disableHireButton.bind(this) }
@@ -33,7 +34,7 @@ export class SamplePoPageDynamicSearchHiringProcessesComponent implements OnInit
     items: [{ label: 'Home', action: this.beforeRedirect.bind(this) }, { label: 'Hiring processes' }]
   };
 
-  public readonly filters: Array<any> = [
+  public readonly filters: Array<PoPageDynamicSearchFilters> = [
     { property: 'hireStatus', label: 'Hire Status', options: this.statusOptions, gridColumns: 6 },
     { property: 'name', gridColumns: 6 },
     { property: 'city', gridColumns: 6 },

--- a/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.service.ts
@@ -140,7 +140,11 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
   getPageOptions() {
     return {
       actions: [{ label: 'Find on Google' }],
-      filters: [{ property: 'idCard', gridColumns: 6 }]
+      filters: [
+        { property: 'idCard', gridColumns: 6 },
+        { property: 'city', initValue: 'Ontario' }
+      ],
+      keepFilters: true
     };
   }
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
@@ -6,5 +6,6 @@ export * from './interfaces/po-page-dynamic-table-before-detail.interface';
 export * from './interfaces/po-page-dynamic-table-field.interface';
 export * from './interfaces/po-page-dynamic-table-options.interface';
 export * from './interfaces/po-page-dynamic-table-metadata.interface';
+export * from './interfaces/po-page-dynamic-table-filters.interface';
 
 export * from './po-page-dynamic-table.module';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-filters.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-filters.interface.ts
@@ -1,0 +1,15 @@
+import { PoPageDynamicTableField } from '../../..';
+
+/**
+ * @usedBy PoPageDynamicTableComponent
+ *
+ * @description
+ *
+ * Interface para a customização de uma página dinâmica que permite atribuir valores iniciais aos filtros de busca avançada.
+ */
+export interface PoPageDynamicTableFilters extends PoPageDynamicTableField {
+  /**
+   * Define um Valor inicial para um filtro de busca avançada.
+   */
+  initValue?: any;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
@@ -1,7 +1,7 @@
 import { PoBreadcrumb } from '@po-ui/ng-components';
 
-import { PoPageDynamicTableField } from './po-page-dynamic-table-field.interface';
 import { PoPageDynamicTableActions } from './po-page-dynamic-table-actions.interface';
+import { PoPageDynamicTableFilters } from './po-page-dynamic-table-filters.interface';
 
 /**
  * @usedBy PoPageDynamicTableComponent
@@ -16,7 +16,7 @@ export interface PoPageDynamicTableOptions {
    *
    * Caso precise alterar um field que já exista deve ser passado o atributo `property` com o mesmo conteúdo do original.
    */
-  fields?: Array<PoPageDynamicTableField>;
+  fields?: Array<PoPageDynamicTableFilters>;
 
   /**
    * Ações que o usuário poderá executar na página através de botões.
@@ -36,4 +36,11 @@ export interface PoPageDynamicTableOptions {
    * Caso esse atributo seja utilizado ele sempre irá substituir o original.
    */
   title?: string;
+
+  /**
+   * Mantém na modal de Busca Avançada os valores preenchidos do último filtro realizado pelo usuário.
+   *
+   * Caso esse atributo seja utilizado ele sempre irá substituir o original.
+   */
+  keepFilters?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
@@ -4,7 +4,7 @@ import { PoBreadcrumb } from '@po-ui/ng-components';
 
 import { convertToBoolean } from '../../utils/util';
 
-import { PoPageDynamicTableField } from './interfaces/po-page-dynamic-table-field.interface';
+import { PoPageDynamicTableFilters } from './interfaces/po-page-dynamic-table-filters.interface';
 
 @Directive()
 export class PoPageDynamicListBaseComponent {
@@ -49,13 +49,13 @@ export class PoPageDynamicListBaseComponent {
    *
    * > Caso não seja definido fields a tabela assumirá o comportamento padrão.
    */
-  @Input('p-fields') set fields(fields: Array<PoPageDynamicTableField>) {
+  @Input('p-fields') set fields(fields: Array<PoPageDynamicTableFilters>) {
     this._fields = Array.isArray(fields) ? [...fields] : [];
 
     this.setFieldsProperties(this.fields);
   }
 
-  get fields(): Array<PoPageDynamicTableField> {
+  get fields(): Array<PoPageDynamicTableFilters> {
     return this._fields;
   }
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -2,6 +2,7 @@
   [p-actions]="pageActions"
   [p-breadcrumb]="breadcrumb"
   [p-filters]="filters"
+  [p-keep-filters]="keepFilters"
   [p-title]="title"
   (p-advanced-search)="onAdvancedSearch($event)"
   (p-change-disclaimers)="onChangeDisclaimers($event)"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -145,7 +145,8 @@ describe('PoPageDynamicTableComponent:', () => {
               detail: '/new_datail',
               new: '/new'
             },
-            fields: [{ property: 'filter1' }, { property: 'filter3' }]
+            fields: [{ property: 'filter1' }, { property: 'filter3' }],
+            keepFilters: true
           };
         };
 
@@ -165,6 +166,10 @@ describe('PoPageDynamicTableComponent:', () => {
         expect(component.breadcrumb).toEqual({
           items: [{ label: 'Test' }, { label: 'Test2' }]
         });
+        expect(component.keepFilters).toBeTrue();
+
+        component.ngOnDestroy();
+        expect(component['subscriptions']['_subscriptions']).toBeNull();
       }));
 
       it('should configure properties based on the return of onload route', fakeAsync(() => {
@@ -220,6 +225,20 @@ describe('PoPageDynamicTableComponent:', () => {
 
       expect(component['loadData']).toHaveBeenCalled();
       expect(component['params']).toBe(filter);
+    });
+
+    it('onAdvancedSearch: should call `updateFilterValue` with filter if `keepFilters` is true', () => {
+      const filter = 'filterValue';
+      component.keepFilters = true;
+
+      spyOn(component, <any>'loadData').and.returnValue(EMPTY);
+      spyOn(component, <any>'updateFilterValue');
+
+      component.onAdvancedSearch(filter);
+
+      expect(component['loadData']).toHaveBeenCalled();
+      expect(component['params']).toBe(filter);
+      expect(component['updateFilterValue']).toHaveBeenCalledWith(filter);
     });
 
     it('onChangeDisclaimers: should call `onAdvancedSearch` with filter', () => {
@@ -418,6 +437,20 @@ describe('PoPageDynamicTableComponent:', () => {
         expect(component.title).toEqual('Titulo Original');
       }));
 
+      it(`shouldn't call 'loadData' if 'initialFilters'`, () => {
+        const fakeMetadata = { subscribe: () => 'metadata' };
+        const fakeLoadData = { subscribe: () => 'data' };
+        const spyMetaData = spyOn(fakeMetadata, 'subscribe');
+        const spyLoadData = spyOn(fakeLoadData, 'subscribe');
+        spyOn(component, <any>'getInitialValuesFromFilter').and.returnValue({ name: 'teste' });
+        spyOn(component, <any>'loadData').and.returnValue(fakeLoadData);
+        spyOn(component, <any>'getMetadata').and.returnValue(fakeMetadata);
+
+        component['loadDataFromAPI']();
+        expect(spyMetaData).toHaveBeenCalled();
+        expect(spyLoadData).not.toHaveBeenCalled();
+      });
+
       it('should call `getMetadata` and mantain properties when response is empty', fakeAsync(() => {
         const activatedRoute: any = {
           snapshot: {
@@ -442,6 +475,29 @@ describe('PoPageDynamicTableComponent:', () => {
         expect(component.autoRouter).toEqual(true);
         expect(component.title).toEqual('Test');
       }));
+    });
+
+    describe('getInitialValuesFromFilter', () => {
+      it('should return formatted init values from filters', () => {
+        const filters = { name: 'teste' };
+        component.fields = [{ property: 'name', filter: true, initValue: 'teste' }, { property: 'city' }];
+
+        const returnedValue = component['getInitialValuesFromFilter']();
+
+        expect(returnedValue).toEqual(filters);
+      });
+
+      it('should delete empty props', () => {
+        const filters = { name: 'teste' };
+        component.fields = [
+          { property: 'name', filter: true, initValue: 'teste' },
+          { property: 'city', filter: true, initValue: undefined }
+        ];
+
+        const returnedValue = component['getInitialValuesFromFilter']();
+
+        expect(returnedValue).toEqual(filters);
+      });
     });
 
     it('navigateTo: shouldn`t call `router.config.unshift` and `navigateTo` only one time if `autoRouter` is false', fakeAsync(() => {
@@ -1215,6 +1271,36 @@ describe('PoPageDynamicTableComponent:', () => {
       component.onSort(sortedColumn);
 
       expect(component['sortedColumn']).toEqual(expectedValue);
+    });
+
+    it('onAdvancedSearch: should call `updateFilterValue` with filter if `keepFilters` is true', () => {
+      const filter = 'filterValue';
+      component.keepFilters = true;
+
+      spyOn(component, <any>'loadData').and.returnValue(EMPTY);
+      spyOn(component, <any>'updateFilterValue');
+
+      component.onAdvancedSearch(filter);
+
+      expect(component['loadData']).toHaveBeenCalled();
+      expect(component['params']).toBe(filter);
+      expect(component['updateFilterValue']).toHaveBeenCalledWith(filter);
+    });
+
+    it('updateFilterValue: ', () => {
+      component.fields = [
+        { property: 'name', label: 'Name', filter: true, gridColumns: 6 },
+        { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true }
+      ];
+      const expectedFields = [
+        { property: 'name', label: 'Name', filter: true, gridColumns: 6, initValue: 'Test' },
+        { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true }
+      ];
+      const filter = { name: 'Test' };
+
+      component['updateFilterValue'](filter);
+
+      expect(component.fields).toEqual(expectedFields);
     });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -1,5 +1,6 @@
 <po-page-dynamic-table
   p-auto-router
+  p-keep-filters
   p-title="Users"
   [p-actions]="actions"
   [p-breadcrumb]="breadcrumb"

--- a/projects/templates/src/lib/services/po-page-customization/po-page-customization.service.ts
+++ b/projects/templates/src/lib/services/po-page-customization/po-page-customization.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 
 import { Observable, from } from 'rxjs';
 import { map } from 'rxjs/operators';
+
 import { PoPageDynamicOptionsSchema, PoPageDynamicOptionsProp } from './po-page-dynamic-options.interface';
 
 type urlOrFunction = string | Function;
@@ -26,16 +27,16 @@ export class PoPageCustomizationService {
   changeOriginalOptionsToNewOptions<T, K>(objectToChange: T, newOptions: K) {
     Object.keys(newOptions).forEach(key => {
       const value = newOptions[key];
-      if (objectToChange[key]) {
+      if (objectToChange[key] !== undefined) {
         if (Array.isArray(value)) {
           objectToChange[key] = [...value];
           return;
         }
-        if (typeof value === 'number' || typeof value === 'string') {
+        if (typeof value === 'number' || typeof value === 'string' || typeof value === 'boolean') {
           objectToChange[key] = value;
           return;
         }
-        if (typeof value === 'object') {
+        if (value !== null && typeof value === 'object') {
           objectToChange[key] = { ...value };
         }
       }
@@ -58,7 +59,7 @@ export class PoPageCustomizationService {
       {} as T
     );
 
-    Object.keys(mergePageOptions).forEach(key => !mergePageOptions[key] && delete mergePageOptions[key]);
+    Object.keys(mergePageOptions).forEach(key => mergePageOptions[key] === undefined && delete mergePageOptions[key]);
 
     return mergePageOptions;
   }
@@ -67,7 +68,7 @@ export class PoPageCustomizationService {
     if (prop.merge) {
       return this.mergeOptions(originalOption[prop.nameProp], newPageOptions[prop.nameProp], prop.keyForMerge);
     } else {
-      return newPageOptions[prop.nameProp] || originalOption[prop.nameProp];
+      return newPageOptions[prop.nameProp] ?? originalOption[prop.nameProp];
     }
   }
 

--- a/projects/ui/src/lib/index.ts
+++ b/projects/ui/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from './po.module';
 
 export * from './components/index';
+export * from './decorators/index';
 export * from './directives/index';
 export * from './guards/index';
 export * from './interceptors/index';


### PR DESCRIPTION
**PO-PAGE-DYNAMIC-SEARCH E PO-PAGE-DYNAMIC-TABLE**

**DTHFUI-1285**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Não é possível abrir os componente com algum filtro aplicado e refletindo tanto nos disclaimers quanto nos valores da modal de busca avançada.

**Qual o novo comportamento?**
- Criada nova propriedade `p-keep-filters` que permite manter na modal de busca avançada os valores do último filtro realizado pelo usuário.
- Criada nova propriedade `initValue` para os `filters` (po-page-dynamic-search) e para os `fields` (po-page-dynamic-table) que permite inicializar o filtro de busca avançada do componente com um valor inicial.
- Novo comportamento possibilita também ativar ou desativar a propriedade `p-keep-filters` através da propriedade `p-load` e que por sua vez também permite o funcionamento na configuração via rota.

**Simulação**
po-page-dynamic-search
- Sample Hiring Processes - verificar o funcionamento do filtro buscando da API e também é possível verificar a alteração da propriedade `p-keep-filters` e `initValue` que é alterada na funcionalidade da propriedade `p-load`.

po-page-dynamic-table
- Sample Users - Testar também a funcionalidade da propriedade `p-keep-filters`, porém este sample está com problema na API portanto sempre traz todos os dados independente do filtro caso queira verificar que os filtros estão sendo enviados via parâmetros nas urls de chamada da API.
- Testar também via rota. Para o teste será necessário subir uma aplicação backend e criar um endpoint para o `p-load` via metadata. Pode ser usado o back-end de testes: [app-demo-portinari-api](https://github.com/jhosefmarks/app-demo-portinari-api), mas será necessário criar um novo endpoint `/load-metadata` alterando o valor de retorno para simular a alteração na propriedade `p-keep-filters` e incluir em algum field a propriedade `initValue` para testar a funcionalidade por completo.

**Obs:** caso seja feita uma busca rápida a modal de filtro de busca avançada não deverá trazer nenhum valor preenchido. 