### PR TITLE
feat(page-login): adiciona botão de suporte

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
@@ -94,4 +94,7 @@ export interface PoPageLoginLiterals {
 
   /** Mensagem de "Boas-vindas" para o usuário que aparece acima dos campos de entrada. */
   welcome?: string;
+
+  /** Label do botão de suporte. */
+  support?: string;
 }

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -46,7 +46,8 @@ export const poPageLoginLiteralsDefault = {
       'without success your user will be blocked and you will be left 24 hours without being able to access :(',
     createANewPasswordNow: 'Better create a new password now! You will be able to log into the system right away.',
     iForgotMyPassword: 'I forgot my password',
-    welcome: 'Welcome'
+    welcome: 'Welcome',
+    support: 'Support'
   },
   es: <PoPageLoginLiterals>{
     title: 'Bienvenido',
@@ -73,7 +74,8 @@ export const poPageLoginLiteralsDefault = {
     createANewPasswordNow:
       '¡Mejor crear una nueva contraseña ahora! Usted podrá entrar en el sistema inmediatamente después.',
     iForgotMyPassword: 'Olvide mi contraseña',
-    welcome: 'Bienvenido'
+    welcome: 'Bienvenido',
+    support: 'Soporte'
   },
   pt: <PoPageLoginLiterals>{
     title: 'Bem-vindo',
@@ -99,7 +101,8 @@ export const poPageLoginLiteralsDefault = {
     yourUserWillBeBlocked: 'sem sucesso seu usuário será bloqueado e você fica 24 horas sem poder acessar :(',
     createANewPasswordNow: 'Melhor criar uma senha nova agora! Você vai poder entrar no sistema logo em seguida.',
     iForgotMyPassword: 'Esqueci minha senha',
-    welcome: 'Boas-vindas'
+    welcome: 'Boas-vindas',
+    support: 'Suporte'
   },
   ru: <PoPageLoginLiterals>{
     title: 'Добро пожаловать!',
@@ -125,7 +128,8 @@ export const poPageLoginLiteralsDefault = {
     yourUserWillBeBlocked: 'Ваш пользователь будет заблокирован, и Вы останетесь на 24 часа без возможности доступа :(',
     createANewPasswordNow: 'Лучше создайте новый пароль сейчас! Вы сможете сразу войти в систему.',
     iForgotMyPassword: 'Я забыл свой пароль',
-    welcome: 'добро пожаловать'
+    welcome: 'добро пожаловать',
+    support: 'Поддержка'
   }
 };
 
@@ -193,6 +197,7 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
   private _productName: string;
   private _recovery: string | PoPageLoginRecovery | Function;
   private _registerUrl: string;
+  private _support: string | Function;
 
   /**
    * @optional
@@ -805,6 +810,32 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
 
   get blockedUrl(): string {
     return this._blockedUrl;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Exibe um botão para suporte.
+   *
+   * A propriedade aceita os seguintes tipos:
+   *
+   * - **String**: URL externa ou uma rota válida;
+   * - **Function**: Função a ser disparada ao clicar no botão de suporte;
+   * ```
+   * <po-page-login>
+   *   [p-support]="this.mySupport.bind(this)">
+   * </po-page-login>
+   * ```
+   *
+   */
+  @Input('p-support') set support(value: string | Function) {
+    this._support = value;
+  }
+
+  get support() {
+    return this._support;
   }
 
   /**

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
@@ -1,3 +1,8 @@
+<button class="po-page-login-support" (click)="activateSupport()" [hidden]="!support">
+  <span class="po-icon po-icon-help"></span>
+  {{ pageLoginLiterals?.support }}
+</button>
+
 <po-page-background
   #pageLogin
   p-show-select-language

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
@@ -196,6 +196,28 @@ describe('PoPageLoginComponent: ', () => {
       expect(component['validateArrayChanges']).not.toHaveBeenCalled();
     });
 
+    it('activateSupport: should call setUrlRedirect if support is a string', () => {
+      const expectedValue = '/string';
+      component.support = expectedValue;
+      spyOn(component, <any>'setUrlRedirect');
+
+      component.activateSupport();
+
+      expect(component['setUrlRedirect']).toHaveBeenCalledWith(expectedValue);
+    });
+
+    it('activateSupport: should call support if it is a function', () => {
+      component.support = () => {};
+
+      spyOn(component, <any>'setUrlRedirect');
+      spyOn(component, <any>'support');
+
+      component.activateSupport();
+
+      expect(component.support).toHaveBeenCalled();
+      expect(component['setUrlRedirect']).not.toHaveBeenCalled();
+    });
+
     describe('changePasswordModel:', () => {
       it('should call `setPasswordErrors` with `passwordErrors`', () => {
         const errors = ['error'];
@@ -815,21 +837,21 @@ describe('PoPageLoginComponent: ', () => {
 
     it('Loading: should disabled button when property is `true`.', () => {
       switchLoading(true);
-      const button = fixture.debugElement.nativeElement.querySelector('button');
+      const button = fixture.debugElement.nativeElement.querySelector('.po-button-primary');
 
       expect(button.getAttribute('disabled')).not.toBeNull();
     });
 
     it('Label: should have label equal Enter on loading when `p-loading` is `false`.', () => {
       switchLoading(false);
-      const button = fixture.debugElement.nativeElement.querySelector('button');
+      const button = fixture.debugElement.nativeElement.querySelector('.po-button-primary');
 
       expect(button.innerHTML).toContain(poPageLoginLiteralsDefault.en.submitLabel);
     });
 
     it('Label: should set alternative label on loading when `p-loading` is `true`.', () => {
       switchLoading(true);
-      const button = fixture.debugElement.nativeElement.querySelector('button');
+      const button = fixture.debugElement.nativeElement.querySelector('.po-button-primary');
 
       expect(button.innerHTML).toContain(poPageLoginLiteralsDefault.en.submittedLabel);
     });
@@ -1043,6 +1065,37 @@ describe('PoPageLoginComponent: ', () => {
       const tag = nativeElement.querySelector('po-tag');
 
       expect(tag).toBeFalsy();
+    });
+  });
+
+  describe('support button', () => {
+    it('should show support button if support is a string', () => {
+      component.support = '/teste';
+
+      fixture.detectChanges();
+
+      const support = nativeElement.querySelector('.po-page-login-support');
+
+      expect(support).toBeTruthy();
+    });
+
+    it('should show support button if support is a function', () => {
+      component.support = () => {};
+
+      fixture.detectChanges();
+
+      const support = nativeElement.querySelector('.po-page-login-support');
+
+      expect(support).toBeTruthy();
+    });
+
+    it('shouldn`t show button if doesn`t have `support`', () => {
+      component.support = undefined;
+      fixture.detectChanges();
+
+      const support = nativeElement.querySelector('.po-page-login-support');
+
+      expect(support.hidden).toBeTruthy();
     });
   });
 });

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
@@ -88,6 +88,19 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
     this.checkingForRouteMetadata(this.activatedRoute.snapshot.data);
   }
 
+  activateSupport() {
+    switch (typeof this.support) {
+      case 'string': {
+        this.setUrlRedirect(this.support);
+        break;
+      }
+      case 'function': {
+        this.support();
+        break;
+      }
+    }
+  }
+
   changeLoginModel() {
     if (this.authenticationUrl) {
       this.loginErrors = [];

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-labs/sample-po-page-login-labs.component.html
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-labs/sample-po-page-login-labs.component.html
@@ -17,6 +17,7 @@
   [p-recovery]="recovery"
   [p-register-url]="registerUrl"
   [p-secondary-logo]="secondaryLogo"
+  [p-support]="support"
   (p-login-submit)="loginSubmit($event)"
 >
 </po-page-login>
@@ -96,11 +97,15 @@
   </div>
 
   <div class="po-row">
-    <po-input class="po-lg-4" name="background" [(ngModel)]="background" p-clean p-label="Background"> </po-input>
+    <po-input class="po-lg-6" name="background" [(ngModel)]="background" p-clean p-label="Background"> </po-input>
 
-    <po-input class="po-lg-4" name="recovery" [(ngModel)]="recovery" p-clean p-label="Recovery"> </po-input>
+    <po-input class="po-lg-6" name="support" [(ngModel)]="support" p-clean p-label="Support"> </po-input>
+  </div>
 
-    <po-input class="po-lg-4" name="registerUrl" [(ngModel)]="registerUrl" p-clean p-label="Register URL"> </po-input>
+  <div class="po-row">
+    <po-input class="po-lg-6" name="recovery" [(ngModel)]="recovery" p-clean p-label="Recovery"> </po-input>
+
+    <po-input class="po-lg-6" name="registerUrl" [(ngModel)]="registerUrl" p-clean p-label="Register URL"> </po-input>
   </div>
 
   <div class="po-row">

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-labs/sample-po-page-login-labs.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-labs/sample-po-page-login-labs.component.ts
@@ -31,6 +31,7 @@ export class SamplePoPageLoginLabsComponent implements OnInit {
   properties: Array<string>;
   recovery: string;
   registerUrl: string;
+  support: string;
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'hideRememberUser', label: 'Hide remember user' },
@@ -107,5 +108,6 @@ export class SamplePoPageLoginLabsComponent implements OnInit {
     this.productName = '';
     this.recovery = '';
     this.registerUrl = '';
+    this.support = '';
   }
 }


### PR DESCRIPTION
**PO-PAGE-LOGIN**

**DTHFUI-3712**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não possui botão de suporte disponível aos usuários no template.

**Qual o novo comportamento?**
Ao atribuir valor para a nova propriedade p-support é habilitado um botão opcional de suporte que aceita tanto uma strinq que redirecionará o usuário para a url inserida, quanto uma função que será executada o clicar no botão. O label do botão está disponível nos 4 idiomas suportados e também foi inserido na interface PoPageLoginLiterals sendo possível sobrescrevê-lo conforme demais propriedades dessa interface.

**Simulação**
- Testar no Sample Labs do Portal;
- Testar a tradução;
- Testar nos diversos navegadores;
- Testar com o tema da Totvs;
- Testar a responsividade;
- Testar também com a propriedade `p-background`;

OBS: Possui PR no [po-theme-totvs](https://github.com/totvs/po-theme-totvs/pull/49) e no [po-style](https://github.com/po-ui/po-style/pull/130).