### PR TITLE
feat(page-dynamic-table): nova propriedade `p-page-custom-actions`

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
@@ -1,5 +1,6 @@
 export * from './po-page-dynamic-table.component';
 export * from './interfaces/po-page-dynamic-table-actions.interface';
+export * from './interfaces/po-page-dynamic-table-custom-action.interface';
 export * from './interfaces/po-page-dynamic-table-before-duplicate.interface';
 export * from './interfaces/po-page-dynamic-table-before-edit.interface';
 export * from './interfaces/po-page-dynamic-table-before-new.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-action.interface.ts
@@ -1,0 +1,43 @@
+/**
+ * @usedBy PoPageDynamicTableComponent
+ *
+ * @description
+ *
+ * Interface com as propriedades para adicionar uma ação customizada na página.
+ */
+export interface PoPageDynamicTableCustomAction {
+  /**
+   * Rótulo do botão que será exibido.
+   */
+  label: string;
+
+  /**
+   * Ação que será executada ao clicar no botão.
+   *
+   * A ação do tipo string representa um endpoint que deverá ser do tipo `POST`.
+   *
+   * Ao referenciar uma função, utilize em conjunto a propriedade `.bind()`, desta forma:
+   * ```
+   * action: this.myFunction.bind(this)
+   * ```
+   *
+   * Tanto o endpoint quanto a função, receberá o recurso selecionado pelo usuário na tabela, caso
+   * a propriedade `selectable` seja `true`.
+   *
+   * > Ao utilizar a propriedade `url` e a `action`, somente a `action` será executada.
+   */
+  action?: string | ((resources?: any) => void);
+
+  /**
+   * Rota para o qual será redirecionado ao clicar no botão.
+   *
+   * > Ao utilizar a propriedade `url` e a `action`, somente a `action` será executada.
+   */
+  url?: string;
+
+  /**
+   * Ao utilizar essa propriedade ela habilita a seleção na tabela e também desabilita
+   * o botão de ação caso nenhum recurso for selecionado.
+   */
+  selectable?: boolean;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
@@ -2,6 +2,7 @@ import { PoBreadcrumb } from '@po-ui/ng-components';
 
 import { PoPageDynamicTableActions } from './po-page-dynamic-table-actions.interface';
 import { PoPageDynamicTableFilters } from './po-page-dynamic-table-filters.interface';
+import { PoPageDynamicTableCustomAction } from './po-page-dynamic-table-custom-action.interface';
 
 /**
  * @usedBy PoPageDynamicTableComponent
@@ -61,4 +62,19 @@ export interface PoPageDynamicTableOptions {
    * ```
    */
   concatFilters?: boolean;
+
+  /**
+   * Lista de ações customizadas na página.
+   *
+   * Essas ações ficam localizadas na parte superior da página em botões com ações.
+   *
+   * Exemplo de utilização:
+   * ```
+   * [
+   *  { label: 'Export', action: this.export.bind(this) },
+   *  { label: 'Print', action: this.print.bind(this) }
+   * ];
+   * ```
+   */
+  pageCustomActions?: Array<PoPageDynamicTableCustomAction>;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.spec.ts
@@ -229,6 +229,44 @@ describe('PoPageDynamicTableActionsService:', () => {
       }));
     });
 
+    describe('customAction:', () => {
+      const resource = {
+        name: 'User',
+        age: 40
+      };
+
+      it('should send resource to api', fakeAsync(() => {
+        service.customAction('/customAction', resource).subscribe();
+
+        const req = httpMock.expectOne(request => request.url === `/customAction`);
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(resource);
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({});
+
+        tick();
+      }));
+
+      it('should send resource to function', done => {
+        const testFn = jasmine.createSpy('customAction');
+
+        service.customAction(testFn, resource).subscribe(() => {
+          expect(testFn).toHaveBeenCalledWith(resource);
+          done();
+        });
+      });
+
+      it('should send empty array to function if resource is undefined', done => {
+        const testFn = jasmine.createSpy('customAction');
+
+        service.customAction(testFn).subscribe(() => {
+          expect(testFn).toHaveBeenCalledWith([]);
+          done();
+        });
+      });
+    });
+
     describe('executeAction', () => {
       const resource = { name: 'Name' };
       const id = '1';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-actions.service.ts
@@ -1,6 +1,8 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
 import { Observable, of } from 'rxjs';
+
 import { PoPageDynamicTableActions } from './interfaces/po-page-dynamic-table-actions.interface';
 import { PoPageDynamicTableBeforeDuplicate } from './interfaces/po-page-dynamic-table-before-duplicate.interface';
 import { PoPageDynamicTableBeforeEdit } from './interfaces/po-page-dynamic-table-before-edit.interface';
@@ -8,6 +10,7 @@ import { PoPageDynamicTableBeforeNew } from './interfaces/po-page-dynamic-table-
 import { PoPageDynamicTableBeforeRemove } from './interfaces/po-page-dynamic-table-before-remove.interface';
 import { PoPageDynamicTableBeforeDetail } from './interfaces/po-page-dynamic-table-before-detail.interface';
 import { PoPageDynamicTableBeforeRemoveAll } from './interfaces/po-page-dynamic-table-before-remove-all.interface';
+import { PoPageDynamicTableCustomAction } from './interfaces/po-page-dynamic-table-custom-action.interface';
 
 interface ExecuteActionParameter {
   action: string | Function;
@@ -70,6 +73,10 @@ export class PoPageDynamicTableActionsService {
     resource: any
   ): Observable<PoPageDynamicTableBeforeDetail> {
     return this.executeAction({ action, id, resource });
+  }
+
+  customAction(action: PoPageDynamicTableCustomAction['action'], resource: any = []) {
+    return this.executeAction({ action, resource });
   }
 
   private executeAction<T>({ action, resource = {}, id }: ExecuteActionParameter): Observable<T> {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-literals.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-literals.ts
@@ -1,0 +1,63 @@
+export const poPageDynamicTableLiteralsDefault = {
+  en: {
+    pageAction: 'New',
+    pageActionRemoveAll: 'Delete',
+    tableActionView: 'View',
+    tableActionEdit: 'Edit',
+    tableActionDuplicate: 'Duplicate',
+    tableActionDelete: 'Delete',
+    confirmRemoveTitle: 'Confirm delete',
+    confirmRemoveMessage: 'Are you sure you want to delete this record? You can not undo this action.',
+    confirmRemoveAllTitle: 'Confirm batch deletion',
+    confirmRemoveAllMessage: 'Are you sure you want to delete all these records? You can not undo this action.',
+    loadDataErrorNotification: 'Service not found',
+    removeSuccessNotification: 'Item deleted successfully',
+    removeAllSuccessNotification: 'Items deleted successfully'
+  },
+  es: {
+    pageAction: 'Nuevo',
+    pageActionRemoveAll: 'Borrar',
+    tableActionView: 'Visualizar',
+    tableActionEdit: 'Editar',
+    tableActionDuplicate: 'Duplicar',
+    tableActionDelete: 'Borrar',
+    confirmRemoveTitle: 'Confirmar la exclusión',
+    confirmRemoveMessage: '¿Está seguro de que desea eliminar este registro? No puede deshacer esta acción.',
+    confirmRemoveAllTitle: 'Confirmar la exclusión por lotes',
+    confirmRemoveAllMessage: '¿Está seguro de que desea eliminar todos estos registros? No puede deshacer esta acción.',
+    loadDataErrorNotification: 'Servicio no informado.',
+    removeSuccessNotification: 'Elemento eliminado con éxito',
+    removeAllSuccessNotification: 'Elementos eliminados con éxito'
+  },
+  pt: {
+    pageAction: 'Novo',
+    pageActionRemoveAll: 'Excluir',
+    tableActionView: 'Visualizar',
+    tableActionEdit: 'Editar',
+    tableActionDuplicate: 'Duplicar',
+    tableActionDelete: 'Excluir',
+    confirmRemoveTitle: 'Confirmar exclusão',
+    confirmRemoveMessage: 'Tem certeza de que deseja excluir esse registro? Você não poderá desfazer essa ação.',
+    confirmRemoveAllTitle: 'Confirmar exclusão em lote',
+    confirmRemoveAllMessage:
+      'Tem certeza de que deseja excluir todos esses registros? Você não poderá desfazer essa ação.',
+    loadDataErrorNotification: 'Serviço não informado.',
+    removeSuccessNotification: 'Item excluido com sucesso',
+    removeAllSuccessNotification: 'Items excluidos com sucesso'
+  },
+  ru: {
+    pageAction: 'Новый',
+    pageActionRemoveAll: 'Удалить',
+    tableActionView: 'Просмотр',
+    tableActionEdit: 'Редактировать',
+    tableActionDuplicate: 'Дублировать',
+    tableActionDelete: 'Удалить',
+    confirmRemoveTitle: 'Подтверждение удаления',
+    confirmRemoveMessage: 'Вы уверены, что хотите удалить эту запись?  Вы не можете отменить это действие.',
+    confirmRemoveAllTitle: 'Подтвердите удаление пакета',
+    confirmRemoveAllMessage: 'Вы уверены, что хотите удалить все эти записи? Вы не можете отменить это действие.',
+    loadDataErrorNotification: 'Сервис не найден',
+    removeSuccessNotification: 'Элемент успешно удален',
+    removeAllSuccessNotification: 'Элементы успешно удалены'
+  }
+};

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -12,7 +12,7 @@
   <po-table
     p-sort="true"
     [p-actions]="tableActions"
-    [p-selectable]="hasActionRemoveAll"
+    [p-selectable]="enableSelectionTable"
     [p-columns]="columns"
     [p-items]="items"
     [p-show-more-disabled]="!hasNext"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -200,7 +200,9 @@ describe('PoPageDynamicTableComponent:', () => {
             items: [{ label: 'Home' }, { label: 'Hiring processes' }]
           },
           title: 'Original Title',
-          pageCustomActions: [{ label: 'Custom Action', action: 'endpoint/' }]
+          pageCustomActions: [{ label: 'Custom Action', action: 'endpoint/' }],
+          keepFilters: true,
+          concatFilters: true
         };
 
         const custom = { title: 'New Title' };
@@ -221,6 +223,8 @@ describe('PoPageDynamicTableComponent:', () => {
         });
 
         expect(component.pageCustomActions).toEqual([{ label: 'Custom Action', action: 'endpoint/' }]);
+        expect(component.keepFilters).toBe(true);
+        expect(component.concatFilters).toBe(true);
       }));
     });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -409,6 +409,8 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
           this.fields = response.fields || this.fields;
           this.title = response.title || this.title;
           this.pageCustomActions = response.pageCustomActions || this.pageCustomActions;
+          this.keepFilters = response.keepFilters || this.keepFilters;
+          this.concatFilters = response.concatFilters || this.concatFilters;
         }),
         switchMap(() => this.loadOptionsOnInitialize(onLoad))
       );

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -4,6 +4,7 @@
   p-keep-filters
   p-title="Users"
   [p-actions]="actions"
+  [p-page-custom-actions]="pageCustomActions"
   [p-breadcrumb]="breadcrumb"
   [p-fields]="fields"
   [p-service-api]="serviceApi"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -3,9 +3,12 @@ import { Component } from '@angular/core';
 import { PoBreadcrumb } from '@po-ui/ng-components';
 import { PoPageDynamicTableActions } from '@po-ui/ng-templates';
 
+import { SamplePoPageDynamicTableUsersService } from './sample-po-page-dynamic-table-users.service';
+
 @Component({
   selector: 'sample-po-page-dynamic-table-users',
-  templateUrl: './sample-po-page-dynamic-table-users.component.html'
+  templateUrl: './sample-po-page-dynamic-table-users.component.html',
+  providers: [SamplePoPageDynamicTableUsersService]
 })
 export class SamplePoPageDynamicTableUsersComponent {
   public readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
@@ -36,4 +39,15 @@ export class SamplePoPageDynamicTableUsersComponent {
     { property: 'birthdate', label: 'Birthdate', type: 'date', gridColumns: 6 },
     { property: 'city', label: 'City', filter: true, duplicate: true, options: this.cityOptions, gridColumns: 12 }
   ];
+
+  public pageCustomActions = [
+    { label: 'Print', action: this.printPage.bind(this) },
+    { label: 'Download .csv', action: this.usersService.downloadCsv.bind(this.usersService, this.serviceApi) }
+  ];
+
+  constructor(private usersService: SamplePoPageDynamicTableUsersService) {}
+
+  printPage() {
+    window.print();
+  }
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable()
+export class SamplePoPageDynamicTableUsersService {
+  constructor(public http: HttpClient) {}
+
+  downloadCsv(endpoint) {
+    this.http.get(endpoint).subscribe(data => {
+      const csvStr = this.parseJsonToCsv(data['items']);
+      const dataUri = 'data:text/csv;charset=utf-8,' + csvStr;
+
+      const exportFileDefaultName = 'data.csv';
+
+      const linkElement = document.createElement('a');
+      linkElement.setAttribute('href', dataUri);
+      linkElement.setAttribute('download', exportFileDefaultName);
+      linkElement.click();
+    });
+  }
+
+  parseJsonToCsv(jsonData = []) {
+    if (!jsonData.length) {
+      return '';
+    }
+
+    const keys = Object.keys(jsonData[0]);
+    const columnDelimiter = ',';
+    const lineDelimiter = '\n';
+    const csvColumnHeader = keys.join(columnDelimiter);
+
+    const csvStr = jsonData.reduce((accCsvStr, currentItem) => {
+      keys.forEach((key, index) => {
+        if (index && index < keys.length - 1) {
+          accCsvStr += columnDelimiter;
+        }
+
+        accCsvStr += currentItem[key];
+      });
+
+      return accCsvStr + lineDelimiter;
+    }, csvColumnHeader + lineDelimiter);
+
+    return encodeURIComponent(csvStr);
+  }
+}


### PR DESCRIPTION

**Po Page Dynamic Table**

**DTHFUI-3710**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
O usuário só conseguia adicionar as ações padrão do template.

**Qual o novo comportamento?**
Agora o usuário consegue adicionar novas ações customizadas na página e também possibilita a habilitação da seleção dos dados da tabela baseado na propriedade selectable. 
O usuário também pode utilizar através do load e do metadata.

- Também foi adicionado a correção para que o usuário possa utilizar o concatFilters e o keepFilters no endpoint de metadados. Por isso é necessários testar essa parte também. 

**Simulação**
- Pode ser utilizado o sample do portal. 
- Lembrar de testar os endpoints e o envio do resource. 

- [app_dynamic_tabel.zip](https://github.com/po-ui/po-angular/files/5001440/app_dynamic_tabel.zip)
