### PR TITLE
fix(table): corrige tooltip em colunas do tipo label

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1265,6 +1265,18 @@ describe('PoTableComponent:', () => {
       expect(component.tooltipText).toBe('Label Tooltip Value');
     });
 
+    it(`checkingIfColumnHasTooltip: should apply undefined to tooltipText if 'getColumnLabel' returns undefined`, () => {
+      const column = { type: 'label', tooltip: 'Label Tooltip Value' };
+      const row = {};
+
+      spyOn(component, <any>'getColumnLabel').and.returnValue(undefined);
+
+      component['checkingIfColumnHasTooltip'](column, row);
+
+      expect(component.getColumnLabel).toHaveBeenCalledWith(row, column);
+      expect(component.tooltipText).toBeUndefined();
+    });
+
     it(`calculateHeightTableContainer: should call 'setTableOpacity' with 1`, () => {
       spyOn(component, <any>'setTableOpacity');
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -377,7 +377,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
     if (column.type === 'label') {
       const columnLabel = this.getColumnLabel(row, column);
-      return (this.tooltipText = columnLabel.tooltip);
+      return (this.tooltipText = columnLabel?.tooltip);
     }
   }
 


### PR DESCRIPTION
**po-table**

**DTHFUI-3438**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando passado o mouse sobre uma coluna do tipo label com um valor diferente dos especificados dá erro no console.

**Qual o novo comportamento?**
Revisada e ajustada validação para propriedade `tooltipText`

**Simulação**
Utilizar `sample-po-table-components` passando um valor diferente na propriedade `status`.