### PR TITLE
feat(list-view): permite traduzir literais usando serviço i18n

### DIFF
--- a/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.spec.ts
@@ -1,14 +1,16 @@
 import * as UtilsFunctions from '../../utils/util';
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 import { poLocaleDefault } from '../../utils/util';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 import { PoListViewBaseComponent, poListViewLiteralsDefault } from './po-list-view-base.component';
 
 describe('PoListViewBaseComponent:', () => {
+  const languageService: PoLanguageService = new PoLanguageService();
   let component: PoListViewBaseComponent;
 
   beforeEach(() => {
-    component = new PoListViewBaseComponent();
+    component = new PoListViewBaseComponent(languageService);
   });
 
   describe('Properties:', () => {
@@ -65,7 +67,7 @@ describe('PoListViewBaseComponent:', () => {
     });
 
     it('p-literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('zw');
+      component['language'] = 'zw';
 
       component.literals = {};
 
@@ -73,7 +75,7 @@ describe('PoListViewBaseComponent:', () => {
     });
 
     it('p-literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component.literals = {};
 
@@ -81,7 +83,7 @@ describe('PoListViewBaseComponent:', () => {
     });
 
     it('p-literals: should be in english if browser is setted with `en`', () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('en');
+      component['language'] = 'en';
 
       component.literals = {};
 
@@ -89,7 +91,7 @@ describe('PoListViewBaseComponent:', () => {
     });
 
     it('p-literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
 
       component.literals = {};
 
@@ -97,7 +99,7 @@ describe('PoListViewBaseComponent:', () => {
     });
 
     it('p-literals: should be in russian if browser is setted with `ru`', () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue('ru');
+      component['language'] = 'ru';
 
       component.literals = {};
 
@@ -105,7 +107,7 @@ describe('PoListViewBaseComponent:', () => {
     });
 
     it('p-literals: should accept custom literals', () => {
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       const customLiterals = Object.assign({}, poListViewLiteralsDefault[poLocaleDefault]);
 
@@ -120,7 +122,7 @@ describe('PoListViewBaseComponent:', () => {
     it('p-literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       expectPropertiesValues(component, 'literals', invalidValues, poListViewLiteralsDefault[poLocaleDefault]);
     });

--- a/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.ts
@@ -1,6 +1,7 @@
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { browserLanguage, poLocaleDefault, convertToBoolean } from '../../utils/util';
+import { poLocaleDefault, convertToBoolean } from '../../utils/util';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 import { PoListViewAction } from './interfaces/po-list-view-action.interface';
 import { PoListViewLiterals } from './interfaces/po-list-view-literals.interface';
@@ -56,6 +57,7 @@ export class PoListViewBaseComponent {
   private _literals: PoListViewLiterals;
   private _select: boolean;
   private _showMoreDisabled: boolean;
+  private language: string = poLocaleDefault;
 
   popupTarget: any;
   selectAll: boolean = false;
@@ -150,22 +152,23 @@ export class PoListViewBaseComponent {
    * </po-list-view>
    * ```
    *
-   * > O objeto padrão de literais será traduzido de acordo com o idioma do browser (pt, en, es).
+   * > O objeto padrão de literais será traduzido de acordo com o idioma do
+   * [`PoI18nService`](/documentation/po-i18n) ou do browser.
    */
   @Input('p-literals') set literals(value: PoListViewLiterals) {
     if (value instanceof Object && !(value instanceof Array)) {
       this._literals = {
         ...poListViewLiteralsDefault[poLocaleDefault],
-        ...poListViewLiteralsDefault[browserLanguage()],
+        ...poListViewLiteralsDefault[this.language],
         ...value
       };
     } else {
-      this._literals = poListViewLiteralsDefault[browserLanguage()];
+      this._literals = poListViewLiteralsDefault[this.language];
     }
   }
 
   get literals() {
-    return this._literals || poListViewLiteralsDefault[browserLanguage()];
+    return this._literals || poListViewLiteralsDefault[this.language];
   }
 
   /** Recebe uma propriedade que será utilizada para recuperar o valor do objeto que será usado como link para o título. */
@@ -229,6 +232,10 @@ export class PoListViewBaseComponent {
    * Ao ser disparado, o método inserido na ação irá receber como parâmetro o item da lista clicado.
    */
   @Output('p-title-action') titleAction?: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor(languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
 
   onClickAction(listViewAction: PoListViewAction, item) {
     const cleanItem = this.deleteInternalAttrs(item);

--- a/projects/ui/src/lib/components/po-list-view/po-list-view.component.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 
 import { isTypeof } from '../../utils/util';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { PoPopupComponent } from '../po-popup/po-popup.component';
 
 import { PoListViewAction } from './interfaces/po-list-view-action.interface';
@@ -60,8 +61,8 @@ export class PoListViewComponent extends PoListViewBaseComponent implements Afte
 
   private differ;
 
-  constructor(private changeDetector: ChangeDetectorRef, differs: IterableDiffers) {
-    super();
+  constructor(private changeDetector: ChangeDetectorRef, differs: IterableDiffers, languageService: PoLanguageService) {
+    super(languageService);
     this.differ = differs.find([]).create(null);
   }
 


### PR DESCRIPTION
**List View**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Atualmente a tradução da literal só responde ao idioma do browser.

**Qual o novo comportamento?**

Permite traduzir as literais de acordo com o serviço i18n.

**Simulação**

Configurar o i18n na aplicação para usar um idioma default, independente do idioma do browser.

```
const i18nConfig: PoI18nConfig = {
  default: {
    language: 'ru' // Russo
  },
  contexts: {}
};


...
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ...
    PoI18nModule.config(i18nConfig)
  ],
  bootstrap: [AppComponent]
})
export class AppModule {}
```