### PR TITLE
fix(rich-text): corrige abertura de links com CMD ou Ctrl

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
@@ -35,13 +35,17 @@ describe('PoRichTextBodyComponent:', () => {
       expect(component.bodyElement.nativeElement.designMode).toEqual(expectedValue);
     });
 
-    it('onInit: should call `updateValueWithModelValue`', fakeAsync(() => {
+    it('onInit: should call `updateValueWithModelValue` and `addClickListenerOnAnchorElements`', fakeAsync(() => {
       spyOn(component, <any>'updateValueWithModelValue');
+      spyOn(component, <any>'addClickListenerOnAnchorElements');
 
       component.ngOnInit();
       tick(50);
 
-      expect(component['updateValueWithModelValue']).toHaveBeenCalled();
+      expect(component['updateValueWithModelValue']).toHaveBeenCalledBefore(
+        component['addClickListenerOnAnchorElements']
+      );
+      expect(component['addClickListenerOnAnchorElements']).toHaveBeenCalled();
     }));
 
     describe('executeCommand:', () => {
@@ -289,15 +293,16 @@ describe('PoRichTextBodyComponent:', () => {
       expect(component['emitSelectionCommands']).toHaveBeenCalled();
     });
 
-    it('onPaste: should call `addClickListenerOnAnchorElements` and `update`', () => {
+    it('onPaste: should call `addClickListenerOnAnchorElements` and `update`', fakeAsync(() => {
       spyOn(component, <any>'addClickListenerOnAnchorElements');
       spyOn(component, <any>'update');
 
       component.onPaste();
+      tick(50);
 
       expect(component['addClickListenerOnAnchorElements']).toHaveBeenCalled();
-      expect(component['update']).toHaveBeenCalled();
-    });
+      expect(component['update']).toHaveBeenCalledBefore(component['addClickListenerOnAnchorElements']);
+    }));
 
     it('update: should call `updateModel`', fakeAsync(() => {
       spyOn(component, <any>'updateModel');

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
@@ -49,7 +49,10 @@ export class PoRichTextBodyComponent implements OnInit {
     this.bodyElement.nativeElement.designMode = 'on';
 
     // timeout necessário para setar o valor vindo do writeValue do componente principal.
-    setTimeout(() => this.updateValueWithModelValue());
+    setTimeout(() => {
+      this.updateValueWithModelValue();
+      this.addClickListenerOnAnchorElements();
+    });
   }
 
   executeCommand(command: string | { command: any; value: string | any }) {
@@ -121,8 +124,8 @@ export class PoRichTextBodyComponent implements OnInit {
   }
 
   onPaste() {
-    this.addClickListenerOnAnchorElements();
     this.update();
+    setTimeout(() => this.addClickListenerOnAnchorElements());
   }
 
   update() {


### PR DESCRIPTION
**PO-RICH-TEXT**

**DTHFUI-3907**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A tentar abrir um link já carregado na inicialização do componente ou um link posteriormente colado, não é possível abrir o link.

**Qual o novo comportamento?**
Corrige abertura de links com CMD/ctrl de um conteúdo já carregado no componente ou um link colado posteriormente.

**Simulação**
No sample Recipe do portal é possível testar se o link da receita abre com o CMD ou Ctrl, também é possível copiar e colar um link para verificar se o mesmo também abre normalmente.