### PR TITLE
docs(sync): corrige link do repositorio de demonstração

### DIFF
--- a/docs/guides/sync-fundamentals.md
+++ b/docs/guides/sync-fundamentals.md
@@ -802,4 +802,4 @@ o método `PoSyncService.prepare()` logo após o método `PoSynceService.destroy
 
 PO Conference Application é um aplicativo de demonstração do PO Sync baseado no [Ionic Conference Application](https://github.com/ionic-team/ionic-conference-app). Tendo como objetivo, demonstrar as funcionalidades do PO Sync de forma didática.
 
-> Acesse o repositório do aplicativo [neste link](https://github.com/po-ui/po-conference-sample).
+> Acesse o repositório do aplicativo [neste link](https://github.com/po-ui/po-sample-conference).


### PR DESCRIPTION
Corrige link do repositorio do aplicativo PO Conference Application que
estava quebrado.

**guides**

**sem issue**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O link do repositorio do aplicativo PO Conference Application aponta para um endereço errado

**Qual o novo comportamento?**
O link do repositorio do aplicativo PO Conference Application aponta para o endereço correto

**Simulação**
Acessar a documentação dos fundamentos do Sync, ir até o final da página e acessar o repositório do aplicativo de demonstração.