### PR TITLE
fix(lookup): adiciona tratamento de erro para pesquisa

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -19,14 +19,14 @@ describe('PoPageDynamicDetailComponent:', () => {
   let component: PoPageDynamicDetailComponent;
   let fixture: ComponentFixture<PoPageDynamicDetailComponent>;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, HttpClientTestingModule, RouterTestingModule.withRoutes([])],
       providers: [PoDialogService],
       declarations: [PoPageDynamicDetailComponent],
       schemas: [NO_ERRORS_SCHEMA]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageDynamicDetailComponent);

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -20,14 +20,14 @@ describe('PoPageDynamicEditComponent: ', () => {
   let component: PoPageDynamicEditComponent;
   let fixture: ComponentFixture<PoPageDynamicEditComponent>;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, HttpClientTestingModule, RouterTestingModule.withRoutes([]), PoDialogModule],
       providers: [],
       declarations: [PoPageDynamicEditComponent, PoDynamicFormStubComponent],
       schemas: [NO_ERRORS_SCHEMA]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageDynamicEditComponent);

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { PoLookupFilterService } from './po-lookup-filter.service';
 
@@ -26,8 +26,8 @@ describe('PoLookupFilterService', () => {
   });
 
   describe('Methods:', () => {
-    it(`getFilteredItems: should return the request response and create request with url, page, pageSize, filter
-      and params correctly`, () => {
+    it(`getFilteredItems: should return the request response and create request with url, page, pageSize, filter, 
+    headers and params correctly`, fakeAsync(() => {
       service['url'] = 'http://url.com';
       const page = 1;
       const pageSize = 20;
@@ -39,19 +39,22 @@ describe('PoLookupFilterService', () => {
         .getFilteredItems({ filter, page, pageSize, filterParams })
         .subscribe(response => expect(response).toEqual(expectedResponse));
 
-      httpMock
-        .expectOne(httpRequest => {
-          return (
-            httpRequest.url === service['url'] &&
-            httpRequest.method === 'GET' &&
-            httpRequest.params.get('page') === <any>page &&
-            httpRequest.params.get('pageSize') === <any>pageSize &&
-            httpRequest.params.get('filter') === 'name' &&
-            httpRequest.params.get('name') === 'test'
-          );
-        })
-        .flush(expectedResponse);
-    });
+      const req = httpMock.expectOne(httpRequest => {
+        return (
+          httpRequest.url === service['url'] &&
+          httpRequest.method === 'GET' &&
+          httpRequest.params.get('page') === <any>page &&
+          httpRequest.params.get('pageSize') === <any>pageSize &&
+          httpRequest.params.get('filter') === 'name' &&
+          httpRequest.params.get('name') === 'test'
+        );
+      });
+
+      expect(req.request.headers.get('X-PO-No-Message')).toBe('true');
+
+      req.flush(expectedResponse);
+      tick();
+    }));
 
     it(`getFilteredItems: should call 'validateParams' and set its return as the request parameter`, () => {
       service['url'] = 'http://url.com';
@@ -69,7 +72,7 @@ describe('PoLookupFilterService', () => {
       httpMock.expectOne(httpRequest => httpRequest.params.get('name') === 'test').flush({});
     });
 
-    it(`getObjectByValue: should return the request response and create request with url and 'filterParams' correctly`, () => {
+    it(`getObjectByValue: should return the request response and create request with url, headers and 'filterParams' correctly`, fakeAsync(() => {
       service['url'] = 'http://url.com';
       const filterParams = { name: 'test' };
       const value = '1';
@@ -82,16 +85,19 @@ describe('PoLookupFilterService', () => {
         expect(response).toEqual(expectedResponse);
       });
 
-      httpMock
-        .expectOne(httpRequest => {
-          return (
-            httpRequest.url === 'http://url.com/1' &&
-            httpRequest.method === 'GET' &&
-            httpRequest.params.get('name') === 'test'
-          );
-        })
-        .flush(expectedResponse);
-    });
+      const req = httpMock.expectOne(httpRequest => {
+        return (
+          httpRequest.url === 'http://url.com/1' &&
+          httpRequest.method === 'GET' &&
+          httpRequest.params.get('name') === 'test'
+        );
+      });
+
+      expect(req.request.headers.get('X-PO-No-Message')).toBe('true');
+
+      req.flush(expectedResponse);
+      tick();
+    }));
 
     it(`getObjectByValue: should call 'validateParams' and set its return as the request parameter`, () => {
       service['url'] = 'http://url.com';

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs';
@@ -19,6 +19,10 @@ import { PoLookupFilteredItemsParams } from '../interfaces/po-lookup-filtered-it
 export class PoLookupFilterService implements PoLookupFilter {
   private url: string;
 
+  readonly headers: HttpHeaders = new HttpHeaders({
+    'X-PO-No-Message': 'true'
+  });
+
   constructor(private httpClient: HttpClient) {}
 
   getFilteredItems(filteredItemsParams: PoLookupFilteredItemsParams): Observable<any> {
@@ -28,13 +32,13 @@ export class PoLookupFilterService implements PoLookupFilter {
 
     const params = { ...restFilteredItemsParams, ...validatedFilterParams };
 
-    return this.httpClient.get(this.url, { params });
+    return this.httpClient.get(this.url, { headers: this.headers, params });
   }
 
   getObjectByValue(value: string, filterParams?: any): Observable<any> {
     const validatedFilterParams = this.validateParams(filterParams);
 
-    return this.httpClient.get(`${this.url}/${value}`, { params: validatedFilterParams });
+    return this.httpClient.get(`${this.url}/${value}`, { headers: this.headers, params: validatedFilterParams });
   }
 
   setUrl(url: string) {

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
@@ -1,5 +1,5 @@
 import { QueryList } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, async } from '@angular/core/testing';
 
 import { of, throwError } from 'rxjs';
 
@@ -20,11 +20,11 @@ describe('PoStepperComponent:', () => {
 
   let poSteps = [];
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [PoStepperModule]
     });
-  });
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoStepperComponent);


### PR DESCRIPTION
**po-lookup**

**DTHFUI-3503**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando realizada consulta no lookup que retorna um status 404 o table fica em modo "carregando" e não faz o tratamento adequado.

**Qual o novo comportamento?**
Se ocorrer erro como 404 na pesquisa de um registro, remove-se o loading e exibe a mensagem de registro não encontrado. Foi também definido no cabeçalho da requisição o parâmetro `X-PO-No-Message` para dispensar a notificação de erro do interceptor.

* Adicionado *compileComponents()* nos arquivos de teste dos componentes `page-dynamic-edit` e `page-dynamic-detail` pois estavam gerando erros intermitentes.

**Simulação**
Os samples ainda apontam para a api antiga. Mas foi criada a [PR em po-sample-api](https://github.com/po-ui/po-sample-api/pull/13) para facilitar na revisão. Apontar o serviço para ela no sample basic. 
*Os samples que consomem o serviço `SamplePoLookupService` (Hero por exemplo) exibirão a notificação pois eles tem um tratamento customizado para requisições.

Exemplo
[app.zip](https://github.com/po-ui/po-angular/files/4697782/app.zip)
