### PR TITLE
feat(page-dynamic-edit): adiciona action beforeCancel

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
@@ -1,9 +1,9 @@
 export * from './po-page-dynamic-edit.component';
 export * from './interfaces/po-page-dynamic-edit-actions.interface';
 export * from './interfaces/po-page-dynamic-edit-field.interface';
+export * from './interfaces/po-page-dynamic-edit-before-cancel.interface';
 export * from './interfaces/po-page-dynamic-edit-before-save.interface';
 export * from './interfaces/po-page-dynamic-edit-metadata.interface';
 export * from './interfaces/po-page-dynamic-edit-options.interface';
-export * from './interfaces/po-page-dynamic-edit-before-save.interface';
 
 export * from './po-page-dynamic-edit.module';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
@@ -1,3 +1,4 @@
+import { PoPageDynamicEditBeforeCancel } from './po-page-dynamic-edit-before-cancel.interface';
 import { PoPageDynamicEditBeforeSave } from './po-page-dynamic-edit-before-save.interface';
 
 /**
@@ -8,6 +9,22 @@ import { PoPageDynamicEditBeforeSave } from './po-page-dynamic-edit-before-save.
  * Interface para as ações do componente po-page-dynamic-edit.
  */
 export interface PoPageDynamicEditActions {
+  /**
+   * @description
+   *
+   * Rota ou método que será chamado antes de executar a ação de cancelamento (cancel).
+   *
+   * Tanto o método como a API receberão o recurso e devem retornar um objeto com a definição de `PoPageDynamicEditBeforeCancel`.
+   *
+   * > A url será chamada via POST
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeCancel**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   *
+   */
+  beforeCancel?: string | (() => PoPageDynamicEditBeforeCancel);
+
   /**
    * @description
    *
@@ -29,6 +46,8 @@ export interface PoPageDynamicEditActions {
    *
    * Rota de redirecionamento para ação de cancelar, caso não seja especificada será usado o comando `navigator.back()`.
    *
+   * > Se passada uma função, é responsabilidade do desenvolvedor implementar a navegação ou outro comportamento desejado.
+   *
    * > Caso queira esconder a ação deve ser passado o valor `false`;
    *
    * ```
@@ -37,7 +56,7 @@ export interface PoPageDynamicEditActions {
    * };
    * ```
    */
-  cancel?: string | boolean;
+  cancel?: string | boolean | Function;
 
   /**
    * @description

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-before-cancel.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-before-cancel.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * @usedBy PoPageDynamicEditComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeCancel`.
+ */
+export interface PoPageDynamicEditBeforeCancel {
+  /**
+   * Nova rota para navegação que substituirá a definida anteriormente em `cancel`.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de cancelamento de edição da página (cancel)
+   */
+  allowAction?: boolean;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.spec.ts
@@ -33,6 +33,50 @@ describe('PoPageDynamicEditActions:', () => {
   });
 
   describe('Methods: ', () => {
+    describe('beforeCancel', () => {
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeCancel('/test/cancel').subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/test/cancel');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({});
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = () => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+
+        service.beforeCancel(testFn).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        tick();
+      }));
+
+      it('should not get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeCancel(testFn).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
+
     describe('beforeSave:', () => {
       const resource = { name: 'Mario' };
 

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.ts
@@ -2,8 +2,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { of, Observable } from 'rxjs';
 
-import { PoPageDynamicEditBeforeSave } from './interfaces/po-page-dynamic-edit-before-save.interface';
 import { PoPageDynamicEditActions } from './interfaces/po-page-dynamic-edit-actions.interface';
+import { PoPageDynamicEditBeforeCancel } from './interfaces/po-page-dynamic-edit-before-cancel.interface';
+import { PoPageDynamicEditBeforeSave } from './interfaces/po-page-dynamic-edit-before-save.interface';
+
+interface ExecuteActionParameter {
+  action: string | Function;
+  resource?: any;
+}
 
 @Injectable({
   providedIn: 'root'
@@ -15,17 +21,25 @@ export class PoPageDynamicEditActionsService {
 
   constructor(private http: HttpClient) {}
 
-  beforeSave(path: PoPageDynamicEditActions['beforeSave'], resource: any): Observable<PoPageDynamicEditBeforeSave> {
-    const resourceToPost = resource ?? {};
+  beforeCancel(action: PoPageDynamicEditActions['beforeCancel']): Observable<PoPageDynamicEditBeforeCancel> {
+    return this.executeAction({ action });
+  }
 
-    if (!path) {
-      return of({});
+  beforeSave(action: PoPageDynamicEditActions['beforeSave'], body: any): Observable<PoPageDynamicEditBeforeSave> {
+    const resource = body ?? {};
+
+    return this.executeAction({ action, resource });
+  }
+
+  private executeAction<T>({ action, resource = {} }: ExecuteActionParameter): Observable<T> {
+    if (!action) {
+      return of(<T>{});
     }
 
-    if (typeof path === 'string') {
-      return this.http.post(path, resourceToPost, { headers: this.headers });
+    if (typeof action === 'string') {
+      return this.http.post<T>(action, resource, { headers: this.headers });
     }
 
-    return of(path(resourceToPost));
+    return of(action(resource));
   }
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -130,7 +130,7 @@ describe('PoPageDynamicEditComponent: ', () => {
     };
 
     it('cancel: should call `goBack` if `form.dirty` is falsy', () => {
-      const path = '/people';
+      const actions = { cancel: '/peopleA', beforeCancel: '/peopleB' };
 
       const dynamicForm: any = {
         form: {
@@ -143,14 +143,14 @@ describe('PoPageDynamicEditComponent: ', () => {
       spyOn(component['poDialogService'], 'confirm');
       spyOn(component, <any>'goBack');
 
-      component['cancel'](path);
+      component['cancel'](actions.cancel, actions.beforeCancel);
 
-      expect(component['goBack']).toHaveBeenCalled();
+      expect(component['goBack']).toHaveBeenCalledWith(actions.cancel, actions.beforeCancel);
       expect(component['poDialogService'].confirm).not.toHaveBeenCalled();
     });
 
     it('cancel: should call `poDialogService.confirm` if `form.dirty` is truthy', () => {
-      const path = '/people';
+      const actions = { cancel: '/peopleA', beforeCancel: '/peopleB' };
 
       const dynamicForm: any = {
         form: {
@@ -163,7 +163,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       spyOn(component, <any>'goBack');
       spyOn(component['poDialogService'], 'confirm');
 
-      component['cancel'](path);
+      component['cancel'](actions.cancel, actions.beforeCancel);
 
       expect(component['poDialogService'].confirm).toHaveBeenCalled();
       expect(component['goBack']).not.toHaveBeenCalled();
@@ -198,28 +198,133 @@ describe('PoPageDynamicEditComponent: ', () => {
       expect(component['getDetailFields']()).toEqual([]);
     });
 
-    it('goBack: should call `router.navigate` and not call `history.back` if path is truthy', () => {
-      const path = '/people/:id';
+    describe('goBack', () => {
+      it('should call `executeBackAtion` passing `action.cancel` as param if beforeBack returns null', () => {
+        const actions = { cancel: '/people-list', beforeCancel: '/people-list-b' };
 
-      spyOn(component['router'], <any>'navigate');
-      spyOn(window.history, 'back');
+        const spybeforeCancel = spyOn(component['poPageDynamicEditActionsService'], 'beforeCancel').and.returnValue(
+          of(null)
+        );
+        const spyExecuteBackAction = spyOn(component, <any>'executeBackAction');
 
-      component['goBack'](path);
+        component['goBack'](actions.cancel, actions.beforeCancel);
 
-      expect(component['router'].navigate).toHaveBeenCalled();
-      expect(window.history.back).not.toHaveBeenCalled();
+        expect(spybeforeCancel).toHaveBeenCalled();
+        expect(spyExecuteBackAction).toHaveBeenCalledWith(actions.cancel, undefined, undefined);
+      });
+
+      it('should call `executeBackAction` passing action.cancel, newUrl and allowAction as param values', () => {
+        const actions = { cancel: '/people-list', beforeCancel: '/people-list-b' };
+        const newUrl = '/newUrl';
+        const allowAction = false;
+
+        const spybeforeCancel = spyOn(component['poPageDynamicEditActionsService'], 'beforeCancel').and.returnValue(
+          of({ allowAction, newUrl })
+        );
+        const spyExecuteBackAction = spyOn(component, <any>'executeBackAction');
+
+        component['goBack'](actions.cancel, actions.beforeCancel);
+
+        expect(spybeforeCancel).toHaveBeenCalled();
+        expect(spyExecuteBackAction).toHaveBeenCalledWith(actions.cancel, allowAction, newUrl);
+      });
     });
 
-    it('goBack: shouldn`t call `router.navigate` and call `history.back` if path is falsy', () => {
-      const path = '';
+    describe('executeBackAction', () => {
+      it('should call `history.back` if action.cancel is a boolean type', () => {
+        const actionCancel = true;
 
-      spyOn(component['router'], <any>'navigate');
-      spyOn(window.history, 'back');
+        const spyHistoryBack = spyOn(window.history, 'back');
 
-      component['goBack'](path);
+        component['executeBackAction'](actionCancel);
 
-      expect(component['router'].navigate).not.toHaveBeenCalled();
-      expect(window.history.back).toHaveBeenCalled();
+        expect(spyHistoryBack).toHaveBeenCalled();
+      });
+
+      it('should call `history.back` if action.cancel is undefined', () => {
+        const actionCancel = undefined;
+
+        const spyHistoryBack = spyOn(window.history, 'back');
+
+        component['executeBackAction'](actionCancel);
+
+        expect(spyHistoryBack).toHaveBeenCalled();
+      });
+
+      it('should call `router.navigate` if action.cancel is a string type', () => {
+        const actionCancel = '/list';
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+
+        component['executeBackAction'](actionCancel);
+
+        expect(spyNavigate).toHaveBeenCalledWith([actionCancel]);
+      });
+
+      it('should call the function from action.cancel', () => {
+        const canceFn = {
+          fn: () => {}
+        };
+
+        const spyCancelFn = spyOn(canceFn, 'fn');
+
+        component['executeBackAction'](canceFn.fn);
+
+        expect(spyCancelFn).toHaveBeenCalled();
+      });
+
+      it('should call `router.navigate` passing `newUrl` as value if allowAction is true', () => {
+        const actionCancel = '/list';
+        const newUrl = '/new-list';
+        const allowAction = true;
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+
+        component['executeBackAction'](actionCancel, allowAction, newUrl);
+
+        expect(spyNavigate).toHaveBeenCalledWith([newUrl]);
+      });
+
+      it('should call `router.navigate` passing `newUrl` as value if allowAction is null', () => {
+        const actionCancel = '/list';
+        const newUrl = '/new-list';
+        const allowAction = null;
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+
+        component['executeBackAction'](actionCancel, allowAction, newUrl);
+
+        expect(spyNavigate).toHaveBeenCalledWith([newUrl]);
+      });
+
+      it('should call `router.navigate` passing `newUrl` as value if allowAction is undefined', () => {
+        const actionCancel = '/list';
+        const newUrl = '/new-list';
+        const allowAction = undefined;
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+
+        component['executeBackAction'](actionCancel, allowAction, newUrl);
+
+        expect(spyNavigate).toHaveBeenCalledWith([newUrl]);
+      });
+
+      it('shouldn`t call anything if `allowAction` is false', () => {
+        const actionCancel = {
+          fn: () => {}
+        };
+        const allowAction = false;
+
+        const spyNavigate = spyOn(component['router'], <any>'navigate');
+        const spyHistoryBack = spyOn(window.history, 'back');
+        const spyBackFn = spyOn(actionCancel, 'fn');
+
+        component['executeBackAction'](actionCancel.fn, allowAction);
+
+        expect(spyNavigate).not.toHaveBeenCalled();
+        expect(spyHistoryBack).not.toHaveBeenCalled();
+        expect(spyBackFn).not.toHaveBeenCalled();
+      });
     });
 
     it('navigateTo: should call `resolveUrl`, `router.navigate` and not call `history.back` if path is truthy', () => {
@@ -686,7 +791,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: true };
 
       spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
-      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'executeSave').and.returnValue(of({}));
       spyOn(component, <any>'updateModel');
 
       component['save']('testSave/');
@@ -698,7 +803,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: undefined };
 
       spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
-      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'executeSave').and.returnValue(of({}));
       spyOn(component, <any>'updateModel');
 
       component['save']('testSave/');
@@ -710,7 +815,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: null };
 
       spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
-      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'executeSave').and.returnValue(of({}));
       spyOn(component, <any>'updateModel');
 
       component['save']('testSave/');
@@ -722,7 +827,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       const returnBeforeSave: PoPageDynamicEditBeforeSave = { newUrl: 'newUrl' };
 
       spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
-      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'executeSave').and.returnValue(of({}));
       spyOn(component, <any>'updateModel');
 
       component['save']('testSave/');
@@ -735,7 +840,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       const saveAction = 'testSave/';
 
       spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
-      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'executeSave').and.returnValue(of({}));
       spyOn(component, <any>'updateModel');
 
       component['save'](saveAction);
@@ -748,7 +853,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       const saveAction = 'testSave/';
 
       spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
-      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'executeSave').and.returnValue(of({}));
       spyOn(component, <any>'updateModel');
 
       component['save'](saveAction);
@@ -761,7 +866,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       const saveAction = 'testSave/';
 
       spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
-      spyOn(component, <any>'executeSave');
+      spyOn(component, <any>'executeSave').and.returnValue(of({}));
       spyOn(component, <any>'updateModel');
 
       component['save'](saveAction);
@@ -852,25 +957,24 @@ describe('PoPageDynamicEditComponent: ', () => {
       component['activatedRoute'] = activatedRoute;
       component.model = Object.assign({}, model);
 
-      spyOn(component['poPageDynamicService'], 'updateResource').and.returnValue(EMPTY);
+      spyOn(component['poPageDynamicService'], 'updateResource').and.returnValue(of({}));
       spyOn(component['poNotification'], 'success');
       spyOn(component, <any>'navigateTo');
 
       spyOn(component['poPageDynamicService'], 'createResource');
       spyOn(component['poNotification'], 'warning');
 
-      component['executeSave'](path);
-
+      component['executeSave'](path).subscribe(() => {
+        expect(component['navigateTo']).toHaveBeenCalledWith(path);
+        expect(component['poNotification'].success).toHaveBeenCalledWith(
+          component.literals.saveNotificationSuccessUpdate
+        );
+        expect(component['poPageDynamicService'].createResource).not.toHaveBeenCalled();
+        expect(component['poPageDynamicService'].updateResource).toHaveBeenCalledWith(id, model);
+      });
       tick();
 
       expect(component['poNotification'].warning).not.toHaveBeenCalled();
-      expect(component['poPageDynamicService'].createResource).not.toHaveBeenCalled();
-
-      expect(component['navigateTo']).toHaveBeenCalledWith(path);
-      expect(component['poNotification'].success).toHaveBeenCalledWith(
-        component.literals.saveNotificationSuccessUpdate
-      );
-      expect(component['poPageDynamicService'].updateResource).toHaveBeenCalledWith(id, model);
     }));
 
     it('executeSave: should call `createResource`, `poNotification.success` and `navigateTo` if `params.id` is truthy', fakeAsync(() => {
@@ -888,23 +992,25 @@ describe('PoPageDynamicEditComponent: ', () => {
       component['activatedRoute'] = activatedRoute;
       component.model = Object.assign({}, model);
 
-      spyOn(component['poPageDynamicService'], 'createResource').and.returnValue(EMPTY);
+      spyOn(component['poPageDynamicService'], 'createResource').and.returnValue(of({}));
       spyOn(component['poNotification'], 'success');
       spyOn(component, <any>'navigateTo');
 
       spyOn(component['poPageDynamicService'], 'updateResource');
       spyOn(component['poNotification'], 'warning');
 
-      component['executeSave'](path);
+      component['executeSave'](path).subscribe(() => {
+        expect(component['navigateTo']).toHaveBeenCalledWith(path);
+        expect(component['poNotification'].success).toHaveBeenCalledWith(
+          component.literals.saveNotificationSuccessSave
+        );
+        expect(component['poPageDynamicService'].updateResource).not.toHaveBeenCalled();
+        expect(component['poPageDynamicService'].createResource).toHaveBeenCalledWith(model);
+      });
 
       tick();
 
       expect(component['poNotification'].warning).not.toHaveBeenCalled();
-      expect(component['poPageDynamicService'].updateResource).not.toHaveBeenCalled();
-
-      expect(component['navigateTo']).toHaveBeenCalledWith(path);
-      expect(component['poNotification'].success).toHaveBeenCalledWith(component.literals.saveNotificationSuccessSave);
-      expect(component['poPageDynamicService'].createResource).toHaveBeenCalledWith(model);
     }));
 
     it('getKeysByFields: should return array with only key fields', () => {
@@ -979,6 +1085,9 @@ describe('PoPageDynamicEditComponent: ', () => {
       const actions: PoPageDynamicEditActions = {
         cancel: 'people'
       };
+
+      spyOn(component, <any>'save');
+      spyOn(component, <any>'cancel');
 
       const pageActions = component['getPageActions'](actions);
 


### PR DESCRIPTION
**page-dynamic-edit**

**DTHFUI-2627**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A ação *cancel* retorna imediatamente para a rota indicada após confirmação.

**Qual o novo comportamento?**
• Adicionada propriedade **beforeCancel** para que o desenvolvedor possa executar uma ação antes da função de cancelamento (*cancel*).
• Agora a propriedade **cancel** aceita também uma função.
• Tratamento para Observables aninhados presentes em **beforeSave** e também incluídos no Subscription.

**Simulação**
[Anexado app para validações](https://github.com/po-ui/po-angular/files/4652094/app.zip). Pode usar o componente **Editar**

Pode também mockar o serviço no [beeceptor](https://beeceptor.com/). Basta criar um método POST retornando o objeto

```
{ "allowAction": true,
"newUrl": "/newUrl"
}
```

- **save** e **cancel** com string
- **save** e **cancel** com func;
- **save**  e **cancel** com undefined e null


- **beforeSave** e **beforeCancel** com string
- **beforeSave** e **beforeCancel** com func
- **beforeSave** e **beforeCancel** com newURL undefined
- **beforeSave** e **beforeCancel** com allowAction false
- **beforeSave** e **beforeCancel** com null