### PR TITLE
feat(page-dynamic-table): adiciona action beforeDuplicate

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
@@ -1,5 +1,6 @@
 export * from './po-page-dynamic-table.component';
 export * from './interfaces/po-page-dynamic-table-actions.interface';
+export * from './interfaces/po-page-dynamic-table-before-duplicate.interface';
 export * from './interfaces/po-page-dynamic-table-before-edit.interface';
 export * from './interfaces/po-page-dynamic-table-before-new.interface';
 export * from './interfaces/po-page-dynamic-table-before-remove.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
@@ -2,6 +2,7 @@ import { PoPageDynamicTableBeforeEdit } from './po-page-dynamic-table-before-edi
 import { PoPageDynamicTableBeforeNew } from './po-page-dynamic-table-before-new.interface';
 import { PoPageDynamicTableBeforeRemove } from './po-page-dynamic-table-before-remove.interface';
 import { PoPageDynamicTableBeforeDetail } from './po-page-dynamic-table-before-detail.interface';
+import { PoPageDynamicTableBeforeDuplicate } from './po-page-dynamic-table-before-duplicate.interface';
 
 /**
  * @usedBy PoPageDynamicTableComponent
@@ -29,17 +30,37 @@ export interface PoPageDynamicTableActions {
   /**
    * @description
    *
-   * Rota para duplicação do recurso, caso seja preenchida irá habilitar a ação de duplicação na tabela.
+   * Rota ou método que será chamado antes de duplicar um recurso (duplicate). O método recebe os parâmetros `key` e também um objeto com as propriedades marcadas com `duplicate: true`.
    *
-   * > Os valores a serem duplicados serão enviados via query string.
+   * Tanto o método como a API devem retornar um objeto com a definição de `PoPageDynamicTableBeforeDuplicate`.
+   *
+   * > A url será chamada via POST junto com a key especificada no metadata, por exemplo: `POST {beforeDuplicate}/{key}`.
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeDuplicate**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   */
+  beforeDuplicate?: string | ((key: string, resource: any) => PoPageDynamicTableBeforeDuplicate);
+
+  /**
+   * @description
+   *
+   * Rota ou função para duplicação do recurso, caso seja preenchida irá habilitar a ação de duplicação na tabela.
+   *
+   * > Os valores a serem duplicados serão enviados via query string, exceto para aqueles definidos como `key: true` no metadata.
    *
    * ```
    * actions = {
    *   duplicate: 'duplicate'
    * };
    * ```
+   *
+   * Se for passado um método:
+   *  - receberá como parâmetro na chamada do método um objeto com as propriedades marcadas com `duplicate: true`, exceto para aquelas definidas como `key: true` no metadata.
+   *  - é responsabilidade do desenvolvedor implementar a navegação e/ou envio dos dados
+   * para o servidor ou outro comportamento desejado.
    */
-  duplicate?: string;
+  duplicate?: string | ((resource: any) => void);
 
   /**
    * @description

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-duplicate.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-duplicate.interface.ts
@@ -1,0 +1,31 @@
+/**
+ * @usedBy PoPageDynamicTableComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeDuplicate`.
+ */
+export interface PoPageDynamicTableBeforeDuplicate {
+  /**
+   * Nova rota para navegação que substituirá a definida anteriormente em `duplicate`.
+   *
+   * > Os valores a serem duplicados serão enviados via query string, exceto para aqueles definidos como `key: true`.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de duplicação de recurso (*duplicate*)
+   */
+  allowAction?: boolean;
+
+  /**
+   *  Objeto com as novas propriedades para duplicação, o mesmo substituirá o objeto atual.
+   *
+   * > Essa opção não abrange campos configurados com `key: true`.
+   *
+   * > Os novos valores a serem duplicados serão enviados via query string.
+   *
+   */
+  resource?: any;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
@@ -317,5 +317,78 @@ describe('PoPageDynamicTableActionsService:', () => {
         tick();
       }));
     });
+
+    describe('beforeDuplicate:', () => {
+      const resource = { name: 'Name' };
+      const id = '1';
+
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeDuplicate('/test/duplicate', id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/test/duplicate/1');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = (userId, userResource) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeDuplicate(spyObj.testFn, id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(id, resource);
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function if resource is null', fakeAsync(() => {
+        const testFn = (userId, resourceTest) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeDuplicate(spyObj.testFn, id, null).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(id, {});
+        });
+
+        tick();
+      }));
+
+      it('should not get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeDuplicate(testFn, id, resource).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { PoPageDynamicTableActions } from './interfaces/po-page-dynamic-table-actions.interface';
+import { PoPageDynamicTableBeforeDuplicate } from './interfaces/po-page-dynamic-table-before-duplicate.interface';
 import { PoPageDynamicTableBeforeEdit } from './interfaces/po-page-dynamic-table-before-edit.interface';
 import { PoPageDynamicTableBeforeNew } from './interfaces/po-page-dynamic-table-before-new.interface';
 import { PoPageDynamicTableBeforeRemove } from './interfaces/po-page-dynamic-table-before-remove.interface';
@@ -22,6 +23,16 @@ export class PoPageDynamicTableActionsService {
   });
 
   constructor(private http: HttpClient) {}
+
+  beforeDuplicate(
+    action: PoPageDynamicTableActions['beforeDuplicate'],
+    id: any,
+    body: any
+  ): Observable<PoPageDynamicTableBeforeDuplicate> {
+    const resource = body ?? {};
+
+    return this.executeAction({ action, resource, id });
+  }
 
   beforeEdit(
     action: PoPageDynamicTableActions['beforeEdit'],

--- a/projects/templates/src/lib/utils/util.spec.ts
+++ b/projects/templates/src/lib/utils/util.spec.ts
@@ -24,7 +24,8 @@ import {
   sortValues,
   validateDateRange,
   validValue,
-  valuesFromObject
+  valuesFromObject,
+  removeKeysProperties
 } from './util';
 
 import * as UtilFunctions from './util';
@@ -1049,6 +1050,16 @@ describe('Function valuesFromObject:', () => {
 
   it('should return an empty array if params doesn`t exist', () => {
     expect(valuesFromObject()).toEqual([]);
+  });
+});
+
+describe('Function removeKeysProperties:', () => {
+  it('should return an object without any key property', () => {
+    const newItemValue = { name: 'angular', id: 3 };
+    const expectedResult = { name: 'angular' };
+    const keys = ['id'];
+
+    expect(removeKeysProperties(keys, newItemValue)).toEqual(expectedResult);
   });
 });
 

--- a/projects/templates/src/lib/utils/util.ts
+++ b/projects/templates/src/lib/utils/util.ts
@@ -381,6 +381,26 @@ export function addZero(time: number) {
 }
 
 /**
+ * Remove do objeto as propriedades especificadas.
+ *
+ * Exemplo:
+ *
+ * ```
+ * key: ['id', 'cpf']
+ * newItemValue: { id: '123', cpf: '456', name: 'Test' }
+ * Resultado: { name: 'Test' }
+ * ```
+ *
+ * @param keys lista de propriedades para ser removida do objeto.
+ * @param newItemValue objeto que se deseja remover as propriedades.
+ * @returns objeto sem as propriedades especificadas.
+ */
+export function removeKeysProperties(keys: Array<any>, newItemValue: any) {
+  keys.forEach(key => delete newItemValue[key]);
+  return newItemValue;
+}
+
+/**
  * @deprecated
  * Retorna um ViewContainerRef compatível para projetos com Ivy habilitado ou não.
  *


### PR DESCRIPTION
**page-dynamic-table**

**DTHFUI-2622**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A ação *duplicate* direciona imediatamente para a rota indicada.

**Qual o novo comportamento?**
• Adicionada propriedade **beforeDuplicate** para que o desenvolvedor possa executar uma ação antes de editar recurso (**duplicate**).
• Agora a propriedade **duplicate** aceita também uma função. 

**Simulação**

Anexada [aplicação para teste](https://github.com/po-ui/po-angular/files/4766306/app.zip). Pode testar com o componente Clientes.

- **duplicate** com string
- **duplicate**  com func - recebe como parâmetro objeto contendo apenas as propriedades marcadas com `duplicate: true`.
- **duplicate** com undefined e null

- **beforeDuplicate** com string
- **beforeDuplicate** com func recebendo como parâmetro o id e também o objeto contendo apenas as propriedades marcadas com `duplicate: true`.
- **beforeDuplicate** com newURL undefined
- **beforeDuplicate** com allowAction false
- **beforeDuplicate** com null
- **beforeDuplicate** com resource. Este deve enviar os dados via query string exceto para propriedades `key`.
- **beforeDuplicate** sem resource. Este deve enviar os dados previamente setados no metadata com `duplicate`.