### PR TITLE
fix(lookup): altera p-field-label dinamicamente

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-column.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-column.interface.ts
@@ -13,7 +13,7 @@ export interface PoLookupColumn {
    * por um traço("-"). Por exemplo: "Joinville - SC".
    *
    * Importante
-   * Esta configuração se torna obsoleta caso o atributo `p-field-format` for configurado no componente.
+   * Esta configuração se torna obsoleta caso os atributos `p-field-format` ou `p-field-label` forem configurados no componente.
    */
   fieldLabel?: boolean;
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -503,5 +503,11 @@ describe('PoLookupBaseComponent:', () => {
       expectPropertiesValues(component, 'required', trueValues, true);
       expectPropertiesValues(component, 'required', falseValues, false);
     });
+
+    it('p-field-label: should apply the received value to `keysDescription`', () => {
+      component.fieldLabel = 'label';
+
+      expect(component['keysDescription']).toEqual(['label']);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -28,6 +28,7 @@ import { InputBoolean } from '../../../decorators';
 @Directive()
 export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnDestroy, OnInit, Validator {
   private _disabled?: boolean = false;
+  private _fieldLabel: string;
   private _filterService: PoLookupFilter | string;
   private _noAutocomplete: boolean;
   private _required?: boolean = false;
@@ -125,7 +126,14 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
   @Input('p-field-value') fieldValue: string;
 
   /** Indica a coluna que será utilizada como descrição do campo e como filtro dentro da janela. */
-  @Input('p-field-label') fieldLabel: string;
+  @Input('p-field-label') set fieldLabel(value: string) {
+    this._fieldLabel = value;
+    this.keysDescription = [this.fieldLabel];
+  }
+
+  get fieldLabel() {
+    return this._fieldLabel;
+  }
 
   /** Valor que será repassado como parâmetro para a URL ou aos métodos do serviço que implementam a interface `PoLookupFilter`. */
   @Input('p-filter-params') filterParams?: any;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentRef } from '@angular/core';
-import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -48,6 +48,7 @@ describe('PoLookupComponent:', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PoLookupComponent);
     component = fixture.componentInstance;
+    component.service = TestBed.inject(LookupFilterService);
     component.columns = [
       { property: 'value', label: 'Chave', type: 'number' },
       { property: 'label', label: 'Nome', type: 'string', fieldLabel: true }
@@ -420,5 +421,21 @@ describe('PoLookupComponent:', () => {
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-field-optional')).toBeNull();
     });
+  });
+
+  describe('Integration', () => {
+    it('should set input element value according with fieldLabel', fakeAsync(() => {
+      const serviceResponse = { id: 1234, name: 'Peter Parker', email: 'peterP@mail.com' };
+      component.fieldValue = 'id';
+      component.fieldLabel = 'name';
+      spyOn(component.service, 'getObjectByValue').and.returnValue(of(serviceResponse));
+
+      component.searchById('Peter Parker');
+
+      tick();
+      fixture.detectChanges();
+
+      expect(component.inputEl.nativeElement.value).toBe('Peter Parker');
+    }));
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -162,7 +162,7 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
   searchEvent() {
     const value = this.getViewValue();
 
-    if (this.oldValue !== value) {
+    if (this.oldValue.toString() !== value) {
       this.searchById(value);
     }
   }


### PR DESCRIPTION
**po-lookup**

**DTHFUI-3935**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O input do componente não exibia o valor selecionado se a propriedade p-field-label fosse modificada após a inicialização do componente

**Qual o novo comportamento?**
Agora ao modificar o valor para p-field-label e selecionar um novo item para o lookup ele exibirá conforme a definição de valor da propriedade. Foi também feita uma pequena modificação sem relação com o bug na documentação.

**Simulação**
Campo 'field label' no sample labs do portal 