### PR TITLE
feat(sync): cria schematics ngAdd e ng generate

### DIFF
--- a/docs/guides/sync-fundamentals.md
+++ b/docs/guides/sync-fundamentals.md
@@ -7,6 +7,7 @@
 - [Conhecimentos necessários](guides/sync-fundamentals#knowledge)
 - [*Schemas*](guides/sync-fundamentals#schemas)
   - [Como criar um *schema*](guides/sync-fundamentals#create-schema)
+  - [Schematic](guides/sync-fundamentals#schematic)
 - [Preparando a API para a sincronização](guides/sync-fundamentals#prepare-api)
   - [Exclusão lógica](guides/sync-fundamentals#logical-deletion)
   - [*Endpoint* de sincronização](guides/sync-fundamentals#sync-url)
@@ -25,6 +26,7 @@
   - [Criação de identificador customizado para eventos da fila](guides/sync-fundamentals#custom-request-id)
   - [Alterando as definições dos *schemas*](guides/sync-fundamentals#schemas-definition)
 - [Aplicativo de demonstração do PO Sync](guides/sync-fundamentals#po-conference)
+
 
 <a id="introduction"></a>
 ## Introdução
@@ -124,6 +126,30 @@ Por exemplo, para um *schema* do tipo Pessoa, poderíamos ter os campos: nome, i
 
 Não necessariamente precisam ser representados todos os campos retornados pela API, somente os necessários para as
 manipulações através do PO Sync.
+
+<a id="schematic"></a>
+### Schematic
+
+Você pode utilizar um schematic para criar o arquivo com a estrutura básica do schema.
+
+Para isso utilize o comando
+
+```shell
+ng generate @po-ui/ng-sync:sync-schema
+```
+
+Você também pode informar um caminho completo.
+
+```shell
+ng generate @po-ui/ng-sync:sync-schema --name=conference/schema/conference
+```
+
+Ou apenas o nome do schema que ele criará o arquivo na pasta que o comando for executado.
+
+```shell
+ng generate @po-ui/ng-sync:sync-schema --name=conference
+```
+
 
 <a id="prepare-api"></a>
 ## Preparando a API para a sincronização

--- a/docs/guides/sync-get-started.md
+++ b/docs/guides/sync-get-started.md
@@ -88,8 +88,9 @@ npm install
 ### Passo 3 - Instalando o po-sync
 
 Para instalar o `po-sync` no aplicativo execute o seguinte comando:
+
 ```shell
-npm install @po-ui/ng-sync
+ng add @po-ui/ng-sync
 ```
 
 Após a instalação do `po-sync`, é necessário instalar o plugin
@@ -105,7 +106,9 @@ ionic cordova plugin add cordova-plugin-network-information
 ### Passo 4 - Utilizando o po-sync
 
 #### Passo 4.1 - Importando o `po-sync` e o `po-storage`
-No arquivo `src/app/app.module.ts`, adicione a importação dos módulos do `po-storage` e do `po-sync`:
+No arquivo `src/app/app.module.ts`, adicione a importação dos módulos do `po-storage` e do `po-sync`: 
+
+> Caso você utilize o comando `ng add`, esse passo será feito automaticamente.
 
 ```typescript
 import { NgModule } from '@angular/core';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,6 +56,10 @@ const copyTemplatesCollection = () =>
 
 /** SYNC SCHEMATICS */
 const copySyncMigrations = () => src([`${syncSchematicsFolder}/migrations.json`]).pipe(dest(distSyncSchematicsFolder));
+const copySyncSchemas = () => src([`${syncSchematicsFolder}/**/*/schema.json`]).pipe(dest(distSyncSchematicsFolder));
+const copySyncFiles = () =>
+  src([`${syncSchematicsFolder}/ng-generate/*/files/**`]).pipe(dest(`${distSyncSchematicsFolder}/ng-generate`));
+const copySyncCollection = () => src([`${syncSchematicsFolder}/collection.json`]).pipe(dest(distSyncSchematicsFolder));
 
 /** STORAGE SCHEMATICS */
 const copyStorageSchemas = () =>
@@ -107,7 +111,10 @@ exports.uiSchematics = series(
   parallel(copyUiCollection, copyUiMigrations, copyUiSchemas, copyUiFiles)
 );
 
-exports.syncSchematics = series(buildSyncSchematics, parallel(copySyncMigrations));
+exports.syncSchematics = series(
+  buildSyncSchematics,
+  parallel(copySyncCollection, copySyncMigrations, copySyncSchemas, copySyncFiles)
+);
 
 exports.storageSchematics = series(buildStorageSchematics, parallel(copyStorageCollection, copyStorageSchemas));
 

--- a/projects/schematics/src/build-file/build-file.ts
+++ b/projects/schematics/src/build-file/build-file.ts
@@ -1,0 +1,37 @@
+import { apply, applyTemplates, chain, mergeWith, move, Rule, url, Tree } from '@angular-devkit/schematics';
+
+import { buildDefaultPath } from '@schematics/angular/utility/project';
+import { getWorkspace } from '@schematics/angular/utility/config';
+import { strings } from '@angular-devkit/core';
+import { parseName } from '@schematics/angular/utility/parse-name';
+import { validateName } from '@schematics/angular/utility/validation';
+
+import { getProjectFromWorkspace } from '../project';
+import { FileOptions } from './file-options';
+
+export function buildFile(options: FileOptions): Rule {
+  return (host: Tree) => {
+    const workspace = getWorkspace(host);
+    const project: any = getProjectFromWorkspace(workspace, options.project);
+
+    if (options.path === undefined && project) {
+      options.path = buildDefaultPath(project);
+    }
+
+    const parsedPath = parseName(options.path as string, options.name);
+    options.name = parsedPath.name;
+    options.path = parsedPath.path;
+
+    validateName(options.name);
+
+    const templateSource = apply(url('./files'), [
+      applyTemplates({
+        ...strings,
+        ...options
+      }),
+      move(null as any, parsedPath.path)
+    ]);
+
+    return chain([mergeWith(templateSource)]);
+  };
+}

--- a/projects/schematics/src/build-file/file-options.ts
+++ b/projects/schematics/src/build-file/file-options.ts
@@ -1,0 +1,18 @@
+/**
+ * Creates a new generic file definition in the given or default project.
+ */
+export interface FileOptions {
+  /**
+   * The name of the file.
+   */
+  name: string;
+
+  /**
+   * The path at which to create the file, relative to the current workspace.
+   * Default is a folder with the same name as the file in the project root.
+   */
+  path?: string;
+
+  /** The name of the project. */
+  project?: string;
+}

--- a/projects/schematics/src/build-file/index.ts
+++ b/projects/schematics/src/build-file/index.ts
@@ -1,0 +1,2 @@
+export * from './build-file';
+export * from './file-options';

--- a/projects/schematics/src/index.ts
+++ b/projects/schematics/src/index.ts
@@ -1,5 +1,6 @@
 export * from './build-component';
 export * from './build-target-options';
+export * from './build-file';
 export * from './module';
 export * from './project';
 export * from './package-config';

--- a/projects/sync/README.md
+++ b/projects/sync/README.md
@@ -4,6 +4,13 @@ O **PO Sync** é uma biblioteca para aplicações Angular que possibilita armaze
 
 #### Instalação
 
+Instalando com schematic(recomendado):
+```
+ng add @po-ui/ng-sync
+```
+
+
+
 Instalando com npm:
 ```
 npm install @po-ui/ng-sync

--- a/projects/sync/package.json
+++ b/projects/sync/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/po-ui/po-angular"
   },
+  "schematics": "./schematics/collection.json",
   "ng-update": {
     "migrations": "./schematics/migrations.json",
     "packageGroup": [

--- a/projects/sync/schematics/README.md
+++ b/projects/sync/schematics/README.md
@@ -1,4 +1,4 @@
-# PO UI Schematics
+# PO UI Sync
 
 ## Modo desenvolvimento
 
@@ -13,7 +13,7 @@ Para desenvolver novos schematics ou alterá-los é necessário executar o coman
 Após executar o comando será criado a pasta `dist/ng-schematics` e você estará apto a utilizar a biblioteca
 em modo de desenvolvimento para implementar novas melhorias/correções e etc.
 
-## ng update @po-ui/ng-sync
+# ng update @po-ui/ng-sync
 
 Esse *schematic* é executado através do Angular CLI para oferecer suporte à atualização automática do PO UI em um projeto Angular.
 
@@ -63,9 +63,9 @@ Para testarmos o pacote, devemos incrementar a versão do mesmo,
 caso for uma versão beta devemos alterar a versão também no arquivo `migrations.json`,
 ter o npm registry local em execução, confirmando essas situações, podemos rodar o script abaixo:
 
-`> npm run build:storage && npm run build:storage`
+`> npm run build:sync`
 
-`> npm run publish:storage:local && npm run publish:sync:local`
+`> npm run publish:sync:local`
 
 Por fim, execute os comandos abaixo no seu projeto Angular:
 
@@ -73,6 +73,88 @@ Por fim, execute os comandos abaixo no seu projeto Angular:
 
 `> ng update @po-ui/ng-sync --next --from 1 --migrate-only`
 
-Pode ser utilizado o verdaccio para publicar os pacotes locais, como `@po-ui/ng-storage`, assim não precisamos instalar local e o fluxo fica mais próximo do oficial.
+Pode ser utilizado o verdaccio para publicar os pacotes locais, como `@po-ui/ng-sync`, assim não precisamos instalar local e o fluxo fica mais próximo do oficial.
 
 Se você precisar executar isso várias vezes, desfaça as alterações feitas pelo `ng update` para que o `package.json` volte ao número da versão original e execute `npm install` novamente antes de tentar outra atualização.
+
+# ng add @po-ui/ng-sync
+
+Esse *schematic* é executado através do Angular CLI para adicionar o sync em projetos Ionic.
+
+## Como testar
+
+Há duas possibilidades para execução de testes para os novos *schematics*:
+
+### 1 - npm link
+
+O comando **npm link** criará um link simbólico do pacote que deseja testar dentro do `node_modules` da aplicação. Desta forma, é possível executar *schematics* do `po-sync` diretamente em `./projects/app/src/app`. 
+
+Primeiramente, é necessária a alteração em `angular.json`:
+
+```
+...
+  "defaultProject": "app"
+...
+```
+
+Executar o build do projeto `po-schematic` e `po-sync`:
+
+``` 
+> npm run build:schematic 
+> npm run build:sync 
+```
+
+Agora executaremos o comando de link:
+
+``` 
+> npm link dist/ng-sync 
+```
+
+Por fim, executando o comando abaixo, o pacote  `po-sync` será instalados e também serão adicionados os módulos `PoStorageModule` e `PoSyncModule` em `app.module.ts`:
+
+``` 
+> ng generate @po-ui/ng-sync:ng-add 
+```
+
+> Pra remover posteriormente o pacote `po-sync` do `node_modules` execute `npm uninstall @po-ui/ng-sync`.
+
+### 2 - verdaccio
+
+Para poder testar localmente é necessário instalar [verdaccio](https://github.com/verdaccio/verdaccio), para termos um *npm registry* local,
+onde publicaremos os pacotes para realizar o teste.
+
+Após a instalação, devemos apontar o npm registry para o que iniciaremos localmente.
+
+O comando abaixo subirá o npm local, no endereço http://localhost:4873.
+
+``` 
+> verdaccio 
+```
+
+Em seguida, definiremos o *npm registry*, conforme o comando abaixo:
+
+``` 
+> npm set registry http://localhost:4873 
+```
+
+A partir de agora, os pacotes que publicaremos serão enviados ao nosso registry local.
+
+> Para utilizar *npm registry* global novamente, execute o comando: `npm set registry https://registry.npmjs.org/`.
+
+
+Antes de testarmos o pacotes, devemos fazer duas configurações, são elas:
+
+- Adicionar dentro do arquivo ```verdacio/config.yaml``` a configuração: `max_body_size: 200mb`;
+- Executar o comando: ``` npm adduser --registry http://localhost:4873 ```
+
+Para testarmos o pacote, devemos incrementar a versão do mesmo e ter o npm registry local em execução. confirmando essas situações, podemos rodar o script abaixo:
+
+```
+> npm run build:sync && npm run publish:sync:local
+```
+
+Por fim, execute os comando abaixo no seu projeto Angular:
+
+```
+> ng add @po-ui/ng-sync
+```

--- a/projects/sync/schematics/collection.json
+++ b/projects/sync/schematics/collection.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Add my library to the project.",
+      "factory": "./ng-add/index",
+      "schema": "./ng-add/schema.json"
+    },
+    "sync-schema": {
+      "description": "Create a schema to sync a entity ",
+      "factory": "./ng-generate/sync-schema/index",
+      "schema": "./ng-generate/sync-schema/schema.json"
+    }
+  }
+}

--- a/projects/sync/schematics/ng-add/index.ts
+++ b/projects/sync/schematics/ng-add/index.ts
@@ -1,0 +1,36 @@
+import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+
+import { addPackageToPackageJson } from '@po-ui/ng-schematics/package-config';
+import { addModuleImportToRootModule } from '@po-ui/ng-schematics/module/module';
+
+/** PO Module name that will be inserted into app root module */
+const poStorageModuleName = 'PoStorageModule.forRoot()';
+const poStorageModuleSourcePath = '@po-ui/ng-storage';
+const poPoSyncModuleName = 'PoSyncModule';
+const poPoSyncModuleSourcePath = '@po-ui/ng-sync';
+
+/**
+ * Scaffolds the basics of the PO Storage, this includes:
+ *  - Install dependencies;
+ *  - Imports PoStorageModule to app root module;
+ */
+export default function (options: any): Rule {
+  return chain([
+    addPoPackageAndInstall(),
+    addModuleImportToRootModule(options, poStorageModuleName, poStorageModuleSourcePath),
+    addModuleImportToRootModule(options, poPoSyncModuleName, poPoSyncModuleSourcePath)
+  ]);
+}
+
+function addPoPackageAndInstall(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    addPackageToPackageJson(tree, '@po-ui/ng-sync', '0.0.0-PLACEHOLDER');
+    // install packages
+    context.addTask(new NodePackageInstallTask());
+    // Log de processamento
+    context.logger.info(
+      'Sync added successfully, please execute the command `ionic cordova plugin add cordova-plugin-network-information`'
+    );
+  };
+}

--- a/projects/sync/schematics/ng-add/schema.json
+++ b/projects/sync/schematics/ng-add/schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsNgAdd",
+  "title": "Ng Add Options Schema",
+  "type": "object",
+  "required": []
+}

--- a/projects/sync/schematics/ng-generate/sync-schema/files/__path__/__name@dasherize__/__name@dasherize__.constants.ts.template
+++ b/projects/sync/schematics/ng-generate/sync-schema/files/__path__/__name@dasherize__/__name@dasherize__.constants.ts.template
@@ -1,0 +1,13 @@
+import { PoSyncSchema } from "@po-ui/ng-sync";
+
+export const <%= name %>Schema: PoSyncSchema = {
+  getUrlApi:
+    'http://localhost:8080/<%= name %>',
+  diffUrlApi:
+    'http://localhost:8080/<%= name %>/diff',
+  deletedField: "deleted",
+  fields: ["id", "title", "location", "description"],
+  idField: "id",
+  name: "<%= name %>",
+  pageSize: 1,
+};

--- a/projects/sync/schematics/ng-generate/sync-schema/index.ts
+++ b/projects/sync/schematics/ng-generate/sync-schema/index.ts
@@ -1,0 +1,14 @@
+import { chain, Rule } from '@angular-devkit/schematics';
+
+import { buildFile } from '@po-ui/ng-schematics/build-file';
+
+import { Schema as FileOptions } from './schema';
+
+/** Scaffolds a new <name> component with <po-page-dynamic-search> */
+export default function (options: FileOptions): Rule {
+  return chain([createSyncSchema(options)]);
+}
+
+function createSyncSchema(options: FileOptions): Rule {
+  return buildFile(options);
+}

--- a/projects/sync/schematics/ng-generate/sync-schema/schema.json
+++ b/projects/sync/schematics/ng-generate/sync-schema/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsPOSyncSchema",
+  "title": "Sync Schema Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name to use for the sync schema",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the sync schema?"
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path at which to create the component file, relative to the current workspace. Default is a folder with the same name as the component in the project root.",
+      "visible": false
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    }
+  },
+  "required": ["name"]
+}

--- a/projects/sync/schematics/ng-generate/sync-schema/schema.ts
+++ b/projects/sync/schematics/ng-generate/sync-schema/schema.ts
@@ -1,0 +1,3 @@
+import { Schema as ComponentSchema } from '@po-ui/ng-schematics/build-component';
+
+export interface Schema extends ComponentSchema {}


### PR DESCRIPTION
**sync**

**DTHFUI-3391**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O usuário deve instalar o pacote ng-sync via npm e também adicionar o módulo manualmente. Além disso o schema para o sync também deve ser feito manualmente

**Qual o novo comportamento?**
Definido schematics para inclusão do pacote ng-sync na aplicação e criação do comando ng generate @po-ui/ng-sync:sync-schema

**Simulação**
Para testar com npm link::

1- É necessário alterar em `angular.json`:
` "defaultProject": "app" `

2- Executar o build do projeto `po-schematics`:
`npm run build:schematics`

3 - Incluir o caminho do *.tgz* do `ng-schematics` no `package.json` do sync:

4- Executar o build do projeto `sync`:
`npm run build:sync`

5 - Executar o comando de link:
`npm link dist/ng-sync`

6 - Rode o schematic
`ng generate @po-ui/ng-sync:ng-add `

7 - Por fim, adicione o `SamplePoCodeEditorBasicComponent` em app

Pode-se testar também em uma nova aplicação com `verdaccio`. Lembre-se de publicar local tanto os pacotes `ng-schematics` quanto `ng-sync`.
