### PR TITLE
feat(page-dynamic-edit): permite traduzir literais usando serviço i18n

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -10,6 +10,7 @@ import {
   PoDynamicFormComponent,
   PoGridComponent,
   PoGridRowActions,
+  PoLanguageService,
   PoNotificationService,
   PoPageAction
 } from '@po-ui/ng-components';
@@ -177,10 +178,7 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
   private _keys: Array<any> = [];
   private _pageActions: Array<PoPageAction> = [];
 
-  literals = {
-    ...poPageDynamicEditLiteralsDefault[util.poLocaleDefault],
-    ...poPageDynamicEditLiteralsDefault[util.browserLanguage()]
-  };
+  literals;
   model: any = {};
 
   // beforeSave: return boolean
@@ -362,8 +360,16 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
     private poDialogService: PoDialogService,
     private poPageDynamicService: PoPageDynamicService,
     private poPageCustomizationService: PoPageCustomizationService,
-    private poPageDynamicEditActionsService: PoPageDynamicEditActionsService
-  ) {}
+    private poPageDynamicEditActionsService: PoPageDynamicEditActionsService,
+    languageService: PoLanguageService
+  ) {
+    const language = languageService.getShortLanguage();
+
+    this.literals = {
+      ...poPageDynamicEditLiteralsDefault[util.poLocaleDefault],
+      ...poPageDynamicEditLiteralsDefault[language]
+    };
+  }
 
   ngOnInit(): void {
     this.loadDataFromAPI();

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -62,6 +62,17 @@ export const poPageDynamicEditLiteralsDefault = {
     saveNotificationSuccessSave: 'Recurso salvo com sucesso.',
     saveNotificationSuccessUpdate: 'Recurso atualizado com sucesso.',
     saveNotificationWarning: 'Formulário precisa ser preenchido corretamente.'
+  },
+  ru: {
+    cancelConfirmMessage: 'Вы уверены, что хотите отменить эту операцию?',
+    detailActionNew: 'Новый',
+    pageActionCancel: 'Отменить',
+    pageActionSave: 'Сохранить',
+    pageActionSaveNew: 'Сохранить и создать',
+    registerNotFound: 'Запись не найдена.',
+    saveNotificationSuccessSave: 'Ресурс успешно сохранен.',
+    saveNotificationSuccessUpdate: 'Ресурс успешно обновлен.',
+    saveNotificationWarning: 'Форма должна быть заполнена правильно.'
   }
 };
 


### PR DESCRIPTION
**Page Dynamic Edit**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```