### PR TITLE
fix(dynamic-form): corrige problema ao atualizar valores no validate

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -150,18 +150,22 @@ describe('PoDynamicFormFieldsComponent: ', () => {
         expect(component['getField']).not.toHaveBeenCalled();
       });
 
-      it('should update previous value', async () => {
+      it('should update all previous value with new value', async () => {
         const fakeVisibleField = { property: 'test1' };
+        const previousValue = { test1: 'value1' };
+        const newValue = { test1: 'new value1', test2: 'value2' };
 
-        component['previousValue']['test1'] = 'value';
-        component['value']['test1'] = 'new value';
+        component['previousValue'] = previousValue;
+        component['value'] = newValue;
 
         spyOn(component, <any>'triggerValidationOnForm');
         spyOn(component, <any>'getField').and.returnValue({ changedField: {} });
+        spyOn(component, 'updatePreviousValue').and.callThrough();
 
         await component.onChangeField(fakeVisibleField);
 
-        expect(component['previousValue']['test1']).toBe('new value');
+        expect(component.updatePreviousValue).toHaveBeenCalled();
+        expect(component['previousValue']).toEqual(newValue);
       });
 
       it('shouldn`t call `validateField` if `changedField.validate` doesn`t have value', async () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -64,7 +64,11 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
       this.triggerValidationOnForm(changedFieldIndex);
     }
 
-    this.previousValue[property] = this.value[property];
+    this.updatePreviousValue();
+  }
+
+  updatePreviousValue() {
+    this.previousValue = JSON.parse(JSON.stringify(this.value));
   }
 
   trackBy(index) {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
@@ -194,7 +194,7 @@ describe('PoDynamicFormComponent:', () => {
       expect(component['updateModelWithValidation']).toHaveBeenCalledWith(validatedFields);
     });
 
-    it('updateModelWithValidation: should call updateFieldsForm to set fields', () => {
+    it('updateModelWithValidation: should call updateFieldsForm to set fields and updatePreviousValue', () => {
       const validatedFields = { value: {}, fields: undefined };
 
       const fields = [
@@ -213,10 +213,12 @@ describe('PoDynamicFormComponent:', () => {
 
       spyOn(component, <any>'setFocusOnFieldByProperty');
       spyOn(component['validationService'], 'updateFieldsForm').and.returnValue(expectedFields);
+      spyOn(component.fieldsComponent, 'updatePreviousValue').and.returnValue();
 
       component['updateModelWithValidation'](validatedFields);
 
       expect(component.fields).toEqual(expectedFields);
+      expect(component.fieldsComponent.updatePreviousValue).toHaveBeenCalled();
       expect(component['validationService'].updateFieldsForm).toHaveBeenCalledWith(validatedFields.fields, fields);
     });
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.ts
@@ -52,7 +52,7 @@ export class PoDynamicFormComponent extends PoDynamicFormBaseComponent implement
     return this._form || <any>{};
   }
 
-  @ViewChild('fieldsComponent') fieldsComponent: { focus: (property: string) => void };
+  @ViewChild('fieldsComponent') fieldsComponent: { focus: (property: string) => void; updatePreviousValue: () => void };
 
   constructor(
     private changes: ChangeDetectorRef,
@@ -180,6 +180,7 @@ export class PoDynamicFormComponent extends PoDynamicFormBaseComponent implement
 
   private updateModelWithValidation(formData: PoDynamicFormValidation) {
     Object.assign(this.value, formData.value);
+    this.fieldsComponent.updatePreviousValue();
     this.fields = this.validationService.updateFieldsForm(formData.fields, this.fields);
   }
 }


### PR DESCRIPTION
**Dynamic Form**

**DTHFUI-3644**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Ao comparar o valor anterior com o valor atual durante o validate, não estava sendo atualizado todo o valor do objeto, apenas a propriedade que recebeu o change, caso uma propriedade fosse alterada durante o change pelo desenvolvedor, essa propriedade não era atualizada fazendo com que o validate não fosse disparado para o desenvolvedor.

**Qual o novo comportamento?**

Passa a atualizar todo o objeto (model) garantindo que seja sempre disparado o change.

**Simulação**

Pode ser simulado conforme as informações anexadas a issue ou como o vídeo em anexo.

[dynamic-form-previous-value-error.mp4.zip](https://github.com/po-ui/po-angular/files/4814584/dynamic-form-previous-value-error.mp4.zip)
