### PR TITLE
feat(page-dynamic-table): permite traduzir literais usando serviço i18n

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -82,6 +82,21 @@ export const poPageDynamicTableLiteralsDefault = {
     loadDataErrorNotification: 'Serviço não informado.',
     removeSuccessNotification: 'Item excluido com sucesso',
     removeAllSuccessNotification: 'Items excluidos com sucesso'
+  },
+  ru: {
+    pageAction: 'Новый',
+    pageActionRemoveAll: 'Удалить',
+    tableActionView: 'Просмотр',
+    tableActionEdit: 'Редактировать',
+    tableActionDuplicate: 'Дублировать',
+    tableActionDelete: 'Удалить',
+    confirmRemoveTitle: 'Подтверждение удаления',
+    confirmRemoveMessage: 'Вы уверены, что хотите удалить эту запись?  Вы не можете отменить это действие.',
+    confirmRemoveAllTitle: 'Подтвердите удаление пакета',
+    confirmRemoveAllMessage: 'Вы уверены, что хотите удалить все эти записи? Вы не можете отменить это действие.',
+    loadDataErrorNotification: 'Сервис не найден',
+    removeSuccessNotification: 'Элемент успешно удален',
+    removeAllSuccessNotification: 'Элементы успешно удалены'
   }
 };
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -8,6 +8,7 @@ import {
   InputBoolean,
   PoDialogConfirmOptions,
   PoDialogService,
+  PoLanguageService,
   PoNotificationService,
   PoPageAction,
   PoTableAction,
@@ -190,10 +191,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
 
   hasNext = false;
   items = [];
-  literals = {
-    ...poPageDynamicTableLiteralsDefault[util.poLocaleDefault],
-    ...poPageDynamicTableLiteralsDefault[util.browserLanguage()]
-  };
+  literals;
 
   /**
    * Função ou serviço que será executado na inicialização do componente.
@@ -291,9 +289,17 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     private poNotification: PoNotificationService,
     private poPageDynamicService: PoPageDynamicService,
     private poPageCustomizationService: PoPageCustomizationService,
-    private poPageDynamicTableActionsService: PoPageDynamicTableActionsService
+    private poPageDynamicTableActionsService: PoPageDynamicTableActionsService,
+    languageService: PoLanguageService
   ) {
     super();
+
+    const language = languageService.getShortLanguage();
+
+    this.literals = {
+      ...poPageDynamicTableLiteralsDefault[util.poLocaleDefault],
+      ...poPageDynamicTableLiteralsDefault[language]
+    };
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
**Page Dynamic Table**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```