### PR TITLE
feat(dynamic-view): permite ordenar os fields exibidos

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -1,7 +1,7 @@
 import { Input, Directive } from '@angular/core';
 import { CurrencyPipe, DatePipe, DecimalPipe, TitleCasePipe } from '@angular/common';
 
-import { convertToBoolean, isTypeof } from '../../../utils/util';
+import { convertToBoolean, isTypeof, sortFields } from '../../../utils/util';
 import { PoTimePipe } from '../../../pipes/po-time/po-time.pipe';
 
 import { getGridColumnsClasses, isVisibleField } from '../po-dynamic.util';
@@ -142,7 +142,7 @@ export class PoDynamicViewBaseComponent {
       }
     });
 
-    return newFields;
+    return sortFields(newFields);
   }
 
   // retorna fields ligado ao value mais os atributos do value que não possuiam fields.

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
@@ -75,4 +75,36 @@ export interface PoDynamicViewField extends PoDynamicField {
    *  + Exemplo: com o valor de entrada: `50` e a valor para formatação: `'1.2-5'` o resultado será: `50.00`.
    */
   format?: string;
+
+  /**
+   * Informa a ordem de exibição do campo.
+   *
+   * Exemplo de utilização:
+   *
+   * ```
+   * [
+   *   { property: 'test 1', order: 2 },
+   *   { property: 'test 2', order: 1 },
+   *   { property: 'test 3' },
+   *   { property: 'test 4', order: 3 }
+   * ];
+   * ```
+   *
+   * Na exibição a ordem ficará dessa forma:
+   * ```
+   * [
+   *   { property: 'test 2', order: 1 },
+   *   { property: 'test 1', order: 2 },
+   *   { property: 'test 4', order: 3 },
+   *   { property: 'test 3' }
+   * ];
+   * ```
+   *
+   * Só serão aceitos valores com números inteiros maiores do que zero.
+   *
+   * Campos sem `order` ou com valores negativos, zerados ou inválidos
+   * serão os últimos a serem renderizados e seguirão o posicionamento dentro do
+   * array.
+   */
+  order?: number;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee-on-load/sample-po-dynamic-view-employee-on-load.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee-on-load/sample-po-dynamic-view-employee-on-load.component.ts
@@ -56,9 +56,9 @@ export class SamplePoDynamicViewEmployeeOnLoadComponent {
         wage: this.checkProfile()
       },
       fields: [
-        { property: 'name', divider: 'Personal data by load customization' },
-        { property: 'cpf', tag: true, inverse: true, color: 'color-07' },
-        { property: 'rg', tag: true, inverse: true, color: 'color-07' },
+        { property: 'name', divider: 'Personal data by load customization', order: 1 },
+        { property: 'cpf', tag: true, inverse: true, color: 'color-07', order: 2 },
+        { property: 'rg', tag: true, inverse: true, color: 'color-07', order: 3 },
         { property: 'wage', type: 'string', tag: true, inverse: true, color: 'color-07' },
         { property: 'genre', visible: false },
         { property: 'job', tag: false }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.ts
@@ -8,11 +8,11 @@ import { PoDynamicViewField } from '@po-ui/ng-components';
 })
 export class SamplePoDynamicViewEmployeeComponent {
   fields: Array<PoDynamicViewField> = [
-    { property: 'name', divider: 'Personal data', gridColumns: 4 },
+    { property: 'name', divider: 'Personal data', gridColumns: 4, order: 1 },
     { property: 'age', label: 'Age', gridColumns: 4 },
     { property: 'genre', gridColumns: 4 },
-    { property: 'cpf', label: 'CPF', gridColumns: 4 },
-    { property: 'rg', label: 'RG', gridColumns: 4 },
+    { property: 'cpf', label: 'CPF', gridColumns: 4, order: 2 },
+    { property: 'rg', label: 'RG', gridColumns: 4, order: 3 },
     { property: 'graduation', label: 'Graduation', gridColumns: 4 },
     { property: 'company', label: 'Company', divider: 'Work Data' },
     { property: 'job', tag: true, inverse: true, color: 'color-03', icon: 'po-icon-copy' },


### PR DESCRIPTION
**PO-DYNAMIC-VIEW**

**DTHFUI-3479**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
O usuário não consegue controlar a forma de renderizar os campos, a não ser pela organização da posição do array.

**Qual o novo comportamento?**
Adiciona a propriedade order na interface PoDynamicViewField para poder organizar a ordem em que os campos serão renderizados, independente da posição no array.

**Simulação**
- Pode ser simulado nos samples do Dynamic View no portal.
- Também pode ser validado pelo Page Dynamic Detail, porém não possui samples no portal.

Obs.: os formulários já existentes não podem sofrer alterações.