### PR TITLE
docs(): destaque das interfaces beforeNew e beforeBack

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/index.ts
@@ -1,5 +1,6 @@
 export * from './po-page-dynamic-detail.component';
 export * from './interfaces/po-page-dynamic-detail-actions.interface';
+export * from './interfaces/po-page-dynamic-detail-before-back.interface';
 export * from './interfaces/po-page-dynamic-detail-field.interface';
 export * from './interfaces/po-page-dynamic-detail-metadata.interface';
 export * from './interfaces/po-page-dynamic-detail-options.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-actions.interface.ts
@@ -1,3 +1,5 @@
+import { PoPageDynamicDetailBeforeBack } from './po-page-dynamic-detail-before-back.interface';
+
 /**
  * @usedBy PoPageDynamicDetailComponent
  *
@@ -27,26 +29,15 @@ export interface PoPageDynamicDetailActions {
    * @description
    *
    * Ação que é executada antes da ação `back` e que serve para realização de validações prévias.
-   * - **String**: será feita uma chamada via POST para requisição do recurso.
-   * - **Function**: função que deve ser executada;
    *
-   * Tanto a função como a API devem retornar um objeto com a seguinte definição:
+   * Tanto o método como a API devem retornar um objeto com a definição de `PoPageDynamicDetailBeforeBack`.
    *
-   * ```
-   * - newUrl: string com a nova rota para navegação. Esta rota substituirá a função ou rota definida anteriormente na ação *back*,
-   * - allowAction: boolean que define se deve ou não executar a ação de voltar (*back*)
-   * ```
+   * > A url será chamada via POST
    *
-   * Caso o desenvolvedor queira exibir alguma mensagem nessa ação, ele pode criá-la na função chamada pela beforeBack,
-   * ou então definir a mensagem na resposta da api através do atributo _message conforme definido em https://po-ui.io/guides/api#successMessages
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeBack**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
    *
-   * Exemplo de retorno
-   * ```
-   * {
-   *   newUrl: '/',
-   *   allowAction: true
-   * };
-   * ```
    */
   beforeBack?: string | (() => PoPageDynamicDetailBeforeBack);
 
@@ -77,23 +68,4 @@ export interface PoPageDynamicDetailActions {
    * ```
    */
   remove?: string;
-}
-
-/**
- * @usedBy PoPageDynamicDetailComponent
- *
- * @description
- *
- * Interface para o retorno da função beforeBack.
- */
-export interface PoPageDynamicDetailBeforeBack {
-  /**
-   * Nova rota para navegação. Esta rota substitui a função ou rota definida anteriormente.
-   */
-  newUrl?: string;
-
-  /**
-   * Define se deve ou não executar a ação de voltar (*back*)
-   */
-  allowAction?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-before-back.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-before-back.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * @usedBy PoPageDynamicDetailComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeBack`.
+ */
+export interface PoPageDynamicDetailBeforeBack {
+  /**
+   * Nova rota para salvar o recurso, que substituirá a rota definida anteriormente em `back`.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de inserção (*back*)
+   */
+  allowAction?: boolean;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.ts
@@ -2,10 +2,8 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 
-import {
-  PoPageDynamicDetailActions,
-  PoPageDynamicDetailBeforeBack
-} from './interfaces/po-page-dynamic-detail-actions.interface';
+import { PoPageDynamicDetailActions } from './interfaces/po-page-dynamic-detail-actions.interface';
+import { PoPageDynamicDetailBeforeBack } from './interfaces/po-page-dynamic-detail-before-back.interface';
 
 @Injectable({
   providedIn: 'root'

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
@@ -13,10 +13,7 @@ import {
   PoNotificationService
 } from '@po-ui/ng-components';
 
-import {
-  PoPageDynamicDetailActions,
-  PoPageDynamicDetailBeforeBack
-} from './interfaces/po-page-dynamic-detail-actions.interface';
+import { PoPageDynamicDetailActions } from './interfaces/po-page-dynamic-detail-actions.interface';
 import { PoPageDynamicDetailField } from './interfaces/po-page-dynamic-detail-field.interface';
 import { PoPageDynamicService } from '../../services/po-page-dynamic/po-page-dynamic.service';
 import { PoPageDynamicDetailActionsService } from './po-page-dynamic-detail-actions.service';
@@ -24,6 +21,7 @@ import { PoPageDynamicDetailOptions } from './interfaces/po-page-dynamic-detail-
 import { PoPageCustomizationService } from './../../services/po-page-customization/po-page-customization.service';
 import { PoPageDynamicOptionsSchema } from './../../services/po-page-customization/po-page-dynamic-options.interface';
 import { PoPageDynamicDetailMetaData } from './interfaces/po-page-dynamic-detail-metadata.interface';
+import { PoPageDynamicDetailBeforeBack } from './interfaces/po-page-dynamic-detail-before-back.interface';
 
 type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicDetailOptions);
 

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
@@ -1,6 +1,7 @@
 export * from './po-page-dynamic-edit.component';
 export * from './interfaces/po-page-dynamic-edit-actions.interface';
 export * from './interfaces/po-page-dynamic-edit-field.interface';
+export * from './interfaces/po-page-dynamic-edit-before-save.interface';
 export * from './interfaces/po-page-dynamic-edit-metadata.interface';
 export * from './interfaces/po-page-dynamic-edit-options.interface';
 export * from './interfaces/po-page-dynamic-edit-before-save.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
@@ -16,6 +16,11 @@ export interface PoPageDynamicEditActions {
    * Tanto o método como a API receberão o recurso e devem retornar um objeto com a definição de `PoPageDynamicEditBeforeSave`.
    *
    * > A url será chamada via POST
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeSave**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   *
    */
   beforeSave?: string | ((resource: any) => PoPageDynamicEditBeforeSave);
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
@@ -1,5 +1,6 @@
 export * from './po-page-dynamic-table.component';
 export * from './interfaces/po-page-dynamic-table-actions.interface';
+export * from './interfaces/po-page-dynamic-table-before-new.interface';
 export * from './interfaces/po-page-dynamic-table-field.interface';
 export * from './interfaces/po-page-dynamic-table-options.interface';
 export * from './interfaces/po-page-dynamic-table-metadata.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
@@ -1,3 +1,5 @@
+import { PoPageDynamicTableBeforeNew } from './po-page-dynamic-table-before-new.interface';
+
 /**
  * @usedBy PoPageDynamicTableComponent
  *
@@ -74,45 +76,15 @@ export interface PoPageDynamicTableActions {
    * @description
    *
    *  Método/URL que deve ser chamado antes da ação de inclusão
-   *  A URL será chamada via POST.
    *
-   * Tanto a função como a API devem retornar um objeto com a seguinte definição:
+   * Tanto o método como a API devem retornar um objeto com a definição de `PoPageDynamicTableBeforeNew`.
    *
-   * ```
-   *  newUrl: string com nova rota para inserção, deve substituir a função ou rota definida anteriormente,
-   *  allowAction: boolean que define se deve ou não executar a ação de inserção (new)
-   * ```
-   *
-   * ```
-   * // exemplo de retorno
-   * {
-   *  newUrl: '/other-new-route',
-   *  allowAction: true
-   * }
-   * ```
+   * > A url será chamada via POST
    *
    * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeNew**
-   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
    *
    */
   beforeNew?: string | (() => PoPageDynamicTableBeforeNew);
-}
-
-/**
- * @usedBy PoPageDynamicTableActions
- *
- * @description
- *
- * Interface para o retorno da função beforeNew
- */
-export interface PoPageDynamicTableBeforeNew {
-  /**
-   * Nova rota para inserção, deve substituir a função ou rota definida anteriormente
-   */
-  newUrl?: string;
-
-  /**
-   * Define se deve ou não executar a ação de inserção (new)
-   */
-  allowAction?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-new.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-new.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * @usedBy PoPageDynamicTableComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeNew`.
+ */
+export interface PoPageDynamicTableBeforeNew {
+  /**
+   * Nova rota para salvar o recurso, que substituirá a rota definida anteriormente em `new`.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de inserção (new)
+   */
+  allowAction?: boolean;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
@@ -1,10 +1,8 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import {
-  PoPageDynamicTableActions,
-  PoPageDynamicTableBeforeNew
-} from './interfaces/po-page-dynamic-table-actions.interface';
+import { PoPageDynamicTableActions } from './interfaces/po-page-dynamic-table-actions.interface';
+import { PoPageDynamicTableBeforeNew } from './interfaces/po-page-dynamic-table-before-new.interface';
 
 @Injectable({
   providedIn: 'root'

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -20,15 +20,13 @@ import { PoPageDynamicDetailComponent } from '../po-page-dynamic-detail/po-page-
 
 import { PoPageDynamicListBaseComponent } from './po-page-dynamic-list-base.component';
 import { PoPageDynamicService } from '../../services/po-page-dynamic/po-page-dynamic.service';
-import {
-  PoPageDynamicTableActions,
-  PoPageDynamicTableBeforeNew
-} from './interfaces/po-page-dynamic-table-actions.interface';
+import { PoPageDynamicTableActions } from './interfaces/po-page-dynamic-table-actions.interface';
 import { PoPageDynamicTableOptions } from './interfaces/po-page-dynamic-table-options.interface';
 import { PoPageCustomizationService } from './../../services/po-page-customization/po-page-customization.service';
 import { PoPageDynamicOptionsSchema } from './../../services/po-page-customization/po-page-dynamic-options.interface';
 import { PoPageDynamicTableMetaData } from './interfaces/po-page-dynamic-table-metadata.interface';
 import { PoPageDynamicTableActionsService } from './po-page-dynamic-table-actions.service';
+import { PoPageDynamicTableBeforeNew } from './interfaces/po-page-dynamic-table-before-new.interface';
 
 type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicTableOptions);
 


### PR DESCRIPTION
**docs**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [ ] Samples

**Qual o comportamento atual?**
As interfaces PoPageDynamicDetailBeforeBack e PoPageDynamicTableBeforeNew não estavm bem destacados na documentação

**Qual o novo comportamento?**
Criados arquivos próprios da interfaces para aparecer no portal.

**Simulação**

Conferir a doc do portal