### PR TITLE
refactor(templates): remove função browserLanguage do utils

### DIFF
--- a/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
@@ -1,8 +1,8 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
-import { browserLanguage, convertToBoolean, isTypeof } from './../../utils/util';
-import { PoSelectOption } from '@po-ui/ng-components';
-import { PoLanguageService } from '@po-ui/ng-components';
+import { PoSelectOption, PoLanguageService } from '@po-ui/ng-components';
+
+import { convertToBoolean, isTypeof } from './../../utils/util';
 
 @Component({
   selector: 'po-page-background',

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-summary/po-page-job-scheduler-summary.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-summary/po-page-job-scheduler-summary.component.spec.ts
@@ -1,13 +1,17 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import * as util from '../../../utils/util';
+import { PoLanguageService } from '@po-ui/ng-components';
+
+import { poLocaleDefault } from '../../../utils/util';
 
 import { poPageJobSchedulerLiteralsDefault } from '../po-page-job-scheduler-literals';
 import { PoPageJobSchedulerModule } from '../po-page-job-scheduler.module';
 import { PoPageJobSchedulerSummaryComponent } from './po-page-job-scheduler-summary.component';
 
 describe('PoPageJobSchedulerSummaryComponent:', () => {
+  const languageService: PoLanguageService = new PoLanguageService();
+
   let component: PoPageJobSchedulerSummaryComponent;
   let fixture: ComponentFixture<PoPageJobSchedulerSummaryComponent>;
 
@@ -24,8 +28,8 @@ describe('PoPageJobSchedulerSummaryComponent:', () => {
     component = fixture.componentInstance;
 
     component.literals = {
-      ...poPageJobSchedulerLiteralsDefault[util.poLocaleDefault],
-      ...poPageJobSchedulerLiteralsDefault[util.browserLanguage()]
+      ...poPageJobSchedulerLiteralsDefault[poLocaleDefault],
+      ...poPageJobSchedulerLiteralsDefault[languageService.getShortLanguage()]
     };
 
     fixture.detectChanges();

--- a/projects/templates/src/lib/utils/util.spec.ts
+++ b/projects/templates/src/lib/utils/util.spec.ts
@@ -1,5 +1,4 @@
 import { ViewContainerRef } from '@angular/core';
-import { changeChromeProperties } from '../util-test/util-expect.spec';
 
 import {
   callFunction,
@@ -9,6 +8,8 @@ import {
   convertToBoolean,
   convertToInt,
   formatYear,
+  getBrowserLanguage,
+  getShortBrowserLanguage,
   getFormattedLink,
   isEquals,
   isExternalLink,
@@ -17,17 +18,16 @@ import {
   mapObjectByProperties,
   openExternalLink,
   removeDuplicatedOptions,
+  removeKeysProperties,
   removeUndefinedAndNullOptions,
   setYearFrom0To100,
   sortOptionsByProperty,
   sortValues,
   validateDateRange,
   validValue,
-  valuesFromObject,
-  removeKeysProperties
+  valuesFromObject
 } from './util';
-
-import * as UtilFunctions from './util';
+import { changeChromeProperties } from '../util-test/util-expect.spec';
 
 describe('Language:', () => {
   let navigatorLanguageSpy;
@@ -40,43 +40,11 @@ describe('Language:', () => {
     navigatorLanguageSpy.calls.reset();
   });
 
-  describe('Function browserLanguage:', () => {
-    it('should return `pt` as default language if language is undefined', () => {
-      navigatorLanguageSpy.and.returnValue(undefined);
-
-      expect(UtilFunctions.browserLanguage()).toBe('pt');
-    });
-
-    it('should return `pt` as default language if language is invalid', () => {
-      navigatorLanguageSpy.and.returnValue('wz');
-
-      expect(UtilFunctions.browserLanguage()).toBe('pt');
-    });
-
-    it('should return `en` if browser language is `en-US`', () => {
-      navigatorLanguageSpy.and.returnValue('en-US');
-
-      expect(UtilFunctions.browserLanguage()).toBe('en');
-    });
-
-    it('should return `es` if browser language is `es`', () => {
-      navigatorLanguageSpy.and.returnValue('es');
-
-      expect(UtilFunctions.browserLanguage()).toBe('es');
-    });
-
-    it('should return `ru` if browser language is `ru`', () => {
-      navigatorLanguageSpy.and.returnValue('ru');
-
-      expect(UtilFunctions.browserLanguage()).toBe('ru');
-    });
-  });
-
   describe('Function getBrowserLanguage:', () => {
     it('should return the value of `navigator.language` if it`s defined', () => {
       navigatorLanguageSpy.and.returnValue('pt');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('pt');
+      expect(getShortBrowserLanguage()).toBe('pt');
     });
 
     it('should return the value of `navigator.userLanguage` if it`s defined and `navigator.language` is undefined', () => {
@@ -84,7 +52,7 @@ describe('Language:', () => {
 
       changeChromeProperties(navigator, 'userLanguage', 'en');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('en');
+      expect(getShortBrowserLanguage()).toBe('en');
 
       changeChromeProperties(navigator, 'userLanguage', undefined);
     });
@@ -94,7 +62,7 @@ describe('Language:', () => {
 
       changeChromeProperties(navigator, 'userLanguage', undefined);
 
-      expect(UtilFunctions.getBrowserLanguage()).toBe(undefined);
+      expect(getBrowserLanguage()).toBe(undefined);
     });
   });
 
@@ -102,61 +70,61 @@ describe('Language:', () => {
     it('should return `pt` as default language if language is undefined', () => {
       navigatorLanguageSpy.and.returnValue(undefined);
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('pt');
+      expect(getShortBrowserLanguage()).toBe('pt');
     });
 
     it('should return `pt` as default language if language is invalid', () => {
       navigatorLanguageSpy.and.returnValue('wz');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('pt');
+      expect(getShortBrowserLanguage()).toBe('pt');
     });
 
     it('should return `pt` if browser language is `pt`', () => {
       navigatorLanguageSpy.and.returnValue('pt');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('pt');
+      expect(getShortBrowserLanguage()).toBe('pt');
     });
 
     it('should return `pt` if browser language is `pt-BR`', () => {
       navigatorLanguageSpy.and.returnValue('pt-BR');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('pt');
+      expect(getShortBrowserLanguage()).toBe('pt');
     });
 
     it('should return `en` if browser language is `en`', () => {
       navigatorLanguageSpy.and.returnValue('en');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('en');
+      expect(getShortBrowserLanguage()).toBe('en');
     });
 
     it('should return `en` if browser language is `en-US`', () => {
       navigatorLanguageSpy.and.returnValue('en-US');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('en');
+      expect(getShortBrowserLanguage()).toBe('en');
     });
 
     it('should return `es` if browser language is `es`', () => {
       navigatorLanguageSpy.and.returnValue('es');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('es');
+      expect(getShortBrowserLanguage()).toBe('es');
     });
 
     it('should return `es` if browser language is `es-ES`', () => {
       navigatorLanguageSpy.and.returnValue('es-ES');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('es');
+      expect(getShortBrowserLanguage()).toBe('es');
     });
 
     it('should return `ru` if browser language is `ru`', () => {
       navigatorLanguageSpy.and.returnValue('ru');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('ru');
+      expect(getShortBrowserLanguage()).toBe('ru');
     });
 
     it('should return `ru` if browser language is `ru-RU`', () => {
       navigatorLanguageSpy.and.returnValue('ru-RU');
 
-      expect(UtilFunctions.getShortBrowserLanguage()).toBe('ru');
+      expect(getShortBrowserLanguage()).toBe('ru');
     });
   });
 });

--- a/projects/templates/src/lib/utils/util.ts
+++ b/projects/templates/src/lib/utils/util.ts
@@ -6,17 +6,6 @@ export const poLocales = ['pt', 'en', 'es', 'ru'];
 export const poLocaleDefault = 'pt';
 
 /**
- * @deprecated
- * Utilize o método `getShortBrowserLanguage`.
- *
- * @description
- * Retorna idioma do browser ou o idioma padrão.
- */
-export function browserLanguage() {
-  return getShortBrowserLanguage();
-}
-
-/**
  * Retorna o idioma atual do navegador
  */
 export function getBrowserLanguage(): string {


### PR DESCRIPTION
**Templates**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**

N/A

**Qual o novo comportamento?**

Remove a função browserLanguage do pacotes de templates, agora deve ser usada a função getShortBrowserLanguage ou o serviço PoLanguageService.

**Simulação**

N/A