### PR TITLE
test(ng-template): Correção de testes unitários

### DIFF
--- a/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.spec.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.spec.ts
@@ -1,5 +1,5 @@
 import { By } from '@angular/platform-browser';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -8,7 +8,7 @@ import { throwError } from 'rxjs';
 import { PoFieldModule, PoI18nPipe, PoModalModule } from '@po-ui/ng-components';
 
 import * as utilsFunctions from './../../utils/util';
-import { configureTestSuite, getObservable } from './../../util-test/util-expect.spec';
+import { getObservable } from './../../util-test/util-expect.spec';
 
 import { PoModalPasswordRecoveryComponent } from './po-modal-password-recovery.component';
 import { PoModalPasswordRecoveryErrorMessageComponent } from './po-modal-password-recovery-error-message/po-modal-password-recovery-error-message.component';
@@ -22,13 +22,13 @@ describe('PoModalPasswordRecoveryComponent:', () => {
   let debugElement;
   const fakeSubscription = <any>{ unsubscribe: () => {} };
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, RouterTestingModule.withRoutes([]), PoFieldModule, PoModalModule],
       declarations: [PoModalPasswordRecoveryErrorMessageComponent, PoModalPasswordRecoveryComponent],
       providers: [PoI18nPipe, PoModalPasswordRecoveryService]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoModalPasswordRecoveryComponent);

--- a/projects/templates/src/lib/components/po-page-background/po-page-background.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.component.spec.ts
@@ -1,8 +1,8 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import * as utilFunctions from './../../utils/util';
-import { configureTestSuite, expectPropertiesValues } from './../../util-test/util-expect.spec';
+import { expectPropertiesValues } from './../../util-test/util-expect.spec';
 
 import { PoPageBackgroundComponent } from './po-page-background.component';
 
@@ -11,12 +11,12 @@ describe('PoPageBackgroundComponent:', () => {
   let fixture: ComponentFixture<PoPageBackgroundComponent>;
   let debugElement;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [PoPageBackgroundComponent],
       schemas: [NO_ERRORS_SCHEMA]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageBackgroundComponent);

--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.spec.ts
@@ -1,30 +1,28 @@
 import { ChangeDetectionStrategy, NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { PoPageBlockedUserContactsComponent } from './po-page-blocked-user-contacts.component';
 
-import { configureTestSuite } from '../../../util-test/util-expect.spec';
-
 describe('PoPageBlockedUserContactsComponent: ', () => {
   let component: PoPageBlockedUserContactsComponent;
   let fixture: ComponentFixture<PoPageBlockedUserContactsComponent>;
   let debugElement;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, RouterTestingModule.withRoutes([])],
       declarations: [PoPageBlockedUserContactsComponent],
       providers: [HttpClient, HttpHandler],
       schemas: [NO_ERRORS_SCHEMA]
-    });
+    }).compileComponents();
 
     TestBed.overrideComponent(PoPageBlockedUserContactsComponent, {
       set: { changeDetection: ChangeDetectionStrategy.Default }
     }).createComponent(PoPageBlockedUserContactsComponent);
-  });
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageBlockedUserContactsComponent);

--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-reason/po-page-blocked-user-reason.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-reason/po-page-blocked-user-reason.component.spec.ts
@@ -1,7 +1,5 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { SimpleChange } from '@angular/core';
-
-import { configureTestSuite } from '../../../util-test/util-expect.spec';
 
 import { PoI18nModule } from './../../../../../../ui/src/lib/services/po-i18n/po-i18n.module';
 import { PoI18nPipe } from './../../../../../../ui/src/lib/services/po-i18n/po-i18n.pipe';
@@ -41,12 +39,12 @@ describe('PoPageBlockedUserReasonContactsComponent: ', () => {
     }
   };
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [PoI18nModule.config(config)],
       declarations: [PoI18nPipe, PoPageBlockedUserReasonComponent]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageBlockedUserReasonComponent);

--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user.component.spec.ts
@@ -1,8 +1,7 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { configureTestSuite } from '../../util-test/util-expect.spec';
 import * as utilsFunctions from './../../utils/util';
 
 import { PoPageBlockedUserBaseComponent } from './po-page-blocked-user-base.component';
@@ -14,13 +13,13 @@ describe('PoPageBlockedUserComponent:', () => {
   let fixture: ComponentFixture<PoPageBlockedUserComponent>;
   let nativeElement: any;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes([])],
       declarations: [PoPageBlockedUserComponent],
       schemas: [NO_ERRORS_SCHEMA]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageBlockedUserComponent);

--- a/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 import { EventEmitter, NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import * as utilsFunctions from './../../utils/util';
-import { configureTestSuite, getObservable } from './../../util-test/util-expect.spec';
+import { getObservable } from './../../util-test/util-expect.spec';
 import { of } from 'rxjs';
 
 import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/po-modal-password-recovery.component';
@@ -19,14 +19,14 @@ describe('PoPageChangePasswordComponent:', () => {
   let nativeElement: any;
   const fakeSubscription = <any>{ unsubscribe: () => {} };
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, RouterTestingModule.withRoutes([])],
       declarations: [PoPageChangePasswordComponent],
       providers: [HttpClient, HttpHandler, PoPageChangePasswordService],
       schemas: [NO_ERRORS_SCHEMA]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageChangePasswordComponent);

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
@@ -9,7 +9,7 @@ import { throwError, of } from 'rxjs';
 import { PoDialogService } from '@po-ui/ng-components';
 
 import * as util from '../../utils/util';
-import { configureTestSuite, expectPropertiesValues } from '../../util-test/util-expect.spec';
+import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 
 import { PoPageDynamicDetailComponent } from './po-page-dynamic-detail.component';
 import { PoPageDynamicDetailActions } from './interfaces/po-page-dynamic-detail-actions.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -9,7 +9,7 @@ import { throwError, of, EMPTY } from 'rxjs';
 import { PoDialogModule } from '@po-ui/ng-components';
 
 import * as util from './../../utils/util';
-import { configureTestSuite, expectPropertiesValues } from './../../util-test/util-expect.spec';
+import { expectPropertiesValues } from './../../util-test/util-expect.spec';
 
 import { PoPageDynamicEditComponent } from './po-page-dynamic-edit.component';
 import { PoPageDynamicEditActions } from './interfaces/po-page-dynamic-edit-actions.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.spec.ts
@@ -1,9 +1,7 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import { PoDynamicModule, PoFieldModule, PoModalModule } from '@po-ui/ng-components';
-
-import { configureTestSuite } from './../../../util-test/util-expect.spec';
 
 import { PoAdvancedFilterBaseComponent } from './po-advanced-filter-base.component';
 import { PoAdvancedFilterComponent } from './po-advanced-filter.component';
@@ -13,12 +11,12 @@ describe('PoAdvancedFilterComponent', () => {
   let fixture: ComponentFixture<PoAdvancedFilterComponent>;
   let filters: Array<any>;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, PoDynamicModule, PoFieldModule, PoModalModule],
       declarations: [PoAdvancedFilterComponent]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoAdvancedFilterComponent);

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick, async } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Routes } from '@angular/router';
@@ -10,7 +10,7 @@ import { PoDynamicFieldType } from '@po-ui/ng-components';
 import { PoPageDynamicSearchComponent } from './po-page-dynamic-search.component';
 import { PoAdvancedFilterComponent } from './po-advanced-filter/po-advanced-filter.component';
 import { PoPageCustomizationModule } from '../../services/po-page-customization/po-page-customization.module';
-import { configureTestSuite, expectBrowserLanguageMethod } from './../../util-test/util-expect.spec';
+import { expectBrowserLanguageMethod } from './../../util-test/util-expect.spec';
 
 export const routes: Routes = [];
 
@@ -18,14 +18,14 @@ describe('PoPageDynamicSearchComponent:', () => {
   let component: PoPageDynamicSearchComponent;
   let fixture: ComponentFixture<PoPageDynamicSearchComponent>;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, RouterTestingModule.withRoutes(routes), PoPageCustomizationModule],
       declarations: [PoPageDynamicSearchComponent, PoAdvancedFilterComponent],
       providers: [TitleCasePipe],
       schemas: [NO_ERRORS_SCHEMA]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageDynamicSearchComponent);

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -9,7 +9,7 @@ import { of, EMPTY } from 'rxjs';
 import { PoDialogModule, PoNotificationModule, PoTableColumnSort, PoTableColumnSortType } from '@po-ui/ng-components';
 
 import * as utilsFunctions from '../../utils/util';
-import { configureTestSuite, expectPropertiesValues } from '../../util-test/util-expect.spec';
+import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 import { PoPageDynamicDetailComponent } from '../po-page-dynamic-detail/po-page-dynamic-detail.component';
 
 import { PoPageDynamicTableComponent } from './po-page-dynamic-table.component';
@@ -19,7 +19,7 @@ describe('PoPageDynamicTableComponent:', () => {
   let component: PoPageDynamicTableComponent;
   let fixture: ComponentFixture<PoPageDynamicTableComponent>;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
@@ -32,8 +32,8 @@ describe('PoPageDynamicTableComponent:', () => {
       declarations: [PoPageDynamicTableComponent],
       providers: [],
       schemas: [NO_ERRORS_SCHEMA]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageDynamicTableComponent);

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-execution/po-page-job-scheduler-execution.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-execution/po-page-job-scheduler-execution.component.spec.ts
@@ -1,9 +1,9 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { throwError } from 'rxjs';
 
-import { configureTestSuite, expectPropertiesValues } from './../../../util-test/util-expect.spec';
+import { expectPropertiesValues } from './../../../util-test/util-expect.spec';
 import { getObservable } from '../../../util-test/util-expect.spec';
 
 import { PoPageJobSchedulerExecutionComponent } from './po-page-job-scheduler-execution.component';
@@ -15,11 +15,11 @@ describe('PoPageJobSchedulerExecutionComponent:', () => {
 
   let debugElement;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes([]), PoPageJobSchedulerModule]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageJobSchedulerExecutionComponent);

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.spec.ts
@@ -1,7 +1,6 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { configureTestSuite } from '../../../util-test/util-expect.spec';
 import { getObservable } from '../../../util-test/util-expect.spec';
 
 import { PoPageJobSchedulerModule } from '../po-page-job-scheduler.module';
@@ -13,11 +12,11 @@ describe('PoPageJobSchedulerParametersComponent:', () => {
 
   let debugElement;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes([]), PoPageJobSchedulerModule]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageJobSchedulerParametersComponent);

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-summary/po-page-job-scheduler-summary.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-summary/po-page-job-scheduler-summary.component.spec.ts
@@ -1,8 +1,7 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import * as util from '../../../utils/util';
-import { configureTestSuite } from '../../../util-test/util-expect.spec';
 
 import { poPageJobSchedulerLiteralsDefault } from '../po-page-job-scheduler-literals';
 import { PoPageJobSchedulerModule } from '../po-page-job-scheduler.module';
@@ -14,11 +13,11 @@ describe('PoPageJobSchedulerSummaryComponent:', () => {
 
   let debugElement;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes([]), PoPageJobSchedulerModule]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageJobSchedulerSummaryComponent);

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
@@ -1,9 +1,9 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { Observable, of } from 'rxjs';
 
-import { changeBrowserInnerWidth, configureTestSuite } from './../../util-test/util-expect.spec';
+import { changeBrowserInnerWidth } from './../../util-test/util-expect.spec';
 import { getObservable } from '../../util-test/util-expect.spec';
 
 import { PoJobSchedulerInternal } from './interfaces/po-job-scheduler-internal.interface';
@@ -14,11 +14,11 @@ describe('PoPageJobSchedulerComponent:', () => {
   let component: PoPageJobSchedulerComponent;
   let fixture: ComponentFixture<PoPageJobSchedulerComponent>;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes([]), PoPageJobSchedulerModule]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageJobSchedulerComponent);

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
@@ -1,7 +1,7 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, async } from '@angular/core/testing';
 import { throwError } from 'rxjs';
 
-import { configureTestSuite, expectPropertiesValues, getObservable } from '../../util-test/util-expect.spec';
+import { expectPropertiesValues, getObservable } from '../../util-test/util-expect.spec';
 import { poLocaleDefault } from './../../utils/util';
 import * as UtilFunctions from './../../utils/util';
 
@@ -24,12 +24,12 @@ describe('ThPageLoginBaseComponent: ', () => {
   let component: PoPageLoginBaseComponent;
   let servicePageLogin: PoPageLoginService;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [PoPageLoginService]
-    });
-  });
+    }).compileComponents();
+  }));
 
   const booleanValidTrueValues = [true, 'true', 1, ''];
   const booleanValidFalseValues = [false, 'false', 0];

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-popover/po-page-login-popover.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-popover/po-page-login-popover.component.spec.ts
@@ -1,10 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { PoPageLoginPopoverComponent } from './po-page-login-popover.component';
 
 import * as UtilFunctions from './../../../utils/util';
-import { configureTestSuite } from '../../../util-test/util-expect.spec';
 import { PoI18nPipe } from './../../../../../../ui/src/lib/services/po-i18n/po-i18n.pipe';
 
 describe('ThPageLoginPopoverComponent: ', () => {
@@ -12,12 +11,12 @@ describe('ThPageLoginPopoverComponent: ', () => {
   let fixture: ComponentFixture<PoPageLoginPopoverComponent>;
   let nativeElement: any;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes([])],
       declarations: [PoI18nPipe, PoPageLoginPopoverComponent]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageLoginPopoverComponent);

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -14,7 +14,6 @@ import {
   PoSwitchComponent
 } from '@po-ui/ng-components';
 
-import { configureTestSuite } from './../../util-test/util-expect.spec';
 import { poLocaleDefault } from './../../utils/util';
 
 import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/po-modal-password-recovery.component';
@@ -37,7 +36,7 @@ describe('PoPageLoginComponent: ', () => {
 
   let nativeElement: any;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, RouterTestingModule.withRoutes([])],
       declarations: [
@@ -52,8 +51,8 @@ describe('PoPageLoginComponent: ', () => {
       ],
       providers: [HttpClient, HttpHandler, PoPageLoginService],
       schemas: [NO_ERRORS_SCHEMA]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoPageLoginComponent);

--- a/projects/templates/src/lib/util-test/util-expect.spec.ts
+++ b/projects/templates/src/lib/util-test/util-expect.spec.ts
@@ -3,49 +3,6 @@ import { ComponentFixture, getTestBed, TestBed } from '@angular/core/testing';
 import { Observable } from 'rxjs';
 
 /**
- * Reconfigura a suíte de testes atuais para impedir a recompilação de componentes angular após cada teste.
- * Força o TestBed a recriar o ngZone e todos os serviços injetáveis, configurando diretamente a variável _instantiated para
- * `false` após cada teste.
- * Limpa todas as alterações e reverte a configuração do TestBed após o término da suíte.
- *
- * Referência : https://blog.angularindepth.com/angular-unit-testing-performance-34363b7345ba
- *
- * @param configureModule parâmetro opcional que pode ser usado para configurar o TestBed para o conjunto de testes atual
- * diretamente na chamada configureTestSuite (não é necessário o BeforeAll extra neste caso).
- */
-export const configureTestSuite = (configureModule?: any) => {
-  const testBedApi: any = getTestBed();
-  const originReset = TestBed.resetTestingModule;
-
-  beforeAll(() => {
-    TestBed.resetTestingModule();
-    TestBed.resetTestingModule = () => TestBed;
-  });
-
-  if (configureModule) {
-    beforeAll(done =>
-      (async () => {
-        configureModule();
-
-        await TestBed.compileComponents();
-      })()
-        .then(done)
-        .catch(done.fail)
-    );
-  }
-
-  afterEach(() => {
-    testBedApi._activeFixtures.forEach((fixture: ComponentFixture<any>) => fixture.destroy());
-    testBedApi._instantiated = false;
-  });
-
-  afterAll(() => {
-    TestBed.resetTestingModule = originReset;
-    TestBed.resetTestingModule();
-  });
-};
-
-/**
  * Expect dinamico para validar metódos setters.
  *
  * @param comp componente a ser testado

--- a/projects/ui/src/lib/components/po-progress/po-progress.component.spec.ts
+++ b/projects/ui/src/lib/components/po-progress/po-progress.component.spec.ts
@@ -1,6 +1,5 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
-import { configureTestSuite } from 'projects/templates/src/lib/util-test/util-expect.spec';
 import { Observable } from 'rxjs';
 
 import { PoProgressComponent } from './po-progress.component';
@@ -13,11 +12,11 @@ describe('PoProgressComponent:', () => {
 
   let nativeElement: any;
 
-  configureTestSuite(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [PoProgressModule]
-    });
-  });
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoProgressComponent);


### PR DESCRIPTION
**ng-template**

dthfui 3546
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Retirada função configureTestSuite poisna versão 9 o testbed foi
otimizado e essa função estava causando algumas instabilidades na
execução dos testes unitários.

**Qual o novo comportamento?**
Os testes foram revisados

**Simulação**
Basta rodar os testes.
