### PR TITLE
fix(table): corrige no sample o uso da propriedade showMoreDisabled

### DIFF
--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -12,7 +12,7 @@
   [p-loading]="properties.includes('loading')"
   [p-max-columns]="maxColumns"
   [p-selectable]="selection.includes('selectable')"
-  [p-show-more-disabled]="!properties.includes('showMoreDisabled')"
+  [p-show-more-disabled]="properties.includes('showMoreDisabled')"
   [p-single-select]="selection.includes('singleSelect')"
   [p-sort]="properties.includes('sort')"
   [p-striped]="properties.includes('striped')"


### PR DESCRIPTION
**TABLE**

**DTHFUI-3857**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

No Sample Po Table Labs o uso da propriedade p-show-more-disabled
esta incorreto.

**Qual o novo comportamento?**
Quando marcar a opção "Show more disabled" deve desabilitar o botão de "carregar mais resultados", e
Quando desmarcar deve habilitar o botão "carregar mais resultados".

**Simulação**
Sample Po Table Labs