### PR TITLE
fix(combo): corrige filtragem dos itens

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -847,7 +847,7 @@ describe('PoComboBaseComponent:', () => {
         expect(component.visibleOptions).toEqual(component.options);
       });
 
-      it(`should not set 'visibleOptions' with 'component.comboOptionsList' if 'newOptions' are falsy`, () => {
+      it(`should set 'visibleOptions' with empty array if selectedValue and options are falsy`, () => {
         component.options = undefined;
         component.selectedValue = undefined;
         component['comboOptionsList'] = [];
@@ -856,7 +856,7 @@ describe('PoComboBaseComponent:', () => {
 
         component.updateComboList();
 
-        expect(component.visibleOptions).toBeUndefined();
+        expect(component.visibleOptions).toEqual(component['comboOptionsList']);
       });
 
       it('should set `visibleOptions` with `options param` if `options param` is true and `selectedValue` is false', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -591,12 +591,10 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
 
     const newOptions = !options && this.selectedValue ? [{ ...this.selectedOption }] : copyOptions;
 
-    if (newOptions.length) {
-      this.visibleOptions = newOptions;
+    this.visibleOptions = newOptions;
 
-      if (!this.selectedView && this.visibleOptions.length) {
-        this.selectedView = copyOptions.find(option => option.value !== undefined);
-      }
+    if (!this.selectedView && this.visibleOptions.length) {
+      this.selectedView = copyOptions.find(option => option.value !== undefined);
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -1,3 +1,4 @@
+import { By } from '@angular/platform-browser';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
@@ -1532,18 +1533,8 @@ describe('PoComboComponent:', () => {
 
       expect(comboItemLink).toBeFalsy();
     });
-  });
 
-  describe('Integration:', () => {
-    beforeEach(() => {
-      component = fixture.componentInstance;
-
-      fixture.detectChanges();
-
-      nativeElement = fixture.debugElement.nativeElement;
-    });
-
-    it('noData: should display `noDataTemplate` if don´t have `visibleOptions` and visibleOptions.length.', () => {
+    it('should display `noDataTemplate` if don´t have `visibleOptions` and visibleOptions.length.', () => {
       component.visibleOptions = [];
 
       fixture.detectChanges();
@@ -1558,7 +1549,7 @@ describe('PoComboComponent:', () => {
       expect(noDataTemplate).toBeTruthy();
     });
 
-    it('noData: shouldn´t display `noDataTemplate` if have `visibleOptions` and visibleOptions.length.', () => {
+    it('shouldn´t display `noDataTemplate` if have `visibleOptions` and visibleOptions.length.', () => {
       component.visibleOptions = [{ label: '1', value: '1' }];
 
       fixture.detectChanges();
@@ -1573,7 +1564,7 @@ describe('PoComboComponent:', () => {
       expect(noDataTemplate).toBeNull();
     });
 
-    it('noData: should display `literals.noData` in Spanish if browser language is `es`.', () => {
+    it('should display `literals.noData` in Spanish if browser language is `es`.', () => {
       spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('es');
       component.visibleOptions = [];
 
@@ -1588,6 +1579,37 @@ describe('PoComboComponent:', () => {
       const noDataTemplateTextCompare = 'Datos no encontrados';
 
       expect(noDataTemplateText).toEqual(noDataTemplateTextCompare);
+    });
+  });
+
+  describe('Integration:', () => {
+    it('should return empty array and display `po-combo-container-no-data` if not found searched option', () => {
+      const searchTerm = 'Acre';
+      const keyUpEvent = { target: { value: searchTerm } };
+      component.options = [
+        { label: 'Santa Catarina', value: 'sc' },
+        { label: 'São Paulo', value: 'sp' },
+        { label: 'Rio Janeiro', value: 'rj' }
+      ];
+
+      fixture.debugElement.query(By.css('input')).triggerEventHandler('keyup', keyUpEvent);
+      fixture.detectChanges();
+
+      expect(component.visibleOptions).toEqual([]);
+      expect(fixture.debugElement.query(By.css('.po-combo-container-no-data'))).toBeTruthy();
+    });
+
+    it('should return found option and not display `po-combo-container-no-data` if found searched option', () => {
+      const searchTerm = 'Santa';
+      const keyUpEvent = { target: { value: searchTerm } };
+      const optionFound = [{ label: 'Santa Catarina', value: 'sc' }];
+      component.options = [...optionFound, { label: 'São Paulo', value: 'sp' }, { label: 'Rio Janeiro', value: 'rj' }];
+
+      fixture.debugElement.query(By.css('input')).triggerEventHandler('keyup', keyUpEvent);
+      fixture.detectChanges();
+
+      expect(component.visibleOptions).toEqual(optionFound);
+      expect(fixture.debugElement.query(By.css('.po-combo-container-no-data'))).toBeNull();
     });
   });
 });


### PR DESCRIPTION
**combo**

**DTHFUI-3578**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A funcionalidade de filtro não está funcionando corretamente quando é usado um valor inválido (que não existe), tanto para lista fixa de opções como para listas preenchidas através de um serviço.

**Qual o novo comportamento?**
Ao usar um valor inexistente deve mostrar a mensagem que não encontrou nenhum dado como fazia anteriormente.

**Simulação**
Simular nos samples do portal.

Obs.: A incongruência na filtragem de itens nos samples que consomem serviço é relacionada com o backend e será tratada em uma outra tarefa. 