### PR TITLE
feat(page-dynamic-detail): permite traduzir literais usando serviço i18n

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
@@ -54,6 +54,15 @@ export const poPageDynamicDetailLiteralsDefault = {
     confirmRemoveMessage: 'Tem certeza de que deseja excluir esse registro? Você não poderá desfazer essa ação.',
     removeNotificationSuccess: 'Item excluído com sucesso.',
     registerNotFound: 'Registro não encontrado.'
+  },
+  ru: {
+    pageActionEdit: 'Редактировать',
+    pageActionRemove: 'Удалить',
+    pageActionBack: 'Назад',
+    confirmRemoveTitle: 'Подтверждение удаления',
+    confirmRemoveMessage: 'Вы уверены, что хотите удалить эту запись?  Вы не можете отменить это действие.',
+    removeNotificationSuccess: 'Элемент успешно удален.',
+    registerNotFound: 'Запись не найдена.'
   }
 };
 

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
@@ -4,14 +4,16 @@ import { Route, Router, ActivatedRoute } from '@angular/router';
 import { Subscription, concat, EMPTY, Observable, throwError, of } from 'rxjs';
 import { tap, catchError, map, switchMap } from 'rxjs/operators';
 
-import * as util from '../../utils/util';
 import {
   PoBreadcrumb,
-  PoPageAction,
-  PoDialogService,
   PoDialogConfirmOptions,
-  PoNotificationService
+  PoDialogService,
+  PoLanguageService,
+  PoNotificationService,
+  PoPageAction
 } from '@po-ui/ng-components';
+
+import * as util from '../../utils/util';
 
 import { PoPageDynamicDetailActions } from './interfaces/po-page-dynamic-detail-actions.interface';
 import { PoPageDynamicDetailField } from './interfaces/po-page-dynamic-detail-field.interface';
@@ -146,10 +148,7 @@ export class PoPageDynamicDetailComponent implements OnInit, OnDestroy {
   private _keys: Array<any> = [];
   private _pageActions: Array<PoPageAction> = [];
 
-  literals = {
-    ...poPageDynamicDetailLiteralsDefault[util.poLocaleDefault],
-    ...poPageDynamicDetailLiteralsDefault[util.browserLanguage()]
-  };
+  literals;
   model: any = {};
 
   /**
@@ -283,8 +282,16 @@ export class PoPageDynamicDetailComponent implements OnInit, OnDestroy {
     private poDialogService: PoDialogService,
     private poPageDynamicService: PoPageDynamicService,
     private poPageDynamicDetailActionsService: PoPageDynamicDetailActionsService,
-    private poPageCustomizationService: PoPageCustomizationService
-  ) {}
+    private poPageCustomizationService: PoPageCustomizationService,
+    languageService: PoLanguageService
+  ) {
+    const language = languageService.getShortLanguage();
+
+    this.literals = {
+      ...poPageDynamicDetailLiteralsDefault[util.poLocaleDefault],
+      ...poPageDynamicDetailLiteralsDefault[language]
+    };
+  }
 
   ngOnInit(): void {
     this.loadDataFromAPI();


### PR DESCRIPTION
**Page Dynamic Detail**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```