### PR TITLE
Feat(page-login): Remember language selection stored in localstorage

### DIFF
--- a/projects/templates/src/lib/components/po-page-background/po-page-background.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.component.spec.ts
@@ -5,6 +5,7 @@ import * as utilFunctions from './../../utils/util';
 import { expectPropertiesValues } from './../../util-test/util-expect.spec';
 
 import { PoPageBackgroundComponent } from './po-page-background.component';
+import { PoLanguageService } from '@po-ui/ng-components';
 
 describe('PoPageBackgroundComponent:', () => {
   let component: PoPageBackgroundComponent;
@@ -76,10 +77,10 @@ describe('PoPageBackgroundComponent:', () => {
   });
 
   describe('Methods:', () => {
-    it('ngOnInit: should get the browserLanguage and apply it to `selectedLanguageOption`', () => {
+    it('ngOnInit: should get the stored language on localstorage (or browserLanguage by default if en, pt, es or ru) and apply it to `selectedLanguageOption`', () => {
       component.ngOnInit();
-
-      expect(component.selectedLanguageOption).toBe(utilFunctions.browserLanguage());
+      const languageService = new PoLanguageService();
+      expect(component.selectedLanguageOption).toBe(languageService.getShortLanguage());
     });
 
     it('onChangeLanguage: should emit `selectedLanguage`', () => {

--- a/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 import { browserLanguage, convertToBoolean, isTypeof } from './../../utils/util';
 import { PoSelectOption } from '@po-ui/ng-components';
+import { PoLanguageService } from '@po-ui/ng-components';
 
 @Component({
   selector: 'po-page-background',
@@ -77,8 +78,10 @@ export class PoPageBackgroundComponent implements OnInit {
    */
   @Output('p-selected-language') selectedLanguage?: EventEmitter<any> = new EventEmitter<any>();
 
+  constructor(public poLanguageService: PoLanguageService) {}
+
   ngOnInit() {
-    this.selectedLanguageOption = browserLanguage();
+    this.selectedLanguageOption = this.poLanguageService.getShortLanguage();
   }
 
   onChangeLanguage() {

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
@@ -9,12 +9,11 @@ import * as UtilFunctions from './../../utils/util';
 import { PoPageLoginBaseComponent, poPageLoginLiteralsDefault } from './po-page-login-base.component';
 import { PoPageLoginCustomField } from './interfaces/po-page-login-custom-field.interface';
 import { PoPageLoginService } from './po-page-login.service';
+import { PoLanguageService } from '@po-ui/ng-components';
 
 const routerStub = {
   navigate: jasmine.createSpy('navigate')
 };
-
-@Directive()
 export class PoPageLoginComponent extends PoPageLoginBaseComponent {
   protected concatenateLoginHintWithContactEmail(contactEmail: string): void {}
   protected concatenateTitleWithProductName(productName: string): void {}
@@ -25,11 +24,12 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent {
 describe('PoPageLoginBaseComponent: ', () => {
   let component: PoPageLoginBaseComponent;
   let servicePageLogin: PoPageLoginService;
+  let languageService: PoLanguageService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [],
-      providers: [PoPageLoginService]
+      providers: [PoPageLoginService, PoLanguageService]
     }).compileComponents();
   }));
 
@@ -39,7 +39,9 @@ describe('PoPageLoginBaseComponent: ', () => {
 
   beforeEach(() => {
     servicePageLogin = new PoPageLoginService(undefined);
-    component = new PoPageLoginComponent(servicePageLogin, <any>routerStub);
+    languageService = new PoLanguageService();
+
+    component = new PoPageLoginComponent(servicePageLogin, <any>routerStub, languageService);
   });
 
   it('should be created', () => {

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -11,6 +11,8 @@ import {
   poLocaleDefault
 } from './../../utils/util';
 
+import { PoLanguageService } from '@po-ui/ng-components';
+
 import { PoPageLogin } from './interfaces/po-page-login.interface';
 import { PoPageLoginAuthenticationType } from './enums/po-page-login-authentication-type.enum';
 import { PoPageLoginCustomField } from './interfaces/po-page-login-custom-field.interface';
@@ -853,7 +855,13 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
     };
   }
 
-  constructor(private loginService: PoPageLoginService, public router: Router) {}
+  constructor(
+    private loginService: PoPageLoginService,
+    public router: Router,
+    public poLanguageService: PoLanguageService
+  ) {
+    this.selectedLanguage = this.poLanguageService.getShortLanguage();
+  }
 
   ngOnDestroy() {
     if (this.loginSubscription) {

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
@@ -11,6 +11,8 @@ import {
   ViewContainerRef
 } from '@angular/core';
 
+import { PoLanguageService } from '@po-ui/ng-components';
+
 import { isExternalLink } from '../../utils/util';
 import { PoComponentInjectorService } from '@po-ui/ng-components';
 
@@ -69,9 +71,10 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
     private poComponentInjector: PoComponentInjectorService,
     differs: IterableDiffers,
     loginService: PoPageLoginService,
-    router: Router
+    router: Router,
+    poLanguageService: PoLanguageService
   ) {
-    super(loginService, router);
+    super(loginService, router, poLanguageService);
     this.differ = differs.find([]).create(null);
   }
 


### PR DESCRIPTION
Feat(combo): Remember user language selection stored in localstorage
_____________________________________________________________________________
**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Cada vez que abre a tela do componente po-page-login é 
necesessário selecionar o idioma de uso da aplicacao. 
Atualmente seleciona sempre o idioma do browser.

**Qual o novo comportamento?**
Eh carregado por default o ultimo idioma selecionado no browser, 
baseda na variavel guardada no localstorage pelo PO-login-page

**Simulação**
Acessar um componente po-Page-Login, selecionar idioma diferente 
do browser e fazer login.
Fechar a janela, acessar o login novamente e conferir que o idioma 
selecionado no passo anterior esta pre-selecionado.