### PR TITLE
feat(page-dynamic-detail): adiciona action beforeRemove

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/index.ts
@@ -1,6 +1,7 @@
 export * from './po-page-dynamic-detail.component';
 export * from './interfaces/po-page-dynamic-detail-actions.interface';
 export * from './interfaces/po-page-dynamic-detail-before-back.interface';
+export * from './interfaces/po-page-dynamic-detail-before-remove.interface';
 export * from './interfaces/po-page-dynamic-detail-field.interface';
 export * from './interfaces/po-page-dynamic-detail-metadata.interface';
 export * from './interfaces/po-page-dynamic-detail-options.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-actions.interface.ts
@@ -1,4 +1,5 @@
 import { PoPageDynamicDetailBeforeBack } from './po-page-dynamic-detail-before-back.interface';
+import { PoPageDynamicDetailBeforeRemove } from './po-page-dynamic-detail-before-remove.interface';
 
 /**
  * @usedBy PoPageDynamicDetailComponent
@@ -44,6 +45,21 @@ export interface PoPageDynamicDetailActions {
   /**
    * @description
    *
+   * Rota ou método que será chamado antes de excluir um recurso (remove).
+   *
+   * Tanto o método como a API devem retornar um objeto com a definição de `PoPageDynamicDetailBeforeRemove`.
+   *
+   * > A url será chamada via POST
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeRemove**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   */
+  beforeRemove?: string | ((id: any, resource: any) => PoPageDynamicDetailBeforeRemove);
+
+  /**
+   * @description
+   *
    * Rota para edição do recurso, caso seja preenchida irá habilitar a ação de edição na tabela.
    *
    * > A rota deve conter um parâmetro chamando id.
@@ -61,11 +77,7 @@ export interface PoPageDynamicDetailActions {
    *
    * Rota de redirecionamento que será executada após a confirmação da exclusão do registro.
    *
-   * ```
-   * actions = {
-   *   remove: 'new'
-   * };
-   * ```
+   * > Se passada uma função, é responsabilidade do desenvolvedor implementar a navegação ou outro comportamento desejado.
    */
-  remove?: string;
+  remove?: string | ((id: any, resource: any) => void);
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-before-back.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-before-back.interface.ts
@@ -8,12 +8,12 @@
  */
 export interface PoPageDynamicDetailBeforeBack {
   /**
-   * Nova rota para salvar o recurso, que substituirá a rota definida anteriormente em `back`.
+   * Nova rota para retorno que substituirá a definida anteriormente em `back`.
    */
   newUrl?: string;
 
   /**
-   * Define se deve ou não executar a ação de inserção (*back*)
+   * Define se deve ou não executar a ação de retorno (*back*)
    */
   allowAction?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-before-remove.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-before-remove.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * @usedBy PoPageDynamicDetailComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeRemove`.
+ */
+export interface PoPageDynamicDetailBeforeRemove {
+  /**
+   * Nova rota para navegação que substituirá a definida anteriormente em `remove`.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de exclusão (*remove*)
+   */
+  allowAction?: boolean;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.spec.ts
@@ -1,7 +1,7 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 
 import { PoPageDynamicDetailActionsService } from './po-page-dynamic-detail-actions.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 describe('PoPageDynamicDetailActionsService', () => {
   let service: PoPageDynamicDetailActionsService;
@@ -65,6 +65,152 @@ describe('PoPageDynamicDetailActionsService', () => {
         const testFn = undefined;
         service.beforeBack(testFn).subscribe(response => {
           expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
+
+    describe('BeforeRemove', () => {
+      const resource = { name: 'Name' };
+      const id = '1';
+
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeRemove('/test/remove', id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/test/remove/1');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = (userId, userResource) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeRemove(spyObj.testFn, id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(id, resource);
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function if resource is null', fakeAsync(() => {
+        const testFn = (userId, resourceTest) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeRemove(spyObj.testFn, id, null).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(id, {});
+        });
+
+        tick();
+      }));
+
+      it('should not get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeRemove(testFn, id, resource).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
+
+    describe('executeAction', () => {
+      const resource = { name: 'Name' };
+      const id = '1';
+
+      it('should get data from a function', fakeAsync(() => {
+        const action = () => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+
+        service['executeAction']<{ newUrl: string; allowAction: boolean }>({ action, resource }).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        tick();
+      }));
+
+      it('should return empty object if action is undefined', fakeAsync(() => {
+        const action = undefined;
+
+        service['executeAction']({ action }).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+
+      it('should get data from a api with `ID` and `resource`', fakeAsync(() => {
+        const action = '/test/remove';
+
+        service['executeAction']<{ newUrl: string; allowAction: boolean }>({ action, resource, id }).subscribe(
+          response => {
+            expect(response.newUrl).toBe('/newurl');
+            expect(response.allowAction).toBeTrue();
+          }
+        );
+
+        const req = httpMock.expectOne(request => request.url === '/test/remove/1');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a api without `ID` and `resource`', fakeAsync(() => {
+        const action = '/test/new';
+
+        service['executeAction']<{ newUrl: string; allowAction: boolean }>({ action }).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/test/new');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({});
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
         });
 
         tick();


### PR DESCRIPTION
**page-dynamic-detail**

**DTHFUI-2632**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A ação *remove* retorna imediatamente para a rota indicada após confirmação.

**Qual o novo comportamento?**
- Adicionada propriedade beforeRemove para que o desenvolvedor possa executar uma ação antes da função de exclusão (remove).
- Corrigido bug onde era exibido o botão de exclusão mesmo quando se tratava de um registro não encontrado. Pode simular excluindo um registro e depois retornar para a url proveniente dele.
- Ajuste pequeno na documentação de `po-page-dynamic-detail-before-back.interface.ts`



**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/4645206/app.zip)


As realizadas foram:
-**remove** com string
-**remove** com func;
-**remove** com undefined

-**beforeRemove** com string
-**beforeRemove** com func
-**beforeRemove** newURL undefined
-**beforeRemove** com allowAction false
-**beforeRemove** com null

Pode chamar o serviço através da [branch existente](https://github.com/po-ui/po-sample-api/tree/before-remove/DTHFUI-2632) em **po-sample-api**. 
Considerar aprovação desta branch para implementações em sample futuro.




