### PR TITLE
feat(page-dynamic-table): adiciona propriedade beforeRemoveAll

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
@@ -4,6 +4,7 @@ export * from './interfaces/po-page-dynamic-table-before-duplicate.interface';
 export * from './interfaces/po-page-dynamic-table-before-edit.interface';
 export * from './interfaces/po-page-dynamic-table-before-new.interface';
 export * from './interfaces/po-page-dynamic-table-before-remove.interface';
+export * from './interfaces/po-page-dynamic-table-before-remove-all.interface';
 export * from './interfaces/po-page-dynamic-table-before-detail.interface';
 export * from './interfaces/po-page-dynamic-table-field.interface';
 export * from './interfaces/po-page-dynamic-table-options.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
@@ -3,6 +3,7 @@ import { PoPageDynamicTableBeforeNew } from './po-page-dynamic-table-before-new.
 import { PoPageDynamicTableBeforeRemove } from './po-page-dynamic-table-before-remove.interface';
 import { PoPageDynamicTableBeforeDetail } from './po-page-dynamic-table-before-detail.interface';
 import { PoPageDynamicTableBeforeDuplicate } from './po-page-dynamic-table-before-duplicate.interface';
+import { PoPageDynamicTableBeforeRemoveAll } from './po-page-dynamic-table-before-remove-all.interface';
 
 /**
  * @usedBy PoPageDynamicTableComponent
@@ -113,8 +114,29 @@ export interface PoPageDynamicTableActions {
   /** Habilita a ação de exclusão na tabela. */
   remove?: boolean | ((id: string, resource: any) => boolean);
 
-  /** Habilita a ação de exclusão em lote na página. */
-  removeAll?: boolean;
+  /** Habilita a ação de exclusão em lote na página.
+   *
+   * Se for um valor boolean terá o seguinte comportamento:
+   * - `true`: Habilita o botão para exclusão em lote e caso o usuário confirme
+   * a ação irá enviar os recursos selecionados para a rota configurada
+   *
+   * - `false`: Desabilita o botão
+   *
+   * Se o valor for uma função o botão irá aparecer na tela e caso confirme
+   * a função passada será responsável por tratar a exclusão dos recursos
+   * no back-end e retornar um array com os itens que serão excluídos da tabela.
+   *
+   * A lista de itens deve ser construída com todas as propriedades
+   * marcadas com o atributo `key: true` na sua definição das colunas.
+   *
+   * Por exemplo:
+   * - Recursos com as propriedades id e name definidas como *key*:
+   * ```
+   * [{ id: 1, name: 'Mario' },{ id: 2, name: 'Gabriel' }]
+   * ```
+   *
+   */
+  removeAll?: boolean | ((resources: Array<any>) => Array<any>);
 
   /**
    * @description
@@ -163,4 +185,22 @@ export interface PoPageDynamicTableActions {
    *
    */
   beforeDetail?: string | ((id?: string, resource?: any) => PoPageDynamicTableBeforeDetail);
+
+  /**
+   * @description
+   *
+   * Método/URL que deve ser chamado antes de executar o evento de exclusão em lote (removeAll).
+   *
+   * Tanto o método como a API receberão uma lista com as keys dos recursos que serão repassados para o
+   * `removeAll` para serem excluídos e devem retornar um objeto com a definição de
+   * `PoPageDynamicTableBeforeRemoveAll`.
+   *
+   * > A URL será chamada via POST.
+   *
+   * Caso o desenvolvedor queira que apareça alguma mensagem nessa ação ele pode criá-la na função chamada pela **beforeRemoveAll**
+   * ou definir a mensagem no atributo `_messages` na resposta da API conforme definido
+   * em [Guia de implementação de APIs](https://po-ui.io/guides/api#successMessages)
+   *
+   */
+  beforeRemoveAll?: string | ((resources?: Array<any>) => PoPageDynamicTableBeforeRemoveAll);
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-remove-all.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-remove-all.interface.ts
@@ -1,0 +1,39 @@
+/**
+ * @usedBy PoPageDynamicTableComponent
+ *
+ * @description
+ *
+ * Definição da estrutura de retorno da url ou método executado através da
+ * propriedade `beforeRemoveAll`.
+ */
+export interface PoPageDynamicTableBeforeRemoveAll {
+  /**
+   * Nova rota para enviar o `remove all`, deve substituir a rota definida anteriormente.
+   *
+   * Caso o `remove all` seja configurado como função e for passado o atributo `newUrl`
+   * a função será ignorada e o comando será enviado pela rota definida em `newUrl`
+   *
+   */
+  newUrl?: string;
+
+  /**
+   * Define se deve ou não executar a ação de exclusão `(remove all)`
+   */
+  allowAction?: boolean;
+
+  /**
+   * Lista com as keys dos recursos que serão enviados para a ação `removeAll`
+   * que por sua vez excluirá os itens da tabela.
+   * Deve substituir a lista selecionada na tela pelo usuário.
+   *
+   * A lista é construída com todas as propriedades marcadas com o atributo `key: true`
+   * na sua definição.
+   * Por exemplo:
+   *
+   * - Recursos com as propriedades id e name definidas como *key*:
+   * ```
+   * [{ id: 1, name: 'Mario' },{ id: 2, name: 'Gabriel' }]
+   * ```
+   */
+  resources?: Array<any>;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
@@ -172,6 +172,63 @@ describe('PoPageDynamicTableActionsService:', () => {
       }));
     });
 
+    describe('beforeRemoveAll:', () => {
+      const resources = [
+        {
+          name: 'Gabriel',
+          age: 3
+        },
+        {
+          name: 'Mario',
+          age: 5
+        }
+      ];
+
+      it('should get data from a api', fakeAsync(() => {
+        service.beforeRemoveAll('/teste/remove', resources).subscribe(response => {
+          expect(response.newUrl).toBe('/newurl');
+          expect(response.allowAction).toBeTrue();
+        });
+
+        const req = httpMock.expectOne(request => request.url === `/teste/remove`);
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resources);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({
+          newUrl: '/newurl',
+          allowAction: true
+        });
+
+        tick();
+      }));
+
+      it('should get data from a function', fakeAsync(() => {
+        const testFn = () => ({
+          newUrl: '/newurlfromfunction',
+          allowAction: true,
+          resources
+        });
+
+        service.beforeRemoveAll(testFn, resources).subscribe(response => {
+          expect(response.newUrl).toBe('/newurlfromfunction');
+          expect(response.allowAction).toBeTrue();
+          expect(response.resources).toEqual(resources);
+        });
+
+        tick();
+      }));
+
+      it('should not get data from undefined', fakeAsync(() => {
+        const testFn = undefined;
+        service.beforeRemoveAll(testFn, [{}]).subscribe(response => {
+          expect(response).toEqual({});
+        });
+
+        tick();
+      }));
+    });
+
     describe('executeAction', () => {
       const resource = { name: 'Name' };
       const id = '1';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
@@ -7,6 +7,7 @@ import { PoPageDynamicTableBeforeEdit } from './interfaces/po-page-dynamic-table
 import { PoPageDynamicTableBeforeNew } from './interfaces/po-page-dynamic-table-before-new.interface';
 import { PoPageDynamicTableBeforeRemove } from './interfaces/po-page-dynamic-table-before-remove.interface';
 import { PoPageDynamicTableBeforeDetail } from './interfaces/po-page-dynamic-table-before-detail.interface';
+import { PoPageDynamicTableBeforeRemoveAll } from './interfaces/po-page-dynamic-table-before-remove-all.interface';
 
 interface ExecuteActionParameter {
   action: string | Function;
@@ -56,6 +57,13 @@ export class PoPageDynamicTableActionsService {
     return this.executeAction({ action, id, resource });
   }
 
+  beforeRemoveAll(
+    action: PoPageDynamicTableActions['beforeRemoveAll'],
+    resources: Array<any>
+  ): Observable<PoPageDynamicTableBeforeRemoveAll> {
+    return this.executeAction({ action, resource: resources });
+  }
+
   beforeDetail(
     action: PoPageDynamicTableActions['beforeDetail'],
     id: string,
@@ -74,7 +82,9 @@ export class PoPageDynamicTableActionsService {
 
       return this.http.post<T>(url, resource, { headers: this.headers });
     }
-
-    return of(action(id, resource));
+    if (id) {
+      return of(action(id, resource));
+    }
+    return of(action(resource));
   }
 }


### PR DESCRIPTION
**page-dynamic-table**

**DTHFUI-2626**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A ação *removeAll* deleta os registros selecionados

**Qual o novo comportamento?**
• Adicionada propriedade **beforeRemoveAll** para que o desenvolvedor possa executar uma ação antes de editar recurso (**removeAll**).
• Agora a propriedade **removeAll** aceita também uma função. Esta função pode retornar um objeto contendo os recursos para exclusão. 


**Simulação**
- Projeto para simulação
[app_beforeRemoveAll.zip](https://github.com/po-ui/po-angular/files/4772945/app_beforeRemoveAll.zip)


- **removeAll** com string
- **removeAll**  com func;
- **removeAll** com undefined e null

- **beforeRemoveAll** com string
- **beforeRemoveAll** com func
- **beforeRemoveAll** com newURL undefined
- **beforeRemoveAll** com allowAction false
- **beforeRemoveAll** com null
- **beforeRemoveAll** com resources