### PR TITLE
fix(page-dynamic-table): correção no tratamento da ação removeAll

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-remove-all.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-before-remove-all.interface.ts
@@ -34,6 +34,8 @@ export interface PoPageDynamicTableBeforeRemoveAll {
    * ```
    * [{ id: 1, name: 'Mario' },{ id: 2, name: 'Gabriel' }]
    * ```
+   *
+   * Esse recurso será passado para a ação `removeAll` também se for um array vazio `[]`
    */
   resources?: Array<any>;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -1462,7 +1462,7 @@ describe('PoPageDynamicTableComponent:', () => {
         expect(component.items).toEqual([{ id: '2', name: 'react', $selected: true }]);
       }));
 
-      it(`should not call 'poNotification.success' if beforeRemoveAll returns an empty resource`, fakeAsync(() => {
+      it(`should call 'poNotification.success' if beforeRemoveAll returns an empty resource`, fakeAsync(() => {
         const action = true;
         const beforeRemoveAll: PoPageDynamicTableBeforeRemoveAll = {
           resources: []
@@ -1474,8 +1474,7 @@ describe('PoPageDynamicTableComponent:', () => {
 
         tick();
 
-        expect(successSpy).not.toHaveBeenCalled();
-        expect(deleteSpy).not.toHaveBeenCalled();
+        expect(deleteSpy).toHaveBeenCalled();
       }));
 
       it(`should not call 'poNotification.success' if beforeRemoveAll returns an undefined resource`, fakeAsync(() => {
@@ -1579,50 +1578,80 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(component.pageActions).toEqual(pageAction);
     });
 
-    it('setRemoveAllAction: shouldn`t set page action remove all if `_actions.removeAll` is false', () => {
-      const actions = {
-        new: 'newValue',
-        remove: true,
-        removeAll: false
-      };
+    describe('setRemoveAllAction:', () => {
+      it('shouldn`t set page action remove all if `_actions.removeAll` is false', () => {
+        const actions = {
+          new: 'newValue',
+          remove: true,
+          removeAll: false
+        };
 
-      const pageAction = [
-        {
-          label: component.literals.pageAction,
-          action: jasmine.any(Function),
-          disabled: !component.actions.new
+        const pageAction = [
+          {
+            label: component.literals.pageAction,
+            action: jasmine.any(Function),
+            disabled: !component.actions.new
+          }
+        ];
+
+        component['setPageActions'](actions);
+
+        component['setRemoveAllAction']();
+
+        expect(component.pageActions).toEqual(pageAction);
+      });
+
+      it('should set page action remove all if `_actions.removeAll` is true', () => {
+        const actions = {
+          new: 'newValue',
+          remove: true,
+          removeAll: true
+        };
+
+        const pageAction = [
+          {
+            label: component.literals.pageAction,
+            action: jasmine.any(Function),
+            disabled: false
+          },
+          {
+            label: component.literals.pageActionRemoveAll,
+            action: jasmine.any(Function),
+            disabled: jasmine.any(Function)
+          }
+        ];
+        component.actions = actions;
+
+        expect(component.pageActions).toEqual(pageAction);
+      });
+
+      it('should set disable to true if there is no selectable items', () => {
+        const actions = {
+          new: 'newValue',
+          remove: true,
+          removeAll: true
+        };
+
+        component.actions = actions;
+        component.items = [];
+        if (typeof component.pageActions[1].disabled === 'function') {
+          expect(component.pageActions[1].disabled()).toBeTrue();
         }
-      ];
+      });
 
-      component['setPageActions'](actions);
+      it('should set disable to false if there is selectable items', () => {
+        const actions = {
+          new: 'newValue',
+          remove: true,
+          removeAll: true
+        };
 
-      component['setRemoveAllAction']();
-
-      expect(component.pageActions).toEqual(pageAction);
-    });
-
-    it('setRemoveAllAction: should set page action remove all if `_actions.removeAll` is true', () => {
-      const actions = {
-        new: 'newValue',
-        remove: true,
-        removeAll: true
-      };
-
-      const pageAction = [
-        {
-          label: component.literals.pageAction,
-          action: jasmine.any(Function),
-          disabled: false
-        },
-        {
-          label: component.literals.pageActionRemoveAll,
-          action: jasmine.any(Function),
-          disabled: false
+        component.actions = actions;
+        component.items = [{ name: 'Mario', $selected: true }];
+        if (typeof component.pageActions[1].disabled === 'function') {
+          expect(component.pageActions[1].disabled()).toBeFalse();
         }
-      ];
-      component.actions = actions;
-
-      expect(component.pageActions).toEqual(pageAction);
+      });
     });
 
     describe('setTableActions:', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -670,7 +670,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     const allow = allowAction ?? true;
     const resourcestoDelete = resources ?? originalResources;
 
-    if (allow && resourcestoDelete?.length) {
+    if (allow && Array.isArray(resourcestoDelete)) {
       if (typeof actionRemoveAll === 'boolean' || newUrl) {
         return this.poPageDynamicService.deleteResources(resourcestoDelete, newUrl).pipe(
           tap(() => {
@@ -711,14 +711,17 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
 
   private setRemoveAllAction() {
     const action = this._actions;
-    if (action.removeAll) {
-      const visibleRemove = !this.showRemove(action.removeAll);
+    if (this.showRemove(action.removeAll)) {
       this._pageActions.push({
         label: this.literals.pageActionRemoveAll,
         action: this.confirmRemoveAll.bind(this, action.removeAll, action.beforeRemoveAll),
-        disabled: visibleRemove
+        disabled: this.disableRemoveAll.bind(this)
       });
     }
+  }
+
+  private disableRemoveAll(): boolean {
+    return !this.getSelectedItemsKeysToRemove();
   }
 
   private setTableActions(actions: PoPageDynamicTableActions) {


### PR DESCRIPTION
**page-dynamic-table**

**DTHFUI-3643**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [X] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O botão de exclusão em lote ficava habilitado mesmo com nenhum item selecionado, além disso caso seja passado no beforeRemoveAll seja passado um array em branco, a função removeAll não era chamada.

**Qual o novo comportamento?**
Alterado o botão de exclusão em lote que ficará habilitado somente se houver um ou mais
itens para excluir. Além disso caso o beforeRemoveAll retorne um array vazio
na propriedade resources a função removeAll será chamada.


**Simulação**
- Projeto para simulação
[removeAll.zip](https://github.com/po-ui/po-angular/files/4827353/removeAll.zip)
- Também e possivel testar no portal.
