### PR TITLE
feat(dialog): permite traduzir literais usando serviço i18n

### DIFF
--- a/projects/ui/src/lib/services/po-dialog/po-dialog.component.spec.ts
+++ b/projects/ui/src/lib/services/po-dialog/po-dialog.component.spec.ts
@@ -2,8 +2,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { configureTestSuite } from './../../util-test/util-expect.spec';
 
-import * as UtilsFunctions from '../../utils/util';
-
 import { poDialogAlertLiteralsDefault, PoDialogComponent, poDialogConfirmLiteralsDefault } from './po-dialog.component';
 import { PoDialogAlertOptions, PoDialogConfirmOptions } from './interfaces/po-dialog.interface';
 import { PoDialogModule } from './po-dialog.module';
@@ -214,7 +212,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it('setDialogLiterals: should set `literalsAlert` in portuguese if browser is setted with an unsupported language.', () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('xx');
+      component['language'] = 'xx';
 
       component['setDialogLiterals'](alertOptions, PoDialogType.Alert);
 
@@ -222,7 +220,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it('setDialogLiterals: should set `literalsConfirm` in portuguese if browser is setted with an unsupported language.', () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('xx');
+      component['language'] = 'xx';
 
       component['setDialogLiterals'](confirmOptions, PoDialogType.Confirm);
 
@@ -230,7 +228,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it(`setDialogLiterals: should set 'literalsAlert' in english.`, () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('en');
+      component['language'] = 'en';
 
       component['setDialogLiterals'](alertOptions, PoDialogType.Alert);
 
@@ -238,7 +236,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it(`setDialogLiterals: should set 'literalsAlert' in spanish.`, () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
 
       component['setDialogLiterals'](alertOptions, PoDialogType.Alert);
 
@@ -246,7 +244,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it(`setDialogLiterals: should set 'literalsAlert' in portuguese.`, () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component['setDialogLiterals'](alertOptions, PoDialogType.Alert);
 
@@ -254,7 +252,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it(`setDialogLiterals: should set 'literalsConfirm' in english.`, () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('en');
+      component['language'] = 'en';
 
       component['setDialogLiterals'](confirmOptions, PoDialogType.Confirm);
 
@@ -262,7 +260,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it(`setDialogLiterals: should set 'literalsConfirm' in spanish.`, () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
 
       component['setDialogLiterals'](confirmOptions, PoDialogType.Confirm);
 
@@ -270,7 +268,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it(`setDialogLiterals: should set 'literalsAlert' in russian.`, () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('ru');
+      component['language'] = 'ru';
 
       component['setDialogLiterals'](alertOptions, PoDialogType.Alert);
 
@@ -278,7 +276,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it(`setDialogLiterals: should set 'literalsConfirm' in portuguese.`, () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component['setDialogLiterals'](confirmOptions, PoDialogType.Confirm);
 
@@ -294,7 +292,7 @@ describe('PoDialogComponent:', () => {
         ok: () => {}
       };
 
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component['setDialogLiterals'](alertOptionsCustom, PoDialogType.Alert);
 
@@ -311,7 +309,7 @@ describe('PoDialogComponent:', () => {
         cancel: () => {}
       };
 
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component['setDialogLiterals'](confirmOptionsCustom, PoDialogType.Confirm);
 

--- a/projects/ui/src/lib/services/po-dialog/po-dialog.component.ts
+++ b/projects/ui/src/lib/services/po-dialog/po-dialog.component.ts
@@ -2,7 +2,9 @@ import { Component, ComponentRef, OnDestroy, OnInit, ViewChild } from '@angular/
 
 import { Subscription } from 'rxjs';
 
-import { browserLanguage, poLocaleDefault } from '../../utils/util';
+import { poLocaleDefault } from '../../utils/util';
+
+import { PoLanguageService } from '../po-language/po-language.service';
 
 import { PoDialogAlertLiterals } from './interfaces/po-dialog-alert-literals.interface';
 import { PoDialogAlertOptions, PoDialogConfirmOptions } from './interfaces/po-dialog.interface';
@@ -37,6 +39,8 @@ export const poDialogConfirmLiteralsDefault = {
   templateUrl: './po-dialog.component.html'
 })
 export class PoDialogComponent implements OnDestroy, OnInit {
+  private language: string;
+
   // ViewChild para o uso do po-modal.component
   @ViewChild(PoModalComponent, { static: true }) poModal: PoModalComponent;
 
@@ -61,6 +65,10 @@ export class PoDialogComponent implements OnDestroy, OnInit {
   // Atributo para armazenar a referencia do componente criado via serviço.
   private componentRef: ComponentRef<PoDialogComponent>;
   private closeSubscription: Subscription;
+
+  constructor(languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
 
   ngOnDestroy() {
     this.closeSubscription.unsubscribe();
@@ -145,11 +153,11 @@ export class PoDialogComponent implements OnDestroy, OnInit {
     const literals = dialogOptions.literals;
 
     if (dialogType === PoDialogType.Alert) {
-      this.literalsAlert = { ...alertLiterals[poLocaleDefault], ...alertLiterals[browserLanguage()], ...literals };
+      this.literalsAlert = { ...alertLiterals[poLocaleDefault], ...alertLiterals[this.language], ...literals };
     } else {
       this.literalsConfirm = {
         ...confirmLiterals[poLocaleDefault],
-        ...confirmLiterals[browserLanguage()],
+        ...confirmLiterals[this.language],
         ...literals
       };
     }


### PR DESCRIPTION
**Dialog**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```