### PR TITLE
perf(switch): implementa ChangeDetectionStrategy.OnPush

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.spec.ts
@@ -1,3 +1,6 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
 import { expectPropertiesValues, expectSettersMethod } from '../../../util-test/util-expect.spec';
 
 import { PoSwitchBaseComponent } from './po-switch-base.component';
@@ -8,14 +11,20 @@ describe('PoSwitchBaseComponent:', () => {
   let fakeInstance;
 
   beforeEach(() => {
-    component = new PoSwitchBaseComponent();
+    TestBed.configureTestingModule({
+      providers: [ChangeDetectorRef]
+    });
+
+    const changeDetector = TestBed.inject(ChangeDetectorRef);
+
+    component = new PoSwitchBaseComponent(changeDetector);
 
     fakeInstance = {
       disabled: false,
       switchValue: false,
       changeValue: (value: any) => {},
       changeDetector: {
-        detectChanges: () => {}
+        markForCheck: () => {}
       },
       propagateChange: (value: any) => {},
       ngModelChange: {
@@ -116,16 +125,25 @@ describe('PoSwitchBaseComponent:', () => {
   it('should updated switchValue on writeValue', () => {
     component.switchValue = true;
 
+    component['changeDetector'] = <any>{ markForCheck: () => {} };
+    spyOn(component['changeDetector'], 'markForCheck');
+
     component.writeValue(false);
 
+    expect(component['changeDetector'].markForCheck).toHaveBeenCalled();
     expect(component.switchValue).toBeFalsy();
   });
 
   it('shouldn`t updated switchValue on writeValue if new value equals old value', () => {
     component.switchValue = true;
 
+    component['changeDetector'] = <any>{ markForCheck: () => {} };
+
+    spyOn(component['changeDetector'], 'markForCheck');
+
     component.writeValue(true);
 
+    expect(component['changeDetector'].markForCheck).not.toHaveBeenCalled();
     expect(component.switchValue).toBeTruthy();
   });
 

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
@@ -1,5 +1,5 @@
 import { ControlValueAccessor } from '@angular/forms';
-import { EventEmitter, Input, Output, Directive } from '@angular/core';
+import { ChangeDetectorRef, EventEmitter, Input, Output, Directive } from '@angular/core';
 
 import { convertToBoolean } from '../../../utils/util';
 import { InputBoolean } from '../../../decorators';
@@ -105,6 +105,8 @@ export class PoSwitchBaseComponent implements ControlValueAccessor {
   // Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
   @Output('ngModelChange') ngModelChange?: EventEmitter<any> = new EventEmitter<any>();
 
+  constructor(private changeDetector: ChangeDetectorRef) {}
+
   changeValue(value: any) {
     if (this.switchValue !== value) {
       this.switchValue = value;
@@ -133,6 +135,8 @@ export class PoSwitchBaseComponent implements ControlValueAccessor {
   writeValue(value: any): void {
     if (value !== this.switchValue) {
       this.switchValue = !!value;
+
+      this.changeDetector.markForCheck();
     }
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
@@ -7,7 +7,7 @@ import { PoSwitchLabelPosition } from './po-switch-label-position.enum';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from './../po-field-container/po-field-container.component';
 
-describe('PoRadioGroupComponent', () => {
+describe('PoSwitchComponent', () => {
   let component: PoSwitchComponent;
   let fixture: ComponentFixture<PoSwitchComponent>;
   let nativeElement: any;
@@ -21,8 +21,6 @@ describe('PoRadioGroupComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PoSwitchComponent);
     component = fixture.componentInstance;
-
-    fixture.detectChanges();
 
     nativeElement = fixture.debugElement.nativeElement;
   });

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewChecked,
   AfterViewInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -42,6 +43,7 @@ import { PoSwitchLabelPosition } from './po-switch-label-position.enum';
 @Component({
   selector: 'po-switch',
   templateUrl: './po-switch.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -50,15 +52,11 @@ import { PoSwitchLabelPosition } from './po-switch-label-position.enum';
     }
   ]
 })
-export class PoSwitchComponent extends PoSwitchBaseComponent implements AfterViewChecked, AfterViewInit {
+export class PoSwitchComponent extends PoSwitchBaseComponent implements AfterViewInit {
   @ViewChild('switchContainer', { static: true }) switchContainer: ElementRef;
 
-  constructor(private changeDetector: ChangeDetectorRef) {
-    super();
-  }
-
-  ngAfterViewChecked(): void {
-    this.changeDetector.detectChanges();
+  constructor(changeDetector: ChangeDetectorRef) {
+    super(changeDetector);
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
**SWITCH**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**


**Qual o novo comportamento?**
implementa ChangeDetectionStrategy.OnPush no componente para deixa-lo mais performático.

E também anteriormente o componente fazia a detecção de mudança todas vez que sua view era checked (ngAfterViewChecked) fazendo que todos os componentes presentes no DOM realizasse a checkagem.


**Simulação**
- Pode-se utilizar componentes como po-table,input e colocar um get com check e imprimi-lo para verificar a diferença.
```
<component>.html

<div> ... </div>
{{ check }}
```

```
<component>.ts

get check() {
    console.log('<component> check')
    return '';
}
```
- Sample Portal, e;

```
app.component.html

<po-switch name="cnpj" [(ngModel)]="person.cnpj" p-label="cnpj" (p-change)="onChangeCNPJ(person)">
</po-switch>

<po-switch name="cpf" [(ngModel)]="person.cpf" p-label="CPF" (p-change)="onChangeCPF(person)">
</po-switch>
```

```
app.component.ts

  person = {
    cpf: false,
    cnpj: false
  };


  onChangeCPF(person) {
    person.cnpj = person.cpf ? !person.cpf : person.cnpj;
  }

  onChangeCNPJ(person) {
    person.cpf = person.cnpj ? !person.cnpj : person.cpf;
  }
``` 