### PR TITLE
fix(multiselect): corrige exibição do campo de pesquisa

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
@@ -1,7 +1,7 @@
 <div #container class="po-multiselect-container" [hidden]="!show">
   <po-multiselect-search
     #searchElement
-    *ngIf="!hideSearch && haveOptions"
+    *ngIf="!hideSearch && hasOptions"
     [p-literals]="literals"
     [p-placeholder]="placeholderSearch"
     (p-change)="callChangeSearch($event)"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.spec.ts
@@ -1,3 +1,4 @@
+import { By } from '@angular/platform-browser';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { configureTestSuite } from './../../../../util-test/util-expect.spec';
@@ -27,7 +28,6 @@ describe('PoMultiselectDropdownComponent:', () => {
       { label: 'label1', value: 'value1' },
       { label: 'label2', value: 'value2' }
     ];
-    component.haveOptions = true;
 
     fixture.detectChanges();
   });
@@ -160,22 +160,29 @@ describe('PoMultiselectDropdownComponent:', () => {
     expect(component.show).toBeFalsy();
   }));
 
-  describe('Methods:', () => {
-    it('checkInitialOptions: should set haveOptions to true if have options', () => {
-      component.haveOptions = false;
+  describe('Properties: ', () => {
+    it('hasOptions: should return true if have options', () => {
+      const expectedValue = true;
 
-      component['checkInitialOptions']();
+      component.options = [{ value: 'Value', label: 'Value' }];
 
-      expect(component.haveOptions).toBe(true);
+      expect(component['hasOptions']).toBe(expectedValue);
     });
 
-    it('checkInitialOptions: shouldn`t set haveOptions to true if options is empty', () => {
-      component.haveOptions = false;
+    it('hasOptions: should return false if haven`t options', () => {
+      const expectedValue = false;
+
+      component.options = undefined;
+
+      expect(component['hasOptions']).toBe(expectedValue);
+    });
+
+    it('hasOptions: should return true if options is empty', () => {
+      const expectedValue = false;
+
       component.options = [];
 
-      component['checkInitialOptions']();
-
-      expect(component.haveOptions).toBe(false);
+      expect(component['hasOptions']).toBe(expectedValue);
     });
   });
 
@@ -195,6 +202,24 @@ describe('PoMultiselectDropdownComponent:', () => {
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('.po-multiselect-container-no-data')).toBeNull();
+    });
+
+    it('should show `po-multiselect-search` if have options and hideSearch is false', () => {
+      component.options = [{ value: '1', label: 'Option 1' }];
+      component.hideSearch = false;
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('po-multiselect-search'))).toBeTruthy();
+    });
+
+    it('shouldn`t show `po-multiselect-search` if haven`t options', () => {
+      component.options = [];
+      component.hideSearch = false;
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('po-multiselect-search'))).toBe(null);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
@@ -18,7 +18,6 @@ import { PoMultiselectSearchComponent } from './../po-multiselect-search/po-mult
 export class PoMultiselectDropdownComponent {
   scrollTop = 0;
   show: boolean = false;
-  haveOptions: boolean = false;
 
   /** Propriedade que indica se o campo de pesquisa deverá ser escondido. */
   @Input('p-hide-search') hideSearch?: boolean = false;
@@ -51,6 +50,10 @@ export class PoMultiselectDropdownComponent {
   @ViewChild('container', { read: ElementRef, static: true }) container: ElementRef;
   @ViewChild('ulElement', { read: ElementRef, static: true }) ulElement: ElementRef;
   @ViewChild('searchElement') searchElement: PoMultiselectSearchComponent;
+
+  get hasOptions() {
+    return !!this.options?.length;
+  }
 
   scrollTo(index) {
     this.scrollTop = index <= 2 ? 0 : index * 44 - 88;
@@ -92,7 +95,6 @@ export class PoMultiselectDropdownComponent {
 
   controlVisibility(toOpen) {
     this.show = toOpen;
-    this.checkInitialOptions();
 
     setTimeout(() => {
       if (toOpen && this.searchElement && !this.hideSearch) {
@@ -100,11 +102,5 @@ export class PoMultiselectDropdownComponent {
         this.searchElement.clean();
       }
     });
-  }
-
-  private checkInitialOptions() {
-    if (this.options.length) {
-      this.haveOptions = true;
-    }
   }
 }


### PR DESCRIPTION
**MULTISELECT**

**DTHFUI-3425**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao adicionar itens dinamicamente, como no seu exemplo de Labs,
o campo de busca não era apresentado e com isso
ocasionava erro ao selecionar um item.


**Qual o novo comportamento?**
Realizado o controle de verificação das options
dinamicamente para que o campo seja apresentado corretamente.

**Simulação**
- Gerar o Portal, e;
- Utilizar Sample Po Multiselect Labs;