### PR TITLE
fix(po-i18n): permite mesclar contextos adicionados em "lazy modules"

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@po-ui/style": "2.3.0",
     "core-js": "3.6.4",
     "custom-idle-queue": "2.1.2",
+    "deepmerge": "^4.2.2",
     "http-status-codes": "^1.4.0",
     "localforage": "1.4.0",
     "lokijs": "1.5.8",

--- a/projects/ui/ng-package.json
+++ b/projects/ui/ng-package.json
@@ -2,7 +2,11 @@
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/ng-components",
   "lib": {
-    "entryFile": "./src/public-api.ts"
+    "entryFile": "./src/public-api.ts",
+    "umdModuleIds": {
+      "deepmerge": "deepmerge",
+      "uuid": "uuid"
+    }
   },
-  "whitelistedNonPeerDependencies": ["@po-ui/style", "@po-ui/ng-schematics"]
+  "whitelistedNonPeerDependencies": ["@po-ui/style", "@po-ui/ng-schematics", "deepmerge", "uuid"]
 }

--- a/projects/ui/src/lib/services/po-i18n/index.ts
+++ b/projects/ui/src/lib/services/po-i18n/index.ts
@@ -1,4 +1,5 @@
 export * from './interfaces/po-i18n-config.interface';
+export * from './interfaces/po-i18n-config-context.interface';
 export * from './interfaces/po-i18n-config-default.interface';
 export * from './interfaces/po-i18n-literals.interface';
 export * from './po-i18n.pipe';

--- a/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config-context.interface.ts
+++ b/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config-context.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * @description
+ *
+ * <a id="poI18nConfigContext"></a>
+ *
+ * Interface para a configuração dos contextos do módulo `PoI18nModule`.
+ *
+ * @usedBy PoI18nModule
+ */
+export interface PoI18nConfigContext {
+  [name: string]: { [language: string]: { [literal: string]: string } } | { url: string };
+}

--- a/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
+++ b/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
@@ -1,3 +1,4 @@
+import { PoI18nConfigContext } from './po-i18n-config-context.interface';
 import { PoI18nConfigDefault } from './po-i18n-config-default.interface';
 
 /**
@@ -10,7 +11,9 @@ import { PoI18nConfigDefault } from './po-i18n-config-default.interface';
  * @usedBy PoI18nModule
  */
 export interface PoI18nConfig {
-  /** Configurações padrões. */
+  /**
+   * Configurações padrões.
+   */
   default?: PoI18nConfigDefault;
 
   /**
@@ -20,30 +23,34 @@ export interface PoI18nConfig {
    *
    * Portanto podemos utilizar constantes, onde devemos informar o nome do contexto recebendo um objeto com os
    * idiomas suportados e o arquivo de literais, por exemplo:
-   * ```
-   *  import { generalEn } from './i18n/general-en';
-   *  import { generalPt } from './i18n/general-pt';
+   *
+   * ```typescript
+   * import { generalEn } from './i18n/general-en';
+   * import { generalPt } from './i18n/general-pt';
+   *
    * ...
-   *  general: {
-   *    pt: generalPt,
-   *    en: generalEn
-   *  }
+   * general: {
+   *   pt: generalPt,
+   *   en: generalEn
+   * }
    * ...
    * ```
    *
    * E como informado, podemos utilizar a propriedade `url` que deve receber a URL do serviço que
    * retorne as literais traduzidas, por exemplo:
-   * ```
-   *   hcm: {
-   *     url: 'http://localhost:3000/api/translations/hcm/'
-   *   }
+   *
+   * ```typescript
+   * hcm: {
+   *   url: 'http://localhost:3000/api/translations/hcm/'
+   * }
    * ```
    *
    * Ao optar por utilizar um serviço, deverá ser definida a URL específica do contexto,
    * como nos exemplos abaixo:
+   *
    * ```
-   *  http://server:port/api/translations/crm
-   *  http://server:port/api/translations/general
+   * http://server:port/api/translations/crm
+   * http://server:port/api/translations/general
    * ```
    *
    * Os idiomas e literais serão automaticamente buscados com parâmetros na própria URL:
@@ -53,9 +60,10 @@ export interface PoI18nConfig {
    * serviço deve retornar todas as literais do idioma.
    *
    * Exemplos de requisição:
+   *
    * ```
-   *  http://server:port/api/translations/crm?language=pt-br
-   *  http://server:port/api/translations/crm?language=pt-br&literals=add,remove,text
+   * http://server:port/api/translations/crm?language=pt-br
+   * http://server:port/api/translations/crm?language=pt-br&literals=add,remove,text
    * ```
    *
    * > Sempre que o idioma solicitado não for encontrado, será buscado por `pt-br`.
@@ -63,18 +71,19 @@ export interface PoI18nConfig {
    * Existe também a possibilidade de utilizar ambos, onde será feito a busca das literais nas constantes e depois efetua
    * a busca no serviço, com isso as constantes podem servir como *backup* caso o serviço esteja indisponível, por exemplo:
    *
-   * ```
-   *  import { generalEn } from './i18n/general-en';
-   *  import { generalPt } from './i18n/general-pt';
+   * ```typescript
+   * import { generalEn } from './i18n/general-en';
+   * import { generalPt } from './i18n/general-pt';
+   *
    * ...
-   *  general: {
-   *    pt: generalPt,
-   *    en: generalEn,
-   *    url: 'http://localhost:3000/api/translations/hcm/'
-   *  }
+   * general: {
+   *   pt: generalPt,
+   *   en: generalEn,
+   *   url: 'http://localhost:3000/api/translations/hcm/'
+   * }
    * ...
    * ```
    * > Caso a constante contenha alguma literal que o serviço não possua será utilizado a literal da constante.
    */
-  contexts: object;
+  contexts: PoI18nConfigContext;
 }

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
@@ -1,13 +1,33 @@
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HttpRequest } from '@angular/common/http';
-
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { NgModule } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import * as utils from '../../utils/util';
-
 import { PoI18nModule, PoI18nService } from '../po-i18n';
 import { PoLanguageModule } from '../po-language';
+import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
+
+const lazyConfig: PoI18nConfig = {
+  contexts: {
+    general: {
+      'pt-br': {
+        insert: 'insert'
+      }
+    },
+    special: {
+      'pt-br': {
+        delete: 'delete'
+      }
+    }
+  }
+};
+
+@NgModule({
+  imports: [PoI18nModule.forChild(lazyConfig)]
+})
+class LazyModule {}
 
 describe('PoI18nService:', () => {
   describe('without Service:', () => {
@@ -43,7 +63,7 @@ describe('PoI18nService:', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, PoLanguageModule, PoI18nModule.config(config)]
+        imports: [HttpClientTestingModule, LazyModule, PoLanguageModule, PoI18nModule.forRoot(config)]
       });
 
       service = TestBed.inject(PoI18nService);
@@ -113,6 +133,22 @@ describe('PoI18nService:', () => {
         expect(literals['text']).toBeTruthy();
         expect(literals['add']).toBeTruthy();
 
+        done();
+      });
+    });
+
+    it('should return literal merged from context added in a "lazy module"', done => {
+      service.getLiterals({ context: 'general', language: 'pt-br' }).subscribe(literals => {
+        expect(literals['insert']).toBeTruthy();
+        expect(literals['insert']).toBe(lazyConfig.contexts['general']['pt-br']['insert']);
+        done();
+      });
+    });
+
+    it('should return literal from context added in a "lazy module"', done => {
+      service.getLiterals({ context: 'special', language: 'pt-br' }).subscribe(literals => {
+        expect(literals['delete']).toBeTruthy();
+        expect(literals['delete']).toBe(lazyConfig.contexts['special']['pt-br']['delete']);
         done();
       });
     });

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
@@ -1,14 +1,12 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject } from '@angular/core';
-
 import { Observable } from 'rxjs';
 
 import { isLanguage, reloadCurrentPage } from '../../utils/util';
 import { PoLanguageService } from '../po-language/po-language.service';
-
-import { I18N_CONFIG } from './po-i18n-config-injection-token';
 import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 import { PoI18nLiterals } from './interfaces/po-i18n-literals.interface';
+import { I18N_CONFIG } from './po-i18n-config-injection-token';
 
 /**
  * @description
@@ -256,7 +254,7 @@ export class PoI18nBaseService {
     const context = options['context'] ? options['context'] : this.contextDefault;
     const literals: Array<string> = options['literals'] ? options['literals'] : [];
 
-    return new Observable(observer => {
+    return new Observable<any>(observer => {
       if (this.servicesContext[context]) {
         // Faz o processo de busca de um contexto que contém serviço
         this.getLiteralsFromContextService(language, context, literals, observer);

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-config-injection-token.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-config-injection-token.ts
@@ -2,4 +2,4 @@ import { InjectionToken } from '@angular/core';
 
 import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 
-export const I18N_CONFIG = new InjectionToken<PoI18nConfig>('I18N_CONFIG');
+export const I18N_CONFIG = new InjectionToken<Array<PoI18nConfig>>('I18N_CONFIG');

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
@@ -1,10 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { all as deepmergeAll } from 'deepmerge';
 
 import { PoLanguageService } from './../po-language/po-language.service';
-
-import { PoI18nBaseService } from './po-i18n-base.service';
 import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
+import { PoI18nBaseService } from './po-i18n-base.service';
 
 /**
  * @docsExtends PoI18nBaseService
@@ -14,6 +14,10 @@ import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 export class PoI18nService extends PoI18nBaseService {}
 
 // Função usada para retornar instância para o módulo po-i18n.module
-export function returnPoI18nService(config: PoI18nConfig, http: HttpClient, languageService: PoLanguageService) {
-  return new PoI18nService(config, http, languageService);
+export function returnPoI18nService(
+  configs: Array<PoI18nConfig>,
+  http: HttpClient,
+  languageService: PoLanguageService
+) {
+  return new PoI18nService(deepmergeAll<PoI18nConfig>(configs), http, languageService);
 }


### PR DESCRIPTION
**PoI18nModule**

**#321**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [X] Testes unitários
- [X] Documentação
- [x] Samples

**Qual o comportamento atual?**

Atualmente quando a aplicação possui como dependência outro módulo que utiliza o `PoI18nModule` (uma biblioteca Angular por exemplo), as configurações de i18n da aplicação sobrescreviam as configurações de i18n do módulo importado.

**Qual o novo comportamento?**

Foi criado o método `forChild` que permite adicionar novos contextos para o módulo de i18n do PO. Para isto alguns ajustes foram necessários:

* Agora os contextos podem ser "mesclados" (mesmo se utilizado o método `config`)
* O `provider` **I18N_CONFIG** agora é `multi`
* Ao criar o serviço para o módulo atual, os contextos são mesclados
* Foi adicionada uma biblioteca de terceiro que permite efetuar **deep merge** de objetos
* Por convenção foi criado o método `forRoot` que chama o método `config`

- Documentação e testes alterados.

**Simulação**

Executar a simulação relatada na ISSUE #321.