### PR TITLE
feat(code-editor): adiciona propriedade `p-suggestions`

### DIFF
--- a/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable-suggestion.interface.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable-suggestion.interface.ts
@@ -1,0 +1,39 @@
+/**
+ * @usedBy PoCodeEditorRegister, PoCodeEditorComponent
+ *
+ * @description
+ *
+ * Interface para configuração da lista de sugestão do autocomplete do code editor.
+ */
+export interface PoCodeEditorRegisterableSuggestion {
+  /** Texto que será exibido na lista de sugestões. */
+  label: string;
+
+  /** Texto que será inserido no editor ao selecionar a sugestão exibida pelo autocomplete. */
+  insertText: string;
+
+  /** Texto de ajuda que será exibido caso o usuário deseje ver mais informações sobre a sugestão. */
+  documentation?: string;
+}
+
+/**
+ * @usedBy PoCodeEditorRegister, PoCodeEditorRegisterable
+ *
+ * @description
+ *
+ * Interface do objeto usado pelo monaco para lista de sugestão do autocomplete do code editor.
+ */
+export interface PoCodeEditorRegisterableSuggestionType {
+  provideCompletionItems: () => { suggestions: Array<PoCodeEditorRegisterableSuggestion> };
+}
+
+/**
+ *
+ * @description
+ *
+ * Interface do objeto usado pelo monaco para lista de sugestão do autocomplete do code editor.
+ * Utilizado internamente pelo serviço PoCodeEditorSuggestionService
+ */
+export interface PoCodeEditorSuggestionList {
+  [index: string]: Array<PoCodeEditorRegisterableSuggestion>;
+}

--- a/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable.interface.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable.interface.ts
@@ -1,4 +1,5 @@
 import { PoCodeEditorRegisterableOptions } from './po-code-editor-registerable-options.interface';
+import { PoCodeEditorRegisterableSuggestionType } from './po-code-editor-registerable-suggestion.interface';
 
 /**
  * @usedBy PoCodeEditorRegister
@@ -13,4 +14,7 @@ export interface PoCodeEditorRegisterable {
 
   /** Opções de configuração da sintaxe customizada. */
   options: PoCodeEditorRegisterableOptions;
+
+  /** Lista de sugestões para a função de autocomplete. */
+  suggestions?: PoCodeEditorRegisterableSuggestionType;
 }

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.spec.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.spec.ts
@@ -3,6 +3,7 @@ import { Directive } from '@angular/core';
 import { expectPropertiesValues } from './../../util-test/util-expect.spec';
 
 import { PoCodeEditorBaseComponent } from './po-code-editor-base.component';
+import { PoCodeEditorRegisterableSuggestion } from './interfaces/po-code-editor-registerable-suggestion.interface';
 
 @Directive()
 class PoCodeEditorTestComponent extends PoCodeEditorBaseComponent {
@@ -10,6 +11,7 @@ class PoCodeEditorTestComponent extends PoCodeEditorBaseComponent {
   setLanguage(value: any) {}
   setReadOnly(value: any) {}
   setTheme(value: any) {}
+  setSuggestions(value: any) {}
 }
 
 describe('PoCodeEditorBaseComponent', () => {
@@ -33,6 +35,47 @@ describe('PoCodeEditorBaseComponent', () => {
     spyOn(component, 'setLanguage');
     expectPropertiesValues(component, 'language', validValues, validValues);
     expect(component.setLanguage).toHaveBeenCalled();
+  });
+
+  it('shouldn`t call `setLanguage` when setting `language` with a configured editor', () => {
+    const language = 'java';
+
+    component.editor = undefined;
+
+    spyOn(component, 'setLanguage');
+
+    component.language = language;
+
+    expect(component.setLanguage).not.toHaveBeenCalled();
+  });
+
+  it('should call `setSuggestions` when setting `suggestions` with a configured editor', () => {
+    const suggestions: Array<PoCodeEditorRegisterableSuggestion> = [
+      { label: 'po', insertText: 'Portinari UI' },
+      { label: 'ng', insertText: 'Angular', documentation: 'Framework Javascript.' }
+    ];
+
+    component.editor = {};
+
+    spyOn(component, 'setSuggestions');
+
+    component.suggestions = suggestions;
+
+    expect(component.setSuggestions).toHaveBeenCalled();
+    expect(component.suggestions).toEqual(suggestions);
+  });
+
+  it('shouldn`t call `setSuggestions` when setting `suggestions` with a configured editor', () => {
+    const suggestions: Array<PoCodeEditorRegisterableSuggestion> = [{ label: 'po', insertText: 'Portinari UI' }];
+
+    component.editor = undefined;
+
+    spyOn(component, 'setSuggestions');
+
+    component.suggestions = suggestions;
+
+    expect(component.setSuggestions).not.toHaveBeenCalled();
+    expect(component.suggestions).toEqual(suggestions);
   });
 
   it('should set show-diff', () => {
@@ -79,6 +122,30 @@ describe('PoCodeEditorBaseComponent', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('should call `setReadOnly` when setting `readonly` with a configured editor', () => {
+    const readonly = true;
+
+    component.editor = {};
+
+    spyOn(component, 'setReadOnly');
+
+    component.readonly = readonly;
+
+    expect(component.setReadOnly).toHaveBeenCalled();
+  });
+
+  it('shouldn`t call `setReadOnly` when setting `readonly` with a configured editor', () => {
+    const readonly = true;
+
+    component.editor = undefined;
+
+    spyOn(component, 'setReadOnly');
+
+    component.readonly = readonly;
+
+    expect(component.setReadOnly).not.toHaveBeenCalled();
+  });
+
   it('should set height', () => {
     const invalidHeights = ['', '0', '100', null, undefined, false, true];
 
@@ -101,7 +168,6 @@ describe('PoCodeEditorBaseComponent', () => {
   });
 
   it('should register function OnChangePropagate', () => {
-    expect(component.onChangePropagate(1)).toBeUndefined();
     component.onChangePropagate = undefined;
     const func = () => true;
 
@@ -110,7 +176,6 @@ describe('PoCodeEditorBaseComponent', () => {
   });
 
   it('should register function registerOnTouched', () => {
-    expect(component.onTouched(1)).toBeUndefined();
     component.onTouched = undefined;
     const func = () => true;
 

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.ts
@@ -1,6 +1,8 @@
 import { Input, Directive } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 
+import { PoCodeEditorRegisterableSuggestion } from './interfaces/po-code-editor-registerable-suggestion.interface';
+
 const PO_CODE_EDITOR_THEMES = ['vs-dark', 'vs', 'hc-black'];
 const PO_CODE_EDITOR_THEME_DEFAULT = 'vs';
 
@@ -9,7 +11,7 @@ const PO_CODE_EDITOR_THEME_DEFAULT = 'vs';
  *
  * O `po-code-editor` é um componente para edição de código fonte baseado no Monaco Editor da Microsoft.
  *
- * Sendo assim, algumas configurações presentes no Monaco podem ser utilizadas aqui, como a escolha da liguagem
+ * Sendo assim, algumas configurações presentes no Monaco podem ser utilizadas aqui, como a escolha da linguagem
  * (utilizando o highlight syntax específico), escolha do tema e opção de diff, além de ser muito similar ao Visual
  * Studio Code, com autocomplete e fechamento automático de brackets.
  *
@@ -68,6 +70,7 @@ export abstract class PoCodeEditorBaseComponent implements ControlValueAccessor 
   private _language = 'plainText';
   private _readonly: boolean = false;
   private _showDiff: boolean = false;
+  private _suggestions: Array<PoCodeEditorRegisterableSuggestion>;
   private _theme = PO_CODE_EDITOR_THEME_DEFAULT;
 
   editor: any;
@@ -154,6 +157,41 @@ export abstract class PoCodeEditorBaseComponent implements ControlValueAccessor 
    *
    * @description
    *
+   * Lista de sugestões usadas pelo autocomplete dentro do editor.
+   *
+   * Para visualizar a lista de sugestões use o comando `CTRL + SPACE`.
+   *
+   * Caso o editor esteja usando uma linguagem que já tenha uma lista de sugestões predefinida, o valor passado será adicionado
+   * a lista preexistente, aumentando as opções para o usuário.
+   *
+   * Caso tenha mais de um editor da mesma linguagem na aplicação, as sugestões serão adicionadas para que todos os editores da mesma linguagem
+   * tenham as mesmas sugestões.
+   *
+   * ```
+   *  <po-code-editor
+   *    [p-suggestions]="[{ label: 'po', insertText: 'Portinari UI' }, { label: 'ng', insertText: 'Angular' }]">
+   *  </po-code-editor>
+   * ```
+   *
+   * Ao fornecer uma lista de sugestões é possível acelerar a escrita de scripts pelos usuários.
+   */
+  @Input('p-suggestions') set suggestions(values: Array<PoCodeEditorRegisterableSuggestion>) {
+    this._suggestions = values;
+
+    if (this.editor && this._suggestions) {
+      this.setSuggestions(this._suggestions);
+    }
+  }
+
+  get suggestions(): Array<PoCodeEditorRegisterableSuggestion> {
+    return this._suggestions;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Define um tema para o editor.
    *
    * Temas válidos:
@@ -196,8 +234,10 @@ export abstract class PoCodeEditorBaseComponent implements ControlValueAccessor 
     return `${this._height}px`;
   }
 
-  onTouched = (value: any) => undefined;
-  onChangePropagate = (value: any) => undefined;
+  /* istanbul ignore next */
+  onTouched = (value: any) => {};
+  /* istanbul ignore next */
+  onChangePropagate = (value: any) => {};
 
   getOptions() {
     return { language: this.language, theme: this.theme, readOnly: this.readonly };
@@ -218,6 +258,8 @@ export abstract class PoCodeEditorBaseComponent implements ControlValueAccessor 
   abstract setTheme(value: any);
 
   abstract setReadOnly(value: any);
+
+  abstract setSuggestions(value: any);
 
   protected convertToBoolean(val: any): boolean {
     if (typeof val === 'string') {

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-register.service.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-register.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { PoCodeEditorRegisterable } from './interfaces/po-code-editor-registerable.interface';
 import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-registerable-options.interface';
+import { PoCodeEditorRegisterableSuggestionType } from './interfaces/po-code-editor-registerable-suggestion.interface';
 
 /**
  * @description
@@ -17,6 +18,21 @@ import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-reg
  * ```
  * import { PoCodeEditorModule, PoCodeEditorRegisterable } from '@po-ui/ng-code-editor';
  *
+ * declare const monaco: any; // Importante para usar configurações com tipos definidos pelo Monaco
+ *
+ * // A função `provideCompletionItems` precisa ser exportada para ser compatível com AOT.
+ * export function provideCompletionItems() {
+ *   const suggestions = [{
+ *     label: 'terraform',
+ *     insertText: '#terraform language'
+ *   }, {
+ *     label: 'server',
+ *     insertText: 'server ${1:ip}'
+ *   }];
+ *
+ *   return { suggestions: suggestions };
+ * }
+ *
  * const customEditor: PoCodeEditorRegisterable = {
  *   language: 'terraform',
  *   options: {
@@ -27,10 +43,9 @@ import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-reg
  *     tokenizer: {
  *      ...
  *     }
- *   }
+ *   },
+ *   suggestions: { provideCompletionItems: provideCompletionItems }
  * };
- * As configurações para o registro de uma nova sintaxe no Monaco code editor podem ser encontradas em
- * [**Monaco Editor**](https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-custom-languages).
  *
  * @NgModule({
  *   declarations: [],
@@ -41,12 +56,18 @@ import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-reg
  *   bootstrap: [AppComponent]
  * })
  * ```
+ *
+ * > As configurações para o registro de uma nova sintaxe no Monaco code editor podem ser encontradas em
+ * > [**Monaco Editor**](https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-custom-languages).
  */
 @Injectable()
 export class PoCodeEditorRegister implements PoCodeEditorRegisterable {
   /** Sintaxe a ser registrada. */
   language: string;
 
-  /** Opções da sintaxe para registro no po-code-editor */
+  /** Opções da sintaxe para registro no po-code-editor. */
   options: PoCodeEditorRegisterableOptions;
+
+  /** Lista de sugestões para a função de autocomplete (CTRL + SPACE). */
+  suggestions?: PoCodeEditorRegisterableSuggestionType;
 }

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-suggestion.service.spec.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-suggestion.service.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PoCodeEditorSuggestionService } from './po-code-editor-suggestion.service';
+import { PoCodeEditorRegisterableSuggestion } from './interfaces/po-code-editor-registerable-suggestion.interface';
+
+describe('PoCodeEditorSuggestionService', () => {
+  let service: PoCodeEditorSuggestionService;
+  const htmlSuggestions_1: Array<PoCodeEditorRegisterableSuggestion> = [
+    { label: 'po', insertText: '<po-ui></po-ui>', documentation: 'best library!' },
+    { label: 'angular', insertText: '<angular></angular>', documentation: 'best framework!' }
+  ];
+
+  const htmlSuggestions_2: Array<PoCodeEditorRegisterableSuggestion> = [
+    { label: 'po', insertText: '<po-ui></po-ui>', documentation: 'best library!' },
+    { label: 'angular', insertText: '<angular></angular>', documentation: 'best framework!' },
+    { label: 'vue', insertText: '<vue></vue>', documentation: 'vuezin' }
+  ];
+
+  const htmlSuggestions_3: Array<PoCodeEditorRegisterableSuggestion> = [
+    { label: 'po', insertText: '<po-ui></po-ui>', documentation: 'best library!' },
+    { label: 'angular', insertText: '<angular></angular>', documentation: 'best framework!' },
+    { label: 'react', insertText: '<vue></vue>', documentation: 'me' }
+  ];
+
+  const jsSuggestions: Array<PoCodeEditorRegisterableSuggestion> = [
+    { label: 'log', insertText: 'console.log', documentation: 'debug time' },
+    { label: 'alert', insertText: 'alert()', documentation: 'Hello' }
+  ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PoCodeEditorSuggestionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should add a array of new suggestion for two different languages', () => {
+    expect(service.getSuggestion('html', htmlSuggestions_1)).toEqual(htmlSuggestions_1);
+    expect(service.getSuggestion('js', jsSuggestions)).toEqual(jsSuggestions);
+  });
+
+  it('should deduplicate two arrays of new suggestion from the same language', () => {
+    service.getSuggestion('html', htmlSuggestions_1);
+    expect(service.getSuggestion('html', htmlSuggestions_2)).toEqual([
+      { label: 'vue', insertText: '<vue></vue>', documentation: 'vuezin' }
+    ]);
+    expect(service.getSuggestion('html', htmlSuggestions_3)).toEqual([
+      { label: 'react', insertText: '<vue></vue>', documentation: 'me' }
+    ]);
+  });
+});

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-suggestion.service.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-suggestion.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import {
+  PoCodeEditorSuggestionList,
+  PoCodeEditorRegisterableSuggestion
+} from './interfaces/po-code-editor-registerable-suggestion.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PoCodeEditorSuggestionService {
+  private suggestions: PoCodeEditorSuggestionList = {};
+  constructor() {}
+
+  public getSuggestion(language: string, newSuggestion: Array<PoCodeEditorRegisterableSuggestion>) {
+    if (this.suggestions[language]) {
+      const deduplicateSuggestions = this.deduplicateSuggestions(this.suggestions[language], newSuggestion);
+      this.suggestions[language] = [...this.suggestions[language], ...deduplicateSuggestions];
+      return deduplicateSuggestions;
+    } else {
+      return (this.suggestions[language] = [...newSuggestion]);
+    }
+  }
+
+  private deduplicateSuggestions(
+    originalSuggestions: Array<PoCodeEditorRegisterableSuggestion>,
+    newSuggestions: Array<PoCodeEditorRegisterableSuggestion>
+  ) {
+    return newSuggestions.filter(
+      newItem => !originalSuggestions.find(originalItem => originalItem['label'] === newItem['label'])
+    );
+  }
+}

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor.component.spec.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor.component.spec.ts
@@ -70,17 +70,32 @@ describe('PoCodeEditorComponent', () => {
     expect(fakeThis.setMonacoLanguage).toHaveBeenCalledTimes(1);
   });
 
-  it('should call monaco register sintax', () => {
+  it('should call monaco `register` sintax', () => {
     const fakeThis = {
+      setSuggestions: () => {},
       codeEditorRegister: {
-        language: 'terraform'
+        language: 'terraform',
+        options: {},
+        suggestions: {
+          provideCompletionItems: () => {
+            return {
+              suggestions: [
+                {
+                  label: 'terraform',
+                  insertText: '#terraform language'
+                }
+              ]
+            };
+          }
+        }
       }
     };
 
     (<any>window).monaco = {
       languages: {
         register: () => {},
-        setMonarchTokensProvider: () => {}
+        setMonarchTokensProvider: () => {},
+        registerCompletionItemProvider: () => {}
       }
     };
 
@@ -90,6 +105,79 @@ describe('PoCodeEditorComponent', () => {
     component['registerCustomLanguage'].call(fakeThis);
     expect((<any>window).monaco.languages.register).toHaveBeenCalled();
     expect((<any>window).monaco.languages.setMonarchTokensProvider).toHaveBeenCalled();
+  });
+
+  it('shouldn`t call monaco `register` without a defined language', () => {
+    const fakeThis = {
+      codeEditorRegister: {
+        language: undefined,
+        options: {},
+        suggestions: undefined
+      }
+    };
+
+    (<any>window).monaco = {
+      languages: {
+        register: () => {},
+        setMonarchTokensProvider: () => {},
+        registerCompletionItemProvider: () => {}
+      }
+    };
+
+    spyOn((<any>window).monaco.languages, <any>'register');
+    spyOn((<any>window).monaco.languages, <any>'setMonarchTokensProvider');
+    spyOn((<any>window).monaco.languages, <any>'registerCompletionItemProvider');
+
+    component['registerCustomLanguage'].call(fakeThis);
+    expect((<any>window).monaco.languages.register).not.toHaveBeenCalled();
+    expect((<any>window).monaco.languages.setMonarchTokensProvider).not.toHaveBeenCalled();
+    expect((<any>window).monaco.languages.registerCompletionItemProvider).not.toHaveBeenCalled();
+  });
+
+  it('shouldn`t call monaco `setMonarchTokensProvider` without a defined options', () => {
+    const fakeThis = {
+      codeEditorRegister: {
+        language: 'PoLanguage',
+        options: undefined,
+        suggestions: undefined
+      }
+    };
+
+    (<any>window).monaco = {
+      languages: {
+        register: () => {},
+        setMonarchTokensProvider: () => {},
+        registerCompletionItemProvider: () => {}
+      }
+    };
+
+    spyOn((<any>window).monaco.languages, <any>'setMonarchTokensProvider');
+
+    component['registerCustomLanguage'].call(fakeThis);
+    expect((<any>window).monaco.languages.setMonarchTokensProvider).not.toHaveBeenCalled();
+  });
+
+  it('shouldn`t call monaco `registerCompletionItemProvider` without a defined suggestions', () => {
+    const fakeThis = {
+      codeEditorRegister: {
+        language: 'PoLanguage',
+        options: {},
+        suggestions: undefined
+      }
+    };
+
+    (<any>window).monaco = {
+      languages: {
+        register: () => {},
+        setMonarchTokensProvider: () => {},
+        registerCompletionItemProvider: () => {}
+      }
+    };
+
+    spyOn((<any>window).monaco.languages, <any>'registerCompletionItemProvider');
+
+    component['registerCustomLanguage'].call(fakeThis);
+    expect((<any>window).monaco.languages.registerCompletionItemProvider).not.toHaveBeenCalled();
   });
 
   it('should not call monaco register sintax when language is invalid', () => {

--- a/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-suggestion/sample-po-code-editor-suggestion.component.html
+++ b/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-suggestion/sample-po-code-editor-suggestion.component.html
@@ -1,0 +1,1 @@
+<po-code-editor [p-suggestions]="suggestions" [p-language]="language"> </po-code-editor>

--- a/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-suggestion/sample-po-code-editor-suggestion.component.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-suggestion/sample-po-code-editor-suggestion.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sample-po-code-editor-suggestion',
+  templateUrl: './sample-po-code-editor-suggestion.component.html'
+})
+export class SamplePoCodeEditorSuggestionComponent {
+  language = 'html';
+  suggestions = [
+    { label: 'po', insertText: 'PO UI' },
+    { label: 'ng', insertText: 'Angular' },
+    { label: 'po-btn', insertText: '<po-button p-label="${1:label}"></po-button>' },
+    { label: 'po-inp', insertText: '<po-input name="${1:name}" [(ngModel)]="${2:model}"></po-input>' }
+  ];
+}

--- a/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.constant.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.constant.ts
@@ -1,4 +1,28 @@
+import { PoCodeEditorRegisterableSuggestion } from '@po-ui/ng-code-editor';
 import { PoCodeEditorRegisterable } from '@po-ui/ng-code-editor';
+
+declare const monaco: any;
+
+/** Definição da lista de sugestões para o autocomplete.
+ *
+ * > A função `provideCompletionItems` precisa ser exportada para ser compatível com AOT.
+ *
+ * Documentação: https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-custom-languages
+ */
+export function provideCompletionItems() {
+  const suggestions: Array<PoCodeEditorRegisterableSuggestion> = [
+    {
+      label: 'terraform',
+      insertText: '#terraform language'
+    },
+    {
+      label: 'server',
+      insertText: 'server ${1:ip}'
+    }
+  ];
+
+  return { suggestions };
+}
 
 /** Definindo propriedades de uma nova sintaxe. */
 export const customRegister: PoCodeEditorRegisterable = {
@@ -42,5 +66,6 @@ export const customRegister: PoCodeEditorRegisterable = {
         ['', '', '@pop']
       ]
     }
-  }
+  },
+  suggestions: { provideCompletionItems: provideCompletionItems }
 };

--- a/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.module.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.module.ts
@@ -3,30 +3,14 @@
  */
 
 // import { NgModule } from '@angular/core';
-
 // import { HttpClientModule } from '@angular/common/http';
-
-// import { PoModule } from '@po-ui/ng-components';
 //
-// import { PoCodeEditorModule, PoCodeEditorRegisterable } from '@po-ui/ng-code-editor';
-
-// const customRegister: PoCodeEditorRegisterable = {
-//   language: 'terraform'
-//   options: {
-//     keywords: ['resource', 'provider', 'variable', 'output', 'module', 'true', 'false'],
-//     operators: ['{', '}', '(', ')', '[', ']', '?', ':'],
-//     symbols:  /[=><!~?:&|+\-*\/\^%]+/,
-//     escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
-//     tokenizer: {
-//      ...
-//     }
-//   }
-// };
+// import { PoCodeEditorModule } from '@po-ui/ng-code-editor';
+//
 //
 // @NgModule({
 //   imports: [
 //     HttpClientModule,
-
 //     PoModule,
 //     PoCodeEditorModule.forRegister(customRegister)
 //   ],

--- a/projects/code-editor/src/lib/index.ts
+++ b/projects/code-editor/src/lib/index.ts
@@ -5,5 +5,6 @@ export { PoCodeEditorRegister } from './components/po-code-editor/po-code-editor
 export { PoCodeEditorRegisterable } from './components/po-code-editor/interfaces/po-code-editor-registerable.interface';
 export { PoCodeEditorRegisterableOptions } from './components/po-code-editor/interfaces/po-code-editor-registerable-options.interface';
 export { PoCodeEditorRegisterableTokens } from './components/po-code-editor/interfaces/po-code-editor-registerable-tokens.interface';
+export { PoCodeEditorRegisterableSuggestion } from './components/po-code-editor/interfaces/po-code-editor-registerable-suggestion.interface';
 
 export { PoCodeEditorModule } from './components/po-code-editor/po-code-editor.module';


### PR DESCRIPTION
**CODE-EDITOR**

**DTHFUI-2797**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Não era possivel incluir novas sugestões ao editor

**Qual o novo comportamento?**
Além de adicionar a propriedade `p-suggestions` ao componente, foram
adicionados alguns testes para aumentar o coverage do componente
garantido mais qualidade ao código.

Com essa nova funcionalidade o desenvolvedor pode adicionar uma lista
de sugestões para o autocomplete (além de snippets) quando cria uma nova
sintaxe ou diretamente a uma linguagem já existentes diretamente no
componente.

**Simulação**

É possível realizar o testes nesses dois projetos

[app_terraform_2.zip](https://github.com/po-ui/po-angular/files/5144060/app_terraform_2.zip)
[app_code_editor.zip](https://github.com/po-ui/po-angular/files/5131738/app_code_editor.zip)

