### PR TITLE
feat(page-login): adiciona a propriedade `welcome` nas literais

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
@@ -21,7 +21,21 @@ export interface PoPageLoginLiterals {
   /** Texto que questiona o esquecimento da senha no popover de aviso de bloqueio. */
   forgotYourPassword?: string;
 
-  /** Título exibido no topo da página. */
+  /**
+   * @deprecated 4.x.x
+   *
+   * @description
+   *
+   * **Deprecated 4.x.x**.
+   *
+   * > Removido o tratamento para concatenar o nome do produto com a palavra "Bem-vindo".
+   * Sobre a utilização:
+   * - Essa propriedade será usada apenas na ausência do texto da propriedade `p-product-name`.
+   * - Para alterar a mensagem de boas-vindas, utilize a propriedade `welcome`.
+   *
+   *
+   * Título exibido no topo da página.
+   */
   title?: string;
 
   /** Texto do link de 'esqueci minha senha' exibido no popover de aviso de bloqueio. */
@@ -77,4 +91,7 @@ export interface PoPageLoginLiterals {
 
   /** Texto que informa ao usuário que o mesmo será bloqueado e por quanto tempo no popover de aviso de bloqueio. */
   yourUserWillBeBlocked?: string;
+
+  /** Mensagem de "Boas-vindas" para o usuário que aparece acima dos campos de entrada. */
+  welcome?: string;
 }

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
@@ -20,7 +20,7 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent {
   protected setPasswordErrors(value: Array<string>): void {}
 }
 
-describe('ThPageLoginBaseComponent: ', () => {
+describe('PoPageLoginBaseComponent: ', () => {
   let component: PoPageLoginBaseComponent;
   let servicePageLogin: PoPageLoginService;
 
@@ -214,7 +214,7 @@ describe('ThPageLoginBaseComponent: ', () => {
       spyOnProperty(component, 'language').and.returnValue('en');
 
       component.literals = {
-        'title': 'Custom Title',
+        'welcome': 'Custom welcome',
         'loginHint': 'Custom Login Hint'
       };
 
@@ -222,12 +222,11 @@ describe('ThPageLoginBaseComponent: ', () => {
       component.contactEmail = 'user@mail.com';
 
       const concatedLoginHint = { 'loginHint': 'Custom Login Hint user@mail.com' };
-      const concatedTitle = { 'title': 'Custom Title on Produto' };
+
       const expectedResult = {
         ...poPageLoginLiteralsDefault[poLocaleDefault],
         ...poPageLoginLiteralsDefault[component.language],
         ...concatedLoginHint,
-        ...concatedTitle,
         ...component.literals
       };
 
@@ -238,7 +237,7 @@ describe('ThPageLoginBaseComponent: ', () => {
       spyOnProperty(component, 'language').and.returnValue('en');
 
       component.literals = {
-        'title': 'Custom Title',
+        'welcome': 'Custom welcome',
         'loginHint': 'Custom Login Hint'
       };
 

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -45,7 +45,8 @@ export const poPageLoginLiteralsDefault = {
     yourUserWillBeBlocked:
       'without success your user will be blocked and you will be left 24 hours without being able to access :(',
     createANewPasswordNow: 'Better create a new password now! You will be able to log into the system right away.',
-    iForgotMyPassword: 'I forgot my password'
+    iForgotMyPassword: 'I forgot my password',
+    welcome: 'Welcome'
   },
   es: <PoPageLoginLiterals>{
     title: 'Bienvenido',
@@ -71,7 +72,8 @@ export const poPageLoginLiteralsDefault = {
     yourUserWillBeBlocked: 'sin éxito su usuario sera bloqueado y usted vás permanecer 24 horas sin poder acceder a :(',
     createANewPasswordNow:
       '¡Mejor crear una nueva contraseña ahora! Usted podrá entrar en el sistema inmediatamente después.',
-    iForgotMyPassword: 'Olvide mi contraseña'
+    iForgotMyPassword: 'Olvide mi contraseña',
+    welcome: 'Bienvenido'
   },
   pt: <PoPageLoginLiterals>{
     title: 'Bem-vindo',
@@ -96,7 +98,8 @@ export const poPageLoginLiteralsDefault = {
     attempts: '{0} vez(es) ',
     yourUserWillBeBlocked: 'sem sucesso seu usuário será bloqueado e você fica 24 horas sem poder acessar :(',
     createANewPasswordNow: 'Melhor criar uma senha nova agora! Você vai poder entrar no sistema logo em seguida.',
-    iForgotMyPassword: 'Esqueci minha senha'
+    iForgotMyPassword: 'Esqueci minha senha',
+    welcome: 'Boas-vindas'
   },
   ru: <PoPageLoginLiterals>{
     title: 'Добро пожаловать!',
@@ -121,7 +124,8 @@ export const poPageLoginLiteralsDefault = {
     attempts: '{0} раз(а) ',
     yourUserWillBeBlocked: 'Ваш пользователь будет заблокирован, и Вы останетесь на 24 часа без возможности доступа :(',
     createANewPasswordNow: 'Лучше создайте новый пароль сейчас! Вы сможете сразу войти в систему.',
-    iForgotMyPassword: 'Я забыл свой пароль'
+    iForgotMyPassword: 'Я забыл свой пароль',
+    welcome: 'добро пожаловать'
   }
 };
 
@@ -130,13 +134,6 @@ export const poPageLoginLiteralIn = {
   es: 'en',
   pt: 'em',
   ru: 'в'
-};
-
-export const poPageLoginLiteralTo = {
-  en: 'to',
-  es: 'al',
-  pt: 'ao',
-  ru: 'к'
 };
 
 /**
@@ -319,12 +316,7 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
    *
    * @description
    *
-   * Valor customizado que sucede o título de boas-vindas.
-   *
-   * > Esta propriedade é sobreposta se `p-literals` contiver uma definição customizada para a literal `title`.
-   *
-   * > Veja mais sobre as literais na propriedade `p-literals`.
-   *
+   * Texto customizado que fica entre a logo e a mensagem de boas-vindas.
    */
   @Input('p-product-name') set productName(value: string) {
     this._productName = value;
@@ -416,7 +408,7 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
    *    highlightInfo: '',
    *    iForgotMyPassword: 'Esqueci minha senha',
    *    ifYouTryHarder: 'Se tentar mais ',
-   *    title: 'Seja bem-vindo',
+   *    welcome: 'Boas-vindas',
    *    loginErrorPattern: 'Login obrigatório',
    *    loginHint: 'Caso não possua usuário entre em contato com o suporte',
    *    loginLabel: 'Insira seu usuário',
@@ -853,13 +845,10 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
       ? this.concatenateLoginHintWithContactEmail(this.contactEmail)
       : undefined;
 
-    const titleWithProductName = this.productName ? this.concatenateTitleWithProductName(this.productName) : undefined;
-
     return {
       ...poPageLoginLiteralsDefault[poLocaleDefault],
       ...poPageLoginLiteralsDefault[this.language],
       ...loginHintWithContactEmail,
-      ...titleWithProductName,
       ...this.literals
     };
   }
@@ -943,8 +932,6 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
   }
 
   protected abstract concatenateLoginHintWithContactEmail(contactEmail: string);
-
-  protected abstract concatenateTitleWithProductName(productName: string);
 
   protected abstract setLoginErrors(value: Array<string>): void;
 

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
@@ -7,10 +7,13 @@
   [p-secondary-logo]="secondaryLogo"
   (p-selected-language)="onSelectedLanguage($event)"
 >
-  <div class="po-page-login-header po-mb-2 po-mb-sm-1 po-pt-sm-1">
-    <div class="po-page-login-header-title po-mb-sm-1">{{ pageLoginLiterals.title }}</div>
-    <po-tag *ngIf="environment" p-type="warning" [p-value]="environment"> </po-tag>
-  </div>
+  <header class="po-page-login-header">
+    <h1 class="po-mb-md-4 po-mb-sm-1">
+      <div class="po-page-login-header-product-name">{{ productName || literals?.title }}</div>
+      <po-tag *ngIf="environment" p-type="warning" [p-value]="environment"> </po-tag>
+    </h1>
+    <div class="po-page-login-header-welcome po-mb-md-4 po-mb-sm-2">{{ pageLoginLiterals.welcome }}</div>
+  </header>
 
   <form #loginForm="ngForm" class="po-page-login-form">
     <div class="po-row">

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
@@ -22,7 +22,6 @@ import { PoPageLoginAuthenticationType } from './enums/po-page-login-authenticat
 import {
   PoPageLoginBaseComponent,
   poPageLoginLiteralIn,
-  poPageLoginLiteralTo,
   poPageLoginLiteralsDefault
 } from './po-page-login-base.component';
 import { PoPageLoginComponent } from './po-page-login.component';
@@ -779,24 +778,6 @@ describe('PoPageLoginComponent: ', () => {
       );
     });
 
-    it(`concatenateTitleWithProductName: should call 'concatenateLiteral'`, () => {
-      const title = 'email@mail.com';
-      const defaultTitleLiteral = poPageLoginLiteralsDefault[poLocaleDefault].title;
-      const prepositionLiteral = poPageLoginLiteralTo[poLocaleDefault];
-
-      spyOn(component, <any>'concatenateLiteral');
-      spyOnProperty(component, 'language').and.returnValue(poLocaleDefault);
-
-      component['concatenateTitleWithProductName'](title);
-
-      expect(component['concatenateLiteral']).toHaveBeenCalledWith(
-        title,
-        'title',
-        defaultTitleLiteral,
-        prepositionLiteral
-      );
-    });
-
     it(`concatenateLiteral: should call 'concatenate' and return expected value`, () => {
       const value = 'Portal RH';
       const currentLiteral = 'title';
@@ -853,12 +834,46 @@ describe('PoPageLoginComponent: ', () => {
       expect(button.innerHTML).toContain(poPageLoginLiteralsDefault.en.submittedLabel);
     });
 
-    it('should contain a `div` header with two `div` with the classes of messages.', () => {
-      const header = fixture.debugElement.nativeElement.querySelector('div.po-page-login-header');
-      const messages = fixture.debugElement.nativeElement.querySelectorAll('div.po-page-login-header > div');
+    it('should contain productName and welcome if productName and welcome are defined', () => {
+      const productName = 'custom product name';
+      const welcome = 'custom welcome';
 
-      expect(messages.length).toEqual(1);
-      expect(header.getElementsByClassName('po-page-login-header-title').length).toBeTruthy();
+      component.literals = { welcome };
+      component.productName = productName;
+
+      fixture.detectChanges();
+
+      const productNameElement = fixture.debugElement.nativeElement.querySelector('.po-page-login-header-product-name');
+      const welcomeElement = fixture.debugElement.nativeElement.querySelector('.po-page-login-header-welcome');
+
+      expect(productNameElement.innerText).toBe(productName);
+      expect(welcomeElement.innerText).toBe(welcome);
+    });
+
+    it('should contain value of title if productName is undefined', () => {
+      const title = 'custom title';
+      component.literals = { title };
+
+      component.productName = undefined;
+
+      fixture.detectChanges();
+
+      const productNameElement = fixture.debugElement.nativeElement.querySelector('.po-page-login-header-product-name');
+
+      expect(productNameElement.innerText).toBe(title);
+    });
+
+    it('should use value of productName if title and productName are defined', () => {
+      const productName = 'custom product name';
+      component.literals = { title: 'custom title' };
+
+      component.productName = productName;
+
+      fixture.detectChanges();
+
+      const productNameElement = fixture.debugElement.nativeElement.querySelector('.po-page-login-header-product-name');
+
+      expect(productNameElement.innerText).toBe(productName);
     });
 
     it('customField po-input: should have po-input when placeholder is filled and shouldn`t have po-select and po-combo.', () => {

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
@@ -19,7 +19,6 @@ import { PoModalPasswordRecoveryType } from '../po-modal-password-recovery/enums
 import {
   PoPageLoginBaseComponent,
   poPageLoginLiteralIn,
-  poPageLoginLiteralTo,
   poPageLoginLiteralsDefault
 } from './po-page-login-base.component';
 import { PoPageLoginRecovery } from './interfaces/po-page-login-recovery.interface';
@@ -228,13 +227,6 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
     const prepositionLiteral = poPageLoginLiteralIn[this.language];
 
     return this.concatenateLiteral(contactEmail, 'loginHint', defaultLoginHintLiteral, prepositionLiteral);
-  }
-
-  protected concatenateTitleWithProductName(productName: string) {
-    const defaultTitleLiteral = poPageLoginLiteralsDefault[this.language].title;
-    const prepositionLiteral = poPageLoginLiteralTo[this.language];
-
-    return this.concatenateLiteral(productName, 'title', defaultTitleLiteral, prepositionLiteral);
   }
 
   protected setLoginErrors(errors: Array<string>) {


### PR DESCRIPTION
**Page Login**

**DTHFUI-3709**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente o template concatenava a palavra "Bem-vindo" junto com o nome do produto. E se a literal `title` fosse adicionada
ele substituía o "bem-vindo + o nome do produto" pelo `title`.

**Qual o novo comportamento?**
- depreciado a propriedade `title`. Enquanto houver o suporte, o valor do `title` substituirá o valor do `p-product-name`, quando este não for preenchido. 
- criação da propriedade `welcome` que apresenta a mensagem bem-vindo
- p-product-name passa a aparecer no layout sem a concatenação com a palavra "bem-vindo".
- alterações visuais conforme o protótipo da issue.
- alteração em algumas tags semânticas visando uma melhor acessibilidade para leitores de tela. 


**Simulação**
- Testar com os samples do portal
- E as diferentes combinações com título, logo e nome do produto.

**Validar:**
[PR Style](https://github.com/po-ui/po-style/pull/126) e [Tema customizado](https://github.com/totvs/po-theme-totvs/pull/46)