### PR TITLE
docs(table): ajusta documentação sobre templates da coluna

### DIFF
--- a/projects/ui/src/lib/components/po-table/interfaces/po-table-column.interface.ts
+++ b/projects/ui/src/lib/components/po-table/interfaces/po-table-column.interface.ts
@@ -216,6 +216,10 @@ export interface PoTableColumn {
    *
    * - `time`: valor de horário.
    *  + Aceita o tipo _string_ nos formatos **'HH:mm:ss'** ou **'HH:mm:ss.ffffff'**, por exemplo: `'23:12:45'`.
+   * - `cellTemplate`: Indica que a coluna será utilizada como template, em conjunto com o
+   * [PoTableCellTemplate](/documentation/po-table-cell-template).
+   * - `columnTemplate`: Indica que a coluna será utilizada como template, em conjunto com o
+   * [PoTableColumnTemplate](/documentation/po-table-column-template).
    *
    * @default `string`
    */

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -74,6 +74,9 @@ export const poTableLiteralsDefault = {
  *
  * > As linhas de detalhes podem também ser customizadas através do [`p-table-row-template`](/documentation/po-table-row-template).
  *
+ * > As colunas podem ser customizadas através dos templates [`p-table-column-template`](/documentation/po-table-column-template)
+ * e [`p-table-cell-template`](/documentation/po-table-cell-template).
+ *
  * O componente permite gerenciar a exibição das colunas dinamicamente. Esta funcionalidade pode ser acessada através do ícone de engrenagem
  * no canto superior direito do cabeçalho da tabela.
  *

--- a/projects/ui/src/lib/components/po-table/po-table-cell-template/po-table-cell-template.directive.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-cell-template/po-table-cell-template.directive.ts
@@ -39,7 +39,7 @@ import { Directive, TemplateRef } from '@angular/core';
  * ...
  * export class AppComponent {
  *
- *    public items = [{
+ *    items = [{
  *      code: 1200,
  *      product: 'Rice',
  *      status: 'CANCELED',
@@ -53,17 +53,17 @@ import { Directive, TemplateRef } from '@angular/core';
  *      status3: ''
  *      }];
  *
- *    public columns = [
- *       { property: 'code', label: 'ID', type: 'string' },
- *       { property: 'product', label: 'PRODUTO', type: 'string' },
- *       { property: 'status', label: 'STATUS', type: 'cell-template' },
- *       { property: 'status2', label: 'STATUS 2', type: 'cell-template' },
- *       { property: 'status3', label: 'STATUS 3', type: 'cell-template' }
- *      ];
+ *    columns = [
+ *       { property: 'code', label: 'ID' },
+ *       { property: 'product', label: 'PRODUTO' },
+ *       { property: 'status', label: 'STATUS', type: 'cellTemplate' },
+ *       { property: 'status2', label: 'STATUS 2', type: 'cellTemplate' },
+ *       { property: 'status3', label: 'STATUS 3', type: 'cellTemplate' }
+ *    ];
  * }
  * ...
  * ```
- * > OBS: Sempre adicionar o **type** da property que deseja manipular com a directiva como `cellTemplate`
+ * > Observação: Sempre adicionar o **type** da coluna que deseja manipular com a directiva como `cellTemplate`
  */
 @Directive({
   selector: '[p-table-cell-template]'

--- a/projects/ui/src/lib/components/po-table/po-table-column-template/po-table-column-template.directive.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-template/po-table-column-template.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, Input, TemplateRef } from '@angular/core';
+
 /**
  * @usedBy PoTableComponent
  *
@@ -49,7 +50,8 @@ import { Directive, Input, TemplateRef } from '@angular/core';
  * export class AppComponent {
  *
  *    targetProperty= 'status';
- *    public items = [{
+ *
+ *    items = [{
  *      code: 1200,
  *      product: 'Rice',
  *      status: 'CANCELED'
@@ -57,17 +59,17 @@ import { Directive, Input, TemplateRef } from '@angular/core';
  *      code: 1355,
  *      product: 'Bean',
  *      status: 'FINISHED'
- *      }];
+ *    }];
  *
- *    public columns = [
- *       { property: 'code', label: 'ID', type: 'string' },
- *       { property: 'product', label: 'PRODUTO', type: 'string' },
- *       { property: 'status', label: 'STATUS', type: 'column-template' }
- *      ];
+ *    columns = [
+ *      { property: 'code', label: 'ID' },
+ *      { property: 'product', label: 'PRODUTO' },
+ *      { property: 'status', label: 'STATUS', type: 'columnTemplate' }
+ *    ];
  * }
  * ...
  * ```
- * > OBS: Sempre adicionar o **type** da property que deseja manipular com a directiva como `columnTemplate`
+ * > Observação: Sempre adicionar o **type** da coluna que deseja manipular com a directiva como `columnTemplate`
  */
 
 @Directive({
@@ -82,10 +84,8 @@ export class PoTableColumnTemplateDirective {
    * Variável responsável por armazenar a property da coluna da tabela que será adicionado o template.
    *
    * Caso não seja informada esta propriedade, serão apresentados normalmente os dados da coluna.
-   *
-   * @default `true`
    */
-  @Input('p-property') targetProperty;
+  @Input('p-property') targetProperty: string;
 
   // Necessário manter templateRef para o funcionamento do column template.
   constructor(public templateRef: TemplateRef<any>) {}


### PR DESCRIPTION

**Table**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [x ] Documentação
- [ ] Samples

**Qual o comportamento atual?**


**Qual o novo comportamento?**
- PoTableColumn.type não possuia os valores possiveis de utilizar, columnTemplate e cellTemplate;
- Não havia destaque dos novos templates na pagina inicial;
- O input p-property não aparecia na doc do PoTableColumnTemplate
- O type nos exemplos das documentações de templates estavam errados.


**Simulação**
- Rodar portal