### PR TITLE
feat(disclaimer-group): permite traduzir literais usando serviço i18n

### DIFF
--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.spec.ts
@@ -2,7 +2,9 @@ import { expectSettersMethod } from './../../util-test/util-expect.spec';
 
 import * as UtilsFunction from '../../utils/util';
 
-import { PoDisclaimer } from '../po-disclaimer//po-disclaimer.interface';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+
+import { PoDisclaimer } from '../po-disclaimer/po-disclaimer.interface';
 import { PoDisclaimerGroupBaseComponent } from './po-disclaimer-group-base.component';
 import { tick, fakeAsync } from '@angular/core/testing';
 
@@ -11,7 +13,9 @@ describe('PoDisclaimerGroupBaseComponent:', () => {
     find: () => ({ create: () => {} })
   };
 
-  const component = new PoDisclaimerGroupBaseComponent(<any>differ);
+  const languageService = new PoLanguageService();
+
+  const component = new PoDisclaimerGroupBaseComponent(<any>differ, languageService);
 
   it('should be created', () => {
     expect(component instanceof PoDisclaimerGroupBaseComponent).toBeTruthy();

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
@@ -1,6 +1,7 @@
 import { DoCheck, EventEmitter, Input, IterableDiffers, Output, Directive } from '@angular/core';
 
-import { browserLanguage, convertToBoolean, isKeyCodeEnter, poLocaleDefault, uuid } from '../../utils/util';
+import { convertToBoolean, isKeyCodeEnter, poLocaleDefault, uuid } from '../../utils/util';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 import { PoDisclaimer } from '../po-disclaimer/po-disclaimer.interface';
 
@@ -32,10 +33,7 @@ export class PoDisclaimerGroupBaseComponent implements DoCheck {
   private differ;
   private previousDisclaimers: Array<PoDisclaimer> = [];
 
-  readonly literals = {
-    ...poDisclaimerGroupLiteralsDefault[poLocaleDefault],
-    ...poDisclaimerGroupLiteralsDefault[browserLanguage()]
-  };
+  literals;
 
   /** Lista de *disclaimers*. */
 
@@ -108,8 +106,15 @@ export class PoDisclaimerGroupBaseComponent implements DoCheck {
    */
   @Output('p-remove-all') removeAll?: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(differs: IterableDiffers) {
+  constructor(differs: IterableDiffers, languageService: PoLanguageService) {
+    const language = languageService.getShortLanguage();
+
     this.differ = differs.find([]).create(null);
+
+    this.literals = {
+      ...poDisclaimerGroupLiteralsDefault[poLocaleDefault],
+      ...poDisclaimerGroupLiteralsDefault[language]
+    };
   }
 
   ngDoCheck() {

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
@@ -7,7 +7,8 @@ import { PoDisclaimer } from '../po-disclaimer/po-disclaimer.interface';
 export const poDisclaimerGroupLiteralsDefault = {
   en: { removeAll: 'Remove all' },
   es: { removeAll: 'Eliminar todos' },
-  pt: { removeAll: 'Remover todos' }
+  pt: { removeAll: 'Remover todos' },
+  ru: { removeAll: 'Удалить все' }
 };
 
 /**

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.ts
@@ -1,5 +1,7 @@
 import { Component, IterableDiffers } from '@angular/core';
 
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+
 import { PoDisclaimerGroupBaseComponent } from './po-disclaimer-group-base.component';
 
 /**
@@ -29,7 +31,7 @@ import { PoDisclaimerGroupBaseComponent } from './po-disclaimer-group-base.compo
   templateUrl: './po-disclaimer-group.component.html'
 })
 export class PoDisclaimerGroupComponent extends PoDisclaimerGroupBaseComponent {
-  constructor(differs: IterableDiffers) {
-    super(differs);
+  constructor(differs: IterableDiffers, languageService: PoLanguageService) {
+    super(differs, languageService);
   }
 }


### PR DESCRIPTION
**Disclaimer Group**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```