### PR TITLE
feat(page-dynamic-search): implementa `p-concat-filters` 

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
@@ -158,6 +158,27 @@ export abstract class PoPageDynamicSearchBaseComponent {
   keepFilters: boolean = false;
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Permite a utilização da pesquisa rápida junto com a pesquisa avançada.
+   *
+   * Desta forma, ao ter uma pesquisa avançada estabelecida e ser
+   * preenchido a pesquisa rápida, o filtro será concatenado adicionando a pesquisa
+   * rápida também na lista de `disclaimers`.
+   *
+   * > Os valores que são emitidos no `p-quick-search` e no `p-advanced-search`
+   * permanecem separados durante a emissão dos valores alterados. A concatenação
+   * é apenas nos `disclaimers`.
+   *
+   * @default `false`
+   */
+  @InputBoolean()
+  @Input('p-concat-filters')
+  concatFilters: boolean = false;
+
+  /**
    * Função ou serviço que será executado na inicialização do componente.
    *
    * A propriedade aceita os seguintes tipos:

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-options.interface.ts
@@ -43,4 +43,17 @@ export interface PoPageDynamicSearchOptions {
    * Caso esse atributo seja utilizado ele sempre irá substituir o original.
    */
   keepFilters?: boolean;
+
+  /**
+   * Permite a utilização da pesquisa rápida junto com a pesquisa avançada.
+   *
+   * Desta forma, ao ter uma pesquisa avançada estabelecida e ser
+   * preenchido a pesquisa rápida, o filtro será concatenado adicionando a pesquisa
+   * rápida também na lista de disclaimers.
+   *
+   * > Os valores que são emitidos no `p-quick-search` e no `p-advanced-search`
+   * permanecem separados durante a emissão dos valores alterados. A concatenação
+   * é apenas nos `disclaimers`.
+   */
+  concatFilters?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -103,11 +103,24 @@ describe('PoPageDynamicSearchComponent:', () => {
         expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
       });
 
-      it('should update filters value if `keepFilters` is true', () => {
+      it('should update filters value if `keepFilters` is true and `concatFilters` is false', () => {
         component.keepFilters = true;
+        component.concatFilters = false;
         component.filters = [{ property: 'city', initValue: 'Ontario' }];
 
         const expectedValue = [{ property: 'city' }];
+
+        component.onAction('quickFilter');
+
+        expect(component.filters).toEqual(expectedValue);
+      });
+
+      it('shouldn`t update filters value if `concatFilters` and `keepFilters` are true', () => {
+        component.keepFilters = true;
+        component.concatFilters = true;
+        component.filters = [{ property: 'city', initValue: 'Ontario' }];
+
+        const expectedValue = [{ property: 'city', initValue: 'Ontario' }];
 
         component.onAction('quickFilter');
 
@@ -183,7 +196,7 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(convertedFilters).toEqual(expectedFormattedFilters);
     });
 
-    it(`formatsFilterValuesToUpdateDisclaimers: should formats filter value to update disclaimers`, () => {
+    it(`formatArrayToObjectKeyValue: should formats filter value to update disclaimers`, () => {
       const filterToBeFormatted = [
         { property: 'city', initValue: 'Ontario' },
         { property: 'name', value: 'teste' },
@@ -191,7 +204,7 @@ describe('PoPageDynamicSearchComponent:', () => {
       ];
       const expectedFormattedFilters = { city: 'Ontario', name: 'teste' };
 
-      const convertedFilters = component['formatsFilterValuesToUpdateDisclaimers'](filterToBeFormatted);
+      const convertedFilters = component['formatArrayToObjectKeyValue'](filterToBeFormatted);
 
       expect(convertedFilters).toEqual(expectedFormattedFilters);
     });
@@ -219,106 +232,27 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(component['getFieldByProperty'](fields, fieldName)).toEqual(result);
     });
 
-    it(`onChangeDisclaimerGroup: should call 'changeDisclaimers.emit', 'formatsFilterValuesToUpdateDisclaimers' and 'setFilters'
-    if 'disclaimersEqualsFilters' and 'isQuickSearch' are 'false'`, () => {
-      const disclaimers = [{ label: 'City: Ontario', property: 'city', value: 'Ontario' }];
-      const formattedDisclaimersToEmitToAdvancedFilter = { city: 'Ontario' };
+    it(`onRemoveDisclaimer: should call 'changeDisclaimers.emit' if disclaimers have been removed`, () => {
+      component.disclaimerGroup.disclaimers = [
+        { label: 'City: Ontario', property: 'city', value: 'Ontario' },
+        { label: 'Name: Test', property: 'name', value: 'Test' }
+      ];
+      const currentDisclaimers = [{ label: 'City: Ontario', property: 'city', value: 'Ontario' }];
+      const removedDisclaimer = { label: 'Name: Test', property: 'name', value: 'Test' };
 
       spyOn(component.changeDisclaimers, 'emit');
-      spyOn(component, <any>'disclaimersEqualsFilters').and.returnValue(false);
-      spyOn(component, <any>'isQuickSearch').and.returnValue(false);
-      spyOn(component, <any>'formatsFilterValuesToUpdateDisclaimers').and.returnValue(
-        formattedDisclaimersToEmitToAdvancedFilter
-      );
-      spyOn(component, <any>'setFilters');
 
-      component['onChangeDisclaimerGroup'](disclaimers);
+      component['onRemoveDisclaimer']({ removedDisclaimer, currentDisclaimers });
 
-      expect(component.changeDisclaimers.emit).toHaveBeenCalledWith(disclaimers);
-      expect(component['formatsFilterValuesToUpdateDisclaimers']).toHaveBeenCalledWith(disclaimers);
-      expect(component['setFilters']).toHaveBeenCalledWith(formattedDisclaimersToEmitToAdvancedFilter);
+      expect(component.changeDisclaimers.emit).toHaveBeenCalledWith(currentDisclaimers);
     });
 
-    it(`onChangeDisclaimerGroup: should call 'changeDisclaimers.emit', 'formatsFilterValuesToUpdateDisclaimers' and 'setFilters'
-    if 'disclaimers' is empty`, () => {
-      const disclaimers = [];
-      const formattedDisclaimersToEmitToAdvancedFilter = { city: 'Ontario' };
-
+    it(`onRemoveAllDisclaimers: should call 'changeDisclaimers.emit' if all disclaimers are removed`, () => {
       spyOn(component.changeDisclaimers, 'emit');
-      spyOn(component, <any>'disclaimersEqualsFilters').and.returnValue(true);
-      spyOn(component, <any>'isQuickSearch').and.returnValue(true);
-      spyOn(component, <any>'formatsFilterValuesToUpdateDisclaimers').and.returnValue(
-        formattedDisclaimersToEmitToAdvancedFilter
-      );
-      spyOn(component, <any>'setFilters');
 
-      component['onChangeDisclaimerGroup'](disclaimers);
+      component['onRemoveAllDisclaimers']();
 
-      expect(component.changeDisclaimers.emit).toHaveBeenCalledWith(disclaimers);
-      expect(component['formatsFilterValuesToUpdateDisclaimers']).toHaveBeenCalledWith(disclaimers);
-      expect(component['setFilters']).toHaveBeenCalledWith(formattedDisclaimersToEmitToAdvancedFilter);
-    });
-
-    it(`onChangeDisclaimerGroup: should't call 'changeDisclaimers.emit', 'formatsFilterValuesToUpdateDisclaimers' and 'setFilters'
-    if 'disclaimersEqualsFilters' and 'isQuickSearch' are 'true' and 'disclaimers' isn't 'empty'`, () => {
-      const disclaimers = [{ label: 'City: Ontario', property: 'city', value: 'Ontario' }];
-      const formattedDisclaimersToEmitToAdvancedFilter = { city: 'Ontario' };
-
-      spyOn(component.changeDisclaimers, 'emit');
-      spyOn(component, <any>'disclaimersEqualsFilters').and.returnValue(true);
-      spyOn(component, <any>'isQuickSearch').and.returnValue(true);
-      spyOn(component, <any>'formatsFilterValuesToUpdateDisclaimers').and.returnValue(
-        formattedDisclaimersToEmitToAdvancedFilter
-      );
-      spyOn(component, <any>'setFilters');
-
-      component['onChangeDisclaimerGroup'](disclaimers);
-
-      expect(component.changeDisclaimers.emit).not.toHaveBeenCalledWith(disclaimers);
-      expect(component['formatsFilterValuesToUpdateDisclaimers']).not.toHaveBeenCalledWith(disclaimers);
-      expect(component['setFilters']).not.toHaveBeenCalledWith(formattedDisclaimersToEmitToAdvancedFilter);
-    });
-
-    it(`disclaimersEqualsFilters: should compare the value of the disclaimers and filters and return
-    false if the values ​​are not the same`, () => {
-      const disclaimers = [{ label: 'City: Ontario', property: 'city', value: 'Ontario' }];
-      const formattedDisclaimers = { city: 'Ontario' };
-      const formattedFilters = { name: 'Teste' };
-
-      spyOn(component, <any>'formatsFilterValuesToUpdateDisclaimers').and.returnValues(
-        formattedDisclaimers,
-        formattedFilters
-      );
-
-      const expectedReturn = component['disclaimersEqualsFilters'](disclaimers);
-
-      expect(component['formatsFilterValuesToUpdateDisclaimers']).toHaveBeenCalledTimes(2);
-      expect(expectedReturn).toBeFalse();
-    });
-
-    it(`disclaimersEqualsFilters: should compare the value of the disclaimers and filters and return
-    true if the values ​​are the same`, () => {
-      const disclaimers = [{ label: 'City: Ontario', property: 'city', value: 'Ontario' }];
-      const formattedDisclaimers = { city: 'Ontario' };
-      const formattedFilters = { city: 'Ontario' };
-
-      spyOn(component, <any>'formatsFilterValuesToUpdateDisclaimers').and.returnValues(
-        formattedDisclaimers,
-        formattedFilters
-      );
-
-      const expectedReturn = component['disclaimersEqualsFilters'](disclaimers);
-
-      expect(component['formatsFilterValuesToUpdateDisclaimers']).toHaveBeenCalledTimes(2);
-      expect(expectedReturn).toBeTrue();
-    });
-
-    it(`isQuickSearch: should return true if 'disclaimers' have a property with value 'search'`, () => {
-      const disclaimers = [{ label: 'Pesquisa rápida: teste', property: 'search', value: 'teste' }];
-
-      const expectedReturn = component['isQuickSearch'](disclaimers);
-
-      expect(expectedReturn).toBeTruthy();
+      expect(component.changeDisclaimers.emit).toHaveBeenCalledWith([]);
     });
 
     it(`setDisclaimers: should return disclaimers based on the 'filters', call 'getFieldByProperty'
@@ -556,6 +490,85 @@ describe('PoPageDynamicSearchComponent:', () => {
         });
         expect(component.keepFilters).toBeTrue();
       }));
+    });
+  });
+
+  describe('Integration:', () => {
+    it(`shouldn't call 'changeDisclaimers.emit' if disclaimers have been added because of quickSearch`, () => {
+      component.filters = [{ property: 'city', initValue: 'Ontario' }];
+
+      spyOn(component.changeDisclaimers, 'emit');
+
+      component.literals.quickSearchLabel = 'Search';
+      component.onAction('Chicago');
+
+      expect(component.changeDisclaimers.emit).not.toHaveBeenCalled();
+    });
+
+    it(`should add quickSearch and advanced filter in disclaimers if concat-filters is true and advanced filter is defined`, () => {
+      component.concatFilters = true;
+
+      component.filters = [{ property: 'city', initValue: 'Ontario' }];
+
+      component.literals.quickSearchLabel = 'Search';
+      component.onAction('Chicago');
+
+      const currentDisclaimers = [
+        { label: 'City: Ontario', value: 'Ontario', property: 'city' },
+        { property: 'search', label: `Search Chicago`, value: 'Chicago' }
+      ];
+
+      expect(component.disclaimerGroup.disclaimers).toEqual(currentDisclaimers);
+    });
+
+    it(`should add advanced filter and quickSearch updated in disclaimers if concat-filters is true and advanced filter is defined`, () => {
+      component.concatFilters = true;
+
+      component.filters = [{ property: 'city', initValue: 'Ontario' }];
+
+      component.literals.quickSearchLabel = 'Search';
+      component.onAction('Chicago');
+
+      component.onAction('Test');
+
+      const currentDisclaimers = [
+        { label: 'City: Ontario', value: 'Ontario', property: 'city' },
+        { property: 'search', label: `Search Test`, value: 'Test' }
+      ];
+
+      expect(component.disclaimerGroup.disclaimers).toEqual(currentDisclaimers);
+    });
+
+    it(`should add advanced search and remove quickSearch in disclaimers if concat-filters is false`, () => {
+      component.concatFilters = false;
+
+      component.literals.quickSearchLabel = 'Search';
+      component.onAction('Chicago');
+      const disclaimersWithQuickFilter = [{ property: 'search', label: `Search Chicago`, value: 'Chicago' }];
+
+      expect(component.disclaimerGroup.disclaimers).toEqual(disclaimersWithQuickFilter);
+
+      const disclaimersWithAdvancedSearch = [{ label: 'City: Ontario', value: 'Ontario', property: 'city' }];
+
+      component.filters = [{ property: 'city', initValue: 'Ontario' }];
+
+      expect(component.disclaimerGroup.disclaimers).toEqual(disclaimersWithAdvancedSearch);
+    });
+
+    it(`should add advanced search and remove quickSearch in disclaimers if concat-filters is true`, () => {
+      component.concatFilters = true;
+
+      component.literals.quickSearchLabel = 'Search';
+      component.onAction('Chicago');
+      const disclaimersWithQuickFilter = [{ property: 'search', label: `Search Chicago`, value: 'Chicago' }];
+
+      expect(component.disclaimerGroup.disclaimers).toEqual(disclaimersWithQuickFilter);
+
+      const disclaimersWithAdvancedSearch = [{ label: 'City: Ontario', value: 'Ontario', property: 'city' }];
+
+      component.filters = [{ property: 'city', initValue: 'Ontario' }];
+
+      expect(component.disclaimerGroup.disclaimers).toEqual(disclaimersWithAdvancedSearch);
     });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
@@ -43,4 +43,22 @@ export interface PoPageDynamicTableOptions {
    * Caso esse atributo seja utilizado ele sempre irá substituir o original.
    */
   keepFilters?: boolean;
+
+  /**
+   * Permite a utilização da pesquisa rápida junto com a pesquisa avançada.
+   *
+   * Desta forma, ao ter uma pesquisa avançada estabelecida e ser
+   * preenchido a pesquisa rápida, o filtro será concatenado adicionando a pesquisa
+   * rápida também na lista de `disclaimers` a aplicando uma nova busca com a concatenação.
+   *
+   * Por exemplo, com os seguintes filtros aplicados:
+   *   - filtro avançado: `{ name: 'Mike', age: '12' }`
+   *   - filtro rápido: `{ search: 'paper' }`
+   *
+   * A requisição dos dados na API ficará com os parâmetros:
+   * ```
+   * page=1&pageSize=10&name=Mike&age=12&search=paper
+   * ```
+   */
+  concatFilters?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -3,6 +3,7 @@
   [p-breadcrumb]="breadcrumb"
   [p-filters]="filters"
   [p-keep-filters]="keepFilters"
+  [p-concat-filters]="concatFilters"
   [p-title]="title"
   (p-advanced-search)="onAdvancedSearch($event)"
   (p-change-disclaimers)="onChangeDisclaimers($event)"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -147,7 +147,8 @@ describe('PoPageDynamicTableComponent:', () => {
               new: '/new'
             },
             fields: [{ property: 'filter1' }, { property: 'filter3' }],
-            keepFilters: true
+            keepFilters: true,
+            concatFilters: true
           };
         };
 
@@ -168,6 +169,7 @@ describe('PoPageDynamicTableComponent:', () => {
           items: [{ label: 'Test' }, { label: 'Test2' }]
         });
         expect(component.keepFilters).toBeTrue();
+        expect(component.concatFilters).toBeTrue();
 
         component.ngOnDestroy();
         expect(component['subscriptions']['_subscriptions']).toBeNull();
@@ -261,6 +263,56 @@ describe('PoPageDynamicTableComponent:', () => {
 
       expect(component['loadData']).toHaveBeenCalledWith({ page: 1, search: filter });
       expect(component['params']).toEqual({ search: filter });
+    });
+
+    it('onQuickSearch: should call `loadData` with merged filter and quickSearch if concatFilters is true', () => {
+      component.concatFilters = true;
+      const termTypedInQuickSearch = 'filterValue';
+
+      const advancedFiltersParams = {
+        city: 'Ontario',
+        name: 'Test'
+      };
+
+      const expectedParams = {
+        ...advancedFiltersParams,
+        search: termTypedInQuickSearch
+      };
+      spyOn(component, <any>'loadData').and.returnValue(EMPTY);
+
+      component.onAdvancedSearch(advancedFiltersParams);
+
+      expect(component['loadData']).toHaveBeenCalledWith({ page: 1, ...advancedFiltersParams });
+      expect(component['params']).toEqual(advancedFiltersParams);
+
+      component.onQuickSearch(termTypedInQuickSearch);
+
+      expect(component['loadData']).toHaveBeenCalledWith({ page: 1, ...expectedParams });
+      expect(component['params']).toEqual(expectedParams);
+    });
+
+    it('onQuickSearch: should call `loadData` only with quickSearch if concatFilters is false', () => {
+      component.concatFilters = false;
+      const termTypedInQuickSearch = 'filterValue';
+
+      const advancedFiltersParams = {
+        city: 'Ontario',
+        name: 'Test'
+      };
+
+      const quickSearchParams = { search: termTypedInQuickSearch };
+
+      spyOn(component, <any>'loadData').and.returnValue(EMPTY);
+
+      component.onAdvancedSearch(advancedFiltersParams);
+
+      expect(component['loadData']).toHaveBeenCalledWith({ page: 1, ...advancedFiltersParams });
+      expect(component['params']).toEqual(advancedFiltersParams);
+
+      component.onQuickSearch(termTypedInQuickSearch);
+
+      expect(component['loadData']).toHaveBeenCalledWith({ page: 1, ...quickSearchParams });
+      expect(component['params']).toEqual(quickSearchParams);
     });
 
     it('onQuickSearch: should call `loadData` with `undefined` and set `params` with `{}` if haven`t `filter`', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -1,5 +1,6 @@
 <po-page-dynamic-table
   p-auto-router
+  p-concat-filters
   p-keep-filters
   p-title="Users"
   [p-actions]="actions"

--- a/projects/ui/src/lib/components/po-disclaimer-group/index.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/index.ts
@@ -1,4 +1,5 @@
 export * from './po-disclaimer-group.component';
 export * from './po-disclaimer-group.interface';
+export * from './po-disclaimer-group-remove-action.interface';
 
 export * from './po-disclaimer-group.module';

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.spec.ts
@@ -4,6 +4,7 @@ import * as UtilsFunction from '../../utils/util';
 
 import { PoDisclaimer } from '../po-disclaimer//po-disclaimer.interface';
 import { PoDisclaimerGroupBaseComponent } from './po-disclaimer-group-base.component';
+import { tick, fakeAsync } from '@angular/core/testing';
 
 describe('PoDisclaimerGroupBaseComponent:', () => {
   const differ = {
@@ -157,8 +158,8 @@ describe('PoDisclaimerGroupBaseComponent:', () => {
       expect(component.isRemoveAll()).toBe(false);
     });
 
-    it('closeItem: should close/remove a disclaimer.', () => {
-      component.closeItem(disclaimers[0]);
+    it('removeDisclaimer: should close/remove a disclaimer.', () => {
+      component['removeDisclaimer'](disclaimers[0]);
 
       expect(component.disclaimers.find(f => f.value === 'hotel')).toBeFalsy();
       expect(component.disclaimers.length).toEqual(2);
@@ -185,18 +186,39 @@ describe('PoDisclaimerGroupBaseComponent:', () => {
       expect(component['emitChangeDisclaimers']).toHaveBeenCalledTimes(1);
     });
 
-    it('closeItem: should call `emitChangeDisclaimers` if `emitChange` is true.', () => {
-      spyOn(component, <any>'emitChangeDisclaimers');
-      component.closeItem(validDisclaimers[0], true);
+    it('removeAllItems: should emit removeAll with removed disclaimers', () => {
+      component.disclaimers = [...validDisclaimers];
 
-      expect(component['emitChangeDisclaimers']).toHaveBeenCalled();
+      spyOn(component.removeAll, <any>'emit');
+      component.removeAllItems();
+
+      expect(component.removeAll.emit).toHaveBeenCalledWith(validDisclaimers);
     });
 
-    it('closeItem: shouldn`t call `emitChangeDisclaimers` if `emitChange` is false.', () => {
-      spyOn(component, <any>'emitChangeDisclaimers');
-      component.closeItem(validDisclaimers[0], false);
+    it('onCloseAction: should remove disclaimer and emit current disclaimers', fakeAsync(() => {
+      spyOn(component.change, <any>'emit');
 
-      expect(component['emitChangeDisclaimers']).not.toHaveBeenCalled();
+      const disclaimerToRemove = { value: 'north', label: 'Region', property: 'region', hideClose: false };
+      const currentDisclaimers = [component.disclaimers[0], component.disclaimers[1]];
+
+      component.onCloseAction(disclaimerToRemove);
+
+      tick();
+
+      expect(component.disclaimers).toEqual(currentDisclaimers);
+      expect(component.change.emit).toHaveBeenCalledWith(component.disclaimers);
+    }));
+
+    it('onCloseAction: should emit removedDisclaimer and currentDisclaimers in remove action', () => {
+      spyOn(component.remove, <any>'emit');
+
+      const removedDisclaimer = { value: 'north', label: 'Region', property: 'region', hideClose: false };
+      const currentDisclaimers = [component.disclaimers[0], component.disclaimers[1]];
+
+      component.onCloseAction(removedDisclaimer);
+
+      expect(component.disclaimers).toEqual(currentDisclaimers);
+      expect(component.remove.emit).toHaveBeenCalledWith({ currentDisclaimers, removedDisclaimer });
     });
 
     it('checkDisclaimers: should return only valid disclaimers.', () => {

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
@@ -94,6 +94,21 @@ export class PoDisclaimerGroupBaseComponent implements DoCheck {
   /** Função que será disparada quando a lista de *disclaimers* for modificada. */
   @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * Função que será disparada quando um *disclaimer* for removido da lista de *disclaimers* pelo usuário.
+   *
+   * Recebe como parâmetro um objeto conforme a interface `PoDisclaimerGroupRemoveAction`.
+   */
+  @Output('p-remove') remove?: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * Função que será disparada quando todos os *disclaimers* forem removidos da lista de *disclaimers* pelo usuário,
+   * utilizando o botão "remover todos".
+   *
+   * Recebe como parâmetro uma lista contendo todos os `disclaimers` removidos.
+   */
+  @Output('p-remove-all') removeAll?: EventEmitter<any> = new EventEmitter<any>();
+
   constructor(differs: IterableDiffers) {
     this.differ = differs.find([]).create(null);
   }
@@ -102,13 +117,14 @@ export class PoDisclaimerGroupBaseComponent implements DoCheck {
     this.checkChanges();
   }
 
-  closeItem(disclaimer: any, emitChange: boolean = true) {
-    const itemIndex = this.disclaimers.findIndex(d => d['$id'] === disclaimer['$id']);
-    this.disclaimers.splice(itemIndex, 1);
+  onCloseAction(disclaimer) {
+    this.removeDisclaimer(disclaimer);
 
-    if (emitChange) {
-      this.emitChangeDisclaimers();
-    }
+    this.emitChangeDisclaimers();
+    this.remove.emit({
+      removedDisclaimer: { ...disclaimer },
+      currentDisclaimers: [...this.disclaimers]
+    });
   }
 
   isRemoveAll() {
@@ -130,9 +146,15 @@ export class PoDisclaimerGroupBaseComponent implements DoCheck {
       }
     });
 
-    removeItems.forEach(disclaimer => this.closeItem(disclaimer, false));
+    removeItems.forEach(disclaimer => this.removeDisclaimer(disclaimer));
 
     this.emitChangeDisclaimers();
+    this.removeAll.emit([...removeItems]);
+  }
+
+  private removeDisclaimer(disclaimer: any) {
+    const itemIndex = this.disclaimers.findIndex(d => d['$id'] === disclaimer['$id']);
+    this.disclaimers.splice(itemIndex, 1);
   }
 
   private checkChanges() {

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-remove-action.interface.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-remove-action.interface.ts
@@ -1,7 +1,7 @@
 import { PoDisclaimer } from '../po-disclaimer/po-disclaimer.interface';
 
 /**
- * @usedBy PoDisclaimerGroupComponent
+ * @usedBy PoDisclaimerGroupComponent, PoPageListComponent
  *
  * @description
  *

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-remove-action.interface.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-remove-action.interface.ts
@@ -1,0 +1,20 @@
+import { PoDisclaimer } from '../po-disclaimer/po-disclaimer.interface';
+
+/**
+ * @usedBy PoDisclaimerGroupComponent
+ *
+ * @description
+ *
+ * Estrutura do objeto representando o estado dos *disclaimers* após a remoção.
+ */
+export interface PoDisclaimerGroupRemoveAction {
+  /**
+   * *Disclaimer* que foi removido.
+   */
+  removedDisclaimer: PoDisclaimer;
+
+  /**
+   * Lista com os *disclaimers* atuais (restantes).
+   */
+  currentDisclaimers: Array<PoDisclaimer>;
+}

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.html
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.html
@@ -17,7 +17,7 @@
     [p-label]="disclaimer.label"
     [p-property]="disclaimer.property"
     [p-value]="disclaimer.value"
-    (p-close-action)="closeItem(disclaimer)"
+    (p-close-action)="onCloseAction(disclaimer)"
   >
   </po-disclaimer>
 </div>

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.spec.ts
@@ -71,7 +71,7 @@ describe('PoDisclaimerGroupComponent:', () => {
   it('should remove/close one disclaimers', () => {
     component.hideRemoveAll = true;
 
-    component.closeItem(disclaimers[0]);
+    component.onCloseAction(disclaimers[0]);
     fixture.detectChanges();
 
     expect(nativeElement.querySelectorAll('po-disclaimer').length).toBe(2);

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.interface.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.interface.ts
@@ -65,4 +65,20 @@ export interface PoDisclaimerGroup {
    * Título do grupo de *disclaimers*.
    */
   title: string;
+
+  /**
+   * Função que será disparada quando um *disclaimer* for removido da lista de
+   * *disclaimers* pelo usuário.
+   *
+   * Recebe como parâmetro um objeto conforme a interface `PoDisclaimerGroupRemoveAction`.
+   */
+  remove?: Function;
+
+  /**
+   * Função que será disparada quando todos os *disclaimers* forem removidos da lista de *disclaimers* pelo usuário,
+   * utilizando o botão "remover todos".
+   *
+   * Recebe como parâmetro uma lista contendo todos os `disclaimers` removidos.
+   */
+  removeAll?: Function;
 }

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
@@ -96,6 +96,8 @@
       [p-hide-remove-all]="disclaimerGroup?.hideRemoveAll"
       [p-title]="disclaimerGroup?.title"
       (p-change)="onChangeDisclaimerGroup($event)"
+      (p-remove)="onRemoveDisclaimer($event)"
+      (p-remove-all)="onRemoveAllDisclaimers($event)"
     >
     </po-disclaimer-group>
   </po-page-header>

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
@@ -342,6 +342,66 @@ describe('PoPageListComponent - Desktop:', () => {
     expect(component.disclaimerGroup.change).toHaveBeenCalled();
   });
 
+  it('onRemoveDisclaimer: should call disclaimerGroup.remove if it`s defined', () => {
+    const currentDisclaimers: Array<PoDisclaimer> = [{ value: 'test2' }, { value: 'test3' }];
+
+    const removedDisclaimer = { value: 'hotel' };
+
+    component.disclaimerGroup = {
+      remove: () => {},
+      disclaimers: currentDisclaimers,
+      title: 'test'
+    };
+
+    const removeData = { removedDisclaimer, currentDisclaimers };
+
+    spyOn(component.disclaimerGroup, 'remove');
+
+    component.onRemoveDisclaimer(removeData);
+
+    expect(component.disclaimerGroup.remove).toHaveBeenCalledWith(removeData);
+  });
+
+  it('onRemoveDisclaimer: shouldn`t return an error if disclaimerGroup.remove is undefined', () => {
+    component.disclaimerGroup = {
+      remove: undefined,
+      disclaimers: [],
+      title: 'test'
+    };
+
+    const result = () => component.onRemoveDisclaimer(undefined);
+
+    expect(result).not.toThrowError();
+  });
+
+  it('onRemoveAllDisclaimers: shouldn`t return an error disclaimerGroup.removeAll is undefined', () => {
+    component.disclaimerGroup = {
+      removeAll: undefined,
+      disclaimers: [],
+      title: 'test'
+    };
+
+    const result = () => component.onRemoveAllDisclaimers(undefined);
+
+    expect(result).not.toThrowError();
+  });
+
+  it('onRemoveAllDisclaimers: should call disclaimerGroup.removeAll if it`s defined', () => {
+    const removedDisclaimers: Array<PoDisclaimer> = [{ value: 'test2' }, { value: 'test3' }];
+
+    component.disclaimerGroup = {
+      removeAll: () => {},
+      disclaimers: removedDisclaimers,
+      title: 'test'
+    };
+
+    spyOn(component.disclaimerGroup, 'removeAll');
+
+    component.onRemoveAllDisclaimers(removedDisclaimers);
+
+    expect(component.disclaimerGroup.removeAll).toHaveBeenCalledWith(removedDisclaimers);
+  });
+
   describe('Templates:', () => {
     const fakeFilter = {
       advancedAction: 'xxx',

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -17,6 +17,8 @@ import { callFunction, getParentRef, isExternalLink, isTypeof, openExternalLink 
 import { PoLanguageService } from './../../../services/po-language/po-language.service';
 
 import { PoPageAction } from '../po-page-action.interface';
+import { PoDisclaimer } from '../../po-disclaimer/po-disclaimer.interface';
+import { PoDisclaimerGroupRemoveAction } from '../../po-disclaimer-group/po-disclaimer-group-remove-action.interface';
 
 import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
 import { PoPageListBaseComponent } from './po-page-list-base.component';
@@ -178,6 +180,18 @@ export class PoPageListComponent extends PoPageListBaseComponent
 
     if (this.disclaimerGroup && this.disclaimerGroup.change) {
       this.disclaimerGroup.change(disclaimers);
+    }
+  }
+
+  onRemoveDisclaimer(removeData: PoDisclaimerGroupRemoveAction) {
+    if (this.disclaimerGroup.remove) {
+      this.disclaimerGroup.remove(removeData);
+    }
+  }
+
+  onRemoveAllDisclaimers(removedDisclaimers: Array<PoDisclaimer>) {
+    if (this.disclaimerGroup.removeAll) {
+      this.disclaimerGroup.removeAll(removedDisclaimers);
     }
   }
 


### PR DESCRIPTION
**Disclaimer Group, Page List, Page Dynamic Search e Page Dynamic Table**

**DTHFUI-2349**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Sempre que se aplicava uma busca rápida, ela sobrescrevia a busca avançada.  

**Qual o novo comportamento?**
Pode utilizar a basca rápida junto com a busca avançada através da propriedade `p-concat-filters`.

- Também foi adicionado este mesmo comportamento no `Page Dynamic Table`
- Deve manter o comportamento atual também quando` p-concat-filters` for `false`

- Para resolver o problema de emitir os disclaimers mais de uma vez, criamos duas propriedade p-remove e p-removeAll no disclaimer-group, para não precisar fazer esses tratamentos para diferenciar quando um disclaimer estiver sendo adicionado ou removido, gerando instabilidade nas funcionalidades do componente.

**Simulação**
Remove:
- Adicionar o evento p-remove e p-remove-all no disclaimer group e verificar se está sendo emitido apenas quando
um disclaimer for removido pelo usuário. 
- Testar a emissão do remove no Page List também.
- Lembrando que o p-change deve continuar funcionando normalmente.

Concat:
- Pode ser simulado no sample do `Page Dynamic Table`
- Adicionar o `p-concat-filters` no sample do `Page Dynamic Search`

[app-teste-concat.zip](https://github.com/po-ui/po-angular/files/4898760/app-teste-concat.zip)
