### PR TITLE
feat(lookup): permite traduzir as literais usando o serviço do i18n

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -101,7 +101,8 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
    * </po-lookup>
    * ```
    *
-   * > O objeto padrão de literais será traduzido de acordo com o idioma do browser (pt, en, es).
+   * > O objeto padrão de literais será traduzido de acordo com o idioma do
+   * [`PoI18nService`](/documentation/po-i18n) ou do browser.
    */
   @Input('p-literals') literals?: PoLookupLiterals;
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
@@ -4,6 +4,7 @@ import * as UtilsFunctions from '../../../../utils/util';
 import { expectPropertiesValues } from '../../../../util-test/util-expect.spec';
 import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
 import { PoTableColumnSortType } from '../../../po-table/enums/po-table-column-sort-type.enum';
+import { PoLanguageService } from '../../../../services/po-language/po-language.service';
 
 import { poLookupLiteralsDefault, PoLookupModalBaseComponent } from './po-lookup-modal-base.component';
 import { PoLookupResponseApi } from '../interfaces/po-lookup-response-api.interface';
@@ -18,7 +19,7 @@ describe('PoLookupModalBaseComponent:', () => {
   let items;
 
   beforeEach(() => {
-    component = new PoLookupModalComponent();
+    component = new PoLookupModalComponent(new PoLanguageService());
 
     component.filterService = {
       getFilteredItems: ({ filter, pageSize }) => of({ items: [], hasNext: false }),
@@ -48,7 +49,7 @@ describe('PoLookupModalBaseComponent:', () => {
 
   describe('Properties:', () => {
     it('literals: should return literals default if `_literals` is undefined', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component['_literals'] = undefined;
 
@@ -58,7 +59,7 @@ describe('PoLookupModalBaseComponent:', () => {
     it('literals: should set title with value of `literals.modalTitle`', () => {
       const literals = { 'modalTitle': 'title' };
 
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component.literals = literals;
 
@@ -67,7 +68,7 @@ describe('PoLookupModalBaseComponent:', () => {
 
     it('literals: shouldn`t define a title if a modalTitle is not defined', () => {
       const literals = { 'modalPrimaryActionLabel': 'action' };
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component.literals = literals;
 
@@ -75,7 +76,7 @@ describe('PoLookupModalBaseComponent:', () => {
     });
 
     it('literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('zw');
+      component['language'] = 'zw';
 
       component.literals = {};
 
@@ -83,7 +84,7 @@ describe('PoLookupModalBaseComponent:', () => {
     });
 
     it('literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component.literals = {};
 
@@ -91,7 +92,7 @@ describe('PoLookupModalBaseComponent:', () => {
     });
 
     it('literals: should be in english if browser is setted with `en`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('en');
+      component['language'] = 'en';
 
       component.literals = {};
 
@@ -99,7 +100,8 @@ describe('PoLookupModalBaseComponent:', () => {
     });
 
     it('literals: should accept custom literals and call `setTableLiterals`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue(UtilsFunctions.poLocaleDefault);
+      component['language'] = UtilsFunctions.poLocaleDefault;
+
       spyOn(component, <any>'setTableLiterals');
 
       const customLiterals = Object.assign({}, poLookupLiteralsDefault[UtilsFunctions.poLocaleDefault]);
@@ -113,7 +115,7 @@ describe('PoLookupModalBaseComponent:', () => {
     });
 
     it('literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
 
       component.literals = {};
 
@@ -121,7 +123,7 @@ describe('PoLookupModalBaseComponent:', () => {
     });
 
     it('literals: should be in russian if browser is setted with `ru`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('ru');
+      component['language'] = 'ru';
 
       component.literals = {};
 
@@ -131,7 +133,7 @@ describe('PoLookupModalBaseComponent:', () => {
     it('literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue(UtilsFunctions.poLocaleDefault);
+      component['language'] = UtilsFunctions.poLocaleDefault;
 
       expectPropertiesValues(
         component,

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -3,12 +3,13 @@ import { EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, Directive } 
 import { Observable, Subscription, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
-import { browserLanguage, isTypeof, poLocaleDefault } from '../../../../utils/util';
+import { isTypeof, poLocaleDefault } from '../../../../utils/util';
 import { PoModalAction } from '../../../../components/po-modal';
 import { PoModalComponent } from '../../../../components/po-modal/po-modal.component';
 import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
 import { PoTableColumnSortType } from '../../../po-table';
 import { poTableLiteralsDefault } from '../../../po-table/po-table-base.component';
+import { PoLanguageService } from '../../../../services/po-language/po-language.service';
 
 import { PoLookupColumn } from '../interfaces/po-lookup-column.interface';
 import { PoLookupFilter } from '../interfaces/po-lookup-filter.interface';
@@ -66,8 +67,9 @@ export const poLookupLiteralsDefault = {
  */
 @Directive()
 export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
-  private _literals: any;
-  private _title: any;
+  private _literals: PoLookupLiterals;
+  private _title: string;
+  private language: string = poLocaleDefault;
 
   hasNext = true;
   isLoading = false;
@@ -116,14 +118,14 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
     if (value instanceof Object && !(value instanceof Array)) {
       this._literals = {
         ...poLookupLiteralsDefault[poLocaleDefault],
-        ...poLookupLiteralsDefault[browserLanguage()],
+        ...poLookupLiteralsDefault[this.language],
         ...value
       };
       if (value.modalTitle) {
         this.title = this.literals.modalTitle;
       }
     } else {
-      this._literals = poLookupLiteralsDefault[browserLanguage()];
+      this._literals = poLookupLiteralsDefault[this.language];
     }
     this.primaryAction.label = this.literals.modalPrimaryActionLabel;
     this.secondaryAction.label = this.literals.modalSecondaryActionLabel;
@@ -131,7 +133,7 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
   }
 
   get literals() {
-    return this._literals || poLookupLiteralsDefault[browserLanguage()];
+    return this._literals || poLookupLiteralsDefault[this.language];
   }
 
   /** Título da modal. */
@@ -151,6 +153,10 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
 
   /** Evento utilizado ao selecionar um registro da tabela. */
   @Output('p-change-model') model: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor(languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
 
   ngOnDestroy() {
     if (this.filterSubscription) {


### PR DESCRIPTION
**Lookup**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```