### PR TITLE
fix(multiselect): corrige desaparecimento do campo de pesquisa

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
@@ -9,12 +9,12 @@
   </po-multiselect-search>
 
   <ul class="po-multiselect-items-container" [scrollTop]="scrollTop" #ulElement>
-    <div *ngIf="!options.length" class="po-multiselect-container-no-data po-text-center">
+    <div *ngIf="!visibleOptions.length" class="po-multiselect-container-no-data po-text-center">
       <span> {{ literals.noData }}</span>
     </div>
 
     <po-multiselect-item
-      *ngFor="let option of options"
+      *ngFor="let option of visibleOptions"
       [p-label]="option.label"
       [p-selected]="isSelectedItem(option)"
       (p-change)="clickItem($event, option)"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.spec.ts
@@ -196,9 +196,18 @@ describe('PoMultiselectDropdownComponent:', () => {
       expect(fixture.nativeElement.querySelector('.po-multiselect-container-no-data')).toBeTruthy();
     });
 
-    it('shouldn`t show `Nenhum dado encontrado` if have options', () => {
+    it('should show `Nenhum dado encontrado` if no have visibleOptions', () => {
+      component.visibleOptions = [];
       component.show = true;
 
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.po-multiselect-container-no-data')).toBeTruthy();
+    });
+
+    it('shouldn`t show `Nenhum dado encontrado` if have visibleOptions', () => {
+      component.show = true;
+      component.visibleOptions = [{ value: '1', label: 'Option 1' }];
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('.po-multiselect-container-no-data')).toBeNull();
@@ -207,10 +216,23 @@ describe('PoMultiselectDropdownComponent:', () => {
     it('should show `po-multiselect-search` if have options and hideSearch is false', () => {
       component.options = [{ value: '1', label: 'Option 1' }];
       component.hideSearch = false;
+      component.visibleOptions = [{ value: '1', label: 'Option 1' }];
 
       fixture.detectChanges();
 
       expect(fixture.debugElement.query(By.css('po-multiselect-search'))).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('.po-multiselect-container-no-data')).toBeNull();
+    });
+
+    it('should show `po-multiselect-search` and `Nenhum dado encontrado` if have options, hideSearch is false and visibleOptions is empty', () => {
+      component.options = [{ value: '1', label: 'Option 1' }];
+      component.hideSearch = false;
+      component.visibleOptions = [];
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('po-multiselect-search'))).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('.po-multiselect-container-no-data')).toBeTruthy();
     });
 
     it('shouldn`t show `po-multiselect-search` if haven`t options', () => {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
@@ -31,8 +31,11 @@ export class PoMultiselectDropdownComponent {
   /** Propriedade que recebe a lista de opções selecionadas. */
   @Input('p-selected-values') selectedValues: Array<any> = [];
 
-  /** Propriedade que recebe a lista de opções que deverão ser criadas no dropdown. */
+  /** Propriedade que recebe a lista com todas as opções. */
   @Input('p-options') options: Array<PoMultiselectOption> = [];
+
+  /** Propriedade que recebe a lista de opções que deverão ser criadas no dropdown. */
+  @Input('p-visible-options') visibleOptions: Array<PoMultiselectOption> = [];
 
   /** Evento disparado a cada tecla digitada na pesquisa. */
   @Output('p-change-search') changeSearch = new EventEmitter();

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -39,7 +39,8 @@
     #dropdownElement
     [p-hide-search]="hideSearch"
     [p-literals]="literals"
-    [p-options]="visibleOptionsDropdown"
+    [p-options]="options"
+    [p-visible-options]="visibleOptionsDropdown"
     [p-selected-values]="getValuesFromOptions(selectedOptions)"
     [p-placeholder-search]="placeholderSearch"
     (p-change)="changeItems($event)"


### PR DESCRIPTION
**PO-MULTISELECT**

**DTHFUI-3825**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao realizar uma busca que não retorne itens o campo de pesquisa desaparece. Caso o usuário queira refazer a busca ele precisa fechar o dropdown e reiniciar o processo. 

**Qual o novo comportamento?**
Ao realizar uma busca que não retorne itens o campo de busca permanece na tela, permitindo que o usuário refaça a busca.

**Simulação**
Nos samples do portal.