### PR TITLE
feat(dynamic-form): adiciona a propriedade `order` nos campos

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -167,4 +167,36 @@ export interface PoDynamicFormField extends PoDynamicField {
    * > Esta propriedade pode ser utilizada quando o `type` for *PoDynamicFieldType.Date* ou *PoDynamicFieldType.DateTime*.
    */
   format?: string;
+
+  /**
+   * Informa a ordem de exibição do campo.
+   *
+   * Exemplo de utilização:
+   *
+   * ```
+   * [
+   *   { property: 'test 1', order: 2 },
+   *   { property: 'test 2', order: 1 },
+   *   { property: 'test 3' },
+   *   { property: 'test 4', order: 3 }
+   * ];
+   * ```
+   *
+   * Na exibição a ordem ficará dessa forma:
+   * ```
+   * [
+   *   { property: 'test 2', order: 1 },
+   *   { property: 'test 1', order: 2 },
+   *   { property: 'test 4', order: 3 },
+   *   { property: 'test 3' }
+   * ];
+   * ```
+   *
+   * Só serão aceitos valores com números inteiros maiores do que zero.
+   *
+   * Campos sem `order` ou com valores negativos, zerados ou inválidos
+   * serão os últimos a serem renderizados e seguirão o posicionamento dentro do
+   * array.
+   */
+  order?: number;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { TitleCasePipe } from '@angular/common';
 
-import { expectPropertiesValues } from '../../../../util-test/util-expect.spec';
+import { expectPropertiesValues, expectArraysSameOrdering } from '../../../../util-test/util-expect.spec';
 
 import * as PoDynamicUtil from '../../po-dynamic.util';
 import { PoDynamicFieldType } from '../../po-dynamic-field-type.enum';
 import { PoDynamicFormFieldsBaseComponent } from './po-dynamic-form-fields-base.component';
+import { PoDynamicFormField } from '../po-dynamic-form-field.interface';
 
 describe('PoDynamicFormFieldsBaseComponent:', () => {
   let component: PoDynamicFormFieldsBaseComponent;
@@ -85,27 +86,107 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
       expect(visibleFields.length).toBe(fields.length);
     });
 
-    it('getVisibleFields: shouldn`t call `isVisibleField` if not exists `field.property`', () => {
-      const fields = [{ label: 'name' }];
-      component.fields = <any>fields;
+    describe('getVisibleFields:', () => {
+      it('should return the ordered fields', () => {
+        const fields: Array<PoDynamicFormField> = [
+          { property: 'test 1', order: 2 },
+          { property: 'test 2', order: 1 },
+          { property: 'test 3', order: 4 },
+          { property: 'test 4', order: 3 }
+        ];
 
-      spyOn(PoDynamicUtil, 'isVisibleField');
-      spyOn(component, <any>'printError');
+        const expectedFields = [
+          { property: 'test 2' },
+          { property: 'test 1' },
+          { property: 'test 4' },
+          { property: 'test 3' }
+        ];
 
-      const visibleFields = component['getVisibleFields']();
+        component.fields = [...fields];
 
-      expect(visibleFields.length).toBe(0);
-      expect(PoDynamicUtil.isVisibleField).not.toHaveBeenCalled();
-    });
+        spyOn(component, <any>'printError');
 
-    it('getVisibleFields: should return only visible fields', () => {
-      const fields = [{ property: 'name' }];
-      const invisibleFields = [{ property: 'age', visible: false }];
-      component.fields = [...fields, ...invisibleFields];
+        const visibleFields = component['getVisibleFields']();
 
-      const visibleFields = component['getVisibleFields']();
+        expectArraysSameOrdering(visibleFields, expectedFields);
+      });
 
-      expect(visibleFields.length).toBe(fields.length);
+      it('should return ordering fields with value default', () => {
+        const fields: Array<PoDynamicFormField> = [
+          { property: 'test 1' },
+          { property: 'test 2', order: 2 },
+          { property: 'test 3', order: 1 },
+          { property: 'test 4', order: -1 },
+          { property: 'test 5', order: 3 }
+        ];
+
+        const expectedFields = [
+          { property: 'test 3' },
+          { property: 'test 2' },
+          { property: 'test 5' },
+          { property: 'test 1' },
+          { property: 'test 4' }
+        ];
+
+        component.fields = [...fields];
+
+        spyOn(component, <any>'printError');
+
+        const visibleFields = component['getVisibleFields']();
+
+        expectArraysSameOrdering(visibleFields, expectedFields);
+      });
+
+      it('should return ordering fields with zero as default value', () => {
+        const fields: Array<PoDynamicFormField> = [
+          { property: 'test 1' },
+          { property: 'test 0', order: 0 },
+          { property: 'test 2', order: 2 },
+          { property: 'test 3', order: 1 },
+          { property: 'test 4', order: -1 },
+          { property: 'test 5', order: 3 }
+        ];
+
+        const expectedFields = [
+          { property: 'test 3' },
+          { property: 'test 2' },
+          { property: 'test 5' },
+          { property: 'test 1' },
+          { property: 'test 0' },
+          { property: 'test 4' }
+        ];
+
+        component.fields = [...fields];
+
+        spyOn(component, <any>'printError');
+
+        const visibleFields = component['getVisibleFields']();
+
+        expectArraysSameOrdering(visibleFields, expectedFields);
+      });
+
+      it('shouldn`t call `isVisibleField` if not exists `field.property`', () => {
+        const fields = [{ label: 'name' }];
+        component.fields = <any>fields;
+
+        spyOn(PoDynamicUtil, 'isVisibleField');
+        spyOn(component, <any>'printError');
+
+        const visibleFields = component['getVisibleFields']();
+
+        expect(visibleFields.length).toBe(0);
+        expect(PoDynamicUtil.isVisibleField).not.toHaveBeenCalled();
+      });
+
+      it('should return only visible fields', () => {
+        const fields = [{ property: 'name' }];
+        const invisibleFields = [{ property: 'age', visible: false }];
+        component.fields = [...fields, ...invisibleFields];
+
+        const visibleFields = component['getVisibleFields']();
+
+        expect(visibleFields.length).toBe(fields.length);
+      });
     });
 
     it('convertOptions: should convert options to object if the options is an array of string', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -1,7 +1,7 @@
 import { Input, EventEmitter, Output, Directive } from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
 
-import { isTypeof } from '../../../../utils/util';
+import { isTypeof, sortFields } from '../../../../utils/util';
 
 import { getGridColumnsClasses, isVisibleField } from '../../po-dynamic.util';
 import { PoDynamicFieldType } from '../../po-dynamic-field-type.enum';
@@ -71,7 +71,7 @@ export class PoDynamicFormFieldsBaseComponent {
       }
     });
 
-    return visibleFields;
+    return sortFields(visibleFields);
   }
 
   // converte um array em string para um array de objetos que contem label e value.

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -24,7 +24,8 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       minLength: 4,
       maxLength: 50,
       gridColumns: 6,
-      gridSmColumns: 12
+      gridSmColumns: 12,
+      order: 1
     },
     {
       property: 'birthday',
@@ -34,11 +35,12 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       gridColumns: 6,
       gridSmColumns: 12,
       maxValue: '2010-01-01',
-      errorMessage: 'The date must be before the year 2010.'
+      errorMessage: 'The date must be before the year 2010.',
+      order: -1
     },
     { property: 'cpf', label: 'CPF', mask: '999.999.999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
     { property: 'cnpj', label: 'CNPJ', mask: '99.999.999/9999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
-    { property: 'genre', gridColumns: 6, gridSmColumns: 12, options: ['Male', 'Female', 'Other'] },
+    { property: 'genre', gridColumns: 6, gridSmColumns: 12, options: ['Male', 'Female', 'Other'], order: 2 },
     { property: 'shortDescription', label: 'Short Description', gridColumns: 12, gridSmColumns: 12, rows: 5 },
     {
       property: 'secretKey',

--- a/projects/ui/src/lib/util-test/util-expect.spec.ts
+++ b/projects/ui/src/lib/util-test/util-expect.spec.ts
@@ -122,6 +122,24 @@ export const expectBrowserLanguageMethod = (language: string, comp: any, method:
 };
 
 /**
+ * Expect dinâmico para validar se dois arrays de objetos possuem a mesma ordenação,
+ * baseado no valor do `property`.
+ *
+ * @param fieldsA Array para comparação
+ * @param fieldsB Array para comparação
+ */
+export const expectArraysSameOrdering = (fieldsA: Array<any>, fieldsB: Array<any>) => {
+  const isEqualOrder = !fieldsA.some(
+    (fieldA: { property: any }, index: number) => fieldA.property !== fieldsB[index]?.property
+  );
+
+  const failMessage = `Expected the arrays to be in the same order`;
+
+  expect(isEqualOrder).toBe(true, failMessage);
+  expect(fieldsA.length === fieldsB.length).toBe(true);
+};
+
+/**
  * Muda a propriedade de inner width da página
  * @param expectedWidth valor esperado para inner width
  */

--- a/projects/ui/src/lib/utils/util.spec.ts
+++ b/projects/ui/src/lib/utils/util.spec.ts
@@ -1364,3 +1364,147 @@ describe('Function getParentRef:', () => {
     expect(getParentRef((viewRef as unknown) as ViewContainerRef)).toEqual(expectedValue);
   });
 });
+
+describe('sortFields:', () => {
+  it('should return the ordered fields', () => {
+    const fields = [
+      { property: 'test 1', order: 2 },
+      { property: 'test 2', order: 1 },
+      { property: 'test 3', order: 4 },
+      { property: 'test 4', order: 3 }
+    ];
+
+    const expectedFields = [
+      { property: 'test 2', order: 1 },
+      { property: 'test 1', order: 2 },
+      { property: 'test 4', order: 3 },
+      { property: 'test 3', order: 4 }
+    ];
+
+    const result = UtilFunctions.sortFields(fields, -1);
+
+    expect(result).toEqual(expectedFields);
+  });
+
+  it('should return ordering fields with value default', () => {
+    const fields = [
+      { property: 'test 1', order: 2 },
+      { property: 'test 2', order: -1 },
+      { property: 'test 3', order: 4 },
+      { property: 'test 4', order: 3 }
+    ];
+
+    const expectedFields = [
+      { property: 'test 1', order: 2 },
+      { property: 'test 4', order: 3 },
+      { property: 'test 3', order: 4 },
+      { property: 'test 2', order: -1 }
+    ];
+
+    const result = UtilFunctions.sortFields(fields, -1);
+
+    expect(result).toEqual(expectedFields);
+  });
+
+  it('should return ordering fields with default values', () => {
+    const fields = [
+      { property: 'test 1', order: 2 },
+      { property: 'test 2', order: -1 },
+      { property: 'test 3' },
+      { property: 'test 4', order: -2 },
+      { property: 'test 5', order: 0 },
+      { property: 'test 6' },
+      { property: 'test 7', order: 4 },
+      { property: 'test 8', order: 2 }
+    ];
+
+    const expectedFields = [
+      { property: 'test 1', order: 2 },
+      { property: 'test 8', order: 2 },
+      { property: 'test 7', order: 4 },
+      { property: 'test 2', order: -1 },
+      { property: 'test 3' },
+      { property: 'test 4', order: -2 },
+      { property: 'test 5', order: 0 },
+      { property: 'test 6' }
+    ];
+
+    const result = UtilFunctions.sortFields(fields);
+
+    expect(result).toEqual(expectedFields);
+  });
+
+  it('should return ordering fields with invalid values', () => {
+    const fields = [
+      { property: 'test 1', order: 2 },
+      { property: 'test 2', order: true },
+      { property: 'test 3' },
+      { property: 'test 4', order: -2 },
+      { property: 'test 5', order: 0 },
+      { property: 'test 6' },
+      { property: 'test 7', order: 4 },
+      { property: 'test 8', order: 'A' }
+    ];
+
+    const expectedFields = [
+      { property: 'test 1', order: 2 },
+      { property: 'test 7', order: 4 },
+      { property: 'test 2', order: true },
+      { property: 'test 3' },
+      { property: 'test 4', order: -2 },
+      { property: 'test 5', order: 0 },
+      { property: 'test 6' },
+      { property: 'test 8', order: 'A' }
+    ];
+
+    const result = UtilFunctions.sortFields(fields);
+
+    expect(result).toEqual(expectedFields);
+  });
+
+  it('should keep the array in the same order if order is undefined', () => {
+    const fields = [
+      { property: 'test 1' },
+      { property: 'test 2' },
+      { property: 'test 3' },
+      { property: 'test 4' },
+      { property: 'test 5' },
+      { property: 'test 6' },
+      { property: 'test 7' }
+    ];
+
+    const expectedFields = [
+      { property: 'test 1' },
+      { property: 'test 2' },
+      { property: 'test 3' },
+      { property: 'test 4' },
+      { property: 'test 5' },
+      { property: 'test 6' },
+      { property: 'test 7' }
+    ];
+
+    const result = UtilFunctions.sortFields(fields, -1);
+
+    expect(result).toEqual(expectedFields);
+  });
+
+  it('should return an empty array if fields is an empty array', () => {
+    const fields = [];
+
+    const expectedFields = [];
+
+    const result = UtilFunctions.sortFields(fields, -1);
+
+    expect(result).toEqual(expectedFields);
+  });
+
+  it('should return an empty array if fields is undefined', () => {
+    const fields = undefined;
+
+    const expectedFields = [];
+
+    const result = UtilFunctions.sortFields(fields);
+
+    expect(result).toEqual(expectedFields);
+  });
+});

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -277,6 +277,44 @@ export function sortOptionsByProperty(options: Array<any>, property: string) {
   });
 }
 
+/**
+ * Ordena o campos baseado no valor da propriedade `order`.
+ *
+ * Só serão aceitos valores com números inteiros maiores do que zero para a ordenação.
+ *
+ * Campos sem `order` ou com valores negativos, zerados ou inválidos
+ * receberão o valor default e seguirão o posicionamento dentro do
+ * array.
+ *
+ * @param fields campo que se deseja ordenar.
+ * @param defaultOrdering valor que será utilizado para manter na posição do array.
+ */
+export function sortFields(fields = [], defaultOrdering = -1) {
+  const resultClassification = { fieldAComesFirst: -1, fieldAComesAfter: 1, keepPositions: 0 };
+
+  const isOrderValid = (order: number) => isTypeof(order, 'number') && order > 0;
+  const applyDefaultOrdering = (order: number) => (isOrderValid(order) ? order : defaultOrdering);
+
+  return fields.sort((fieldA, fieldB) => {
+    const orderA = applyDefaultOrdering(fieldA.order);
+    const orderB = applyDefaultOrdering(fieldB.order);
+
+    if (orderA === orderB) {
+      return resultClassification.keepPositions;
+    }
+
+    if (orderA === defaultOrdering) {
+      return resultClassification.fieldAComesAfter;
+    }
+
+    if (orderB === defaultOrdering) {
+      return resultClassification.fieldAComesFirst;
+    }
+
+    return orderA - orderB;
+  });
+}
+
 export function removeDuplicatedOptions(list: Array<any>) {
   for (let i = 0; i < list.length; i++) {
     if (i === 0) {


### PR DESCRIPTION
**Po Dynamic Form**

**DTHFUI-3478**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
O usuário não consegue controlar a forma de renderizar os campos, a não ser pela organização da posição do array. 

**Qual o novo comportamento?**
Adiciona a propriedade `order` na interface `PoDynamicFormField`
para poder organizar a ordem em que os campos serão renderizados, independente da posição no array.

**Simulação**
- Pode ser simulado nos samples do Dynamic Form no portal.
- Também pode ser validado os samples do: Page Job Scheduler, Page Dynamic Search e Page Dynamic Edit.

Obs.: os formulários já existentes não podem sofrer alterações.