### PR TITLE
fix(schematics): corrige erro ao executar o ng generate

### DIFF
--- a/docs/guides/sync-fundamentals.md
+++ b/docs/guides/sync-fundamentals.md
@@ -141,7 +141,7 @@ Você pode utilizar um schematic para criar o arquivo com a estrutura básica do
 Para isso utilize o comando
 
 ```shell
-ng generate @po-ui/ng-sync:sync
+ng generate @po-ui/ng-sync:schema
 ```
 
 Você também pode informar um caminho completo.

--- a/projects/schematics/src/build-component/build-component.ts
+++ b/projects/schematics/src/build-component/build-component.ts
@@ -10,7 +10,6 @@ import {
   filter,
   noop
 } from '@angular-devkit/schematics';
-import { buildDefaultPath } from '@schematics/angular/utility/workspace';
 import { buildRelativePath, findModuleFromOptions } from '@schematics/angular/utility/find-module';
 import { getWorkspace } from '@schematics/angular/utility/config';
 import { normalize, strings } from '@angular-devkit/core';
@@ -18,7 +17,7 @@ import { parseName } from '@schematics/angular/utility/parse-name';
 import { validateHtmlSelector, validateName } from '@schematics/angular/utility/validation';
 
 import { supportedCssExtensions } from '../utils/supported-css-extensions';
-import { getProjectFromWorkspace } from '../project';
+import { getProjectFromWorkspace, getDefaultPath } from '../project';
 import { addModuleImportToModule, addDeclarationComponentToModule, addExportComponentToModule } from '../module';
 import { Schema as ComponentOptions } from './schema';
 
@@ -28,7 +27,7 @@ export function buildComponent(options: ComponentOptions): Rule {
     const project: any = getProjectFromWorkspace(workspace, options.project);
 
     if (options.path === undefined && project) {
-      options.path = buildDefaultPath(project);
+      options.path = getDefaultPath(project);
     }
 
     options.module = findModuleFromOptions(host, options);

--- a/projects/schematics/src/build-file/build-file.ts
+++ b/projects/schematics/src/build-file/build-file.ts
@@ -1,12 +1,11 @@
 import { apply, applyTemplates, chain, mergeWith, move, Rule, url, Tree } from '@angular-devkit/schematics';
 
-import { buildDefaultPath } from '@schematics/angular/utility/workspace';
 import { getWorkspace } from '@schematics/angular/utility/config';
 import { strings } from '@angular-devkit/core';
 import { parseName } from '@schematics/angular/utility/parse-name';
 import { validateName } from '@schematics/angular/utility/validation';
 
-import { getProjectFromWorkspace } from '../project';
+import { getProjectFromWorkspace, getDefaultPath } from '../project';
 import { FileOptions } from './file-options.interface';
 
 export function buildFile(options: FileOptions): Rule {
@@ -15,7 +14,7 @@ export function buildFile(options: FileOptions): Rule {
     const project: any = getProjectFromWorkspace(workspace, options.project);
 
     if (options.path === undefined && project) {
-      options.path = buildDefaultPath(project);
+      options.path = getDefaultPath(project);
     }
 
     const parsedPath = parseName(options.path as string, options.name);

--- a/projects/schematics/src/project/project.ts
+++ b/projects/schematics/src/project/project.ts
@@ -60,3 +60,11 @@ export function getProjectMainFile(project: WorkspaceProject): string {
 
   return buildOptions.main;
 }
+
+// Return default path of application or library
+export function getDefaultPath(project: WorkspaceProject) {
+  const root = project.sourceRoot ? `/${project.sourceRoot}/` : `/${project.root}/src/`;
+  const projectDirName = project.projectType === 'application' ? 'app' : 'lib';
+
+  return `${root}${projectDirName}`;
+}


### PR DESCRIPTION
**Schematics**

**DTHFUI-3832**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ocorria erro ao executar o ng generate nos pacotes:
@po-ui/ng-sync
@po-ui/ng-components
@po-ui/templates

_Cannot read "ProjectType" of undefined._

**Qual o novo comportamento?**
Para corrigir o problema foi criado uma função no pacote @po-ui/ng-schematics
Que recupera o default path corretamente.

**Simulação**
- Buildar pacotes, utilizar npm link nos schematics, components, templates e sync.
- Rodar ng generate passando o projeto ou definir o projeto default como "app" no angular.json
   - ng g @po-ui/ng-components:po-page-list listagem --project app

ou também publicar no verdaccio os pacotes  e testar em uma aplicação basica.
- ng new projetov10
- cd projetov10
- ng add @po-ui/ng-components
- ng g @po-ui/ng-components:po-page-list data-list

