### PR TITLE
feat(page-dynamic-edit): adiciona parâmetro id

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
@@ -39,7 +39,7 @@ export interface PoPageDynamicEditActions {
    * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
    *
    */
-  beforeSave?: string | ((resource: any) => PoPageDynamicEditBeforeSave);
+  beforeSave?: string | ((resource: any, id: string) => PoPageDynamicEditBeforeSave);
 
   /**
    * @description
@@ -78,7 +78,7 @@ export interface PoPageDynamicEditActions {
    *  - é responsabilidade do desenvolvedor implementar a navegação e/ou envio dos dados
    * para o servidor ou outro comportamento desejado.
    */
-  save?: string | Function;
+  save?: string | ((resource: any, id: string) => void);
 
   /**
    * @description

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.spec.ts
@@ -79,14 +79,15 @@ describe('PoPageDynamicEditActions:', () => {
 
     describe('beforeSave:', () => {
       const resource = { name: 'Mario' };
+      const id = '1';
 
       it('should get data from a api', fakeAsync(() => {
-        service.beforeSave('/newSave', resource).subscribe(response => {
+        service.beforeSave('/newSave', id, resource).subscribe(response => {
           expect(response.newUrl).toBe('/newurl');
           expect(response.allowAction).toBeTrue();
         });
 
-        const req = httpMock.expectOne(request => request.url === '/newSave');
+        const req = httpMock.expectOne(request => request.url === '/newSave/1');
         expect(req.request.method).toBe('POST');
         expect(req.request.body).toEqual(resource);
         expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
@@ -100,7 +101,7 @@ describe('PoPageDynamicEditActions:', () => {
       }));
 
       it('should get data from a function', fakeAsync(() => {
-        const testFn = resourceTest => ({
+        const testFn = (userResource, userId) => ({
           newUrl: '/newurlfromfunction',
           allowAction: true
         });
@@ -110,17 +111,17 @@ describe('PoPageDynamicEditActions:', () => {
 
         const spy = spyOn(spyObj, 'testFn').and.callThrough();
 
-        service.beforeSave(spyObj.testFn, resource).subscribe(response => {
+        service.beforeSave(spyObj.testFn, id, resource).subscribe(response => {
           expect(response.newUrl).toBe('/newurlfromfunction');
           expect(response.allowAction).toBeTrue();
-          expect(spy).toHaveBeenCalledWith(resource);
+          expect(spy).toHaveBeenCalledWith(resource, id);
         });
 
         tick();
       }));
 
       it('should get data from a function if resource is null', fakeAsync(() => {
-        const testFn = resourceTest => ({
+        const testFn = (userResource, userId) => ({
           newUrl: '/newurlfromfunction',
           allowAction: true
         });
@@ -130,10 +131,10 @@ describe('PoPageDynamicEditActions:', () => {
 
         const spy = spyOn(spyObj, 'testFn').and.callThrough();
 
-        service.beforeSave(spyObj.testFn, null).subscribe(response => {
+        service.beforeSave(spyObj.testFn, id, null).subscribe(response => {
           expect(response.newUrl).toBe('/newurlfromfunction');
           expect(response.allowAction).toBeTrue();
-          expect(spy).toHaveBeenCalledWith({});
+          expect(spy).toHaveBeenCalledWith({}, id);
         });
 
         tick();
@@ -141,7 +142,7 @@ describe('PoPageDynamicEditActions:', () => {
 
       it('shouldn`t get data from undefined', fakeAsync(() => {
         const testFn = undefined;
-        service.beforeSave(testFn, resource).subscribe(response => {
+        service.beforeSave(testFn, id, resource).subscribe(response => {
           expect(response).toEqual({});
         });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.ts
@@ -8,6 +8,7 @@ import { PoPageDynamicEditBeforeSave } from './interfaces/po-page-dynamic-edit-b
 
 interface ExecuteActionParameter {
   action: string | Function;
+  id?: string | number;
   resource?: any;
 }
 
@@ -25,21 +26,26 @@ export class PoPageDynamicEditActionsService {
     return this.executeAction({ action });
   }
 
-  beforeSave(action: PoPageDynamicEditActions['beforeSave'], body: any): Observable<PoPageDynamicEditBeforeSave> {
+  beforeSave(
+    action: PoPageDynamicEditActions['beforeSave'],
+    id: string,
+    body: any
+  ): Observable<PoPageDynamicEditBeforeSave> {
     const resource = body ?? {};
-
-    return this.executeAction({ action, resource });
+    return this.executeAction({ action, resource, id });
   }
 
-  private executeAction<T>({ action, resource = {} }: ExecuteActionParameter): Observable<T> {
+  private executeAction<T>({ action, resource = {}, id }: ExecuteActionParameter): Observable<T> {
     if (!action) {
       return of(<T>{});
     }
 
     if (typeof action === 'string') {
-      return this.http.post<T>(action, resource, { headers: this.headers });
+      const url = id ? `${action}/${id}` : action;
+
+      return this.http.post<T>(url, resource, { headers: this.headers });
     }
 
-    return of(action(resource));
+    return of(action(resource, id));
   }
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -761,6 +761,17 @@ describe('PoPageDynamicEditComponent: ', () => {
       expect(component['poPageDynamicService'].updateResource).toHaveBeenCalledWith(id, model);
     }));
 
+    it('save: should call `resolveUniqueKey`', () => {
+      component.model = { name: 'Angular' };
+
+      spyOn(component, <any>'resolveUniqueKey');
+      spyOn(component, <any>'updateModel');
+
+      component['save']('testSave/');
+
+      expect(component['resolveUniqueKey']).toHaveBeenCalledWith(component.model);
+    });
+
     it('save: shouldn`t call executeSave if allowAction is false', () => {
       const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: false };
 
@@ -777,6 +788,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       const returnBeforeSave: PoPageDynamicEditBeforeSave = { allowAction: true };
       const newAction = jasmine.createSpy('newAction');
 
+      spyOn(component, <any>'resolveUniqueKey').and.returnValue('1');
       spyOn(component['poPageDynamicEditActionsService'], 'beforeSave').and.returnValue(of(returnBeforeSave));
       spyOn(component, <any>'executeSave');
       spyOn(component, <any>'updateModel');
@@ -784,7 +796,7 @@ describe('PoPageDynamicEditComponent: ', () => {
       component['save'](newAction);
 
       expect(component['executeSave']).not.toHaveBeenCalled();
-      expect(newAction).toHaveBeenCalledWith(component.model);
+      expect(newAction).toHaveBeenCalledWith(component.model, '1');
     });
 
     it('save: should call executeSave if allowAction is true', () => {
@@ -1124,6 +1136,44 @@ describe('PoPageDynamicEditComponent: ', () => {
 
       expect(pageActions.length).toBe(2);
       expect(Array.isArray(pageActions)).toBe(true);
+    });
+
+    it('resolveUniqueKey: should return `formatUniqueKey` value if `params.id` is truthy', () => {
+      const model = { name: 'name' };
+      const id = '1';
+      const activatedRoute: any = {
+        snapshot: {
+          params: { id }
+        }
+      };
+
+      component['activatedRoute'] = activatedRoute;
+
+      spyOn(component, <any>'formatUniqueKey').and.returnValue('1');
+
+      const expectedResult = component['resolveUniqueKey'](model);
+
+      expect(component['formatUniqueKey']).toHaveBeenCalledWith(model);
+      expect(expectedResult).toBe('1');
+    });
+
+    it('resolveUniqueKey: should return undefined if `params.id` is undefined', () => {
+      const model = { name: 'name' };
+      const id = undefined;
+      const activatedRoute: any = {
+        snapshot: {
+          params: { id }
+        }
+      };
+
+      component['activatedRoute'] = activatedRoute;
+
+      spyOn(component, <any>'formatUniqueKey');
+
+      const expectedResult = component['resolveUniqueKey'](model);
+
+      expect(component['formatUniqueKey']).not.toHaveBeenCalled();
+      expect(expectedResult).toBe(undefined);
     });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -563,6 +563,10 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
     }
   }
 
+  private resolveUniqueKey(item: any) {
+    return this.activatedRoute.snapshot.params['id'] ? this.formatUniqueKey(item) : undefined;
+  }
+
   private resolveUrl(item: any, path: string) {
     const uniqueKey = this.formatUniqueKey(item);
 
@@ -570,9 +574,11 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
   }
 
   private save(saveAction: PoPageDynamicEditActions['save']) {
+    const uniqueKey = this.resolveUniqueKey(this.model);
+
     this.subscriptions.push(
       this.poPageDynamicEditActionsService
-        .beforeSave(this.actions.beforeSave, { ...this.model })
+        .beforeSave(this.actions.beforeSave, uniqueKey, { ...this.model })
         .pipe(
           switchMap(returnBeforeSave => {
             const newAction = returnBeforeSave?.newUrl ?? saveAction;
@@ -587,7 +593,7 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
             if (typeof newAction === 'string') {
               return this.executeSave(newAction);
             } else {
-              newAction({ ...this.model });
+              newAction({ ...this.model }, uniqueKey);
               return EMPTY;
             }
           })


### PR DESCRIPTION
**page-dynamic-edit**

**DTHFUI-3480**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Se executados `save` e `beforeSave`, é passado como parâmetro apenas o recurso.

**Qual o novo comportamento?**
Agora os métodos passarão também o **id** como segundo parâmetro em uma tela de edição. Se tratar-se de tela de inserção, o valor emitido para id será `undefined`.

**Simulação**
[Anexado app para validações](https://github.com/po-ui/po-angular/files/4695290/app.zip)
- [link](http://localhost:4200/list) Ação `new` para testar nova inserção.
- [link](http://localhost:4200/editar/0148093543698) para validações para edição de usuário.

Pode também mockar o serviço no beeceptor. Basta criar um método POST retornando o objeto

```
{ "allowAction": true,
"newUrl": "/newUrl"
}
```

**save** com string

**save** com func;

**save** com undefined e null

**beforeSave** com string

**beforeSave** com func

**beforeSave** com newURL undefined

**beforeSave** com allowAction false

**beforeSave** com null


