### PR TITLE
feat(page-dynamic-detail): adiciona propriedade beforeEdit na actions

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/index.ts
@@ -2,6 +2,7 @@ export * from './po-page-dynamic-detail.component';
 export * from './interfaces/po-page-dynamic-detail-actions.interface';
 export * from './interfaces/po-page-dynamic-detail-before-back.interface';
 export * from './interfaces/po-page-dynamic-detail-before-remove.interface';
+export * from './interfaces/po-page-dynamic-detail-before-edit.interface';
 export * from './interfaces/po-page-dynamic-detail-field.interface';
 export * from './interfaces/po-page-dynamic-detail-metadata.interface';
 export * from './interfaces/po-page-dynamic-detail-options.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-actions.interface.ts
@@ -1,5 +1,6 @@
 import { PoPageDynamicDetailBeforeBack } from './po-page-dynamic-detail-before-back.interface';
 import { PoPageDynamicDetailBeforeRemove } from './po-page-dynamic-detail-before-remove.interface';
+import { PoPageDynamicDetailBeforeEdit } from './po-page-dynamic-detail-before-edit.interface';
 
 /**
  * @usedBy PoPageDynamicDetailComponent
@@ -60,6 +61,21 @@ export interface PoPageDynamicDetailActions {
   /**
    * @description
    *
+   * Rota ou método que será chamado antes de editar um recurso (edit).
+   *
+   * Tanto o método como a API devem retornar um objeto com a definição de `PoPageDynamicDetailBeforeEdit`.
+   *
+   * > A url será chamada via POST
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeEdit**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   */
+  beforeEdit?: string | ((id: any, resource: any) => PoPageDynamicDetailBeforeEdit);
+
+  /**
+   * @description
+   *
    * Rota para edição do recurso, caso seja preenchida irá habilitar a ação de edição na tabela.
    *
    * > A rota deve conter um parâmetro chamando id.
@@ -69,8 +85,10 @@ export interface PoPageDynamicDetailActions {
    *  edit: 'edit/:id'
    * };
    * ```
+   *
+   * > Se passada uma função, é responsabilidade do desenvolvedor implementar a navegação, edição ou outro comportamento desejado.
    */
-  edit?: string;
+  edit?: string | ((id: any, resource: any) => void);
 
   /**
    * @description

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-before-edit.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-before-edit.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * @usedBy PoPageDynamicDetailComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeEdit`.
+ */
+export interface PoPageDynamicDetailBeforeEdit {
+  /**
+   * Nova rota para navegação que substituirá a definida anteriormente em `edit`.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de edição (*edit*)
+   */
+  allowAction?: boolean;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.spec.ts
@@ -71,7 +71,7 @@ describe('PoPageDynamicDetailActionsService', () => {
       }));
     });
 
-    describe('BeforeRemove', () => {
+    describe('beforeRemove:', () => {
       const resource = { name: 'Name' };
       const id = '1';
 
@@ -137,6 +137,79 @@ describe('PoPageDynamicDetailActionsService', () => {
       it('should not get data from undefined', fakeAsync(() => {
         const testFn = undefined;
         service.beforeRemove(testFn, id, resource).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
+
+    describe('beforeEdit:', () => {
+      const resource = { name: 'Name' };
+      const id = '1';
+
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeEdit('/test/edit', id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/test/edit/1');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = (userId, userResource) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeEdit(spyObj.testFn, id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(id, resource);
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function if resource is null', fakeAsync(() => {
+        const testFn = (userId, resourceTest) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeEdit(spyObj.testFn, id, null).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(id, {});
+        });
+
+        tick();
+      }));
+
+      it('should not get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeEdit(testFn, id, resource).subscribe(response => {
           expect(response).toEqual({});
         });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail-actions.service.ts
@@ -5,6 +5,7 @@ import { Observable, of } from 'rxjs';
 import { PoPageDynamicDetailActions } from './interfaces/po-page-dynamic-detail-actions.interface';
 import { PoPageDynamicDetailBeforeBack } from './interfaces/po-page-dynamic-detail-before-back.interface';
 import { PoPageDynamicDetailBeforeRemove } from './interfaces/po-page-dynamic-detail-before-remove.interface';
+import { PoPageDynamicDetailBeforeEdit } from './interfaces/po-page-dynamic-detail-before-edit.interface';
 
 interface ExecuteActionParameter {
   action: string | Function;
@@ -24,6 +25,16 @@ export class PoPageDynamicDetailActionsService {
 
   beforeBack(action?: PoPageDynamicDetailActions['beforeBack']): Observable<PoPageDynamicDetailBeforeBack> {
     return this.executeAction({ action });
+  }
+
+  beforeEdit(
+    action: PoPageDynamicDetailActions['beforeEdit'],
+    id: any,
+    body: any
+  ): Observable<PoPageDynamicDetailBeforeEdit> {
+    const resource = body ?? {};
+
+    return this.executeAction({ action, resource, id });
   }
 
   beforeRemove(

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
@@ -589,14 +589,149 @@ describe('PoPageDynamicDetailComponent:', () => {
       });
     });
 
-    it('openEdit: should call `navigateTo` with object that contains path, url and component properties. ', () => {
+    describe('openEdit:', () => {
+      let openEditUrlSpy: jasmine.Spy;
+      const id = 'key';
+
+      beforeEach(() => {
+        spyOn(component, <any>'formatUniqueKey').and.returnValue(id);
+        openEditUrlSpy = spyOn(component, <any>'openEditUrl');
+      });
+
+      it('should call openEditUrl if action is url and allowAction is true', fakeAsync(() => {
+        const beforeEditResult = {
+          allowAction: true
+        };
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicDetailActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalled();
+      }));
+
+      it('should call openEditUrl if action is url and allowAction is undefined', fakeAsync(() => {
+        const beforeEditResult = {
+          allowAction: undefined
+        };
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicDetailActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalledWith(action);
+      }));
+
+      it('should call openEditUrl if action is url and allowAction is a string', fakeAsync(() => {
+        const beforeEditResult = <any>{
+          allowAction: 'test'
+        };
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicDetailActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalledWith(action);
+      }));
+
+      it('should call openEditUrl if action is url and beforeEditResult is undefined', fakeAsync(() => {
+        const beforeEditResult = undefined;
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicDetailActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalledWith(action);
+      }));
+
+      it('should call openEditUrl if newUrl is defined', fakeAsync(() => {
+        const newUrl = 'new-url/edit';
+        const beforeEditResult = {
+          newUrl
+        };
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicDetailActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalledWith(newUrl);
+      }));
+
+      it('should call action if action is a function, newUrl is undefined', fakeAsync(() => {
+        const beforeEditResult = {
+          newUrl: undefined
+        };
+
+        component.model = {
+          name: 'user name'
+        };
+
+        const action = jasmine.createSpy();
+        spyOn(component['poPageDynamicDetailActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action);
+
+        tick();
+
+        expect(openEditUrlSpy).not.toHaveBeenCalled();
+        expect(action).toHaveBeenCalledWith(id, component.model);
+      }));
+
+      it('shouldn`t call action if action is a function and allowAction is false', fakeAsync(() => {
+        const beforeEditResult = {
+          allowAction: false
+        };
+
+        const action = jasmine.createSpy();
+        spyOn(component['poPageDynamicDetailActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action);
+
+        tick();
+
+        expect(openEditUrlSpy).not.toHaveBeenCalled();
+        expect(action).not.toHaveBeenCalled();
+      }));
+
+      it('shouldn`t call openEditUrl if action is url and allowAction is false', fakeAsync(() => {
+        const beforeEditResult = {
+          allowAction: false
+        };
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicDetailActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action);
+
+        tick();
+
+        expect(openEditUrlSpy).not.toHaveBeenCalled();
+      }));
+    });
+
+    it('openEditUrl: should call `navigateTo` with object that contains path, url and component properties. ', () => {
       const path = '/people/:id';
       const url = '/people/1|2';
 
       spyOn(component, <any>'navigateTo');
       spyOn(component, <any>'resolveUrl').and.returnValue(url);
 
-      component['openEdit'](path);
+      component['openEditUrl'](path);
 
       expect(component['navigateTo']).toHaveBeenCalledWith({ path, url /*, component: PoPageDynamicEditComponent*/ });
     });


### PR DESCRIPTION
**Page Dynamic Detail**

**DTHFUI-2631**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O usuário antes não conseguia fazer uma validação antes de acionar a edição. 

**Qual o novo comportamento?**
Adiciona propriedade `beforeEdit` para o desenvolvedor poder executar
uma função/url antes da função de edição no template.
A propriedade `edit`, agora também passa a receber uma função
além da url.

**Simulação**
- Pode ser usado como backend a branch [page-dynamic-edit/DTHFUI-2631](https://github.com/po-ui/po-sample-api/tree/page-dynamic-edit/DTHFUI-2631)
- No front, pode usar o exemplo anexado. Nele contém algumas possibilidades que podem ser testadas. 
[app-before-edit.zip](https://github.com/po-ui/po-angular/files/4697773/app-before-edit.zip)

