### PR TITLE
feat(multiselect): permite traduzir as literais usando o serviço do i18n

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -1,4 +1,3 @@
-import { fakeAsync, tick } from '@angular/core/testing';
 import { FormControl } from '@angular/forms';
 
 import { expectPropertiesValues, expectSettersMethod } from '../../../util-test/util-expect.spec';
@@ -9,11 +8,16 @@ import {
   poLocaleDefault
 } from '../../../utils/util';
 import * as UtilsFunctions from '../../../utils/util';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoMultiselectBaseComponent, poMultiselectLiteralsDefault } from './po-multiselect-base.component';
 import { PoMultiselectFilterMode } from './po-multiselect-filter-mode.enum';
 
 class PoMultiselectTestComponent extends PoMultiselectBaseComponent {
+  constructor() {
+    super(new PoLanguageService());
+  }
+
   updateVisibleItems() {}
 }
 
@@ -428,7 +432,7 @@ describe('PoMultiselectBaseComponent:', () => {
 
   describe('Properties:', () => {
     it('p-literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('zw');
+      component['language'] = 'zw';
 
       component.literals = {};
 
@@ -436,7 +440,7 @@ describe('PoMultiselectBaseComponent:', () => {
     });
 
     it('p-literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component.literals = {};
 
@@ -444,7 +448,7 @@ describe('PoMultiselectBaseComponent:', () => {
     });
 
     it('p-literals: should be in english if browser is setted with `en`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('en');
+      component['language'] = 'en';
 
       component.literals = {};
 
@@ -452,7 +456,7 @@ describe('PoMultiselectBaseComponent:', () => {
     });
 
     it('p-literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
 
       component.literals = {};
 
@@ -460,7 +464,7 @@ describe('PoMultiselectBaseComponent:', () => {
     });
 
     it('p-literals: should be in russian if browser is setted with `ru`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('ru');
+      component['language'] = 'ru';
 
       component.literals = {};
 
@@ -468,7 +472,7 @@ describe('PoMultiselectBaseComponent:', () => {
     });
 
     it('p-literals: should accept custom literals', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       const customLiterals = Object.assign({}, poMultiselectLiteralsDefault[poLocaleDefault]);
 
@@ -483,7 +487,7 @@ describe('PoMultiselectBaseComponent:', () => {
     it('p-literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       expectPropertiesValues(component, 'literals', invalidValues, poMultiselectLiteralsDefault[poLocaleDefault]);
     });

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -2,7 +2,6 @@ import { EventEmitter, Input, OnInit, Output, Directive } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 
 import {
-  browserLanguage,
   convertToBoolean,
   removeDuplicatedOptions,
   removeUndefinedAndNullOptions,
@@ -10,6 +9,7 @@ import {
   poLocaleDefault
 } from '../../../utils/util';
 import { requiredFailed } from './../validators';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoMultiselectFilterMode } from './po-multiselect-filter-mode.enum';
 import { PoMultiselectLiterals } from './po-multiselect-literals.interface';
@@ -56,6 +56,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   private _options: Array<PoMultiselectOption>;
   private _required?: boolean = false;
   private _sort?: boolean = false;
+  private language: string;
 
   private lastLengthModel;
   private onModelChange: any;
@@ -118,21 +119,22 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * </po-po-multiselect>
    * ```
    *
-   *  > O objeto padrão de literais será traduzido de acordo com o idioma do *browser* (pt, en, es).
+   * > O objeto padrão de literais será traduzido de acordo com o idioma do
+   * [`PoI18nService`](/documentation/po-i18n) ou do browser.
    */
   @Input('p-literals') set literals(value: PoMultiselectLiterals) {
     if (value instanceof Object && !(value instanceof Array)) {
       this._literals = {
         ...poMultiselectLiteralsDefault[poLocaleDefault],
-        ...poMultiselectLiteralsDefault[browserLanguage()],
+        ...poMultiselectLiteralsDefault[this.language],
         ...value
       };
     } else {
-      this._literals = poMultiselectLiteralsDefault[browserLanguage()];
+      this._literals = poMultiselectLiteralsDefault[this.language];
     }
   }
   get literals() {
-    return this._literals || poMultiselectLiteralsDefault[browserLanguage()];
+    return this._literals || poMultiselectLiteralsDefault[this.language];
   }
 
   /**
@@ -298,6 +300,10 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
 
   protected clickOutListener: () => void;
   protected resizeListener: () => void;
+
+  constructor(languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
 
   ngOnInit() {
     this.updateList(this.options);

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -14,6 +14,7 @@ import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { isMobile } from './../../../utils/util';
 import { PoControlPositionService } from './../../../services/po-control-position/po-control-position.service';
 import { PoKeyCodeEnum } from './../../../enums/po-key-code.enum';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoMultiselectBaseComponent } from './po-multiselect-base.component';
 
@@ -85,12 +86,13 @@ export class PoMultiselectComponent extends PoMultiselectBaseComponent implement
   private isCalculateVisibleItems: boolean = true;
 
   constructor(
-    public renderer: Renderer2,
+    private renderer: Renderer2,
     private changeDetector: ChangeDetectorRef,
+    private el: ElementRef,
     private controlPosition: PoControlPositionService,
-    private el: ElementRef
+    languageService: PoLanguageService
   ) {
-    super();
+    super(languageService);
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
**Multiselect**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```