### PR TITLE
feat(combo): permite traduzir as literais usando o serviço do i18n

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -6,12 +6,18 @@ import * as Utils from '../../../utils/util';
 import * as ValidatorsFunctions from '../validators';
 import { expectPropertiesValues, expectSettersMethod } from '../../../util-test/util-expect.spec';
 
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+
 import { PoComboBaseComponent, poComboLiteralsDefault } from './po-combo-base.component';
 import { PoComboFilter } from './interfaces/po-combo-filter.interface';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
 import { PoComboOption } from './interfaces/po-combo-option.interface';
 
 class PoComboTest extends PoComboBaseComponent {
+  constructor() {
+    super(new PoLanguageService());
+  }
+
   getInputValue(): string {
     return '';
   }
@@ -100,13 +106,14 @@ describe('PoComboBaseComponent:', () => {
 
     describe('p-literals:', () => {
       it('should be set `literals` with browser language if `literals` is `undefined`', () => {
+        component['language'] = Utils.browserLanguage();
         component.literals = undefined;
 
         expect(component.literals).toEqual(poComboLiteralsDefault[Utils.browserLanguage()]);
       });
 
       it('should be in portuguese if browser is set with `pt`.', () => {
-        spyOn(Utils, <any>'browserLanguage').and.returnValue('pt');
+        component['language'] = 'pt';
 
         component.literals = {};
 
@@ -114,7 +121,7 @@ describe('PoComboBaseComponent:', () => {
       });
 
       it('should be in english if browser is set with `en`.', () => {
-        spyOn(Utils, <any>'browserLanguage').and.returnValue('en');
+        component['language'] = 'en';
 
         component.literals = {};
 
@@ -122,7 +129,7 @@ describe('PoComboBaseComponent:', () => {
       });
 
       it('should be in spanish if browser is set with `es`.', () => {
-        spyOn(Utils, <any>'browserLanguage').and.returnValue('es');
+        component['language'] = 'es';
 
         component.literals = {};
 
@@ -130,7 +137,7 @@ describe('PoComboBaseComponent:', () => {
       });
 
       it('should be in russian if browser is set with `ru`.', () => {
-        spyOn(Utils, <any>'browserLanguage').and.returnValue('ru');
+        component['language'] = 'ru';
 
         component.literals = {};
 
@@ -138,7 +145,7 @@ describe('PoComboBaseComponent:', () => {
       });
 
       it('should accept custom literals.', () => {
-        spyOn(Utils, <any>'browserLanguage').and.returnValue(Utils.poLocaleDefault);
+        component['language'] = Utils.poLocaleDefault;
 
         const customLiterals = Object.assign({}, poComboLiteralsDefault[Utils.poLocaleDefault]);
         customLiterals.noData = 'Sem dados';

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -1,14 +1,9 @@
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 import { EventEmitter, Input, OnInit, Output, Directive } from '@angular/core';
 
-import {
-  browserLanguage,
-  convertToBoolean,
-  isTypeof,
-  removeDuplicatedOptions,
-  poLocaleDefault,
-  validValue
-} from '../../../utils/util';
+import { convertToBoolean, isTypeof, poLocaleDefault, validValue } from '../../../utils/util';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+
 import { InputBoolean } from '../../../decorators';
 import { requiredFailed } from '../validators';
 
@@ -71,6 +66,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   private _options: Array<PoComboOption | PoComboOptionGroup> = [];
   private _required?: boolean = false;
   private _sort?: boolean = false;
+  private language: string;
 
   protected cacheStaticOptions: Array<PoComboOption | PoComboGroup> = [];
   protected comboOptionsList: Array<PoComboOption | PoComboGroup> = [];
@@ -424,22 +420,23 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * </po-combo>
    * ```
    *
-   * > O objeto padrão de literais será traduzido de acordo com o idioma do *browser* (pt, en, es).
+   * > O objeto padrão de literais será traduzido de acordo com o idioma do
+   * [`PoI18nService`](/documentation/po-i18n) ou do browser.
    */
   @Input('p-literals') set literals(value: PoComboLiterals) {
     if (value instanceof Object && !(value instanceof Array)) {
       this._literals = {
         ...poComboLiteralsDefault[poLocaleDefault],
-        ...poComboLiteralsDefault[browserLanguage()],
+        ...poComboLiteralsDefault[this.language],
         ...value
       };
     } else {
-      this._literals = poComboLiteralsDefault[browserLanguage()];
+      this._literals = poComboLiteralsDefault[this.language];
     }
   }
 
   get literals() {
-    return this._literals || poComboLiteralsDefault[browserLanguage()];
+    return this._literals || poComboLiteralsDefault[this.language];
   }
 
   /** Deve ser informada uma função que será disparada quando houver alterações no ngModel. */
@@ -447,6 +444,10 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
 
   // Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
   @Output('ngModelChange') ngModelChange?: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor(languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
 
   abstract setInputValue(value: any): void;
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -7,8 +7,6 @@ import { Observable } from 'rxjs';
 
 import { changeBrowserInnerWidth, configureTestSuite } from './../../../util-test/util-expect.spec';
 
-import * as UtilsFunctions from '../../../utils/util';
-
 import { PoLoadingModule } from '../../po-loading/po-loading.module';
 
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
@@ -1565,7 +1563,8 @@ describe('PoComboComponent:', () => {
     });
 
     it('should display `literals.noData` in Spanish if browser language is `es`.', () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
+
       component.visibleOptions = [];
 
       fixture.detectChanges();

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -20,6 +20,7 @@ import { debounceTime, distinctUntilChanged, filter, map, tap } from 'rxjs/opera
 
 import { PoControlPositionService } from '../../../services/po-control-position/po-control-position.service';
 import { PoKeyCodeEnum } from './../../../enums/po-key-code.enum';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoComboBaseComponent } from './po-combo-base.component';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
@@ -127,9 +128,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     public renderer: Renderer2,
     private changeDetector: ChangeDetectorRef,
     private controlPosition: PoControlPositionService,
-    private sanitized: DomSanitizer
+    private sanitized: DomSanitizer,
+    languageService: PoLanguageService
   ) {
-    super();
+    super(languageService);
 
     this.differ = differs.find([]).create(null);
   }

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
@@ -174,7 +174,7 @@ export class PoI18nBaseService {
    *
    *   3 - o idioma do navegador utilizado.
    *
-   * > Caso o idioma do navegador não seja suportado pelo PO (`pt`, `en` ou `es`), será retornado valor `pt`.
+   * > Caso o idioma do navegador não seja suportado pelo PO (`pt`, `en`, `es` ou `ru`), será retornado valor `pt`.
    *
    * @returns {string} sigla do idioma padrão.
    */

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
@@ -106,7 +106,7 @@ import { PoLanguageModule } from '../po-language/po-language.module';
  *
  * Os idiomas e literais serão automaticamente buscados com parâmetros na própria URL:
  * - **language**: o idioma será sempre passado por parâmetro e é recomendado utilizar uma das linguagens
- * suportadas pelo PO (`pt-br`, `en-us` ou `es-es`).
+ * suportadas pelo PO (`pt-br`, `en-us`, `es-es` ou `ru`).
  * - **literals**: as literais serão separadas por vírgula. Caso esse parâmetro não seja informado, o
  * serviço deve retornar todas as literais do idioma.
  *


### PR DESCRIPTION
**Combo**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```