### PR TITLE
feat(upload): permite traduzir as literais usando o serviço do i18n

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
@@ -7,6 +7,7 @@ import { expectPropertiesValues, configureTestSuite } from '../../../util-test/u
 
 import * as utilsFunctions from '../../../utils/util';
 import * as ValidatorsFunctions from '../validators';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoUploadBaseComponent, poUploadLiteralsDefault } from './po-upload-base.component';
 import { PoUploadFile } from './po-upload-file';
@@ -18,7 +19,7 @@ import { PoUploadService } from './po-upload.service';
 })
 class PoUploadComponent extends PoUploadBaseComponent {
   constructor(uploadService: PoUploadService) {
-    super(uploadService);
+    super(uploadService, new PoLanguageService());
   }
 
   sendFeedback() {}
@@ -41,7 +42,7 @@ describe('PoUploadBaseComponent:', () => {
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [PoUploadComponent],
-      providers: [HttpClient, HttpHandler, PoUploadService],
+      providers: [HttpClient, HttpHandler, PoUploadService, PoLanguageService],
       imports: [FormsModule]
     });
   });
@@ -562,7 +563,7 @@ describe('PoUploadBaseComponent:', () => {
     });
 
     it('p-literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('zw');
+      component['language'] = 'zw';
 
       component.literals = {};
 
@@ -570,7 +571,7 @@ describe('PoUploadBaseComponent:', () => {
     });
 
     it('p-literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component.literals = {};
 
@@ -578,7 +579,7 @@ describe('PoUploadBaseComponent:', () => {
     });
 
     it('p-literals: should be in english if browser is setted with `en`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('en');
+      component['language'] = 'en';
 
       component.literals = {};
 
@@ -586,7 +587,7 @@ describe('PoUploadBaseComponent:', () => {
     });
 
     it('p-literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
 
       component.literals = {};
 
@@ -594,7 +595,7 @@ describe('PoUploadBaseComponent:', () => {
     });
 
     it('p-literals: should be in russian if browser is setted with `ru`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('ru');
+      component['language'] = 'ru';
 
       component.literals = {};
 
@@ -602,7 +603,7 @@ describe('PoUploadBaseComponent:', () => {
     });
 
     it('p-literals: should accept custom literals', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(utilsFunctions.poLocaleDefault);
+      component['language'] = utilsFunctions.poLocaleDefault;
 
       const customLiterals = Object.assign({}, poUploadLiteralsDefault[utilsFunctions.poLocaleDefault]);
 
@@ -617,7 +618,7 @@ describe('PoUploadBaseComponent:', () => {
     it('p-literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(utilsFunctions.poLocaleDefault);
+      component['language'] = utilsFunctions.poLocaleDefault;
 
       expectPropertiesValues(
         component,

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -1,7 +1,7 @@
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { browserLanguage, convertToBoolean, isEquals, isIE, isMobile, poLocaleDefault } from '../../../utils/util';
+import { convertToBoolean, isEquals, isIE, isMobile, poLocaleDefault } from '../../../utils/util';
 import { requiredFailed } from '../validators';
 
 import { PoUploadFile } from './po-upload-file';
@@ -10,6 +10,7 @@ import { PoUploadLiterals } from './interfaces/po-upload-literals.interface';
 import { PoUploadService } from './po-upload.service';
 import { PoUploadStatus } from './po-upload-status.enum';
 import { InputBoolean } from '../../../decorators';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 export const poUploadLiteralsDefault = {
   en: <PoUploadLiterals>{
@@ -162,6 +163,7 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
   private _isMultiple?: boolean;
   private _literals?: any;
   private _required?: boolean;
+  private language: string;
 
   allowedExtensions: string;
   currentFiles: Array<PoUploadFile>;
@@ -345,15 +347,15 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
     if (value instanceof Object && !(value instanceof Array)) {
       this._literals = {
         ...poUploadLiteralsDefault[poLocaleDefault],
-        ...poUploadLiteralsDefault[browserLanguage()],
+        ...poUploadLiteralsDefault[this.language],
         ...value
       };
     } else {
-      this._literals = poUploadLiteralsDefault[browserLanguage()];
+      this._literals = poUploadLiteralsDefault[this.language];
     }
   }
   get literals() {
-    return this._literals || poUploadLiteralsDefault[browserLanguage()];
+    return this._literals || poUploadLiteralsDefault[this.language];
   }
 
   /** Texto de apoio para o campo. */
@@ -508,7 +510,9 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
   // Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da *tag* `form`.
   @Output('ngModelChange') ngModelChange?: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(protected uploadService: PoUploadService) {}
+  constructor(protected uploadService: PoUploadService, languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
 
   abstract sendFeedback(): void;
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.spec.ts
@@ -1,10 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ChangeDetectorRef } from '@angular/core';
 
-import * as UtilsFunctions from './../../../../utils/util';
 import { expectSettersMethod } from './../../../../util-test/util-expect.spec';
 import { poLocaleDefault } from './../../../../utils/util';
 import { PoServicesModule } from './../../../../services/services.module';
+import { PoLanguageService } from './../../../../services/po-language/po-language.service';
 
 import { PoUploadFileRestrictionsComponent } from './po-upload-file-restrictions.component';
 import { poUploadLiteralsDefault } from '../po-upload-base.component';
@@ -18,7 +18,8 @@ describe('PoUploadFileRestrictionsComponent:', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [PoUploadFileRestrictionsComponent],
-      imports: [PoServicesModule]
+      imports: [PoServicesModule],
+      providers: [PoLanguageService]
     }).compileComponents();
   }));
 
@@ -29,7 +30,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     nativeElement = fixture.debugElement.nativeElement;
     changeDetector = fixture.componentRef.injector.get(ChangeDetectorRef);
 
-    spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('en');
+    component['language'] = 'en';
   });
 
   it('should be created', () => {
@@ -71,7 +72,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     it('formatAllowedExtensions: should return `PNG, JPG and SVG` if allowedExtensions is `png,jpg and svg`', () => {
       const allowedExtensions = ['png', 'jpg', 'svg'];
 
-      spyOnProperty(component, 'language').and.returnValue('en');
+      component['language'] = 'en';
 
       expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('PNG, JPG and SVG');
     });
@@ -79,7 +80,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     it('formatAllowedExtensions: should return `PNG and JPG` if allowedExtensions is `png and jpg`', () => {
       const allowedExtensions = ['png', 'jpg'];
 
-      spyOnProperty(component, 'language').and.returnValue('en');
+      component['language'] = 'en';
 
       expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('PNG and JPG');
     });
@@ -87,7 +88,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     it('formatAllowedExtensions: should return `PNG e JPG` if allowedExtensions is `png and jpg` and `language` is `pt`', () => {
       const allowedExtensions = ['png', 'jpg'];
 
-      spyOnProperty(component, 'language').and.returnValue('pt');
+      component['language'] = 'pt';
 
       expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('PNG e JPG');
     });
@@ -95,7 +96,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     it('formatAllowedExtensions: should return `PNG y JPG` if allowedExtensions is `png and jpg` and `language` is `es`', () => {
       const allowedExtensions = ['png', 'jpg'];
 
-      spyOnProperty(component, 'language').and.returnValue('es');
+      component['language'] = 'es';
 
       expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('PNG y JPG');
     });
@@ -115,7 +116,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     it('setLiterals: should set `literals` with `poUploadLiteralsDefault`', () => {
       component.literals = undefined;
 
-      spyOnProperty(component, 'language').and.returnValue('en');
+      component['language'] = 'en';
 
       component['setLiterals']();
 
@@ -125,7 +126,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     it('setLiterals: should set `literals` with `poUploadLiteralsDefault` and `poLocaleDefault`', () => {
       component.literals = undefined;
 
-      spyOnProperty(component, 'language').and.returnValue('');
+      component['language'] = '';
 
       component['setLiterals']();
 
@@ -168,7 +169,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     });
 
     it('should contain `allowedFormats` if `allowedExtensions` is defined', () => {
-      spyOnProperty(component, 'language').and.returnValue('en');
+      component['language'] = 'en';
       component.allowedExtensions = <any>['png', 'jpg'];
       const allowedExtensions = 'Accepted file formats: PNG and JPG.';
 
@@ -210,7 +211,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     it('should contain `minFileSizeAllowed` if `minFileSize` is defined and `maxFileSize` is undefined', () => {
       component.minFileSize = <any>1048576;
       const minFileSizeAllowed = 'Size limit per file: 1 MB minimum';
-      spyOnProperty(component, 'language').and.returnValue('en');
+      component['language'] = 'en';
 
       component['setLiterals']();
 
@@ -224,7 +225,7 @@ describe('PoUploadFileRestrictionsComponent:', () => {
     it('should contain `maxFileSizeAllowed` if `minFileSize` is undefined and `maxFileSize` is defined', () => {
       component.maxFileSize = <any>1048576;
       const maxFileSizeAllowed = 'Size limit per file: 1 MB maximum';
-      spyOnProperty(component, 'language').and.returnValue('en');
+      component['language'] = 'en';
 
       component['setLiterals']();
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 
-import { browserLanguage, formatBytes, poLocaleDefault } from '../../../../utils/util';
+import { formatBytes, poLocaleDefault } from '../../../../utils/util';
+import { PoLanguageService } from '../../../../services/po-language/po-language.service';
 
 import { poUploadLiteralsDefault } from '../po-upload-base.component';
 
@@ -13,6 +14,7 @@ export class PoUploadFileRestrictionsComponent implements OnInit {
   private _allowedExtensions: string;
   private _maxFileSize: string;
   private _minFileSize: string;
+  private language: string;
 
   literals: any;
 
@@ -42,18 +44,16 @@ export class PoUploadFileRestrictionsComponent implements OnInit {
     return this._minFileSize;
   }
 
-  get language(): string {
-    return browserLanguage();
+  constructor(private changeDetector: ChangeDetectorRef, languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
   }
-
-  constructor(private changeDetector: ChangeDetectorRef) {}
 
   ngOnInit() {
     this.setLiterals();
   }
 
   private formatAllowedExtensions(allowedExtensions: Array<string>): string {
-    const conjunction = { 'pt': 'e', 'en': 'and', 'es': 'y' };
+    const conjunction = { 'pt': 'e', 'en': 'and', 'es': 'y', 'ru': 'и' };
 
     return allowedExtensions
       ? allowedExtensions

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
@@ -7,6 +7,7 @@ import { configureTestSuite } from './../../../util-test/util-expect.spec';
 import { PoButtonModule } from '../../po-button/po-button.module';
 import { PoContainerModule } from '../../po-container/po-container.module';
 import { PoProgressModule } from '../../po-progress/po-progress.module';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
@@ -48,7 +49,7 @@ describe('PoUploadComponent:', () => {
         PoUploadDragDropDirective,
         PoUploadFileRestrictionsComponent
       ],
-      providers: [HttpClient, HttpHandler, PoNotificationService, PoUploadService]
+      providers: [HttpClient, HttpHandler, PoNotificationService, PoUploadService, PoLanguageService]
     });
   });
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
@@ -6,6 +6,7 @@ import { PoButtonComponent } from './../../po-button/po-button.component';
 import { PoI18nPipe } from '../../../services/po-i18n/po-i18n.pipe';
 import { PoNotificationService } from '../../../services/po-notification/po-notification.service';
 import { PoProgressStatus } from '../../po-progress/enums/po-progress-status.enum';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoUploadBaseComponent } from './po-upload-base.component';
 import { PoUploadDragDropComponent } from './po-upload-drag-drop/po-upload-drag-drop.component';
@@ -85,9 +86,10 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
     uploadService: PoUploadService,
     public renderer: Renderer2,
     private i18nPipe: PoI18nPipe,
-    private notification: PoNotificationService
+    private notification: PoNotificationService,
+    languageService: PoLanguageService
   ) {
-    super(uploadService);
+    super(uploadService, languageService);
   }
 
   get displayDragDrop(): boolean {


### PR DESCRIPTION
**Upload**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```