### PR TITLE
feat(page-list): depreciação do atributo ngModel do PageFilter

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -39,28 +39,13 @@ describe('PoPageDynamicSearchComponent:', () => {
 
   describe('Methods:', () => {
     it('get filterSettings: should return `filterSettings` with `advancedAction` equal to `undefined` if haven`t filters', () => {
-      const result = {
-        action: 'onAction',
-        advancedAction: undefined,
-        ngModel: 'quickFilter',
-        placeholder: component.literals.searchPlaceholder
-      };
-
-      expect(component.filterSettings).toEqual(result);
+      expect(component.filterSettings.advancedAction).toBeUndefined();
     });
 
     it('get filterSettings: should return `filterSettings` with `advancedAction` equal to `onAdvancedAction` if have filters', () => {
       const filters: Array<any> = [{ property: 'name' }, { property: 'birthdate' }, { property: 'genre' }];
-
       component.filters = filters;
-      const result = {
-        action: 'onAction',
-        advancedAction: 'onAdvancedAction',
-        ngModel: 'quickFilter',
-        placeholder: component.literals.searchPlaceholder
-      };
-
-      expect(component.filterSettings).toEqual(result);
+      expect(typeof component.filterSettings.advancedAction).toBe('function');
     });
 
     describe('onAction:', () => {
@@ -74,7 +59,6 @@ describe('PoPageDynamicSearchComponent:', () => {
           _disclaimerGroup: {
             disclaimers: []
           },
-          quickFilter: 'quickFilter',
           quickSearch: {
             emit: () => {},
             observers: [1, 2, 3]
@@ -85,16 +69,10 @@ describe('PoPageDynamicSearchComponent:', () => {
         };
       });
 
-      it('should set `quickFilter` to `undefined`', () => {
-        component.onAction.call(fakethis);
-
-        expect(fakethis['quickFilter']).toBeUndefined();
-      });
-
       it('should call `quickSearch.emit` with `quickFilter` if `quickSearch.observers.length` is greather than 0', () => {
         spyOn(fakethis.quickSearch, 'emit');
 
-        component.onAction.call(fakethis);
+        component.onAction.call(fakethis, 'quickFilter');
 
         expect(fakethis.quickSearch.emit).toHaveBeenCalledWith('quickFilter');
       });
@@ -104,7 +82,7 @@ describe('PoPageDynamicSearchComponent:', () => {
 
         spyOn(fakethis.quickSearch, 'emit');
 
-        component.onAction.call(fakethis);
+        component.onAction.call(fakethis, 'quickFilter');
 
         expect(fakethis.quickSearch.emit).not.toHaveBeenCalled();
       });
@@ -112,7 +90,7 @@ describe('PoPageDynamicSearchComponent:', () => {
       it('should set `_dislaimerGroup.disclaimers` with property, label and value', () => {
         const result = [{ property: 'search', label: 'Pesquisa rápida: quickFilter', value: 'quickFilter' }];
 
-        component.onAction.call(fakethis);
+        component.onAction.call(fakethis, 'quickFilter');
 
         expect(fakethis._disclaimerGroup.disclaimers).toEqual(result);
       });
@@ -120,7 +98,7 @@ describe('PoPageDynamicSearchComponent:', () => {
       it('should call `ChangeDetectorRef.detectChanges`', () => {
         spyOn(component['changeDetector'], 'detectChanges');
 
-        component.onAction();
+        component.onAction('quickFilter');
 
         expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
       });
@@ -131,7 +109,7 @@ describe('PoPageDynamicSearchComponent:', () => {
 
         const expectedValue = [{ property: 'city' }];
 
-        component.onAction();
+        component.onAction('quickFilter');
 
         expect(component.filters).toEqual(expectedValue);
       });

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -50,12 +50,10 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
   };
 
   private readonly _filterSettings: PoPageFilter = {
-    action: 'onAction',
-    advancedAction: 'onAdvancedAction',
-    ngModel: 'quickFilter',
+    action: this.onAction.bind(this),
+    advancedAction: this.onAdvancedAction.bind(this),
     placeholder: this.literals.searchPlaceholder
   };
-  private quickFilter;
 
   @ViewChild(PoAdvancedFilterComponent, { static: true }) poAdvancedFilter: PoAdvancedFilterComponent;
 
@@ -72,7 +70,7 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
   }
 
   get filterSettings() {
-    this._filterSettings.advancedAction = this.filters.length === 0 ? undefined : 'onAdvancedAction';
+    this._filterSettings.advancedAction = this.filters.length === 0 ? undefined : this.onAdvancedAction.bind(this);
 
     return Object.assign({}, this._filterSettings, { placeholder: this.literals.searchPlaceholder });
   }
@@ -102,20 +100,18 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
     }
   }
 
-  onAction() {
+  onAction(quickFilter: string) {
     this._disclaimerGroup.disclaimers = [
-      { property: 'search', label: `${this.literals.quickSearchLabel} ${this.quickFilter}`, value: this.quickFilter }
+      { property: 'search', label: `${this.literals.quickSearchLabel} ${quickFilter}`, value: quickFilter }
     ];
 
     if (this.quickSearch.observers && this.quickSearch.observers.length > 0) {
-      this.quickSearch.emit(this.quickFilter);
+      this.quickSearch.emit(quickFilter);
     }
 
     if (this.keepFilters) {
       this.filters.forEach(element => delete element.initValue);
     }
-
-    this.quickFilter = undefined;
 
     this.changeDetector.detectChanges();
   }

--- a/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-hiring-processes/sample-po-list-view-hiring-processes.component.ts
+++ b/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-hiring-processes/sample-po-list-view-hiring-processes.component.ts
@@ -55,8 +55,7 @@ export class SamplePoListViewHiringProcessesComponent implements OnInit {
   ];
 
   readonly filterSettings: PoPageFilter = {
-    action: 'hiringProcessesFilter',
-    ngModel: 'labelFilter',
+    action: this.hiringProcessesFilter.bind(this),
     placeholder: 'Search'
   };
 
@@ -99,7 +98,9 @@ export class SamplePoListViewHiringProcessesComponent implements OnInit {
     this.poNotification.success('Hired candidate!');
   }
 
-  private hiringProcessesFilter(filters = [this.labelFilter]) {
+  private hiringProcessesFilter(labelFilter: string | Array<string>) {
+    const filters = typeof labelFilter === 'string' ? [labelFilter] : [...labelFilter];
+
     this.hiringProcessesFiltered = this.hiringProcesses.filter(item => {
       return Object.keys(item).some(key => !(item[key] instanceof Object) && this.includeFilter(item[key], filters));
     });

--- a/projects/ui/src/lib/components/po-page/po-page-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-filter.interface.ts
@@ -17,7 +17,18 @@ export interface PoPageFilter {
    */
   advancedAction?: string | Function;
 
-  /** Nome do `ngModel` do campo de filtro. */
+  /**
+   * @deprecated 4.x.x
+   *
+   * @description
+   *
+   * ***Deprecated 4.x.x***
+   *
+   * Nome do `ngModel` do campo de filtro.
+   *
+   * > Para pegar o valor utilize o parâmetro passado pelas funções referênciadas em `action` e `advancedAction`
+   *
+   */
   ngModel?: string;
 
   /** Texto de instrução exibido dentro do campo de filtro. */

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
@@ -64,6 +64,7 @@
           </div>
 
           <input
+            #filterInput
             class="po-input po-input-icon-right"
             name="model"
             type="text"

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
@@ -260,7 +260,8 @@ describe('PoPageListComponent - Desktop:', () => {
       callFunction: component.callFunction,
       changeDetector: {
         detectChanges: () => {}
-      }
+      },
+      filterInput: { nativeElement: { value: 'teste' } }
     };
 
     spyOn(context, 'getName');
@@ -454,6 +455,7 @@ describe('PoPageListComponent - Desktop:', () => {
       const changeDetectorSpy = spyOn(component['changeDetector'], 'detectChanges');
       const callFunctionSpy = spyOn(component, 'callFunction');
       component.filter = { action: 'test' };
+      component.filterInput = <any>{ nativeElement: { value: 'test' } };
 
       component.callActionFilter('sction');
 

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -8,7 +8,8 @@ import {
   SimpleChange,
   ViewChild,
   ViewContainerRef,
-  ChangeDetectorRef
+  ChangeDetectorRef,
+  ElementRef
 } from '@angular/core';
 import { Router } from '@angular/router';
 
@@ -52,6 +53,7 @@ export class PoPageListComponent extends PoPageListBaseComponent
   isMobile: boolean;
   limitPrimaryActions: number = 3;
   parentRef: ViewContainerRef;
+  @ViewChild('filterInput') filterInput: ElementRef;
 
   private isRecalculate = true;
   private maxWidthMobile: number = 480;
@@ -150,7 +152,7 @@ export class PoPageListComponent extends PoPageListBaseComponent
   }
 
   callActionFilter(field: string): void {
-    this.callFunction(this.filter[field], this.parentRef);
+    this.callFunction(this.filter[field], this.parentRef, this.filterInput.nativeElement.value);
     this.changeDetector.detectChanges();
   }
 

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.ts
@@ -47,9 +47,8 @@ export class SamplePoPageListHiringProcessesComponent implements OnInit {
   };
 
   public readonly filterSettings: PoPageFilter = {
-    action: 'filterAction',
-    advancedAction: 'advancedFilterActionModal',
-    ngModel: 'labelFilter',
+    action: this.filterAction.bind(this),
+    advancedAction: this.advancedFilterActionModal.bind(this),
     placeholder: 'Search'
   };
 
@@ -92,7 +91,8 @@ export class SamplePoPageListHiringProcessesComponent implements OnInit {
     filters.length ? this.hiringProcessesFilter(filters) : this.resetFilterHiringProcess();
   }
 
-  filterAction(filter = [this.labelFilter]) {
+  filterAction(labelFilter: string | Array<string>) {
+    const filter = typeof labelFilter === 'string' ? [labelFilter] : [...labelFilter];
     this.populateDisclaimers(filter);
     this.filter();
   }

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.ts
@@ -37,9 +37,8 @@ export class SamplePoPageListLabsComponent implements OnInit {
   ];
 
   public readonly filter: PoPageFilter = {
-    action: this.showAction.bind(this, 'Filter'),
-    advancedAction: this.showAction.bind(this, 'Advanced filter'),
-    ngModel: 'filterModel'
+    action: this.showAction.bind(this),
+    advancedAction: this.showAdvanceAction.bind(this)
   };
 
   public readonly iconOptions: Array<PoSelectOption> = [
@@ -156,7 +155,11 @@ export class SamplePoPageListLabsComponent implements OnInit {
     this.disclaimerValue = undefined;
   }
 
-  showAction(label) {
-    this.poNotification.success(`Action clicked: ${label}`);
+  showAction(filter) {
+    this.poNotification.success(`Action clicked: ${filter}`);
+  }
+
+  showAdvanceAction(filter) {
+    this.poNotification.success(`Advance Action clicked: ${filter}`);
   }
 }


### PR DESCRIPTION
**page-list**

**DTHFUI-3738**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
O atributo ngModel fazia com que o frame tivesse que controlar o parentRef oque não é uma boa prática.

**Qual o novo comportamento?**
Foi depreciado o atributo ngModel do PageFilter, agora o conteúdo do campo do filtro é passado via parâmetro nas funções action e advancedAction

**Simulação**
É possivel realizar os testes nos samples do page-list e do dynamic search, essa foi uma refatoração e a funcionalidade para o usuário não foi alterada.
