### PR TITLE
feat(notification): permite traduzir literais usando serviço i18n

### DIFF
--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.spec.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.spec.ts
@@ -114,11 +114,15 @@ describe('PoToasterComponent', () => {
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Error and with action correctly', () => {
+    const toasterActionLabel = component['literals'].closeToaster;
+
     component.configToaster(toasterErrorWithAction);
     fixture.detectChanges();
     expect(fixture.debugElement.query(By.css('.po-toaster-error'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-close'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain('Fechar');
+    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain(
+      toasterActionLabel
+    );
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Info and with action correctly', () => {
@@ -130,19 +134,27 @@ describe('PoToasterComponent', () => {
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Success and with action correctly', () => {
+    const toasterActionLabel = component['literals'].closeToaster;
+
     component.configToaster(toasterSuccessWithAction);
     fixture.detectChanges();
     expect(fixture.debugElement.query(By.css('.po-toaster-success'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-ok'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain('Fechar');
+    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain(
+      toasterActionLabel
+    );
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Warning and with action correctly', () => {
+    const toasterActionLabel = component['literals'].closeToaster;
+
     component.configToaster(toasterWarningWithAction);
     fixture.detectChanges();
     expect(fixture.debugElement.query(By.css('.po-toaster-warning'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-warning'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain('Fechar');
+    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain(
+      toasterActionLabel
+    );
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Error and without action correctly', () => {

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
@@ -2,10 +2,29 @@ import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/co
 
 import { Subject } from 'rxjs';
 
+import { poLocaleDefault } from '../../../utils/util';
+
+import { PoLanguageService } from '../../po-language/po-language.service';
+
 import { PoToasterBaseComponent } from './po-toaster-base.component';
 import { PoToaster } from './po-toaster.interface';
 import { PoToasterType } from './po-toaster-type.enum';
 import { PoToasterOrientation } from './po-toaster-orientation.enum';
+
+export const poToasterLiteralsDefault = {
+  en: {
+    closeToaster: 'Close'
+  },
+  es: {
+    closeToaster: 'Cerca'
+  },
+  pt: {
+    closeToaster: 'Fechar'
+  },
+  ru: {
+    closeToaster: 'близко'
+  }
+};
 
 /**
  * @docsPrivate
@@ -17,6 +36,10 @@ import { PoToasterOrientation } from './po-toaster-orientation.enum';
   templateUrl: './po-toaster.component.html'
 })
 export class PoToasterComponent extends PoToasterBaseComponent {
+  private literals = {
+    ...poToasterLiteralsDefault[poLocaleDefault]
+  };
+
   /* Ícone do Toaster */
   private icon: string;
   /* Margem do Toaster referênte à sua orientação e posição*/
@@ -33,8 +56,17 @@ export class PoToasterComponent extends PoToasterBaseComponent {
   /* Componente toaster */
   @ViewChild('toaster') toaster: ElementRef;
 
-  constructor(public changeDetector: ChangeDetectorRef, private elementeRef?: ElementRef) {
+  constructor(
+    languageService: PoLanguageService,
+    public changeDetector: ChangeDetectorRef,
+    private elementeRef?: ElementRef
+  ) {
     super();
+
+    this.literals = {
+      ...this.literals,
+      ...poToasterLiteralsDefault[languageService.getShortLanguage()]
+    };
   }
 
   /* Muda a posição do Toaster na tela*/
@@ -63,7 +95,7 @@ export class PoToasterComponent extends PoToasterBaseComponent {
     this.orientation = poToaster.orientation;
     this.position = poToaster.position;
     this.action = poToaster.action;
-    this.actionLabel = poToaster.actionLabel ? poToaster.actionLabel : 'Fechar';
+    this.actionLabel = poToaster.actionLabel ? poToaster.actionLabel : this.literals.closeToaster;
     this.componentRef = poToaster.componentRef;
 
     /* Muda a orientação do Toaster */


### PR DESCRIPTION
**Notification**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```