### PR TITLE
feat(components): implementa ng update para versão 3 

### DIFF
--- a/docs/guides/migration-poui-v2.md
+++ b/docs/guides/migration-poui-v2.md
@@ -8,7 +8,7 @@ Este guia contém informações sobre a migração do seu projeto para a versão
 Antes de atualizar a versão do PO UI, é importante que você tenha atualizado o seu projeto para
 o Angular 9, executando o comando abaixo:
 
-``` ng update @angular/cli @angular/core ```
+``` ng update @angular/cli@9 @angular/core@9 ```
 
 > Para realizar a migração completa e avaliar se não precisa fazer alguma alteração veja o [**Guia de Upgrade do Angular**](https://update.angular.io/).
 
@@ -34,7 +34,7 @@ Mas é importante conhecer os **BREAKING CHANGES** e **Depreciações** para rea
 
 Para poder utilizar o comando e realizar a migração, execute os comandos abaixo:
 
-``` npm i --save @po-ui/ng-components ```
+``` npm i --save @po-ui/ng-components@2 ```
 
 ``` ng update @po-ui/ng-components --from 1 --migrate-only ```
 
@@ -153,7 +153,7 @@ Exemplo funções via *property bind*
 
 Para poder utilizar o comando e realizar a migração, execute os comandos abaixo:
 
-``` npm i --save @po-ui/ng-sync ```
+``` npm i --save @po-ui/ng-sync@2 ```
 
 ``` ng update @po-ui/ng-sync --from 1 --migrate-only ```
 

--- a/docs/guides/migration-poui-v3.md
+++ b/docs/guides/migration-poui-v3.md
@@ -1,0 +1,220 @@
+[comment]: # (@label Migração do PO UI para V3)
+[comment]: # (@link guides/migration-poui-v3)
+
+Este guia contém informações sobre a migração do seu projeto para a versão 3 do PO UI.
+
+> Caso você estiver utilizando a v1, veja o guia [**Migração do PO UI para V2**](guides/migration-poui-v2).
+
+## Atualizando o projeto com Angular
+
+Antes de atualizar a versão do PO UI, é importante que você tenha atualizado o seu projeto para
+o Angular 10, executando o comando abaixo:
+
+``` ng update @angular/cli @angular/core ```
+
+> Para realizar a migração completa e avaliar se não precisa fazer alguma alteração veja o [**Guia de Upgrade do Angular**](https://update.angular.io/).
+
+O nosso pacote anterior possuía dependências que eram compatíveis com a versão 9 do Angular, portanto
+pode ser preciso utilizar a *flag* `--force` para que o Angular realize a migração do seu projeto, ignorando a versão das dependências.
+Para avaliar as *flags* disponíveis veja a [**documentação do ng update**](https://angular.io/cli/update).
+
+## Atualizando o PO UI
+
+Para facilitar a migração do seu projeto para o PO UI v3, implementamos o `ng update` nos pacotes abaixo:
+
+- [**@po-ui/ng-components**](guides/migration-poui-v3#components)
+- [**@po-ui/ng-sync**](guides/migration-poui-v3#sync)
+
+
+<a id="components"></a>
+### ng update @po-ui/ng-components
+
+Para realizar a migração, execute o comando abaixo:
+
+``` ng update @po-ui/ng-components --next```
+
+O `ng update` ajudará nas alterações necessárias para seu projeto seguir atualizado, que são elas:
+  - Altera o uso do `[p-checkbox]` para `[p-selectable`] utilizado no `PoTable`
+  - Atualizar as versões dos pacotes:
+    - `@po-ui/ng-componentes`;
+    - `@po-ui/ng-templates`;
+    - `@po-ui/ng-code-editor`;
+    - `@po-ui/ng-storage`;
+    - `@po-ui/ng-sync`;
+    - `@po-ui/ng-tslint`;
+    - `@po-ui/style`;
+
+#### Breaking Changes
+
+<b> Propriedades e Eventos </b>
+
+Remoção das propriedades, onde passam a valer as novas definições, veja a tabela abaixo:
+
+<div class="po-row">
+  <div class="po-sm-12">
+    <table class="po-table">
+      <thead>
+        <tr class="po-table-header">
+          <th class="po-table-header-ellipsis">Componentes</th>
+          <th class="po-table-header-ellipsis">Anteriormente</th>
+          <th class="po-table-header-ellipsis">Substituído por</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="po-table-row">
+          <td class="po-table-column">
+            <a href="/documentation/po-table"><strong>PoTable</strong></a>
+          </td>
+          <td class="po-table-column">
+            [p-checkbox]
+          </td>
+          <td class="po-table-column">
+            [p-selectable]
+          </td>
+        </tr>
+        <tr class="po-table-row">
+          <td class="po-table-column">
+          <a href="/documentation/po-lookup"><strong>PoLookupFilter</strong></a>
+          </td>
+          <td class="po-table-column"> getFilteredData(search, page, pageSize)
+          </td>
+          <td class="po-table-column"> getFilteredItems(params: PoLookupFilteredParams)
+          </td>
+        </tr>
+        <tr class="po-table-row">
+          <td class="po-table-column">
+          <a href="/documentation/po-upload"><strong>PoUploadLiterals</strong></a>
+          </td>
+          <td class="po-table-column"> cancel, deleteFile e tryAgain
+          </td>
+          <td>
+            Não se aplica.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<b> Passar referencia das funções sem .bind ou via string </b>
+
+Até a versão `2.x.x` era possível passar funções para nossas propriedades sem informar o `.bind(this)`,
+pois capturávamos o componente pai e conseguíamos acessar o contexto corrente. Porém depreciamos este comportamento,
+agora necessita passar a referência da função utilizando o `.bind(this)` para que o mesmo execute
+a função no contexto invocado, tanto em funções dentro de *arrays* quanto em funções via *property bind*.
+
+Os componentes que sofrerão este *breaking change*, são:
+- [**PageChangePassword**](http://po-ui.io/documentation/po-page-change-password)
+- [**ButtonGroup**](http://po-ui.io/documentation/po-button-group)
+- [**Menu**](http://po-ui.io/documentation/po-menu)
+- [**MenuPanel**](http://po-ui.io/documentation/po-menu-panel)
+- [**Navbar**](http://po-ui.io/documentation/po-navbar)
+- [**PageList**](http://po-ui.io/documentation/po-page-list)
+- [**PageDefault**](http://po-ui.io/documentation/po-page-default)
+- [**Popup**](http://po-ui.io/documentation/po-popup)
+- [**Stepper**](http://po-ui.io/documentation/po-step)
+- [**Table**](http://po-ui.io/documentation/po-table)
+- [**Toolbar**](http://po-ui.io/documentation/po-toolbar)
+
+Abaixo listamos dois exemplos comparativos com essas depreciações em alguns componentes.
+
+Exemplo via funções dentro de arrays:
+- Antes:
+
+```
+<po-page-default p-title="Página" [p-actions]="actions">
+   ...
+</po-page-default>
+```
+
+```
+export class ExampleFunction () {
+
+  actions: Array<PoPageAction> = [
+    { label: 'Adicionar', action: this.add }
+  ]
+
+  add() {
+    ...
+  }
+}
+```
+
+- Agora:
+
+```
+<po-page-default p-title="Página" [p-actions]="actions">
+   ...
+</po-page-default>
+```
+
+```
+export class ExampleFunction () {
+
+  actions: Array<PoPageAction> = [
+    { label: 'Adicionar', action: this.add.bind(this) }
+  ]
+
+  add() {
+    ...
+  }
+}
+```
+
+Exemplo funções via *property bind*
+- Antes:
+```
+<po-stepper>
+  <po-step p-label="Personal" [p-can-active-next-step]="canActiveNextStep">
+  </po-step>
+</po-stepper>
+```
+
+- Agora:
+```
+<po-stepper>
+  <po-step p-label="Personal" [p-can-active-next-step]="canActiveNextStep.bind(this)">
+  </po-step>
+</po-stepper>
+```
+
+#### Depreciação
+
+Depreciado a propriedade `PoPageFilter.ngModel` no componente [**PoPageList**](/documentation/po-page-list), onde o valor pesquisado será possível recuperar através do parametro a ser recebido no evento `PoPageFilter.onAction`.
+
+<a id="sync"></a>
+### ng update @po-ui/ng-sync
+
+> Caso você também utilize `@po-ui/ng-components` não há necessidade de executar o *ng update* do `@po-ui/ng-sync`.
+
+Para realizar a migração, execute o comando abaixo:
+
+``` ng update @po-ui/ng-sync --next```
+
+O `ng update` ajudará nas alterações necessárias para seu projeto, que será atualizar as versões dos pacotes:
+  - `@po-ui/ng-sync`;
+  - `@po-ui/ng-storage`;
+  - `@po-ui/ng-tslint`;
+
+#### Breaking Change
+
+A remoção ocorreu no retorno do `Endpoint de sincronização`, onde anteriomente deveria retornar a data da última sincronização
+na propriedade `portinari_sync_date`, que agora passa a ser exclusivamente `po_sync_date`, veja o antes e depois:
+
+```
+{
+  "hasNext": false,
+  "items": [],
+  "portinari_sync_date": "2018-10-08T13:57:55.008Z"
+}
+```
+
+A propriedade `portinari_sync_date` foi removida e a correta propriedade é:
+
+```
+{
+  "hasNext": false,
+  "items": [],
+  "po_sync_date": "2018-10-08T13:57:55.008Z"
+}
+```

--- a/projects/schematics/src/package-config/index.ts
+++ b/projects/schematics/src/package-config/index.ts
@@ -1,1 +1,2 @@
 export * from './package-config';
+export * from './update-dependencies.interface';

--- a/projects/schematics/src/package-config/package-config.ts
+++ b/projects/schematics/src/package-config/package-config.ts
@@ -1,5 +1,7 @@
 import { Tree } from '@angular-devkit/schematics';
 
+import { UpdateDependencies } from './update-dependencies.interface';
+
 /** Adds a package to the package.json in the given host tree. */
 export function addPackageToPackageJson(host: Tree, pkg: string, version: string): Tree {
   if (host.exists('package.json')) {
@@ -19,6 +21,39 @@ export function addPackageToPackageJson(host: Tree, pkg: string, version: string
   }
 
   return host;
+}
+
+// Atualiza os pacotes pela versão
+export function updatePackageJson(version: string, { dependencies, devDependencies }: UpdateDependencies) {
+  return (tree: Tree): Tree => {
+    if (tree.exists('package.json')) {
+      const sourceText = tree.read('package.json')!.toString('utf-8');
+      const json = JSON.parse(sourceText);
+
+      if (!json.dependencies) {
+        json.dependencies = {};
+      }
+
+      dependencies?.forEach(pkg => {
+        if (json.dependencies[pkg]) {
+          json.dependencies[pkg] = version;
+        }
+      });
+
+      devDependencies?.forEach(pkg => {
+        if (json.devDependencies[pkg]) {
+          json.devDependencies[pkg] = version;
+        }
+      });
+
+      json.dependencies = sortObjectByKeys(json.dependencies);
+      json.devDependencies = sortObjectByKeys(json.devDependencies);
+
+      tree.overwrite('package.json', JSON.stringify(json, null, 2));
+    }
+
+    return tree;
+  };
 }
 
 /** Gets the version of the specified package by looking at the package.json in the given tree. */

--- a/projects/schematics/src/package-config/update-dependencies.interface.ts
+++ b/projects/schematics/src/package-config/update-dependencies.interface.ts
@@ -1,0 +1,5 @@
+export interface UpdateDependencies {
+  dependencies: Array<string>;
+
+  devDependencies?: Array<string>;
+}

--- a/projects/sync/schematics/migrations.json
+++ b/projects/sync/schematics/migrations.json
@@ -7,7 +7,7 @@
       "factory": "./ng-update/v2/index#updateToV2"
     },
     "migration-v3": {
-      "version": "3",
+      "version": "3.0.0-beta.1",
       "description": "Atualiza @po-ui/ng-sync para v3",
       "factory": "./ng-update/v3/index#updateToV3"
     }

--- a/projects/sync/schematics/migrations.json
+++ b/projects/sync/schematics/migrations.json
@@ -5,6 +5,11 @@
       "version": "2",
       "description": "Atualiza @po-ui/ng-sync para v2",
       "factory": "./ng-update/v2/index#updateToV2"
+    },
+    "migration-v3": {
+      "version": "3",
+      "description": "Atualiza @po-ui/ng-sync para v3",
+      "factory": "./ng-update/v3/index#updateToV3"
     }
   }
 }

--- a/projects/sync/schematics/ng-update/v3/changes.ts
+++ b/projects/sync/schematics/ng-update/v3/changes.ts
@@ -1,0 +1,13 @@
+import { UpdateDependencies } from '@po-ui/ng-schematics/package-config';
+
+export const updateDepedenciesVersion: UpdateDependencies = {
+  dependencies: [
+    '@po-ui/ng-components',
+    '@po-ui/ng-code-editor',
+    '@po-ui/ng-templates',
+    '@po-ui/ng-storage',
+    '@po-ui/ng-sync',
+    '@po-ui/style'
+  ],
+  devDependencies: ['@po-ui/ng-tslint']
+};

--- a/projects/sync/schematics/ng-update/v3/index.ts
+++ b/projects/sync/schematics/ng-update/v3/index.ts
@@ -1,0 +1,16 @@
+import { chain, Tree, SchematicContext } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+
+import { updatePackageJson } from '@po-ui/ng-schematics/package-config';
+
+import { updateDepedenciesVersion } from './changes';
+
+export function updateToV3() {
+  return chain([updatePackageJson('0.0.0-PLACEHOLDER', updateDepedenciesVersion), postUpdate()]);
+}
+
+function postUpdate() {
+  return (_: Tree, context: SchematicContext) => {
+    context.addTask(new NodePackageInstallTask());
+  };
+}

--- a/projects/ui/schematics/migrations.json
+++ b/projects/ui/schematics/migrations.json
@@ -5,6 +5,11 @@
       "version": "2",
       "description": "Atualiza @po-ui/ng-components para v2",
       "factory": "./ng-update/v2/index#updateToV2"
+    },
+    "migration-v3": {
+      "version": "3.0.0-beta.1",
+      "description": "Atualiza @po-ui/ng-components para v3",
+      "factory": "./ng-update/v3/index#updateToV3"
     }
   }
 }

--- a/projects/ui/schematics/ng-update/v3/changes.ts
+++ b/projects/ui/schematics/ng-update/v3/changes.ts
@@ -1,0 +1,21 @@
+import { ReplaceChanges } from '@po-ui/ng-schematics/replace';
+import { UpdateDependencies } from '@po-ui/ng-schematics/package-config';
+
+export const replaceChanges: Array<ReplaceChanges> = [
+  {
+    replace: 'p-checkbox',
+    replaceWith: 'p-selectable'
+  }
+];
+
+export const updateDepedenciesVersion: UpdateDependencies = {
+  dependencies: [
+    '@po-ui/ng-components',
+    '@po-ui/ng-code-editor',
+    '@po-ui/ng-templates',
+    '@po-ui/ng-storage',
+    '@po-ui/ng-sync',
+    '@po-ui/style'
+  ],
+  devDependencies: ['@po-ui/ng-tslint']
+};

--- a/projects/ui/schematics/ng-update/v3/index.ts
+++ b/projects/ui/schematics/ng-update/v3/index.ts
@@ -1,0 +1,77 @@
+import { chain, Tree, SchematicContext } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+
+import { ReplaceChanges } from '@po-ui/ng-schematics/replace';
+import { getWorkspaceConfigGracefully } from '@po-ui/ng-schematics/project';
+import { updatePackageJson } from '@po-ui/ng-schematics/package-config';
+
+import { replaceChanges, updateDepedenciesVersion } from './changes';
+
+export function updateToV3() {
+  return chain([updatePackageJson('0.0.0-PLACEHOLDER', updateDepedenciesVersion), createUpgradeRule(), postUpdate()]);
+}
+
+function postUpdate() {
+  return (_: Tree, context: SchematicContext) => {
+    context.addTask(new NodePackageInstallTask());
+  };
+}
+
+function createUpgradeRule() {
+  return (tree: Tree, context: SchematicContext) => {
+    const logger = context.logger;
+    const workspace = getWorkspaceConfigGracefully(tree);
+
+    if (workspace === null) {
+      logger.error('Não foi possível encontrar o arquivo de configuração de workspace.');
+      return;
+    }
+
+    const projectNames = Object.keys(workspace.projects);
+    for (const projectName of projectNames) {
+      const project = workspace.projects[projectName];
+      const entryFolderProject = project.projectType === 'library' ? 'lib' : 'app';
+      const sourceDir = `${project.sourceRoot}/${entryFolderProject}`;
+
+      applyUpdateInContent(tree, sourceDir);
+    }
+  };
+}
+
+function applyUpdateInContent(tree: Tree, path: string) {
+  const directory = tree.getDir(path);
+  if (directory.subfiles.length) {
+    directory.subfiles.forEach(file => {
+      const filePath = path + '/' + file;
+      const content = tree.read(filePath)!.toString('utf-8');
+      if (!content) {
+        return;
+      }
+
+      let updated = content;
+
+      if (file.endsWith('.html') || file.endsWith('.ts')) {
+        updated = replaceWithChanges(replaceChanges, updated);
+
+        if (updated !== content) {
+          tree.overwrite(filePath, updated);
+        }
+      }
+    });
+  }
+
+  if (directory.subdirs.length) {
+    directory.subdirs.forEach(subDir => {
+      applyUpdateInContent(tree, path + '/' + subDir);
+    });
+  }
+}
+
+function replaceWithChanges(replaces: Array<ReplaceChanges>, content: string = '') {
+  replaces.forEach(({ replace, replaceWith }) => {
+    const regex = new RegExp(replace, 'gi');
+    content = content.replace(regex, <string>replaceWith);
+  });
+
+  return content;
+}


### PR DESCRIPTION
**Ng Update: Components e Sync**

**DTHFUI-3715**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
N/A

**Qual o novo comportamento?**
- Implementa ng update nos pacotes `@po-ui/ng-components` e `@po-ui/ng-sync`.
- Cria documento de migração para v3, neste documento possui as alterações que serão realizadas.


**Simulação**
[projeto-ngv10-pov2.zip](https://github.com/po-ui/po-angular/files/4938008/projeto-ngv10-pov2.zip)
[projeto-posync-v2.zip](https://github.com/po-ui/po-angular/files/4938406/new-po-sync-getting-started.zip)

- Buildar os pacotes com a versão 3
- Publicar localmente no verdaccio
- Executar o `ng update @po-ui/ng-components` em um projeto que possui o @po-ui/ng-components instalado na v2
- Executar o `ng update @po-ui/ng-sync` em um projeto que possui o @po-ui/ng-sync instalado na v2