### PR TITLE
test(po-page-change-password): correção na importação dos módulos do TestBed

### DIFF
--- a/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.spec.ts
@@ -3,6 +3,7 @@ import { EventEmitter, NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
+import { PoModule } from '@po-ui/ng-components';
 
 import * as utilsFunctions from './../../utils/util';
 import { getObservable } from './../../util-test/util-expect.spec';
@@ -12,6 +13,7 @@ import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/
 import { PoModalPasswordRecoveryType } from '../po-modal-password-recovery/enums/po-modal-password-recovery-type.enum';
 import { PoPageChangePasswordComponent } from './po-page-change-password.component';
 import { PoPageChangePasswordService } from './po-page-change-password.service';
+import { PoPageBackgroundModule } from '../po-page-background/index';
 
 describe('PoPageChangePasswordComponent:', () => {
   let component: PoPageChangePasswordComponent;
@@ -21,10 +23,9 @@ describe('PoPageChangePasswordComponent:', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule, RouterTestingModule.withRoutes([])],
+      imports: [FormsModule, RouterTestingModule.withRoutes([]), PoModule, PoPageBackgroundModule],
       declarations: [PoPageChangePasswordComponent],
-      providers: [HttpClient, HttpHandler, PoPageChangePasswordService],
-      schemas: [NO_ERRORS_SCHEMA]
+      providers: [HttpClient, HttpHandler, PoPageChangePasswordService]
     }).compileComponents();
   }));
 


### PR DESCRIPTION
**PO-PAGE-CHANGE-PASSWORD**

**DTHFUI-4017**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao executar os testes de forma geral com npm run test, tem testes falhando de forma intermitente do componente po-page-change-password.

**Qual o novo comportamento?**
Corrigida importação dos módulos do TestBed

**Simulação**

Executar build da PR 5 vezes ou mais.