### PR TITLE
feat(table): adiciona propriedade para remover o gerenciador

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -1267,5 +1267,13 @@ describe('PoTableBaseComponent:', () => {
 
       expect(component.nameColumnDetail).toBeNull();
     });
+
+    it('p-hide-columns-manager: should update property `p-hide-columns-manager` with valid values.', () => {
+      expectPropertiesValues(component, 'hideColumnsManager', booleanValidTrueValues, true);
+    });
+
+    it('p-hide-columns-manager: should update property `p-hide-columns-manager` with invalid values.', () => {
+      expectPropertiesValues(component, 'hideColumnsManager', booleanInvalidValues, false);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -15,6 +15,7 @@ import { PoTableColumn } from './interfaces/po-table-column.interface';
 import { PoTableColumnSort } from './interfaces/po-table-column-sort.interface';
 import { PoTableColumnSortType } from './enums/po-table-column-sort-type.enum';
 import { PoTableLiterals } from './interfaces/po-table-literals.interface';
+import { InputBoolean } from '../../decorators';
 
 export const poTableContainer = ['border', 'shadow'];
 export const poTableContainerDefault = 'border';
@@ -91,6 +92,7 @@ export abstract class PoTableBaseComponent implements OnChanges {
   private _literals: PoTableLiterals;
   private _loading?: boolean = false;
   private _selectable?: boolean;
+  private _columnManager?: boolean = true;
 
   allColumnsWidthPixels: boolean;
   columnMasterDetail: PoTableColumn;
@@ -361,6 +363,17 @@ export abstract class PoTableBaseComponent implements OnChanges {
   get selectable() {
     return this._selectable;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Permite que o gerenciador de colunas, responsável pela definição de quais colunas serão exibidas, seja escondido.
+   *
+   * @default `false`
+   */
+  @Input('p-hide-columns-manager') @InputBoolean() hideColumnsManager?: boolean = false;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -88,8 +88,13 @@
         </th>
 
         <th
+          *ngIf="!displayColumnManagerCell && hideColumnsManager"
+          [class.po-table-header-single-action]="isSingleAction"
+          [class.po-table-header-actions]="!isSingleAction"
+        ></th>
+        <th
           #columnManager
-          *ngIf="hasValidColumns"
+          *ngIf="hasValidColumns && !hideColumnsManager"
           [class.po-table-header-column-manager]="!isSingleAction"
           [class.po-table-header-column-manager-border]="!height && container"
           [class.po-table-header-single-action]="isSingleAction"
@@ -239,7 +244,7 @@
             </span>
           </td>
           <!-- Column Manager -->
-          <td *ngIf="displayColumnManagerCell" class="po-table-column"></td>
+          <td *ngIf="displayColumnManagerCell && !hideColumnsManager" class="po-table-column"></td>
         </tr>
 
         <tr *ngIf="hasMainColumns && hasRowTemplate && row.$showDetail && isShowRowTemplate(row, rowIndex)">
@@ -309,6 +314,7 @@
 </ng-template>
 
 <po-table-column-manager
+  *ngIf="!hideColumnsManager"
   [p-columns]="columns"
   [p-max-columns]="maxColumns"
   [p-target]="columnManagerTarget"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1791,6 +1791,20 @@ describe('PoTableComponent:', () => {
 
       expect(nativeElement.querySelectorAll(`po-table-column-icon po-table-icon`).length).toBe(2);
     });
+
+    it('should not display po-table-column-manager', () => {
+      component.hideColumnsManager = true;
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector(`po-table-column-manager`)).toBe(null);
+    });
+
+    it('should display po-table-column-manager', () => {
+      component.hideColumnsManager = false;
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector(`po-table-column-manager`)).toBeTruthy();
+    });
   });
 
   describe('Properties:', () => {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -4,6 +4,7 @@
   [p-container]="container"
   [p-height]="height"
   [p-hide-detail]="properties.includes('hideDetail')"
+  [p-hide-columns-manager]="properties.includes('hideColumnsManager')"
   [p-hide-select-all]="selection.includes('hideSelectAll')"
   [p-hide-text-overflow]="properties.includes('hideTextOverflow')"
   [p-items]="items"

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -81,7 +81,8 @@ export class SamplePoTableLabsComponent implements OnInit {
     { label: 'Striped', value: 'striped' },
     { label: 'Show more disabled', value: 'showMoreDisabled' },
     { label: 'Hide detail', value: 'hideDetail' },
-    { label: 'Loading', value: 'loading' }
+    { label: 'Loading', value: 'loading' },
+    { label: 'Hide columns manager', value: 'hideColumnsManager' }
   ];
 
   public readonly typeHeaderOptions: Array<PoRadioGroupOption> = [

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.component.html
@@ -1,4 +1,4 @@
-<po-table [p-columns]="columns" [p-items]="items" p-sort="true" [p-striped]="true">
+<po-table p-hide-columns-manager p-sort="true" [p-columns]="columns" [p-items]="items" [p-striped]="true">
   <ng-template p-table-row-template let-rowItem let-i="rowIndex" [p-table-row-template-show]="isUndelivered">
     <po-widget p-title="Transport detail {{ rowItem.code }}">
       <div class="po-row">


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-3580**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente não é possivel desabilitar o gerenciador de colunas na tabela.

**Qual o novo comportamento?**
Através da propriedade [p-hide-columns-manager] é possivel desabilitar o gerenciador.

**Simulação**

_PR style_: https://github.com/po-ui/po-style/pull/116

`<po-table [p-items]="items" [p-columns]="columns" p-hide-columns-manager></po-table>`