### PR TITLE
fix(): retirada do pacote uuid

### DIFF
--- a/projects/code-editor/ng-package.json
+++ b/projects/code-editor/ng-package.json
@@ -4,12 +4,5 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "whitelistedNonPeerDependencies": [
-    "@po-ui/ng-components",
-    "@po-ui/ng-schematics",
-    "monaco-editor",
-    "core-js",
-    "intl",
-    "uuid"
-  ]
+  "whitelistedNonPeerDependencies": ["@po-ui/ng-components", "@po-ui/ng-schematics", "monaco-editor", "core-js", "intl"]
 }

--- a/projects/code-editor/package.json
+++ b/projects/code-editor/package.json
@@ -17,8 +17,7 @@
     "monaco-editor": "0.20.0",
     "core-js": "^3.6.4",
     "intl": "^1.2.5",
-    "tslib": "^2.0.0",
-    "uuid": "^3.3.2"
+    "tslib": "^2.0.0"
   },
   "peerDependencies": {
     "@angular/common": "^10.0.3",

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
@@ -1,8 +1,6 @@
 import { DoCheck, EventEmitter, Input, IterableDiffers, Output, Directive } from '@angular/core';
 
-import { v4 as uuid } from 'uuid';
-
-import { browserLanguage, convertToBoolean, isKeyCodeEnter, poLocaleDefault } from '../../utils/util';
+import { browserLanguage, convertToBoolean, isKeyCodeEnter, poLocaleDefault, uuid } from '../../utils/util';
 
 import { PoDisclaimer } from '../po-disclaimer/po-disclaimer.interface';
 

--- a/projects/ui/src/lib/components/po-menu-panel/po-menu-panel-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu-panel/po-menu-panel-base.component.ts
@@ -1,7 +1,6 @@
 import { Input, Directive } from '@angular/core';
 
-import { v4 as uuid } from 'uuid';
-import { isExternalLink } from '../../utils/util';
+import { isExternalLink, uuid } from '../../utils/util';
 
 import { PoMenuPanelItem } from './po-menu-panel-item/po-menu-panel-item.interface';
 import { PoMenuPanelItemInternal } from './po-menu-panel-item/po-menu-panel-item-internal.interface';

--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
@@ -1,6 +1,5 @@
 import { Input, Directive } from '@angular/core';
 
-import { v4 as uuid } from 'uuid';
 import {
   browserLanguage,
   convertToBoolean,
@@ -8,7 +7,8 @@ import {
   isExternalLink,
   isTypeof,
   poLocaleDefault,
-  validValue
+  validValue,
+  uuid
 } from '../../utils/util';
 
 import { PoMenuFilter } from './po-menu-filter/po-menu-filter.interface';

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.ts
@@ -1,9 +1,8 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 
-import { v4 as uuid } from 'uuid';
-
 import { PoModalBaseComponent } from './po-modal-base.component';
 import { PoModalService } from './po-modal-service';
+import { uuid } from '../../utils/util';
 
 /**
  * @docsExtends PoModalBaseComponent


### PR DESCRIPTION
**NG-COMPONENT**

**DTHFUI-3932**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Na versão 10 o Angular passou a avaliar se o projeto utiliza CommomJS para importar módulos, que dificulta a tarefa de tree shaking. O nosso projeto usava o uuid ao mesmo tempo que também tinhamos uma função própria

**Qual o novo comportamento?**
Substituido o uso da função uuid pela versão do fonte utils.
A razão foi a nova validação do angular 10 sobre módulos que utilizam os imports do tipo CommonJS o warning não deve acontecer mais

**Simulação**
Executar o comando ng serve em qualquer projeto com o PO-UI v3 e Angular 10.

Repassar no portal os comonentes que foram alterados