### PR TITLE
feat(table): adiciona propriedade loading show more

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -1264,5 +1264,13 @@ describe('PoTableBaseComponent:', () => {
     it('p-hide-columns-manager: should update property `p-hide-columns-manager` with invalid values.', () => {
       expectPropertiesValues(component, 'hideColumnsManager', booleanInvalidValues, false);
     });
+
+    it('p-loading-show-more: should update property `p-loading-show-more` with valid values.', () => {
+      expectPropertiesValues(component, 'loadingShowMore', booleanValidTrueValues, true);
+    });
+
+    it('p-loading-show-more: should update property `p-loading-show-more` with invalid values.', () => {
+      expectPropertiesValues(component, 'loadingShowMore', booleanInvalidValues, false);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -281,8 +281,7 @@ export abstract class PoTableBaseComponent implements OnChanges {
    *
    * @description
    *
-   * Bloqueia a interação do usuário com os dados da _table_ assim como no botão 'Carregar mais resultados',
-   * apresentando um _spinning loading_ em ambos.
+   * Bloqueia a interação do usuário com os dados da _table_.
    *
    * @default `false`
    */
@@ -352,6 +351,17 @@ export abstract class PoTableBaseComponent implements OnChanges {
    * @default `false`
    */
   @Input('p-hide-columns-manager') @InputBoolean() hideColumnsManager?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Permite que seja adicionado o estado de carregamento no botão "Carregar mais resultados".
+   *
+   * @default `false`
+   */
+  @Input('p-loading-show-more') @InputBoolean() loadingShowMore?: boolean = false;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -41,7 +41,7 @@
     class="po-offset-xl-4 po-offset-lg-4 po-offset-md-3 po-lg-4 po-md-6"
     [p-disabled]="showMoreDisabled"
     [p-label]="literals.loadMoreData"
-    [p-loading]="loading"
+    [p-loading]="loadingShowMore"
     (p-click)="onShowMore()"
   >
   </po-button>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.html
@@ -4,11 +4,11 @@
 
 <po-table
   p-container="shadow"
+  [p-loading-show-more]="isLoading"
   [p-columns]="columns"
   [p-items]="items"
   [p-show-more-disabled]="showMoreDisabled"
   [p-sort]="true"
-  [p-loading]="isLoading"
   (p-show-more)="showMore($event)"
   (p-sort-by)="sort($event)"
 >

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -12,6 +12,7 @@
   [p-loading]="properties.includes('loading')"
   [p-max-columns]="maxColumns"
   [p-selectable]="selection.includes('selectable')"
+  [p-loading-show-more]="properties.includes('loadingShowMore')"
   [p-show-more-disabled]="properties.includes('showMoreDisabled')"
   [p-single-select]="selection.includes('singleSelect')"
   [p-sort]="properties.includes('sort')"

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -80,6 +80,7 @@ export class SamplePoTableLabsComponent implements OnInit {
     { label: 'Sort', value: 'sort' },
     { label: 'Striped', value: 'striped' },
     { label: 'Show more disabled', value: 'showMoreDisabled' },
+    { label: 'Loading show more', value: 'loadingShowMore' },
     { label: 'Hide detail', value: 'hideDetail' },
     { label: 'Loading', value: 'loading' },
     { label: 'Hide columns manager', value: 'hideColumnsManager' }


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-3911**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O loading do botão "Mostrar mais" é atrelado a propriedade `p-loading` no **PO-TABLE**, ou seja, quando a propriedade `p-loading` está **ativa**, é exibido um _loading_ na tabela e um _spinner loading_ no botão "Mostrar mais..."

**Qual o novo comportamento?**
Foi adicionado a propriedade `p-loading-show-more` que tem a mesma funcionalidade do `p-loading`, exceto que essa nova propriedade refere-se somente ao botão "Mostrar mais...", deixando assim os loadings independentes entre cada componente.

**Simulação**

Esta alteração esta no exemplo, **sample-po-table-components**

app.component.html
```
<po-table
  [p-loading-show-more]="isLoading"
....
```


app.component.ts
``` 
 showMore(sort: PoTableColumnSort) {
    this.isLoading = true;
    setTimeout(() => {
      this.items = this.getItems(sort);
      this.isLoading = false;
    }, 4000);
  }
```



