### PR TITLE
feat(table): adiciona loading ao botao carregar mais

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -278,7 +278,8 @@ export abstract class PoTableBaseComponent implements OnChanges {
    *
    * @description
    *
-   * Bloqueia interação do usuário com os dados da _table_, apresentando um _loading_ ao centro da mesma.
+   * Bloqueia a interação do usuário com os dados da _table_ assim como no botão 'Carregar mais resultados',
+   * apresentando um _spinning loading_ em ambos.
    *
    * @default `false`
    */

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -41,6 +41,7 @@
     class="po-offset-xl-4 po-offset-lg-4 po-offset-md-3 po-lg-4 po-md-6"
     [p-disabled]="showMoreDisabled"
     [p-label]="literals.loadMoreData"
+    [p-loading]="loading"
     (p-click)="onShowMore()"
   >
   </po-button>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.html
@@ -8,6 +8,7 @@
   [p-items]="items"
   [p-show-more-disabled]="showMoreDisabled"
   [p-sort]="true"
+  [p-loading]="isLoading"
   (p-show-more)="showMore($event)"
   (p-sort-by)="sort($event)"
 >

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.ts
@@ -17,6 +17,7 @@ export class SamplePoTableComponentsComponent {
   items: Array<any> = this.sampleComponents.getItems();
   showMoreDisabled: boolean = false;
   title: any;
+  isLoading: boolean = false;
 
   public readonly columns: Array<PoTableColumn> = [
     {
@@ -100,8 +101,12 @@ export class SamplePoTableComponentsComponent {
   }
 
   showMore(sort: PoTableColumnSort) {
+    this.isLoading = true;
     this.showMoreDisabled = true;
-    this.items = this.getItems(sort);
+    setTimeout(() => {
+      this.items = this.getItems(sort);
+      this.isLoading = false;
+    }, 4000);
   }
 
   sort(sort: PoTableColumnSort) {


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-3658**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
Quando o botão "Carregar mais resultados" é clicado, não é retornado um feedback ao usuário que o mesmo esta em estado de carregamento.

**Qual o novo comportamento?**
Caso o usuário tenha habilitado a propriedade p-loading no PO-TABLE, assim que ele clicar no botao "Carregar mais resultados" e este disparar uma requisiçao ao servidor, enquanto a requisição não retornar com os dados, é mostrado ao usuário um loading na tabela e no botão.

**Simulação**
``` html
<po-table
  [p-columns]="columns"
  [p-items]="items"
  [p-show-more-disabled]="showMoreDisabled"
  [p-sort]="true"
  (p-show-more)="showMore($event)"
  [p-loading]="true"
></po-table>
```

``` typescript
 showMoreDisabled: boolean = false;
 loading: boolean = false;

 public showMore() {
    this.isLoading = true;
    this.showMoreDisabled = true;
    setTimeout(() => {
      this.items.push(<ALGUNS ITENS>);
      this.isLoading = false;
      this.showMoreDisabled = false;
    }, 4000);
  }
}
```
