### PR TITLE
fix(list-view): corrige alinhamento da caixa de seleção

### DIFF
--- a/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
@@ -12,7 +12,10 @@
           [class.po-checkbox-group-input-checked]="selectAll"
           [class.po-checkbox-group-input-indeterminate]="selectAll === null"
         />
-        <label class="po-checkbox-group-label po-clickable" (click)="selectAllListItems()">
+        <label
+          class="po-checkbox-group-label po-list-view-selectable-label po-clickable"
+          (click)="selectAllListItems()"
+        >
           {{ literals.selectAll }}
         </label>
       </div>
@@ -37,7 +40,10 @@
                   type="checkbox"
                   [class.po-checkbox-group-input-checked]="item.$selected"
                 />
-                <label class="po-checkbox-group-label po-clickable" (click)="selectListItem(item)"></label>
+                <label
+                  class="po-checkbox-group-label po-list-view-selectable-label po-clickable"
+                  (click)="selectListItem(item)"
+                ></label>
               </div>
               <a
                 *ngSwitchCase="'externalLink'"

--- a/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-hiring-processes/sample-po-list-view-hiring-processes.service.ts
+++ b/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-hiring-processes/sample-po-list-view-hiring-processes.service.ts
@@ -13,7 +13,7 @@ export class SamplePoListViewHiringProcessesService {
         email: 'james@johnson.com',
         telephone: '1-541-754-3010',
         jobDescription: 'Systems Analyst',
-        url: 'https://www.po-ui.com/trabalhe-conosco/'
+        url: 'https://po-ui.io/'
       },
       {
         hireStatus: 'progress',
@@ -24,7 +24,7 @@ export class SamplePoListViewHiringProcessesService {
         email: 'brian@brown.com',
         telephone: '1-543-456-9876',
         jobDescription: 'Trainee',
-        url: 'https://www.po-ui.com/trabalhe-conosco/'
+        url: 'https://po-ui.io/'
       },
       {
         hireStatus: 'canceled',
@@ -45,7 +45,7 @@ export class SamplePoListViewHiringProcessesService {
         email: 'margaret@garcia.com',
         telephone: '1-541-344-2211',
         jobDescription: 'Web developer',
-        url: 'https://www.po-ui.com/trabalhe-conosco/'
+        url: 'https://po-ui.io/'
       },
       {
         hireStatus: 'hired',
@@ -56,7 +56,7 @@ export class SamplePoListViewHiringProcessesService {
         email: 'emma@hall.com',
         telephone: '1-555-321-3234',
         jobDescription: 'Recruiter',
-        url: 'https://www.po-ui.com/trabalhe-conosco/'
+        url: 'https://po-ui.io/'
       },
       {
         hireStatus: 'progress',

--- a/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-labs/sample-po-list-view-labs.component.html
+++ b/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-labs/sample-po-list-view-labs.component.html
@@ -99,6 +99,7 @@
       [(ngModel)]="properties"
       p-columns="3"
       p-label="Properties"
+      p-help='To enable the "Hide Select All" option, you must select the "Select" option first.'
       [p-options]="propertiesOptions"
       (p-change)="changeActionOptions()"
     >

--- a/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-labs/sample-po-list-view-labs.component.ts
+++ b/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-labs/sample-po-list-view-labs.component.ts
@@ -25,6 +25,12 @@ export class SamplePoListViewLabsComponent implements OnInit {
   propertyTitle: string;
   titleAction: string;
 
+  propertiesOptions: Array<PoCheckboxGroupOption> = [
+    { value: 'select', label: 'Select' },
+    { value: 'hideSelectAll', label: 'Hide Select All', disabled: true },
+    { value: 'showMoreDisabled', label: 'Show More Disabled' }
+  ];
+
   readonly actionOptions: Array<PoCheckboxGroupOption> = [
     { label: 'Disabled', value: 'disabled' },
     { label: 'Separator', value: 'separator' },
@@ -36,12 +42,6 @@ export class SamplePoListViewLabsComponent implements OnInit {
     { value: 'po-icon-news', label: 'po-icon-news' },
     { value: 'po-icon-search', label: 'po-icon-search' },
     { value: 'po-icon-world', label: 'po-icon-world' }
-  ];
-
-  readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
-    { value: 'hideSelectAll', label: 'Hide Select All', disabled: true },
-    { value: 'select', label: 'Select' },
-    { value: 'showMoreDisabled', label: 'Show More Disabled' }
   ];
 
   readonly propertyTitleOptions: Array<PoSelectOption> = [
@@ -79,7 +79,13 @@ export class SamplePoListViewLabsComponent implements OnInit {
   }
 
   changeActionOptions() {
-    this.propertiesOptions[0].disabled = !this.properties.includes(this.propertiesOptions[1].value);
+    this.propertiesOptions = this.propertiesOptions.map(propertyOption => {
+      if (propertyOption.value === 'hideSelectAll') {
+        return { ...propertyOption, disabled: !this.properties.includes('select') };
+      } else {
+        return propertyOption;
+      }
+    });
   }
 
   changeLiterals() {


### PR DESCRIPTION
**PO-LIST-VIEW**

**DTHFUI-3908**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [ ] Testes unitários
- [ ] Documentação
- [X] Samples

**Qual o comportamento atual?**
Há um desalinhamento da caixa de seleção, no Sample Labs não é possível utilizar a propriedade `p-hide-select-all` e no Sample Hiring Processes ao clicar no título do item á chamada uma url que não existe.

**Qual o novo comportamento?**
Foi incluída uma classe css que corrige o alinhamento da caixa de seleção. Foi atualizada as urls do sample Hiring Processes e foi corrigido o comportamento da seleção da propriedade Hide Select All no SampleLabs, após selecionar  a propriedade Select.

**Simulação**
Simular nos samples do Portal.

OBS: possui PR no [po-style](https://github.com/po-ui/po-style/pull/135).