### PR TITLE
table: permitir o uso de valores numéricos para a propriedade value das interfaces PoTableColumnLabel e PoTableSubtitleColumn

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
@@ -27,7 +27,7 @@ describe('PoTableColumnLabelComponent:', () => {
     labels = [
       { value: 'success', label: 'Success', color: 'color-11' },
       { value: 'warning', label: 'Warning', color: 'color-08' },
-      { value: 'danger', label: 'Danger', color: 'color-07' }
+      { value: 1, label: 'Danger', color: 'color-07' }
     ];
   });
 
@@ -37,7 +37,7 @@ describe('PoTableColumnLabelComponent:', () => {
 
   describe('Properties:', () => {
     it('value: should call `poColorPaletteService.getColor` with value if value is defined', () => {
-      const value = { color: 'danger', label: 'Danger', value: '1' };
+      const value = { color: 'danger', label: 'Danger', value: 1 };
 
       spyOn(component['poColorPaletteService'], 'getColor');
 

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
@@ -29,7 +29,7 @@ export interface PoTableColumnLabel {
    */
   color?: string;
 
-  /** Texto de exibição. */
+  /** Texto que será exibido na coluna. */
   label: string;
 
   /**
@@ -40,6 +40,6 @@ export interface PoTableColumnLabel {
    */
   tooltip?: string;
 
-  /** Valor da legenda. */
-  value: string;
+  /** Valor que será usado como referência para exibição do conteúdo na coluna. */
+  value: string | number;
 }

--- a/projects/ui/src/lib/components/po-table/po-table-subtitle-footer/po-table-subtitle-column.interface.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-subtitle-footer/po-table-subtitle-column.interface.ts
@@ -6,10 +6,10 @@
  * Interface para configuração das colunas de legenda do Po-Table.
  */
 export interface PoTableSubtitleColumn {
-  /** Valor da legenda. */
-  value: string;
+  /** Valor que será usado como referência para exibição do conteúdo na coluna. */
+  value: string | number;
 
-  /** Texto de exibição. */
+  /** Texto que será exibido no rodapé da tabela como legenda. */
   label: string;
 
   /**
@@ -37,6 +37,6 @@ export interface PoTableSubtitleColumn {
    */
   color?: string;
 
-  /** Conteúdo do status. */
+  /** Conteúdo que será exibido na coluna da tabela. */
   content: string;
 }

--- a/projects/ui/src/lib/components/po-table/po-table-subtitle-footer/po-table-subtitle-footer.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-subtitle-footer/po-table-subtitle-footer.component.spec.ts
@@ -23,9 +23,9 @@ describe('PoTableSubtitleFooterComponent:', () => {
 
     component = fixture.componentInstance;
     component.subtitles = [
-      { value: 'Value', label: 'Label', color: 'color-11', content: 'Success Content' },
-      { value: 'Value', label: 'Label', color: 'color-08', content: 'Warning Content' },
-      { value: 'Value', label: 'Label', color: 'color-07', content: 'Danger Content' }
+      { value: 'Value11', label: 'Label11', color: 'color-11', content: 'Success Content' },
+      { value: 'Value08', label: 'Label08', color: 'color-08', content: 'Warning Content' },
+      { value: 'Value07', label: 'Label07', color: 'color-07', content: 'Danger Content' }
     ];
 
     component.literals = poTableLiteralsDefault.pt;
@@ -61,7 +61,7 @@ describe('PoTableSubtitleFooterComponent:', () => {
 
     describe('ngDoCheck', () => {
       it(`should call 'toggleShowCompleteSubtitle' and set 'isVisible' to 'true' if 'getContainerSize' returns a value greater than 0
-      and 'isVisible' is  'false'`, () => {
+      and 'isVisible' is 'false'`, () => {
         component['isVisible'] = false;
 
         spyOn(component, <any>'getContainerSize').and.returnValue(100);

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -109,7 +109,7 @@ describe('PoTableComponent:', () => {
       subtitles: [
         { value: 'confirmed', color: 'color-11', label: 'Confirmado', content: '1' },
         { value: 'delayed', color: 'color-08', label: 'Atrasado', content: '2' },
-        { value: 'canceled', color: 'color-07', label: 'Cancelado', content: '3' }
+        { value: 0, color: 'color-07', label: 'Cancelado', content: '3' }
       ]
     };
 
@@ -120,7 +120,7 @@ describe('PoTableComponent:', () => {
       labels: [
         { value: 'confirmed', color: 'color-11', label: 'Confirmado' },
         { value: 'delayed', color: 'color-08', label: 'Atrasado' },
-        { value: 'canceled', color: 'color-07', label: 'Cancelado' }
+        { value: 0, color: 'color-07', label: 'Cancelado' }
       ]
     };
 
@@ -153,7 +153,7 @@ describe('PoTableComponent:', () => {
       { id: 8, initial: 'JA', name: 'Japão', total: 100.0, atualization: '2017-10-25', status: 'confirmed' },
       { id: 8, initial: 'JA', name: 'Japão', total: 300.0, atualization: '2017-10-25', status: 'delayed' },
       { id: 9, initial: 'CH', name: 'China', total: 250.0, atualization: '2017-10-10', status: 'confirmed' },
-      { id: 6, initial: 'KO', name: 'Coréia do Sul', total: 86.5, atualization: '07/10/2017', status: 'canceled' }
+      { id: 6, initial: 'KO', name: 'Coréia do Sul', total: 86.5, atualization: '07/10/2017', status: 0 }
     ];
 
     actions = [
@@ -510,7 +510,7 @@ describe('PoTableComponent:', () => {
       subtitles: [
         { value: 'confirmed', color: 'color-11', label: 'Confirmado', content: '1' },
         { value: 'delayed', color: 'color-08', label: 'Atrasado', content: '2' },
-        { value: 'canceled', color: 'color-07', label: 'Cancelado', content: '3' }
+        { value: 0, color: 'color-07', label: 'Cancelado', content: '3' }
       ]
     };
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -59,6 +59,7 @@ import { PoTableSubtitleColumn } from './po-table-subtitle-footer/po-table-subti
  *
  * <example name="po-table-components" title="PO Table - Po Field Components">
  *  <file name="sample-po-table-components/sample-po-table-components.component.ts"> </file>
+ *  <file name="sample-po-table-components/sample-po-table-components.enum.ts"> </file>
  *  <file name="sample-po-table-components/sample-po-table-components.component.html"> </file>
  *  <file name="sample-po-table-components/sample-po-table-components.service.ts"> </file>
  * </example>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.ts
@@ -1,9 +1,10 @@
 import { Component, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { PoModalComponent, PoTableColumn, PoTableColumnSort } from '@po-ui/ng-components';
+import { PoModalComponent, PoTableColumn, PoTableColumnSort, PoTableColumnLabel } from '@po-ui/ng-components';
 
 import { SamplePoTableComponentsService } from './sample-po-table-components.service';
+import { SamplePoTableComponentStatus } from './sample-po-table-components.enum';
 
 @Component({
   selector: 'sample-po-table-components',
@@ -21,10 +22,25 @@ export class SamplePoTableComponentsComponent {
       property: 'status',
       type: 'label',
       width: '5%',
-      labels: [
-        { value: 'stable', color: 'color-11', label: 'Stable', tooltip: 'Published component' },
-        { value: 'experimental', color: 'color-08', label: 'Experimental', tooltip: 'Component in homologation' },
-        { value: 'roadmap', color: 'color-07', label: 'Roadmap', tooltip: 'Component in roadmap' }
+      labels: <Array<PoTableColumnLabel>>[
+        {
+          value: SamplePoTableComponentStatus.Stable,
+          color: 'color-11',
+          label: 'Stable',
+          tooltip: 'Published component'
+        },
+        {
+          value: SamplePoTableComponentStatus.Experimental,
+          color: 'color-08',
+          label: 'Experimental',
+          tooltip: 'Component in homologation'
+        },
+        {
+          value: SamplePoTableComponentStatus.RoadMap,
+          color: 'color-07',
+          label: 'Roadmap',
+          tooltip: 'Component in roadmap'
+        }
       ]
     },
     { property: 'component', type: 'link' },

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.enum.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.enum.ts
@@ -1,0 +1,5 @@
+export enum SamplePoTableComponentStatus {
+  Stable,
+  Experimental,
+  RoadMap
+}

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.service.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.service.ts
@@ -12,7 +12,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-select',
       extra: 'Features',
       extras: ['Filter options (starts, contains, ends)', 'Custom services', 'Navigation by keys'],
-      status: 'stable'
+      status: 0
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -21,7 +21,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-checkbox-group',
       extra: 'Best Practices',
       extras: ['Short and objective texts for items', 'Use with short lists', 'For big lists use PO Multiselect'],
-      status: 'stable'
+      status: 0
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -30,7 +30,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-number',
       extra: 'Features',
       extras: ['Filter options (starts, contains, ends)', 'Custom services', 'Navigation by keys'],
-      status: 'experimental'
+      status: 1
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -39,7 +39,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-combo',
       extra: 'Features',
       extras: ['Filter options (starts, contains, ends)', 'Custom services', 'Navigation by keys'],
-      status: 'stable'
+      status: 0
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -48,7 +48,16 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-multiselect',
       extra: 'Features',
       extras: ['Filter options (starts, contains, ends)', 'Custom services', 'Navigation by keys'],
-      status: 'experimental'
+      status: 1
+    },
+    {
+      favorite: [],
+      component: 'PO Grid',
+      description: 'Create a grid for edition',
+      link: '/documentation/po-grid',
+      extra: 'Features',
+      extras: [],
+      status: 2
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -57,7 +66,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-input',
       extra: 'Features',
       extras: ['Filter options (starts, contains, ends)', 'Custom services', 'Navigation by keys'],
-      status: 'stable'
+      status: 0
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -66,7 +75,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-textarea',
       extra: 'Best Practices',
       extras: ['Recommended to large texts like observations and details', 'For short texts use po-input'],
-      status: 'experimental'
+      status: 1
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -75,7 +84,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-datepicker',
       extra: 'Features',
       extras: ['Multiple idioms ( pt, es , en)', 'Custom date formats', 'Period validation (start date and end date)'],
-      status: 'experimental'
+      status: 1
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -84,7 +93,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-email',
       extra: 'Features',
       extras: ['Filter options (starts, contains, ends)', 'Custom services', 'Navigation by keys'],
-      status: 'stable'
+      status: 0
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -93,7 +102,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-url',
       extra: 'Features',
       extras: ['Filter options (starts, contains, ends)', 'Custom services', 'Navigation by keys'],
-      status: 'stable'
+      status: 0
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -102,7 +111,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-password',
       extra: 'Features',
       extras: ['Filter options (starts, contains, ends)', 'Custom services', 'Navigation by keys'],
-      status: 'stable'
+      status: 0
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -111,7 +120,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-login',
       extra: 'Features',
       extras: ['Filter options (starts, contains, ends)', 'Custom services', 'Navigation by keys'],
-      status: 'stable'
+      status: 0
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -120,7 +129,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-upload',
       extra: 'Features',
       extras: ['Multiple file selection', 'Automatic upload after click', 'File format and size restriction'],
-      status: 'experimental'
+      status: 1
     },
     {
       favorite: ['favorite', 'documentation'],
@@ -129,7 +138,7 @@ export class SamplePoTableComponentsService {
       link: '/documentation/po-avatar',
       extra: 'Features',
       extras: ['Multiple sizes', 'Default image'],
-      status: 'stable'
+      status: 0
     }
   ];
 


### PR DESCRIPTION
**Table**

**DTHFUI-3588**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**

A propriedade value das interfaces PoTableColumnLabel e PoTableSubtitleColumn só aceitam valores no formato de string.

**Qual o novo comportamento?**

A propriedade value das interfaces PoTableColumnLabel e PoTableSubtitleColumn passam a aceitar strings e números.

**Simulação**

Usar um valor numérico em uma dessas propriedades.

Alterei o sample "PO Field Commom Components" para usar número na coluna status e usei um enum para exemplificar o uso.