### PR TITLE
feat(modal): transforma serviço da modal em um singleton

### DIFF
--- a/projects/ui/src/lib/components/po-modal/index.ts
+++ b/projects/ui/src/lib/components/po-modal/index.ts
@@ -1,4 +1,5 @@
 export * from './po-modal-action.interface';
 export * from './po-modal.component';
+export * from './po-modal-service';
 
 export * from './po-modal.module';

--- a/projects/ui/src/lib/components/po-modal/po-modal-service.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class PoModalService {
   modalActive: string;
 }

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ElementRef, Renderer2, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 
 import { v4 as uuid } from 'uuid';
 
@@ -39,13 +39,7 @@ export class PoModalComponent extends PoModalBaseComponent {
   private id: string = uuid();
   private sourceElement;
 
-  onResizeListener: () => void;
-
-  constructor(
-    private poModalService: PoModalService,
-    private renderer: Renderer2,
-    private changeDetector: ChangeDetectorRef
-  ) {
+  constructor(private poModalService: PoModalService) {
     super();
   }
 

--- a/projects/ui/src/lib/components/po-modal/po-modal.module.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 
 import { PoButtonModule } from './../po-button/po-button.module';
 import { PoModalComponent } from './po-modal.component';
-import { PoModalService } from './po-modal-service';
 
 /**
  * @description
@@ -12,7 +11,6 @@ import { PoModalService } from './po-modal-service';
 @NgModule({
   imports: [CommonModule, PoButtonModule],
   declarations: [PoModalComponent],
-  exports: [PoModalComponent],
-  providers: [PoModalService]
+  exports: [PoModalComponent]
 })
 export class PoModalModule {}


### PR DESCRIPTION
Além de transformar o serviço de controle da modal em singleton foram removidos
alguns imports que não estavam sendo utilizados dentro do componente.

**Modal**

**DTHFUI-3463**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente o serviço de controle do modal não é um singleton.

**Qual o novo comportamento?**

Transforma o serviço de controle do modal é um singleton.

**Simulação**

Rodar o projeto anexo a issue e seguir os passos no comentário da mesma.