### PR TITLE
docs: atualiza changelog com informações do angular 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### ⚠ BREAKING CHANGES
 
+* **angular:** atualiza para a versão 10
+
+Atualize seu projeto para utilizar a versão 10 do Angular, acesse a documentação [**Guia de Atualização do Angular**](https://update.angular.io/) para fazer a migração completa.
+
+Veja nossa [**documentação para fazer a migração**](https://github.com/po-ui/po-angular/blob/master/docs/guides/migration-poui-v3.md) para a versão 3.
+
 * **sync:** remove suporte portinari_sync_date
 
 Antes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ Foi removida a propriedade p-size do componente.
 
 Fixes DTHFUI-225
 
-BREAKING CHANGES: removida propriedade p-size
+BREAKING CHANGE: removida propriedade p-size
 
 Foi removida a propriedade p-size do po-button pois o mesmo deve ser
 definido através do uso das classes de grid do PO UI.


### PR DESCRIPTION
docs: atualiza changelog com informações do angular 10

docs(contributing): corrige descrição do commit com breaking change
Para gerar o release e capturar corretamente as quebras de versão,
o corpo do commit deve ter:
BREAKING CHANGE ao invés de
BREAKING CHANGES
