### PR TITLE
docs(page-change-password): corrige erro no sample password modify

### DIFF
--- a/projects/templates/src/lib/components/po-page-change-password/samples/sample-po-page-change-password-modify/sample-po-page-change-password-modify.component.ts
+++ b/projects/templates/src/lib/components/po-page-change-password/samples/sample-po-page-change-password-modify/sample-po-page-change-password-modify.component.ts
@@ -18,7 +18,7 @@ export class SamplePoPageChangePasswordModifyComponent implements OnInit {
   phoneNumber: string;
   url: string;
 
-  @ViewChild(PoPageChangePasswordComponent, { static: true }) changePassword: PoPageChangePasswordComponent;
+  @ViewChild(PoPageChangePasswordComponent) changePassword: PoPageChangePasswordComponent;
 
   public readonly breadcrumb: PoBreadcrumb = {
     items: [{ label: 'Home', link: '/documentation/po-page-change-password' }, { label: 'Profile' }]


### PR DESCRIPTION
**PAGE CHANGE PASSWORD**

**DTHFUI-3876**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [X] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao utilizar o Sample Password Modify e clicar no botão alterar a senha, ocorre um erro no console e não exibe a modal de confirmação.

**Qual o novo comportamento?**
Ao utilizar o Sample Password Modify e clicar no botão de alterar senha, agora é exibida normalmente a modal de confirmação.

**Simulação**
Sample Password Modify do Portal.