### PR TITLE
feat(page-dynamic-table): adiciona action beforeEdit

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
@@ -1,5 +1,6 @@
 export * from './po-page-dynamic-table.component';
 export * from './interfaces/po-page-dynamic-table-actions.interface';
+export * from './interfaces/po-page-dynamic-table-before-edit.interface';
 export * from './interfaces/po-page-dynamic-table-before-new.interface';
 export * from './interfaces/po-page-dynamic-table-before-remove.interface';
 export * from './interfaces/po-page-dynamic-table-before-detail.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
@@ -1,3 +1,4 @@
+import { PoPageDynamicTableBeforeEdit } from './po-page-dynamic-table-before-edit.interface';
 import { PoPageDynamicTableBeforeNew } from './po-page-dynamic-table-before-new.interface';
 import { PoPageDynamicTableBeforeRemove } from './po-page-dynamic-table-before-remove.interface';
 import { PoPageDynamicTableBeforeDetail } from './po-page-dynamic-table-before-detail.interface';
@@ -43,7 +44,22 @@ export interface PoPageDynamicTableActions {
   /**
    * @description
    *
-   * Rota para edição do recurso, caso seja preenchida irá habilitar a ação de edição na tabela.
+   * Rota ou método que será chamado antes de editar um recurso (edit).
+   *
+   * Tanto o método como a API devem retornar um objeto com a definição de `PoPageDynamicTableBeforeEdit`.
+   *
+   * > A url será chamada via POST junto com a key especificada no metadata, por exemplo: `POST {beforeEdit}/{key}`.
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeEdit**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   */
+  beforeEdit?: string | ((id: any, resource: any) => PoPageDynamicTableBeforeEdit);
+
+  /**
+   * @description
+   *
+   * Rota ou função para edição do recurso, caso seja preenchida irá habilitar a ação de edição na tabela.
    *
    * > A rota deve conter um parâmetro chamando id.
    *
@@ -52,8 +68,13 @@ export interface PoPageDynamicTableActions {
    *   edit: 'edit/:id'
    * };
    * ```
+   *
+   * Na função pode ser retornado um objeto representando o recurso modificado.
+   * Dessa forma será atualizada a linha da tabela que está sendo editada. Essa opção não abrange campos configurados com `key: true`.
+   *
+   * > Se passada uma função, é responsabilidade do desenvolvedor implementar a navegação, edição ou outro comportamento desejado.
    */
-  edit?: string;
+  edit?: string | ((id: string, resource: any) => { [key: string]: any });
 
   /**
    * @description

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-edit.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-edit.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * @usedBy PoPageDynamicTableComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeEdit`.
+ */
+export interface PoPageDynamicTableBeforeEdit {
+  /**
+   * Nova rota para navegação que substituirá a definida anteriormente em `edit`.
+   *
+   * > Se for uma url literal, será feito o navigate direto ex: `/edit/22`.
+   *
+   * > Se a url tiver o coringa `:id` esse id será substituído pela chave do recurso ex: `/edit/:id` será convertido para `/edit/22`.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de edição (*edit*)
+   */
+  allowAction?: boolean;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
@@ -244,5 +244,78 @@ describe('PoPageDynamicTableActionsService:', () => {
         tick();
       }));
     });
+
+    describe('beforeEdit:', () => {
+      const resource = { name: 'Name' };
+      const id = '1';
+
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeEdit('/test/edit', id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/test/edit/1');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = (userId, userResource) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeEdit(spyObj.testFn, id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(id, resource);
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function if resource is null', fakeAsync(() => {
+        const testFn = (userId, resourceTest) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeEdit(spyObj.testFn, id, null).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(id, {});
+        });
+
+        tick();
+      }));
+
+      it('should not get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeEdit(testFn, id, resource).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { PoPageDynamicTableActions } from './interfaces/po-page-dynamic-table-actions.interface';
+import { PoPageDynamicTableBeforeEdit } from './interfaces/po-page-dynamic-table-before-edit.interface';
 import { PoPageDynamicTableBeforeNew } from './interfaces/po-page-dynamic-table-before-new.interface';
 import { PoPageDynamicTableBeforeRemove } from './interfaces/po-page-dynamic-table-before-remove.interface';
 import { PoPageDynamicTableBeforeDetail } from './interfaces/po-page-dynamic-table-before-detail.interface';
@@ -21,6 +22,16 @@ export class PoPageDynamicTableActionsService {
   });
 
   constructor(private http: HttpClient) {}
+
+  beforeEdit(
+    action: PoPageDynamicTableActions['beforeEdit'],
+    id: any,
+    body: any
+  ): Observable<PoPageDynamicTableBeforeEdit> {
+    const resource = body ?? {};
+
+    return this.executeAction({ action, resource, id });
+  }
 
   beforeNew(action?: PoPageDynamicTableActions['beforeNew']): Observable<PoPageDynamicTableBeforeNew> {
     return this.executeAction({ action });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -628,6 +628,125 @@ describe('PoPageDynamicTableComponent:', () => {
       // expect(component['navigateTo']).toHaveBeenCalledWith({ path, params, component: PoPageDynamicEditComponent });
     });
 
+    describe('openEdit', () => {
+      let openEditUrlSpy: jasmine.Spy;
+      const id = 'key';
+      const item = 'itemValue';
+
+      beforeEach(() => {
+        spyOn(component, <any>'formatUniqueKey').and.returnValue(id);
+        openEditUrlSpy = spyOn(component, <any>'openEditUrl');
+      });
+
+      it('should call openEditUrl if action is url and allowAction is true', fakeAsync(() => {
+        const beforeEditResult = {
+          allowAction: true
+        };
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action, item);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalledWith(action, item);
+      }));
+
+      it('should call openEditUrl if action is url and allowAction is undefined', fakeAsync(() => {
+        const beforeEditResult = {
+          allowAction: undefined
+        };
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action, item);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalledWith(action, item);
+      }));
+
+      it('should call openEditUrl if action is url and allowAction is a string', fakeAsync(() => {
+        const beforeEditResult = <any>{
+          allowAction: 'test'
+        };
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action, item);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalledWith(action, item);
+      }));
+
+      it('should call openEditUrl if action is url and beforeEditResult is undefined', fakeAsync(() => {
+        const beforeEditResult = undefined;
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action, item);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalledWith(action, item);
+      }));
+
+      it('should call openEditUrl if newUrl is defined', fakeAsync(() => {
+        const newUrl = 'new-url/edit';
+        const beforeEditResult = {
+          newUrl
+        };
+
+        const action = 'test/edit/:id';
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action, item);
+
+        tick();
+
+        expect(openEditUrlSpy).toHaveBeenCalledWith(newUrl, item);
+      }));
+
+      it('should call `action` and `modifyUITableItem` if action is a function and newUrl is undefined', fakeAsync(() => {
+        const beforeEditResult = {
+          newUrl: undefined
+        };
+
+        const action = jasmine.createSpy();
+        const spyModifyUITableItem = spyOn(component, <any>'modifyUITableItem');
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action, item);
+
+        tick();
+
+        expect(openEditUrlSpy).not.toHaveBeenCalled();
+        expect(action).toHaveBeenCalledWith(id, item);
+        expect(spyModifyUITableItem).toHaveBeenCalled();
+      }));
+
+      it('shouldn`t call action if action is a function but allowAction is false', fakeAsync(() => {
+        const beforeEditResult = {
+          allowAction: false
+        };
+
+        const action = jasmine.createSpy();
+        spyOn(component['poPageDynamicTableActionsService'], 'beforeEdit').and.returnValue(of(beforeEditResult));
+
+        component['openEdit'](action, item);
+
+        tick();
+
+        expect(openEditUrlSpy).not.toHaveBeenCalled();
+        expect(action).not.toHaveBeenCalled();
+      }));
+    });
+
     it('openEdit: should call `navigateTo` with object that contains path, url and component properties. ', () => {
       const path = '/people/:id';
       const url = '/people/1|2';
@@ -639,7 +758,42 @@ describe('PoPageDynamicTableComponent:', () => {
       component['openEdit'](path, item);
 
       expect(component['navigateTo']).toHaveBeenCalledWith({ path, url });
-      // expect(component['navigateTo']).toHaveBeenCalledWith({ path, url, component: PoPageDynamicEditComponent });
+    });
+
+    describe('modifyUITableItem:', () => {
+      const items = [{ name: 'react', id: 2 }];
+
+      it('shouldn`t modify item if newItemValue is undefined', () => {
+        component.items = items;
+        const newItemValue = undefined;
+        const expectedValue = items;
+
+        component['modifyUITableItem'](component.items[0], newItemValue);
+
+        expect(component.items).toEqual(expectedValue);
+      });
+
+      it('shouldn`t modify item if newItemValue is null', () => {
+        component.items = items;
+        const newItemValue = null;
+        const expectedValue = items;
+
+        component['modifyUITableItem'](component.items[0], newItemValue);
+
+        expect(component.items).toEqual(expectedValue);
+      });
+
+      it('shouldn`t modify item property value wich is a key element', () => {
+        component.items = items;
+        const newItemValue = { name: 'angular', id: 3 };
+        const expectedValue = { name: 'angular', id: 2 };
+
+        spyOnProperty(component, <any>'keys', 'get').and.returnValue(['id']);
+
+        component['modifyUITableItem'](component.items[0], newItemValue);
+
+        expect(component.items).toEqual([expectedValue]);
+      });
     });
 
     describe('openNew:', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -26,6 +26,7 @@ import { PoPageCustomizationService } from './../../services/po-page-customizati
 import { PoPageDynamicOptionsSchema } from './../../services/po-page-customization/po-page-dynamic-options.interface';
 import { PoPageDynamicTableMetaData } from './interfaces/po-page-dynamic-table-metadata.interface';
 import { PoPageDynamicTableActionsService } from './po-page-dynamic-table-actions.service';
+import { PoPageDynamicTableBeforeEdit } from './interfaces/po-page-dynamic-table-before-edit.interface';
 import { PoPageDynamicTableBeforeNew } from './interfaces/po-page-dynamic-table-before-new.interface';
 import { PoPageDynamicTableBeforeRemove } from './interfaces/po-page-dynamic-table-before-remove.interface';
 import { PoPageDynamicTableBeforeDetail } from './interfaces/po-page-dynamic-table-before-detail.interface';
@@ -436,10 +437,57 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     this.navigateTo({ path, params: { duplicate: JSON.stringify(duplicates) } });
   }
 
-  private openEdit(path: string, item) {
+  private openEdit(actionEdit: PoPageDynamicTableActions['edit'], item) {
+    const id = this.formatUniqueKey(item);
+
+    this.subscriptions.add(
+      this.poPageDynamicTableActionsService
+        .beforeEdit(this.actions.beforeEdit, id, item)
+        .pipe(
+          switchMap((beforeEditResult: PoPageDynamicTableBeforeEdit) =>
+            this.executeEditAction(actionEdit, beforeEditResult, item, id)
+          )
+        )
+        .subscribe()
+    );
+  }
+
+  private executeEditAction(
+    action: PoPageDynamicTableActions['edit'],
+    beforeEditResult: PoPageDynamicTableBeforeEdit,
+    item: any,
+    id: string
+  ) {
+    const newEditAction = beforeEditResult?.newUrl ?? action;
+    const allowAction = beforeEditResult?.allowAction ?? true;
+
+    if (!allowAction) {
+      return EMPTY;
+    }
+
+    if (typeof newEditAction === 'string') {
+      this.openEditUrl(newEditAction, item);
+    } else {
+      const updatedItem = newEditAction(id, item);
+      this.modifyUITableItem(item, updatedItem);
+    }
+
+    return EMPTY;
+  }
+
+  private openEditUrl(path: string, item) {
     const url = this.resolveUrl(item, path);
 
     this.navigateTo({ path, url });
+  }
+
+  private modifyUITableItem(currentItem, newItemValue) {
+    if (typeof newItemValue === 'object' && newItemValue !== null) {
+      this.keys.forEach(key => delete newItemValue[key]);
+
+      const tableItem = this.items.findIndex(item => item === currentItem);
+      this.items[tableItem] = { ...currentItem, ...newItemValue };
+    }
   }
 
   private openNew(actionNew: PoPageDynamicTableActions['new']) {


### PR DESCRIPTION
**page-dynamic-table**

**DTHFUI-2623**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A ação *edit* direciona imediatamente para a rota indicada.

**Qual o novo comportamento?**
• Adicionada propriedade **beforeEdit** para que o desenvolvedor possa executar uma ação antes de editar recurso (**edit**).
• Agora a propriedade **edit** aceita também uma função. Esta função pode retornar um objeto contendo o recurso para atualização da linha. Exceção feita para campos que contém o atributo `key: true`.

**Simulação**
- **edit** com string
- **edit**  com func;
- **edit** com undefined e null
- **edit** com retorno de objeto
- **edit** com retorno de objeto contendo um atributo `key`

- **beforeEdit** com string
- **beforeEdit** com func
- **beforeEdit** com newURL undefined
- **beforeEdit** com allowAction false
- **beforeEdit** com null