### PR TITLE
docs(page-dynamic-table): corrige descrição

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.module.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.module.ts
@@ -14,7 +14,7 @@ import { PoPageDynamicModule } from '../../services/po-page-dynamic/po-page-dyna
 /**
  * @description
  *
- * Módulo do template do po-page-dynamic-search.
+ * Módulo do template do po-page-dynamic-table.
  */
 @NgModule({
   imports: [


### PR DESCRIPTION
A descrição do componente estava como search quando o correto é
table. Corrigida descrição para table.

Fixes #476, DTHFUI-3743

**< COMPONENTE >**
po-page-dynamic-table
**< NÚMERO DA ISSUE >**
#476

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
