### PR TITLE
feat(po-menu): implement i18n to menu and menu filter

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
@@ -14,14 +14,20 @@ export class PoMenuComponent extends PoMenuBaseComponent {
 describe('PoMenuBaseComponent:', () => {
   let component: PoMenuBaseComponent;
 
+  const languageService: any = {
+    getShortLanguage: () => {
+      return 'pt';
+    },
+    getLanguageDefault: () => {
+      return 'pt';
+    }
+  };
   const menuService: any = {
     configProperties: () => {},
     getFilteredData: () => {}
   };
-
   beforeEach(() => {
-    component = new PoMenuComponent(menuService);
-
+    component = new PoMenuComponent(menuService, languageService);
     component.menus = [
       {
         label: 'Level 1.1',

--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
@@ -1,24 +1,18 @@
 import { Input, Directive } from '@angular/core';
 
 import { v4 as uuid } from 'uuid';
-import {
-  browserLanguage,
-  convertToBoolean,
-  convertToInt,
-  isExternalLink,
-  isTypeof,
-  poLocaleDefault,
-  validValue
-} from '../../utils/util';
+import { convertToBoolean, convertToInt, isExternalLink, isTypeof, validValue } from '../../utils/util';
 
 import { PoMenuFilter } from './po-menu-filter/po-menu-filter.interface';
 import { PoMenuItem } from './po-menu-item.interface';
 import { PoMenuService } from './services/po-menu.service';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 export const poMenuLiteralsDefault = {
-  en: { itemNotFound: 'Item not found.' },
-  es: { itemNotFound: 'Elemento no encontrado.' },
-  pt: { itemNotFound: 'Item não encontrado.' }
+  en: { itemNotFound: 'Item not found.', emptyLabelError: 'Attribute PoMenuItem.label can not be empty.' },
+  es: { itemNotFound: 'Elemento no encontrado.', emptyLabelError: 'El atributo PoMenuItem.label no puede ser vacío.' },
+  pt: { itemNotFound: 'Item não encontrado.', emptyLabelError: 'O atributo PoMenuItem.label não pode ser vazio.' },
+  ru: { itemNotFound: 'Предмет не найден.', emptyLabelError: 'Атрибут PoMenuItem.label не может быть пустым.' }
 };
 
 /**
@@ -48,8 +42,8 @@ export abstract class PoMenuBaseComponent {
   filterService: PoMenuFilter;
 
   readonly literals = {
-    ...poMenuLiteralsDefault[poLocaleDefault],
-    ...poMenuLiteralsDefault[browserLanguage()]
+    ...poMenuLiteralsDefault[this.languageService.getLanguageDefault()],
+    ...poMenuLiteralsDefault[this.languageService.getShortLanguage()]
   };
 
   /**
@@ -221,8 +215,7 @@ export abstract class PoMenuBaseComponent {
     return this._shortLogo;
   }
 
-  constructor(public menuService: PoMenuService) {}
-
+  constructor(public menuService: PoMenuService, public languageService: PoLanguageService) {}
   private configService(service: string | PoMenuFilter) {
     if (typeof service === 'string' && service.trim()) {
       // service url
@@ -323,7 +316,7 @@ export abstract class PoMenuBaseComponent {
 
   private validateMenu(menuItem: PoMenuItem): void {
     if (!menuItem.label || menuItem.label.trim() === '') {
-      throw new Error('O atributo PoMenuItem.label não pode ser vazio.');
+      throw new Error(this.literals.emptyLabelError);
     } else if (menuItem.subItems) {
       menuItem.subItems.forEach(subItem => {
         this.validateMenu(subItem);

--- a/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter-literals.interface.ts
@@ -1,0 +1,14 @@
+export interface PoMenuFilterLiterals {
+  /**
+   * @usedBy PoMenuFilterComponent
+   *
+   * @optional
+   *
+   * @description
+   *
+   * Interface dos strings do poMenuFilter
+   *
+   * search: Texto exibido no *placeholder*  do filtro do componente menu.
+   */
+  search?: string;
+}

--- a/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.html
+++ b/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.html
@@ -3,7 +3,7 @@
     #inputFilter
     type="text"
     class="po-menu-filter"
-    placeholder="Pesquisar"
+    [placeholder]="literals.search"
     (keyup)="filterItems(inputFilter.value)"
   />
 

--- a/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.ts
@@ -1,4 +1,13 @@
 import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { PoMenuFilterLiterals } from './po-menu-filter-literals.interface';
+
+export const poMenuFilterLiteralsDefault = {
+  en: <PoMenuFilterLiterals>{ search: 'Search' },
+  es: <PoMenuFilterLiterals>{ search: 'Buscar' },
+  pt: <PoMenuFilterLiterals>{ search: 'Pesquisar' },
+  ru: <PoMenuFilterLiterals>{ search: 'Поиск' }
+};
 
 /**
  * @docsPrivate
@@ -14,6 +23,10 @@ import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@
 export class PoMenuFilterComponent {
   // Variável necessária para o po-clean identificar que deve ser criado.
   readonly clean = true;
+  public literals = {
+    ...poMenuFilterLiteralsDefault[this.languageService.getLanguageDefault()],
+    ...poMenuFilterLiteralsDefault[this.languageService.getShortLanguage()]
+  };
 
   @Input('p-loading') loading: boolean;
 
@@ -21,7 +34,7 @@ export class PoMenuFilterComponent {
   @ViewChild('inputFilter', { read: ElementRef, static: true }) inputFilterElement: ElementRef;
 
   @Output('p-filter') filter = new EventEmitter();
-
+  constructor(public languageService: PoLanguageService) {}
   filterItems(search: string) {
     this.filter.emit(search);
   }

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.ts
@@ -23,6 +23,7 @@ import { PoMenuItem } from './po-menu-item.interface';
 import { PoMenuItemFiltered } from './po-menu-item/po-menu-item-filtered.interface';
 import { PoMenuItemsService } from './services/po-menu-items.service';
 import { PoMenuService } from './services/po-menu.service';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 const poMenuDebounceTime = 400;
 const poMenuMinLength = 3;
@@ -142,9 +143,10 @@ export class PoMenuComponent extends PoMenuBaseComponent implements OnDestroy, O
     private renderer: Renderer2,
     private router: Router,
     private menuItemsService: PoMenuItemsService,
-    menuService: PoMenuService
+    menuService: PoMenuService,
+    languageService: PoLanguageService
   ) {
-    super(menuService);
+    super(menuService, languageService);
   }
 
   private get isActiveItemMenuSubMenu() {


### PR DESCRIPTION
Feat(i18n-menu): implementados strings "Pesquisa" e mensagem de erro no menu label vazio em todos os idiomas, e "item nao encontrado" em russo
_____________________________________________________________________________
**PR Checklist**

- [x] Código
- [] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O string PESQUISAR estava hardcodeado em portugues.
A mensagem de erro quando o label do menu estava vazio, estava hardcodeado em portugues.
A string ITEM NAO ENCONTRADO nao estava implementada para o idioma russo

**Qual o novo comportamento?**
Todas as strings foram definidas em 4 idiomas, e o service i18nLanguage utilizado onde necessário.

**Simulação**
Acessar um componente de MENU e verificar que o idioma do placeholder PESQUISAR está no idioma selecionado no login.
Pesquisar um item inexistente e verificar que a mensagem de retorno está no idioma selecionado no login.
Adicionar um item com label vazio e verificar que a mensagem de error (no console) está no idioma selecionado no login.