### PR TITLE
Page/i18n

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.spec.ts
@@ -2,12 +2,12 @@ import { fakeAsync, tick } from '@angular/core/testing';
 
 import { expectPropertiesValues } from './../../../util-test/util-expect.spec';
 import { poLocaleDefault } from './../../../utils/util';
-import * as UtilFunctions from './../../../utils/util';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoPageDetailBaseComponent, poPageDetailLiteralsDefault } from './po-page-detail-base.component';
 
 describe('PoPageDefaultBaseComponent:', () => {
-  const component = new PoPageDetailBaseComponent();
+  const component = new PoPageDetailBaseComponent(new PoLanguageService());
 
   it('should be created', () => {
     expect(component instanceof PoPageDetailBaseComponent).toBeTruthy();
@@ -15,7 +15,7 @@ describe('PoPageDefaultBaseComponent:', () => {
 
   describe('Properties: ', () => {
     it('p-literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('zw');
+      component['language'] = 'zw';
 
       component.literals = {};
 
@@ -23,7 +23,7 @@ describe('PoPageDefaultBaseComponent:', () => {
     });
 
     it('p-literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component.literals = {};
 
@@ -31,7 +31,7 @@ describe('PoPageDefaultBaseComponent:', () => {
     });
 
     it('p-literals: should be in english if browser is setted with `en`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('en');
+      component['language'] = 'en';
 
       component.literals = {};
 
@@ -39,7 +39,7 @@ describe('PoPageDefaultBaseComponent:', () => {
     });
 
     it('p-literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
 
       component.literals = {};
 
@@ -47,7 +47,7 @@ describe('PoPageDefaultBaseComponent:', () => {
     });
 
     it('p-literals: should be in russian if browser is setted with `ru`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('ru');
+      component['language'] = 'ru';
 
       component.literals = {};
 
@@ -55,7 +55,7 @@ describe('PoPageDefaultBaseComponent:', () => {
     });
 
     it('p-literals: should accept custom literals', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       const customLiterals = poPageDetailLiteralsDefault[poLocaleDefault];
 
@@ -71,7 +71,7 @@ describe('PoPageDefaultBaseComponent:', () => {
     it('p-literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       expectPropertiesValues(component, 'literals', invalidValues, poPageDetailLiteralsDefault[poLocaleDefault]);
     });

--- a/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.ts
@@ -1,6 +1,7 @@
 import { Directive, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 
-import { browserLanguage, poLocaleDefault } from './../../../utils/util';
+import { poLocaleDefault } from './../../../utils/util';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
 import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
@@ -39,6 +40,7 @@ export const poPageDetailLiteralsDefault = {
 export class PoPageDetailBaseComponent {
   private _literals: PoPageDetailLiterals;
   private _title: string;
+  private language: string;
 
   @ViewChild(PoPageContentComponent, { static: true }) poPageContent: PoPageContentComponent;
 
@@ -78,21 +80,22 @@ export class PoPageDetailBaseComponent {
    * </po-page-detail>
    * ```
    *
-   *  > O objeto padrão de literais será traduzido de acordo com o idioma do browser (pt, en, es).
+   * > O objeto padrão de literais será traduzido de acordo com o idioma do
+   * [`PoI18nService`](/documentation/po-i18n) ou do browser.
    */
   @Input('p-literals') set literals(value: PoPageDetailLiterals) {
     if (value instanceof Object && !(value instanceof Array)) {
       this._literals = {
         ...poPageDetailLiteralsDefault[poLocaleDefault],
-        ...poPageDetailLiteralsDefault[browserLanguage()],
+        ...poPageDetailLiteralsDefault[this.language],
         ...value
       };
     } else {
-      this._literals = poPageDetailLiteralsDefault[browserLanguage()];
+      this._literals = poPageDetailLiteralsDefault[this.language];
     }
   }
   get literals() {
-    return this._literals || poPageDetailLiteralsDefault[browserLanguage()];
+    return this._literals || poPageDetailLiteralsDefault[this.language];
   }
 
   /** Título da página. */
@@ -140,4 +143,8 @@ export class PoPageDetailBaseComponent {
    * > Caso não utilizar esta propriedade, o botão de "Remover" não será exibido.
    */
   @Output('p-remove') remove? = new EventEmitter();
+
+  constructor(languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
 }

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.spec.ts
@@ -2,12 +2,12 @@ import { tick, fakeAsync } from '@angular/core/testing';
 
 import { expectPropertiesValues } from './../../../util-test/util-expect.spec';
 import { poLocaleDefault } from './../../../utils/util';
-import * as UtilFunctions from './../../../utils/util';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoPageEditBaseComponent, poPageEditLiteralsDefault } from './po-page-edit-base.component';
 
 describe('PoPageEditBaseComponent:', () => {
-  const component = new PoPageEditBaseComponent();
+  const component = new PoPageEditBaseComponent(new PoLanguageService());
 
   it('should be created', () => {
     expect(component instanceof PoPageEditBaseComponent).toBeTruthy();
@@ -15,7 +15,7 @@ describe('PoPageEditBaseComponent:', () => {
 
   describe('Properties: ', () => {
     it('p-literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('zw');
+      component['language'] = 'zw';
 
       component.literals = {};
 
@@ -23,7 +23,7 @@ describe('PoPageEditBaseComponent:', () => {
     });
 
     it('p-literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component.literals = {};
 
@@ -31,7 +31,7 @@ describe('PoPageEditBaseComponent:', () => {
     });
 
     it('p-literals: should be in english if browser is setted with `en`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('en');
+      component['language'] = 'en';
 
       component.literals = {};
 
@@ -39,7 +39,7 @@ describe('PoPageEditBaseComponent:', () => {
     });
 
     it('p-literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
 
       component.literals = {};
 
@@ -47,7 +47,7 @@ describe('PoPageEditBaseComponent:', () => {
     });
 
     it('p-literals: should be in russian if browser is setted with `ru`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('ru');
+      component['language'] = 'ru';
 
       component.literals = {};
 
@@ -55,7 +55,7 @@ describe('PoPageEditBaseComponent:', () => {
     });
 
     it('p-literals: should accept custom literals', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       const customLiterals = poPageEditLiteralsDefault[poLocaleDefault];
 
@@ -71,7 +71,7 @@ describe('PoPageEditBaseComponent:', () => {
     it('p-literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       expectPropertiesValues(component, 'literals', invalidValues, poPageEditLiteralsDefault[poLocaleDefault]);
     });

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.ts
@@ -1,6 +1,7 @@
 import { Directive, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 
-import { browserLanguage, poLocaleDefault } from './../../../utils/util';
+import { poLocaleDefault } from './../../../utils/util';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
 import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
@@ -43,6 +44,7 @@ export const poPageEditLiteralsDefault = {
 export class PoPageEditBaseComponent {
   private _literals: PoPageEditLiterals;
   private _title: string;
+  private language: string;
 
   @ViewChild(PoPageContentComponent, { static: true }) poPageContent: PoPageContentComponent;
 
@@ -85,21 +87,22 @@ export class PoPageEditBaseComponent {
    * </po-page-edit>
    * ```
    *
-   *  > O objeto padrão de literais será traduzido de acordo com o idioma do browser (pt, en, es).
+   * > O objeto padrão de literais será traduzido de acordo com o idioma do
+   * [`PoI18nService`](/documentation/po-i18n) ou do browser.
    */
   @Input('p-literals') set literals(value: PoPageEditLiterals) {
     if (value instanceof Object && !(value instanceof Array)) {
       this._literals = {
         ...poPageEditLiteralsDefault[poLocaleDefault],
-        ...poPageEditLiteralsDefault[browserLanguage()],
+        ...poPageEditLiteralsDefault[this.language],
         ...value
       };
     } else {
-      this._literals = poPageEditLiteralsDefault[browserLanguage()];
+      this._literals = poPageEditLiteralsDefault[this.language];
     }
   }
   get literals() {
-    return this._literals || poPageEditLiteralsDefault[browserLanguage()];
+    return this._literals || poPageEditLiteralsDefault[this.language];
   }
 
   /** Título da página. */
@@ -147,4 +150,8 @@ export class PoPageEditBaseComponent {
    * > Caso não utilizar esta propriedade, o botão de "Salvar e Novo" não será exibido.
    */
   @Output('p-save-new') saveNew? = new EventEmitter();
+
+  constructor(languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
 }


### PR DESCRIPTION
**Page Detail** e **Page Edit**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```