### PR TITLE
feat(page-list): adiciona tamanho no filtro

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-filter.interface.ts
@@ -22,4 +22,11 @@ export interface PoPageFilter {
 
   /** Texto de instrução exibido dentro do campo de filtro. */
   placeholder?: string;
+
+  /**
+   * Tamanho do filtro em tela, utilizando o *Grid System*,
+   * e limitado ao máximo de 6 colunas. O tamanho mínimo é controlado
+   * conforme resolução de tela para manter a consistência do layout.
+   */
+  width?: number;
 }

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
@@ -44,8 +44,21 @@
       </div>
 
       <!-- FILTER -->
-      <div class="po-page-list-filter-wrapper" *ngIf="filter">
-        <div class="po-field-container-content po-page-filter-content">
+      <div
+        class="po-page-list-filter-wrapper"
+        *ngIf="filter"
+        [ngClass]="hasCustomFilterSize() ? filterSizeClass(filter.width) : ''"
+      >
+        <div
+          class="po-field-container-content po-page-filter-content"
+          [ngClass]="
+            hasCustomFilterSize()
+              ? filter.advancedAction
+                ? 'po-page-filter-input-variable-size'
+                : 'po-page-filter-input-variable-size-wo-adv-search'
+              : ''
+          "
+        >
           <div class="po-field-icon-container-right">
             <span class="po-icon po-icon-search po-field-icon" (click)="callActionFilter('action')"> </span>
           </div>

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
@@ -518,6 +518,21 @@ describe('PoPageListComponent - Desktop:', () => {
       expect(component.hasPageHeader()).toBe(false);
     });
 
+    it('filterSizeClass: should return `po-sm-6 po-md-6 po-lg-6 po-xl-6` when width is 6', () => {
+      component.filter = { width: 6 };
+      expect(component.filterSizeClass(6)).toBe('po-sm-6 po-md-6 po-lg-6 po-xl-6');
+    });
+
+    it('filterSizeClass: should return `po-sm-2 po-md-1 po-lg-1 po-xl-1` when width is 1', () => {
+      component.filter = { width: 1 };
+      expect(component.filterSizeClass(1)).toBe('po-sm-2 po-md-1 po-lg-1 po-xl-1');
+    });
+
+    it('filterSizeClass: should return `po-sm-6 po-md-4 po-lg-2 po-xl-2` when width is 1 and has advancedAction', () => {
+      component.filter = { width: 1, advancedAction: () => {} };
+      expect(component.filterSizeClass(1)).toBe('po-sm-6 po-md-4 po-lg-2 po-xl-2');
+    });
+
     describe('initializeFixedLiterals:', () => {
       it('should return the advanced filter label by `pt` language.', () => {
         component['language'] = 'pt';

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -106,6 +106,19 @@ export class PoPageListComponent extends PoPageListBaseComponent
     return !!(this.title || (this.actions && this.actions.length) || (this.breadcrumb && this.breadcrumb.items.length));
   }
 
+  hasCustomFilterSize(): boolean {
+    return this.filter?.width >= 1 && this.filter?.width <= 6;
+  }
+
+  filterSizeClass(width: number): string {
+    const smWidth = Math.max(this.filter.advancedAction ? 6 : 2, width);
+    const mdWidth = Math.max(this.filter.advancedAction ? 4 : 1, width);
+    if (this.filter.advancedAction) {
+      width = Math.max(width, 2);
+    }
+    return `po-sm-${smWidth} po-md-${mdWidth} po-lg-${width} po-xl-${width}`;
+  }
+
   private onResize(event: Event): void {
     const width = (event.target as Window).innerWidth;
 

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.html
@@ -214,8 +214,10 @@
   <div class="po-row">
     <po-input class="po-md-6" name="title" [(ngModel)]="title" p-label="Title" p-required> </po-input>
 
-    <po-input class="po-md-6" name="filterPlaceholder" [(ngModel)]="filter.placeholder" p-label="Filter placeholder">
+    <po-input class="po-md-3" name="filterPlaceholder" [(ngModel)]="filter.placeholder" p-label="Filter placeholder">
     </po-input>
+
+    <po-input class="po-md-3" name="filterWidth" [(ngModel)]="filter.width" p-label="Filter width"> </po-input>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.ts
@@ -134,6 +134,7 @@ export class SamplePoPageListLabsComponent implements OnInit {
     this.disclaimerGroupTitle = undefined;
     this.filterModel = undefined;
     this.filter.placeholder = undefined;
+    this.filter.width = undefined;
     this.literals = '';
     this.title = 'PO Page List';
 


### PR DESCRIPTION
**po-page-list**

**sem issue - estudo de UX**

incluído o atributo size no filtro, conforme definição de UX da unidade
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Tamanho do filtro do page-list é fixo

**Qual o novo comportamento?**
É possível alterar o tamanho do filtro através da nova propriedade size da interface PoPageFilter, utilizando o número de colunas dentro do grid system (limitado em até 6 colunas, conforme alinhado com @jhosefmarks )

**Simulação**
Esta correção pode ser validada utilizando o sample labs no portal