### PR TITLE
feat(table): implementa opção para mudar a posição do detail

### DIFF
--- a/projects/ui/src/lib/components/po-table/enums/po-table-row-template-arrow-direction.enum.ts
+++ b/projects/ui/src/lib/components/po-table/enums/po-table-row-template-arrow-direction.enum.ts
@@ -1,0 +1,13 @@
+/**
+ * @usedBy PoTableRowTemplateDirective
+ *
+ * @description
+ * Define a posição da arrow que expande o * row template* na tabela, será exibida na esquerda ou direita.
+ */
+export enum PoTableRowTemplateArrowDirection {
+  /** Posiciona a *arrow* na esquerda. (Padrão) */
+  Left = 'LEFT',
+
+  /** Posiciona a *arrow* na direita */
+  Right = 'RIGHT'
+}

--- a/projects/ui/src/lib/components/po-table/index.ts
+++ b/projects/ui/src/lib/components/po-table/index.ts
@@ -1,4 +1,5 @@
 export * from './enums/po-table-column-sort-type.enum';
+export * from './enums/po-table-row-template-arrow-direction.enum';
 export * from './interfaces/po-table-action.interface';
 export * from './interfaces/po-table-boolean.interface';
 export * from './interfaces/po-table-column.interface';

--- a/projects/ui/src/lib/components/po-table/po-table-row-template/po-table-row-template.directive.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-row-template/po-table-row-template.directive.spec.ts
@@ -1,10 +1,26 @@
 import { PoTableRowTemplateDirective } from './po-table-row-template.directive';
+import { PoTableRowTemplateArrowDirection } from '../enums/po-table-row-template-arrow-direction.enum';
 
 describe('PoTableRowTemplateDirective', () => {
   const component = new PoTableRowTemplateDirective(null);
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('tableRowTemplateArrowDirection: should be right', () => {
+    component.tableRowTemplateArrowDirection = PoTableRowTemplateArrowDirection.Right;
+    expect(component.tableRowTemplateArrowDirection).toEqual('RIGHT');
+  });
+
+  it('tableRowTemplateArrowDirection: should be left', () => {
+    component.tableRowTemplateArrowDirection = PoTableRowTemplateArrowDirection.Left;
+    expect(component.tableRowTemplateArrowDirection).toEqual('LEFT');
+  });
+
+  it('tableRowTemplateArrowDirection: should be left when value is null', () => {
+    component.tableRowTemplateArrowDirection = null;
+    expect(component.tableRowTemplateArrowDirection).toEqual('LEFT');
   });
 
   describe('Methods: ', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-row-template/po-table-row-template.directive.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-row-template/po-table-row-template.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, Input, TemplateRef } from '@angular/core';
+import { PoTableRowTemplateArrowDirection } from '../enums/po-table-row-template-arrow-direction.enum';
 
 /**
  * @usedBy PoTableComponent
@@ -92,6 +93,8 @@ import { Directive, Input, TemplateRef } from '@angular/core';
   selector: '[p-table-row-template]'
 })
 export class PoTableRowTemplateDirective {
+  private _tableRowTemplateArrowDirection: PoTableRowTemplateArrowDirection = PoTableRowTemplateArrowDirection.Left;
+
   /**
    * @optional
    *
@@ -106,6 +109,28 @@ export class PoTableRowTemplateDirective {
    * @default `true`
    */
   @Input('p-table-row-template-show') poTableRowTemplateShow: (row: any, index: number) => boolean;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Propriedade responsável por informar a posição do colapse que abrirá os detalhes da linha.
+   *
+   * @default `'LEFT'`
+   */
+  @Input('p-table-row-template-arrow-direction') set tableRowTemplateArrowDirection(
+    value: PoTableRowTemplateArrowDirection
+  ) {
+    value = value?.toUpperCase() as PoTableRowTemplateArrowDirection;
+    this._tableRowTemplateArrowDirection = (<any>Object).values(PoTableRowTemplateArrowDirection).includes(value)
+      ? value
+      : PoTableRowTemplateArrowDirection.Left;
+  }
+
+  get tableRowTemplateArrowDirection() {
+    return this._tableRowTemplateArrowDirection;
+  }
 
   // Necessário manter templateRef para o funcionamento do row template.
   constructor(public templateRef: TemplateRef<any>) {}

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -65,7 +65,10 @@
           </div>
         </th>
 
-        <th *ngIf="hasMasterDetailColumn" class="po-table-header-column po-table-header-master-detail"></th>
+        <th
+          *ngIf="(hasMasterDetailColumn || hasRowTemplate) && !hasRowTemplateWithArrowDirectionRight"
+          class="po-table-header-column po-table-header-master-detail"
+        ></th>
 
         <th *ngIf="!hasMainColumns" #noColumnsHeader class="po-table-header-column po-text-center">
           <ng-container *ngIf="height; then noColumnsWithHeight; else noColumnsWithoutHeight"> </ng-container>
@@ -89,10 +92,16 @@
         </th>
 
         <th
-          *ngIf="!displayColumnManagerCell && hideColumnsManager"
+          *ngIf="hasRowTemplateWithArrowDirectionRight && (hasVisibleActions || hideColumnsManager)"
+          class="po-table-header-column po-table-header-master-detail"
+        ></th>
+
+        <th
+          *ngIf="hasVisibleActions && hideColumnsManager"
           [class.po-table-header-single-action]="isSingleAction"
           [class.po-table-header-actions]="!isSingleAction"
         ></th>
+
         <th
           #columnManager
           *ngIf="hasValidColumns && !hideColumnsManager"
@@ -131,20 +140,31 @@
             <ng-container *ngTemplateOutlet="singleSelect ? inputRadio : inputCheckbox; context: { $implicit: row }">
             </ng-container>
           </td>
+
+          <!-- Valida se a origem do detail é pelo input do po-table -->
           <td
-            *ngIf="(columnMasterDetail && !hideDetail) || hasRowTemplate"
+            *ngIf="columnMasterDetail && !hideDetail && !hasRowTemplate"
             class="po-table-column-detail-toggle"
             (click)="toggleDetail(row)"
           >
-            <span
-              *ngIf="
-                (containsMasterDetail(row) && !hasRowTemplate) || (isShowRowTemplate(row, rowIndex) && hasRowTemplate)
-              "
-              class="po-icon po-clickable"
-              [class.po-icon-arrow-up]="row.$showDetail"
-              [class.po-icon-arrow-down]="!row.$showDetail"
+            <ng-template
+              [ngTemplateOutlet]="poTableColumnDetail"
+              [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
             >
-            </span>
+            </ng-template>
+          </td>
+
+          <!-- Valida se a origem do detail é pela diretiva -->
+          <td
+            *ngIf="hasRowTemplate && !hasRowTemplateWithArrowDirectionRight"
+            class="po-table-column-detail-toggle"
+            (click)="toggleDetail(row)"
+          >
+            <ng-template
+              [ngTemplateOutlet]="poTableColumnDetail"
+              [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+            >
+            </ng-template>
           </td>
 
           <td
@@ -229,6 +249,19 @@
               <span *ngSwitchDefault>{{ row[column.property] }}</span>
             </div>
           </td>
+
+          <td
+            *ngIf="hasRowTemplateWithArrowDirectionRight"
+            class="po-table-column-detail-toggle"
+            (click)="toggleDetail(row)"
+          >
+            <ng-template
+              [ngTemplateOutlet]="poTableColumnDetail"
+              [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+            >
+            </ng-template>
+          </td>
+
           <td *ngIf="isSingleAction" class="po-table-column po-table-column-single-action">
             <div
               *ngIf="firstAction.visible !== false"
@@ -240,12 +273,16 @@
               {{ firstAction.label }}
             </div>
           </td>
+
           <td *ngIf="visibleActions.length > 1" class="po-table-column-actions">
             <span #popupTarget class="po-icon po-icon-more po-clickable" (click)="togglePopup(row, popupTarget)">
             </span>
           </td>
           <!-- Column Manager -->
-          <td *ngIf="displayColumnManagerCell && !hideColumnsManager" class="po-table-column"></td>
+          <td
+            *ngIf="!hasVisibleActions && !hideColumnsManager && !hasRowTemplateWithArrowDirectionRight"
+            class="po-table-column"
+          ></td>
         </tr>
 
         <tr *ngIf="hasMainColumns && hasRowTemplate && row.$showDetail && isShowRowTemplate(row, rowIndex)">
@@ -275,6 +312,16 @@
 </ng-template>
 
 <po-popup #popup [p-actions]="actions" [p-target]="popupTarget"> </po-popup>
+
+<ng-template #poTableColumnDetail let-row="row" let-rowIndex="rowIndex">
+  <span
+    *ngIf="(containsMasterDetail(row) && !hasRowTemplate) || (isShowRowTemplate(row, rowIndex) && hasRowTemplate)"
+    class="po-icon po-clickable"
+    [class.po-icon-arrow-up]="row.$showDetail"
+    [class.po-icon-arrow-down]="!row.$showDetail"
+  >
+  </span>
+</ng-template>
 
 <ng-template #inputRadio let-row>
   <input type="radio" class="po-table-radio" [class.po-table-radio-checked]="row.$selected" />

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -17,6 +17,7 @@ import { PoTableColumn } from './interfaces/po-table-column.interface';
 import { PoTableComponent } from './po-table.component';
 import { PoTableModule } from './po-table.module';
 import { PoTableColumnTemplateDirective } from './po-table-column-template/po-table-column-template.directive';
+import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-arrow-direction.enum';
 
 @Component({ template: 'Search' })
 export class SearchComponent {}
@@ -57,7 +58,8 @@ describe('PoTableComponent:', () => {
     mockTableDetailDiretive = {
       templateRef: null,
       poTableRowTemplate: {},
-      poTableRowTemplateShow: undefined
+      poTableRowTemplateShow: undefined,
+      tableRowTemplateArrowDirection: PoTableRowTemplateArrowDirection.Left
     };
 
     columns = [
@@ -1569,7 +1571,6 @@ describe('PoTableComponent:', () => {
       component.tableRowTemplate = mockTableDetailDiretive;
 
       fixture.detectChanges();
-
       const poTableColumnDetailToggle = nativeElement.querySelector('.po-table-column-detail-toggle');
 
       expect(poTableColumnDetailToggle).toBeTruthy();
@@ -1804,6 +1805,73 @@ describe('PoTableComponent:', () => {
       fixture.detectChanges();
 
       expect(nativeElement.querySelector(`po-table-column-manager`)).toBeTruthy();
+    });
+
+    it('should display .po-table-header-master-detail if columns contains detail and rowTemplate is undefined', () => {
+      component.items = [...items];
+      component.columns = [...columnsWithDetail];
+
+      component.tableRowTemplate = undefined;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector(`th.po-table-header-master-detail`)).toBeTruthy();
+    });
+
+    it(`shouldn't display .po-table-header-master-detail if columns contains detail
+      and rowTemplate but hideColumnsManager is false`, () => {
+      component.items = [...items];
+      component.columns = [...columnsWithDetail];
+      component.actions = [];
+      component.hideColumnsManager = false;
+
+      component.tableRowTemplate = {
+        ...mockTableDetailDiretive,
+        tableRowTemplateArrowDirection: PoTableRowTemplateArrowDirection.Right
+      };
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector(`th.po-table-header-master-detail`)).toBe(null);
+    });
+
+    it(`should contains 3 td if has 2 columns, column manager and haven't actions`, () => {
+      component.items = [{ name: 'John', age: 24 }];
+      component.columns = [{ property: 'name' }, { property: 'age' }];
+      component.actions = [];
+      component.hideColumnsManager = false;
+
+      component.tableRowTemplate = {
+        ...mockTableDetailDiretive,
+        tableRowTemplateArrowDirection: PoTableRowTemplateArrowDirection.Right
+      };
+
+      fixture.detectChanges();
+
+      const columnsManagerTd = 1;
+      const expectedValue = component.columns.length + columnsManagerTd;
+
+      expect(nativeElement.querySelectorAll('td').length).toBe(expectedValue);
+    });
+
+    it(`should contains 4 td if has 2 columns, column manager and actions`, () => {
+      component.items = [{ name: 'John', age: 24 }];
+      component.columns = [{ property: 'name' }, { property: 'age' }];
+      component.actions = [{ label: 'First Action', action: () => {} }];
+      component.hideColumnsManager = false;
+
+      component.tableRowTemplate = {
+        ...mockTableDetailDiretive,
+        tableRowTemplateArrowDirection: PoTableRowTemplateArrowDirection.Right
+      };
+
+      fixture.detectChanges();
+
+      const columnsManagerTd = 1;
+      const masterDetailTd = 1;
+      const expectedValue = component.columns.length + columnsManagerTd + masterDetailTd;
+
+      expect(nativeElement.querySelectorAll('td').length).toBe(expectedValue);
     });
   });
 
@@ -2054,16 +2122,16 @@ describe('PoTableComponent:', () => {
       expect(component.validColumns).toEqual([]);
     });
 
-    it('displayColumnManagerCell: should return false if has visible actions', () => {
+    it('visibleActions: should return true if has visible actions', () => {
       component.actions = [...singleAction];
 
-      expect(component.displayColumnManagerCell).toBe(false);
+      expect(component.hasVisibleActions).toBe(true);
     });
 
-    it('displayColumnManagerCell: should return true if visible actions is empty', () => {
+    it('visibleActions: should return false if visible actions is empty', () => {
       component.actions = [];
 
-      expect(component.displayColumnManagerCell).toBe(true);
+      expect(component.hasVisibleActions).toBe(false);
     });
 
     it('isSingleAction: should return true if has one visible actions', () => {
@@ -2215,5 +2283,19 @@ describe('PoTableComponent:', () => {
 
       expect(res).toEqual(tableColumnTemplate.templateRef);
     });
+  });
+
+  it('hasRowTemplateWithArrowDirectionRight: should be false if tableRowTemplateArrowDirection is left', () => {
+    component.tableRowTemplate = mockTableDetailDiretive;
+    expect(component.hasRowTemplateWithArrowDirectionRight).toBe(false);
+  });
+
+  it('hasRowTemplateWithArrowDirectionRight: should be true if tableRowTemplateArrowDirection is right', () => {
+    component.tableRowTemplate = {
+      ...mockTableDetailDiretive,
+      tableRowTemplateArrowDirection: PoTableRowTemplateArrowDirection.Right
+    };
+
+    expect(component.hasRowTemplateWithArrowDirectionRight).toBe(true);
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -30,6 +30,7 @@ import { PoTableRowTemplateDirective } from './po-table-row-template/po-table-ro
 import { PoTableSubtitleColumn } from './po-table-subtitle-footer/po-table-subtitle-column.interface';
 import { PoTableCellTemplateDirective } from './po-table-cell-template/po-table-cell-template.directive';
 import { PoTableColumnTemplateDirective } from './po-table-column-template/po-table-column-template.directive';
+import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-arrow-direction.enum';
 
 /**
  * @docsExtends PoTableBaseComponent
@@ -139,6 +140,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     });
   }
 
+  get hasRowTemplateWithArrowDirectionRight() {
+    return this.tableRowTemplate?.tableRowTemplateArrowDirection === PoTableRowTemplateArrowDirection.Right;
+  }
+
   get columnCount() {
     const columnCount =
       this.mainColumns.length +
@@ -161,8 +166,8 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return masterDetail && masterDetail.detail ? masterDetail.detail.hideSelect : false;
   }
 
-  get displayColumnManagerCell() {
-    return !this.visibleActions.length;
+  get hasVisibleActions() {
+    return !!this.visibleActions.length;
   }
 
   get firstAction(): PoTableAction {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.component.html
@@ -1,5 +1,11 @@
 <po-table p-hide-columns-manager p-sort="true" [p-columns]="columns" [p-items]="items" [p-striped]="true">
-  <ng-template p-table-row-template let-rowItem let-i="rowIndex" [p-table-row-template-show]="isUndelivered">
+  <ng-template
+    p-table-row-template
+    let-rowItem
+    let-i="rowIndex"
+    [p-table-row-template-arrow-direction]="'right'"
+    [p-table-row-template-show]="isUndelivered"
+  >
     <po-widget p-title="Transport detail {{ rowItem.code }}">
       <div class="po-row">
         <po-select


### PR DESCRIPTION
**PO-TABLE**

**FIX DTHFUI-3718**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Quando se usa a diretiva `p-table-row-template`, hoje não é possível alterar a posição da arrow do detail.

**Qual o novo comportamento?**
Agora foi adicionado na diretiva `p-table-row-template` a propriedade `p-table-row-template-arrow-direction` que permite que o usuário passe _LEFT_ ou _RIGHT_ definindo assim a posição desejada da arrow.

**Simulação**

Foi utilizado o sample `sample-po-table-transport.html` para mostrar o resultado da implementação.


```
<po-table p-hide-columns-manager p-sort="true" [p-columns]="columns" [p-items]="items" [p-striped]="true">
  <ng-template
    p-table-row-template
    [p-table-row-template-arrow-direction]="'RIGHT'"
    let-rowItem
    let-i="rowIndex"
    [p-table-row-template-show]="isUndelivered">
    <po-widget p-title="Transport detail {{ rowItem.code }}">
      <div class="po-row">
        <po-select
          class="po-md-6"
          name="status"
          [(ngModel)]="rowItem.status"
          p-label="Transport status"
          [p-options]="statusOptions">
        </po-select>
      </div>
      <div class="po-row">
        <po-info
          class="po-md-4"
          p-label="Batch of product"
          p-orientation="horizontal"
          [p-value]="rowItem.batch_product">
        </po-info>
        <po-info class="po-md-4" p-label="Driver" p-orientation="horizontal" [p-value]="rowItem.driver"> </po-info>
        <po-info class="po-md-4" p-label="License plate" p-orientation="horizontal" [p-value]="rowItem.license_plate">
        </po-info>
      </div>
    </po-widget>
  </ng-template>
</po-table>
```