### PR TITLE
feat(page-dynamic-table): adiciona propriedade beforeRemove na actions

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
@@ -1,6 +1,7 @@
 export * from './po-page-dynamic-table.component';
 export * from './interfaces/po-page-dynamic-table-actions.interface';
 export * from './interfaces/po-page-dynamic-table-before-new.interface';
+export * from './interfaces/po-page-dynamic-table-before-remove.interface';
 export * from './interfaces/po-page-dynamic-table-field.interface';
 export * from './interfaces/po-page-dynamic-table-options.interface';
 export * from './interfaces/po-page-dynamic-table-metadata.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
@@ -1,4 +1,5 @@
 import { PoPageDynamicTableBeforeNew } from './po-page-dynamic-table-before-new.interface';
+import { PoPageDynamicTableBeforeRemove } from './po-page-dynamic-table-before-remove.interface';
 
 /**
  * @usedBy PoPageDynamicTableComponent
@@ -67,7 +68,7 @@ export interface PoPageDynamicTableActions {
   new?: string | Function;
 
   /** Habilita a ação de exclusão na tabela. */
-  remove?: boolean;
+  remove?: boolean | ((id: string, resource: any) => boolean);
 
   /** Habilita a ação de exclusão em lote na página. */
   removeAll?: boolean;
@@ -87,4 +88,20 @@ export interface PoPageDynamicTableActions {
    *
    */
   beforeNew?: string | (() => PoPageDynamicTableBeforeNew);
+
+  /**
+   * @description
+   *
+   *  Método/URL que deve ser chamado antes da ação de exclusão
+   *
+   * Tanto o método como a API devem retornar um objeto com a definição de `PoPageDynamicTableBeforeRemove`.
+   *
+   * > A url será chamada via POST
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeRemove**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   *
+   */
+  beforeRemove?: string | ((id?: string, resource?: any) => PoPageDynamicTableBeforeRemove);
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-remove.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-remove.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * @usedBy PoPageDynamicTableComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeRemove`.
+ */
+export interface PoPageDynamicTableBeforeRemove {
+  /**
+   * Nova rota para enviar o delete, deve substituir a função ou rota definida anteriormente
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de exclusão (delete)
+   */
+  allowAction?: boolean;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
@@ -69,5 +69,129 @@ describe('PoPageDynamicTableActionsService:', () => {
         tick();
       }));
     });
+
+    describe('beforeRemove:', () => {
+      const id = '5';
+
+      const resource = {
+        name: 'Gabriel',
+        age: 3
+      };
+
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeRemove('/teste/new', id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === `/teste/new/${id}`);
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = () => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+
+        service.beforeRemove(testFn, id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        tick();
+      }));
+
+      it('should not get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeRemove(testFn, '1', {}).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
+
+    describe('executeAction', () => {
+      const resource = { name: 'Name' };
+      const id = '1';
+
+      it('should get data from a function', fakeAsync(() => {
+        const action = () => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+
+        service['executeAction']<{ newUrl: string; allowAction: boolean }>({ action, resource }).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        tick();
+      }));
+
+      it('should return empty object if action is undefined', fakeAsync(() => {
+        const action = undefined;
+
+        service['executeAction']({ action }).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+
+      it('should get data from a api with `ID` and `resource`', fakeAsync(() => {
+        const action = '/test/remove';
+
+        service['executeAction']<{ newUrl: string; allowAction: boolean }>({ action, resource, id }).subscribe(
+          response => {
+            expect(response.newUrl).toBe('/newurl');
+            expect(response.allowAction).toBeTrue();
+          }
+        );
+
+        const req = httpMock.expectOne(request => request.url === '/test/remove/1');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a api without `ID` and `resource`', fakeAsync(() => {
+        const action = '/test/new';
+
+        service['executeAction']<{ newUrl: string; allowAction: boolean }>({ action }).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/test/new');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({});
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+    });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
@@ -3,6 +3,13 @@ import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { PoPageDynamicTableActions } from './interfaces/po-page-dynamic-table-actions.interface';
 import { PoPageDynamicTableBeforeNew } from './interfaces/po-page-dynamic-table-before-new.interface';
+import { PoPageDynamicTableBeforeRemove } from './interfaces/po-page-dynamic-table-before-remove.interface';
+
+interface ExecuteActionParameter {
+  action: string | Function;
+  resource?: any;
+  id?: string | number;
+}
 
 @Injectable({
   providedIn: 'root'
@@ -15,12 +22,28 @@ export class PoPageDynamicTableActionsService {
   constructor(private http: HttpClient) {}
 
   beforeNew(action?: PoPageDynamicTableActions['beforeNew']): Observable<PoPageDynamicTableBeforeNew> {
-    if (action) {
-      if (typeof action === 'string') {
-        return this.http.post<PoPageDynamicTableBeforeNew>(action, {}, { headers: this.headers });
-      }
-      return of(action());
+    return this.executeAction({ action });
+  }
+
+  beforeRemove(
+    action: PoPageDynamicTableActions['beforeRemove'],
+    id: string,
+    resource: any
+  ): Observable<PoPageDynamicTableBeforeRemove> {
+    return this.executeAction({ action, id, resource });
+  }
+
+  private executeAction<T>({ action, resource = {}, id }: ExecuteActionParameter): Observable<T> {
+    if (!action) {
+      return of(<T>{});
     }
-    return of({});
+
+    if (typeof action === 'string') {
+      const url = id ? `${action}/${id}` : action;
+
+      return this.http.post<T>(url, resource, { headers: this.headers });
+    }
+
+    return of(action(id, resource));
   }
 }

--- a/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic.service.spec.ts
+++ b/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic.service.spec.ts
@@ -162,39 +162,139 @@ describe('PoPageDynamicService:', () => {
       }));
     });
 
-    it('deleteResource:should delete a resource.', fakeAsync(() => {
-      poPageDynamicService.configServiceApi({ endpoint: '/test' });
+    describe('deleteResource', () => {
+      it('should delete a resource.', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
 
-      poPageDynamicService.deleteResource(1).subscribe();
+        poPageDynamicService.deleteResource(1).subscribe();
 
-      const req = httpMock.expectOne(request => request.url === '/test/1');
+        const req = httpMock.expectOne(request => request.url === '/test/1');
 
-      expect(req.request.method).toBe('DELETE');
-      expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.method).toBe('DELETE');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
 
-      req.flush({});
-      tick();
-    }));
+        req.flush({});
+        tick();
+      }));
 
-    it('deleteResources:should delete a array of resources.', fakeAsync(() => {
-      poPageDynamicService.configServiceApi({ endpoint: '/test' });
+      it('should delete a resource with endpoint as null', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
 
-      poPageDynamicService.deleteResources([1, 2, 3]).subscribe();
+        poPageDynamicService.deleteResource(1, null).subscribe();
 
-      const req = httpMock.expectOne(request => request.url === '/test');
+        const req = httpMock.expectOne(request => request.url === '/test/1');
 
-      expect(req.request.method).toBe('DELETE');
-      expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
-      expect(req.request.body).toEqual([1, 2, 3]);
+        expect(req.request.method).toBe('DELETE');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
 
-      req.flush({});
-      tick();
-    }));
+        req.flush({});
+        tick();
+      }));
+
+      it('should delete a resource with endpoint as /', fakeAsync(() => {
+        poPageDynamicService.deleteResource(1, '/').subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/1');
+
+        expect(req.request.method).toBe('DELETE');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should delete a resource passing endpoint as parameter.', fakeAsync(() => {
+        poPageDynamicService.deleteResource(1, '/test').subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test/1');
+
+        expect(req.request.method).toBe('DELETE');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({});
+        tick();
+      }));
+    });
+
+    describe('deleteResource', () => {
+      it('should delete a array of resources.', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
+
+        poPageDynamicService.deleteResources([1, 2, 3]).subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test');
+
+        expect(req.request.method).toBe('DELETE');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual([1, 2, 3]);
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should delete a array of resources with endpoin as null', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
+
+        poPageDynamicService.deleteResources([1, 2, 3], null).subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test');
+
+        expect(req.request.method).toBe('DELETE');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual([1, 2, 3]);
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should delete a array of resources passing endpoint as parameter.', fakeAsync(() => {
+        poPageDynamicService.deleteResources([1, 2, 3], '/test').subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test');
+
+        expect(req.request.method).toBe('DELETE');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual([1, 2, 3]);
+
+        req.flush({});
+        tick();
+      }));
+    });
+
     describe('getResources', () => {
       it('should get a array of resources with params.', fakeAsync(() => {
         const params = new HttpParams().set('name', 'mario');
         poPageDynamicService.configServiceApi({ endpoint: '/test' });
         poPageDynamicService.getResources(params).subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test');
+
+        expect(req.request.method).toBe('GET');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.params.get('name')).toBe('mario');
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should get a array of resources with params and endpoint as null.', fakeAsync(() => {
+        const params = new HttpParams().set('name', 'mario');
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
+        poPageDynamicService.getResources(params, null).subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test');
+
+        expect(req.request.method).toBe('GET');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.params.get('name')).toBe('mario');
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should get a array of resources with params passing endpoint as parameter.', fakeAsync(() => {
+        const params = new HttpParams().set('name', 'mario');
+        poPageDynamicService.getResources(params, '/test').subscribe();
 
         const req = httpMock.expectOne(request => request.url === '/test');
 
@@ -220,48 +320,164 @@ describe('PoPageDynamicService:', () => {
       }));
     });
 
-    it('getResource:should get a resources.', fakeAsync(() => {
-      poPageDynamicService.configServiceApi({ endpoint: '/test' });
+    describe('getResource', () => {
+      it('should get a resources.', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
 
-      poPageDynamicService.getResource(3).subscribe();
+        poPageDynamicService.getResource(3).subscribe();
 
-      const req = httpMock.expectOne(request => request.url === '/test/3');
+        const req = httpMock.expectOne(request => request.url === '/test/3');
 
-      expect(req.request.method).toBe('GET');
-      expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.method).toBe('GET');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
 
-      req.flush({});
-      tick();
-    }));
+        req.flush({});
+        tick();
+      }));
 
-    it('createResource:should create a resources.', fakeAsync(() => {
-      poPageDynamicService.configServiceApi({ endpoint: '/test' });
+      it('should get a resources with endpoint as null', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
 
-      poPageDynamicService.createResource({ 'name': 'mario' }).subscribe();
+        poPageDynamicService.getResource(3, null).subscribe();
 
-      const req = httpMock.expectOne(request => request.url === '/test');
+        const req = httpMock.expectOne(request => request.url === '/test/3');
 
-      expect(req.request.method).toBe('POST');
-      expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
-      expect(req.request.body).toEqual({ 'name': 'mario' });
+        expect(req.request.method).toBe('GET');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
 
-      req.flush({});
-      tick();
-    }));
+        req.flush({});
+        tick();
+      }));
 
-    it('updateResource:should update a resources.', fakeAsync(() => {
-      poPageDynamicService.configServiceApi({ endpoint: '/test' });
+      it('should get a resources with endpoint as /', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
 
-      poPageDynamicService.updateResource(1, { 'name': 'mario' }).subscribe();
+        poPageDynamicService.getResource(3, '/').subscribe();
 
-      const req = httpMock.expectOne(request => request.url === '/test/1');
+        const req = httpMock.expectOne(request => request.url === '/3');
 
-      expect(req.request.method).toBe('PUT');
-      expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
-      expect(req.request.body).toEqual({ 'name': 'mario' });
+        expect(req.request.method).toBe('GET');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
 
-      req.flush({});
-      tick();
-    }));
+        req.flush({});
+        tick();
+      }));
+
+      it('should get a resources passing endpoint as parameter.', fakeAsync(() => {
+        poPageDynamicService.getResource(3, '/test').subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test/3');
+
+        expect(req.request.method).toBe('GET');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({});
+        tick();
+      }));
+    });
+
+    describe('createResource', () => {
+      it('should create a resources.', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
+
+        poPageDynamicService.createResource({ 'name': 'mario' }).subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test');
+
+        expect(req.request.method).toBe('POST');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual({ 'name': 'mario' });
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should create a resources with endpoint as null.', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
+
+        poPageDynamicService.createResource({ 'name': 'mario' }, null).subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test');
+
+        expect(req.request.method).toBe('POST');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual({ 'name': 'mario' });
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should create a resources passing endpoint as parameter.', fakeAsync(() => {
+        poPageDynamicService.createResource({ 'name': 'mario' }, '/test').subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test');
+
+        expect(req.request.method).toBe('POST');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual({ 'name': 'mario' });
+
+        req.flush({});
+        tick();
+      }));
+    });
+    describe('updateResource', () => {
+      it('should update a resources.', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
+
+        poPageDynamicService.updateResource(1, { 'name': 'mario' }).subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test/1');
+
+        expect(req.request.method).toBe('PUT');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual({ 'name': 'mario' });
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should update a resources with endpoint as null.', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
+
+        poPageDynamicService.updateResource(1, { 'name': 'mario' }, null).subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test/1');
+
+        expect(req.request.method).toBe('PUT');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual({ 'name': 'mario' });
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should update a resources with endpoint as /.', fakeAsync(() => {
+        poPageDynamicService.configServiceApi({ endpoint: '/test' });
+
+        poPageDynamicService.updateResource(1, { 'name': 'mario' }, '/').subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/1');
+
+        expect(req.request.method).toBe('PUT');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual({ 'name': 'mario' });
+
+        req.flush({});
+        tick();
+      }));
+
+      it('should update a resources passing endpoint as parameter.', fakeAsync(() => {
+        poPageDynamicService.updateResource(1, { 'name': 'mario' }, '/test').subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test/1');
+
+        expect(req.request.method).toBe('PUT');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+        expect(req.request.body).toEqual({ 'name': 'mario' });
+
+        req.flush({});
+        tick();
+      }));
+    });
   });
 });

--- a/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic.service.ts
+++ b/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic.service.ts
@@ -84,32 +84,40 @@ export class PoPageDynamicService {
   }
 
   // Deleta um único recurso
-  deleteResource(id): Observable<any> {
-    return this.http.delete(`${this.endpoint}/${id}`, { headers: this.headers });
+  deleteResource(id, endpoint?: string): Observable<any> {
+    return this.http.delete(`${this.getLocalEndPoint(endpoint, true)}/${id}`, { headers: this.headers });
   }
 
   // Deleta recursos em lote
-  deleteResources(ids: Array<any>): Observable<any> {
-    return this.http.request('delete', `${this.endpoint}`, { headers: this.headers, body: ids });
+  deleteResources(ids: Array<any>, endpoint?: string): Observable<any> {
+    return this.http.request('delete', `${this.getLocalEndPoint(endpoint)}`, { headers: this.headers, body: ids });
   }
 
   // Busca uma lista de recursos
-  getResources(params?: HttpParams): Observable<any> {
-    return this.http.get(this.endpoint, { headers: this.headers, params });
+  getResources(params?: HttpParams, endpoint?: string): Observable<any> {
+    return this.http.get(this.getLocalEndPoint(endpoint), { headers: this.headers, params });
   }
 
   // Busca um único recurso
-  getResource(id): Observable<any> {
-    return this.http.get(`${this.endpoint}/${id}`, { headers: this.headers });
+  getResource(id, endpoint?: string): Observable<any> {
+    return this.http.get(`${this.getLocalEndPoint(endpoint, true)}/${id}`, { headers: this.headers });
   }
 
   // Cria um recurso
-  createResource(resource): Observable<any> {
-    return this.http.post(`${this.endpoint}`, resource, { headers: this.headers });
+  createResource(resource, endpoint?: string): Observable<any> {
+    return this.http.post(`${this.getLocalEndPoint(endpoint)}`, resource, { headers: this.headers });
   }
 
   // Atualiza um recurso
-  updateResource(id, resource): Observable<any> {
-    return this.http.put(`${this.endpoint}/${id}`, resource, { headers: this.headers });
+  updateResource(id, resource, endpoint?: string): Observable<any> {
+    return this.http.put(`${this.getLocalEndPoint(endpoint, true)}/${id}`, resource, { headers: this.headers });
+  }
+
+  private getLocalEndPoint(endpoint?: string, checkSingleBar = false) {
+    endpoint = endpoint ?? this.endpoint;
+    if (checkSingleBar) {
+      endpoint = endpoint === '/' ? '' : endpoint;
+    }
+    return endpoint;
   }
 }


### PR DESCRIPTION
**page-dynamic-table**

**DTHFUI-2625**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Samples
- [x] Documentação

**Qual o comportamento atual?**
A ação remove vai imediatamente para a rota indicada.

**Qual o novo comportamento?**
Adicionada propriedade beforeRemove para que o desenvolvedor possa executar uma função antes da função de remove.

**Simulação**
[projeto_dynamic_templates.zip](https://github.com/po-ui/po-angular/files/4630368/projeto_dynamic_templates.zip)


As realizadas foram:
-**remove** com boolean
-**remove** com func;

-**beforeRemove** com string
-**beforeRemove** com func
-**beforeRemove** newURL undefined
-**beforeRemove** com allowAction false

Pode subir a api com https://github.com/po-ui/po-sample-api/pull/12


