### PR TITLE
feat(page-dynamic-edit): adiciona a propriedade beforeSaveNew nas ações

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
@@ -3,6 +3,7 @@ export * from './interfaces/po-page-dynamic-edit-actions.interface';
 export * from './interfaces/po-page-dynamic-edit-field.interface';
 export * from './interfaces/po-page-dynamic-edit-before-cancel.interface';
 export * from './interfaces/po-page-dynamic-edit-before-save.interface';
+export * from './interfaces/po-page-dynamic-edit-before-save-new.interface';
 export * from './interfaces/po-page-dynamic-edit-metadata.interface';
 export * from './interfaces/po-page-dynamic-edit-options.interface';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-actions.interface.ts
@@ -1,5 +1,6 @@
 import { PoPageDynamicEditBeforeCancel } from './po-page-dynamic-edit-before-cancel.interface';
 import { PoPageDynamicEditBeforeSave } from './po-page-dynamic-edit-before-save.interface';
+import { PoPageDynamicEditBeforeSaveNew } from './po-page-dynamic-edit-before-save-new.interface';
 
 /**
  * @usedBy PoPageDynamicEditComponent
@@ -45,6 +46,23 @@ export interface PoPageDynamicEditActions {
   /**
    * @description
    *
+   * Rota ou método que será chamado antes de executar o evento salvar e abrir novo registro (saveNew).
+   *
+   * Tanto o método como a API receberão o recurso e devem retornar um objeto com a definição de `PoPageDynamicEditBeforeSaveNew`.
+   *
+   * > A URL será chamada via POST. Caso seja a edição de um recurso, a URL será concatenada
+   * com a key especificada no metadata, por exemplo:  `POST {beforeSave}/{key}`.
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeSaveNew**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   *
+   */
+  beforeSaveNew?: string | ((resource: any, id: string) => PoPageDynamicEditBeforeSaveNew);
+
+  /**
+   * @description
+   *
    * Rota de redirecionamento para ação de cancelar, caso não seja especificada será usado o comando `navigator.back()`.
    *
    * > Se passada uma função, é responsabilidade do desenvolvedor implementar a navegação ou outro comportamento desejado.
@@ -84,14 +102,28 @@ export interface PoPageDynamicEditActions {
   /**
    * @description
    *
-   * Rota de redirecionamento que será executada após a confirmação da gravação do registro caso o mesmo esteja editando
-   * um registro.
+   * Rota de redirecionamento ou método para executar o envio dos dados ao servidor.
+   *
+   * A rota de redirecionamento será executada após a confirmação de gravação do registro.
+   *
+   * > Caso tratar-se de um novo registro, será resetado o formulário para um novo registro.
+   * Se estiver editando um registro a rota de redirecionamento será utilizada.
    *
    * ```
    * actions = {
    *   saveNew: 'new'
    * };
    * ```
+   * A rota pode conter um parâmetro id.
+   *
+   * ```
+   * actions = {
+   *   saveNew: 'edit/:id'
+   * };
+   * ```
+   *
+   * Ao informar um método é responsabilidade do desenvolvedor implementar a navegação e/ou envio dos dados
+   * para o servidor ou outro comportamento desejado.
    */
-  saveNew?: string;
+  saveNew?: string | ((resource: any, id?: string) => void);
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-before-save-new.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-before-save-new.interface.ts
@@ -1,0 +1,46 @@
+/**
+ * @usedBy PoPageDynamicEditComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeSaveNew`.
+ */
+export interface PoPageDynamicEditBeforeSaveNew {
+  /**
+   * Nova rota de redirecionamento, que substituirá a rota definida anteriormente em `saveNew`.
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação salvar e novo (saveNew).
+   */
+  allowAction?: boolean;
+
+  /**
+   * Recurso atualizado.
+   *
+   * Será feito uma mesclagem entre os valores existentes e esse novo objeto,
+   * no entanto as propriedades que possuírem `key: true` não serão alteradas.
+   * Por exemplo:
+   *
+   * - recurso anterior com a propriedade id foi que definida como *key*:
+   * ```
+   * { id: 1, name: 'Ane' }
+   * ```
+   *
+   * - recurso retornado no `beforeSaveNew`:
+   * ```
+   * { id: 50, age: 23 }
+   * ```
+   *
+   * - Mesclagem do recurso:
+   * ```
+   * { id: 1, name: 'Ane', age: 23 }
+   * ```
+   *
+   * > Caso `allowAction` seja `false`, o recurso será atualizado apenas localmente, sem concluir
+   * a ação de salvar (saveNew).
+   */
+  resource?: any;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.spec.ts
@@ -149,5 +149,78 @@ describe('PoPageDynamicEditActions:', () => {
         tick();
       }));
     });
+
+    describe('beforeSaveNew:', () => {
+      const resource = { name: 'Mario' };
+      const id = '1';
+
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeSaveNew('/newSave', id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === '/newSave/1');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = (userResource, userId) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeSaveNew(spyObj.testFn, id, resource).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith(resource, id);
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function if resource is null', fakeAsync(() => {
+        const testFn = (userResource, userId) => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true
+        });
+        const spyObj = {
+          testFn
+        };
+
+        const spy = spyOn(spyObj, 'testFn').and.callThrough();
+
+        service.beforeSaveNew(spyObj.testFn, id, null).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(spy).toHaveBeenCalledWith({}, id);
+        });
+
+        tick();
+      }));
+
+      it('shouldn`t get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeSaveNew(testFn, id, resource).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit-actions.service.ts
@@ -5,6 +5,7 @@ import { of, Observable } from 'rxjs';
 import { PoPageDynamicEditActions } from './interfaces/po-page-dynamic-edit-actions.interface';
 import { PoPageDynamicEditBeforeCancel } from './interfaces/po-page-dynamic-edit-before-cancel.interface';
 import { PoPageDynamicEditBeforeSave } from './interfaces/po-page-dynamic-edit-before-save.interface';
+import { PoPageDynamicEditBeforeSaveNew } from './interfaces/po-page-dynamic-edit-before-save-new.interface';
 
 interface ExecuteActionParameter {
   action: string | Function;
@@ -31,6 +32,15 @@ export class PoPageDynamicEditActionsService {
     id: string,
     body: any
   ): Observable<PoPageDynamicEditBeforeSave> {
+    const resource = body ?? {};
+    return this.executeAction({ action, resource, id });
+  }
+
+  beforeSaveNew(
+    action: PoPageDynamicEditActions['beforeSaveNew'],
+    id: string,
+    body: any
+  ): Observable<PoPageDynamicEditBeforeSaveNew> {
     const resource = body ?? {};
     return this.executeAction({ action, resource, id });
   }


### PR DESCRIPTION
**Page Dynamic Edit**

**DTHFUI-2629**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
-

**Qual o novo comportamento?**
Adiciona propriedade beforeSaveNew para o desenvolvedor poder executar
um evento antes da função de salvar e novo, podendo retornar um novo recurso, se possui uma nova rota e também se permite a execução da função (saveNew).

Não pode fazer o merge dos valores que são keys.

**Simulação**
- Buildar os pacotes UI e Templates
- Adicionar o [projeto](https://github.com/po-ui/po-angular/files/4771037/app.zip)
 dentro de ~/po-angular/app/src/app
- Subir localmente sample-po-api ou mudar a URL no projeto.
- Criar novos registros com "save" e "saveNew" com os respectivos before (usando URL/função).
- Editar registros com "save" e "saveNew" com os respectivos before (usando URL/função).

Pode-se utilizar mockable.io para simular o serviço por URL