### PR TITLE
feat(page-dynamic-table): adiciona a propriedade p-table-custom-actions

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/index.ts
@@ -1,5 +1,6 @@
 export * from './po-page-dynamic-table.component';
 export * from './interfaces/po-page-dynamic-table-actions.interface';
+export * from './interfaces/po-page-dynamic-table-custom-table-action.interface';
 export * from './interfaces/po-page-dynamic-table-custom-action.interface';
 export * from './interfaces/po-page-dynamic-table-before-duplicate.interface';
 export * from './interfaces/po-page-dynamic-table-before-edit.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
@@ -1,0 +1,37 @@
+/**
+ * @usedBy PoPageDynamicTableComponent
+ *
+ * @description
+ *
+ * Interface com as propriedades para adicionar uma ação customizada na tabela da página.
+ */
+export interface PoPageDynamicTableCustomTableAction {
+  /**
+   * Rótulo do botão que será exibido.
+   */
+  label: string;
+
+  /**
+   * Ação que será executada ao clicar no botão.
+   *
+   * A ação do tipo string representa um endpoint que deverá ser do tipo `POST`.
+   *
+   * Ao referenciar uma função, utilize em conjunto a propriedade `.bind()`, desta forma:
+   * ```
+   * action: this.myFunction.bind(this)
+   * ```
+   *
+   * Tanto o endpoint quanto a função recebem o recurso da linha que a ação foi disparada.
+   * Podem também retornar o recurso com dados alterados que, consequentemente, serão atualizados na tabela.
+   *
+   * > Ao utilizar a propriedade `url` e a `action`, somente a `action` será executada.
+   */
+  action?: string | ((resource?: any) => any);
+
+  /**
+   * Rota para o qual será redirecionado ao clicar no botão.
+   *
+   * > Ao utilizar a propriedade `url` e a `action`, somente a `action` será executada.
+   */
+  url?: string;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
@@ -3,6 +3,7 @@ import { PoBreadcrumb } from '@po-ui/ng-components';
 import { PoPageDynamicTableActions } from './po-page-dynamic-table-actions.interface';
 import { PoPageDynamicTableFilters } from './po-page-dynamic-table-filters.interface';
 import { PoPageDynamicTableCustomAction } from './po-page-dynamic-table-custom-action.interface';
+import { PoPageDynamicTableCustomTableAction } from './po-page-dynamic-table-custom-table-action.interface';
 
 /**
  * @usedBy PoPageDynamicTableComponent
@@ -64,7 +65,7 @@ export interface PoPageDynamicTableOptions {
   concatFilters?: boolean;
 
   /**
-   * Lista de ações customizadas na página.
+   * Lista de ações customizadas da página que serão incorporadas às ações informadas através da propriedade `actions`
    *
    * Essas ações ficam localizadas na parte superior da página em botões com ações.
    *
@@ -77,4 +78,17 @@ export interface PoPageDynamicTableOptions {
    * ```
    */
   pageCustomActions?: Array<PoPageDynamicTableCustomAction>;
+
+  /**
+   * Lista de ações customizadas da tabela que serão incorporadas às ações informadas através da propriedade `actions`.
+   *
+   * Exemplo de utilização:
+   * ```
+   * [
+   *  { label: 'Apply Discount', action: this.applyDiscount.bind(this) },
+   *  { label: 'Details', action: this.details.bind(this) }
+   * ];
+   * ```
+   */
+  tableCustomActions?: Array<PoPageDynamicTableCustomTableAction>;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -5,8 +5,13 @@
   p-title="Users"
   [p-actions]="actions"
   [p-page-custom-actions]="pageCustomActions"
+  [p-table-custom-actions]="tableCustomActions"
   [p-breadcrumb]="breadcrumb"
   [p-fields]="fields"
   [p-service-api]="serviceApi"
 >
 </po-page-dynamic-table>
+
+<po-modal #userDetailModal p-title="User Detail">
+  <po-dynamic-view [p-fields]="detailFields" [p-value]="detailedUser"> </po-dynamic-view>
+</po-modal>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -1,7 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 
-import { PoBreadcrumb } from '@po-ui/ng-components';
-import { PoPageDynamicTableActions } from '@po-ui/ng-templates';
+import { PoBreadcrumb, PoDynamicViewField, PoModalComponent } from '@po-ui/ng-components';
+import {
+  PoPageDynamicTableActions,
+  PoPageDynamicTableCustomAction,
+  PoPageDynamicTableCustomTableAction
+} from '@po-ui/ng-templates';
 
 import { SamplePoPageDynamicTableUsersService } from './sample-po-page-dynamic-table-users.service';
 
@@ -11,19 +15,22 @@ import { SamplePoPageDynamicTableUsersService } from './sample-po-page-dynamic-t
   providers: [SamplePoPageDynamicTableUsersService]
 })
 export class SamplePoPageDynamicTableUsersComponent {
-  public readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+  @ViewChild('userDetailModal') userDetailModal: PoModalComponent;
 
-  public readonly actions: PoPageDynamicTableActions = {
+  readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+  detailedUser;
+
+  readonly actions: PoPageDynamicTableActions = {
     new: '/documentation/po-page-dynamic-edit',
     remove: true,
     removeAll: true
   };
 
-  public readonly breadcrumb: PoBreadcrumb = {
+  readonly breadcrumb: PoBreadcrumb = {
     items: [{ label: 'Home', link: '/' }, { label: 'People' }]
   };
 
-  public readonly cityOptions: Array<object> = [
+  readonly cityOptions: Array<object> = [
     { value: 'São Paulo', label: 'São Paulo' },
     { value: 'Joinville', label: 'Joinville' },
     { value: 'São Bento', label: 'São Bento' },
@@ -32,7 +39,7 @@ export class SamplePoPageDynamicTableUsersComponent {
     { value: 'Osasco', label: 'Osasco' }
   ];
 
-  public readonly fields: Array<any> = [
+  readonly fields: Array<any> = [
     { property: 'id', key: true },
     { property: 'name', label: 'Name', filter: true, gridColumns: 6 },
     { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true },
@@ -40,14 +47,36 @@ export class SamplePoPageDynamicTableUsersComponent {
     { property: 'city', label: 'City', filter: true, duplicate: true, options: this.cityOptions, gridColumns: 12 }
   ];
 
-  public pageCustomActions = [
+  readonly detailFields: Array<PoDynamicViewField> = [
+    { property: 'status', tag: true, gridLgColumns: 4, divider: 'Personal Data' },
+    { property: 'name', gridLgColumns: 4 },
+    { property: 'nickname', label: 'User name', gridLgColumns: 4 },
+    { property: 'email', gridLgColumns: 4 },
+    { property: 'birthdate', gridLgColumns: 4, type: 'date' },
+    { property: 'genre', gridLgColumns: 4, gridSmColumns: 6 },
+    { property: 'cityName', label: 'City', divider: 'Address' },
+    { property: 'state' },
+    { property: 'country' }
+  ];
+
+  pageCustomActions: Array<PoPageDynamicTableCustomAction> = [
     { label: 'Print', action: this.printPage.bind(this) },
     { label: 'Download .csv', action: this.usersService.downloadCsv.bind(this.usersService, this.serviceApi) }
+  ];
+
+  tableCustomActions: Array<PoPageDynamicTableCustomTableAction> = [
+    { label: 'Details', action: this.onClickUserDetail.bind(this) }
   ];
 
   constructor(private usersService: SamplePoPageDynamicTableUsersService) {}
 
   printPage() {
     window.print();
+  }
+
+  private onClickUserDetail(user) {
+    this.detailedUser = user;
+
+    this.userDetailModal.open();
   }
 }


### PR DESCRIPTION
**PageDynamicTable**

**DTHFUI-3711**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
N/A

**Qual o novo comportamento?**
Adiciona a propriedade p-table-custom-actions
que possibilita a customização das ações da tabela,
unindo-se a ações informada através da propridade p-actions


**Simulação**
Pode ser utilizado o Sample no Portal e o [Projeto APP](https://github.com/po-ui/po-angular/files/5038973/app.zip)