### PR TITLE
fix(table): corrige ordenação quando possui valores inválidos

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -377,7 +377,7 @@ describe('PoTableBaseComponent:', () => {
     expect(component.selectAll).toBe(null);
   });
 
-  it('shoul not sort column', () => {
+  it('should not sort column', () => {
     const unSortedItems = items.slice();
     component.sort = false;
 
@@ -1100,6 +1100,80 @@ describe('PoTableBaseComponent:', () => {
 
       expect(component.subtitleColumns).toEqual(expectedValue);
       expect(spyGetSubtitleColumns).toHaveBeenCalled();
+    });
+
+    describe('sortColumn', () => {
+      it('should sort items by number type column', () => {
+        const sortedItems = [
+          { name: 'Chris Doe', age: null },
+          { name: 'John Doe', age: 30 },
+          { name: 'Evelyn Doe', age: 30 },
+          { name: 'Jane Doe', age: 31 }
+        ];
+
+        component.sort = true;
+        component.columns = [{ property: 'name' }, { property: 'age', type: 'number' }];
+        component.items = [
+          { name: 'John Doe', age: 30 },
+          { name: 'Jane Doe', age: 31 },
+          { name: 'Chris Doe', age: null },
+          { name: 'Evelyn Doe', age: 30 }
+        ];
+
+        component.sortColumn(component.columns.find(c => c.property === 'age'));
+
+        expect(component.items).toEqual(sortedItems);
+      });
+
+      it('should sort items by default type column', () => {
+        const sortedItems = [
+          { name: null, age: 30 },
+          { name: 'Evelyn Doe', age: 30 },
+          { name: 'Jane Doe', age: 31 },
+          { name: 'John Doe', age: 30 }
+        ];
+
+        component.sort = true;
+        component.columns = [{ property: 'name' }, { property: 'age', type: 'number' }];
+        component.items = [
+          { name: 'John Doe', age: 30 },
+          { name: 'Jane Doe', age: 31 },
+          { name: null, age: 30 },
+          { name: 'Evelyn Doe', age: 30 }
+        ];
+
+        component.sortColumn(component.columns.find(c => c.property === 'name'));
+
+        expect(component.items).toEqual(sortedItems);
+      });
+
+      it('should sort items by date type column', () => {
+        const sortedItems = [
+          { name: 'Evelyn Doe', age: 30, birthday: null },
+          { name: 'Mr Doe', age: 65, birthday: null },
+          { name: 'John Doe', age: 45, birthday: '1975-02-20' },
+          { name: 'Jane Doe', age: 44, birthday: '1976-05-12' },
+          { name: 'Chris Doe', age: 25, birthday: '1995-01-05' }
+        ];
+
+        component.sort = true;
+        component.columns = [
+          { property: 'name' },
+          { property: 'age', type: 'number' },
+          { property: 'birthday', type: 'date' }
+        ];
+        component.items = [
+          { name: 'John Doe', age: 45, birthday: '1975-02-20' },
+          { name: 'Mr Doe', age: 65, birthday: null },
+          { name: 'Jane Doe', age: 44, birthday: '1976-05-12' },
+          { name: 'Chris Doe', age: 25, birthday: '1995-01-05' },
+          { name: 'Evelyn Doe', age: 30, birthday: null }
+        ];
+
+        component.sortColumn(component.columns.find(c => c.property === 'birthday'));
+
+        expect(component.items).toEqual(sortedItems);
+      });
     });
   });
 

--- a/projects/ui/src/lib/utils/util.spec.ts
+++ b/projects/ui/src/lib/utils/util.spec.ts
@@ -823,39 +823,39 @@ describe('Function sortValues:', () => {
   });
 
   describe('Invalid values:', () => {
-    const invalidValues: Array<any> = [undefined, null, false, NaN, 0];
+    const invalidValues: Array<any> = [undefined, null, NaN];
     const validParam: string = 'ABC';
     const expectedReturn: number = 0;
 
-    it('should return `0` if `leftSide` is invalid value and `ascending` is `true`', () => {
+    it('should return `-1` if `leftSide` is invalid value and `ascending` is `true`', () => {
       const ascending: boolean = true;
 
       invalidValues.forEach(invalidValue => {
-        expect(sortValues(invalidValue, validParam, ascending)).toBe(expectedReturn);
+        expect(sortValues(invalidValue, validParam, ascending)).toBe(-1);
       });
     });
 
-    it('should return `0` if `leftSide` is invalid value and `ascending` is `false`', () => {
+    it('should return `1` if `leftSide` is invalid value and `ascending` is `false`', () => {
       const ascending: boolean = false;
 
       invalidValues.forEach(invalidValue => {
-        expect(sortValues(invalidValue, validParam, ascending)).toBe(expectedReturn);
+        expect(sortValues(invalidValue, validParam, ascending)).toBe(1);
       });
     });
 
-    it('should return `0` if `rightSide` is invalid value and `ascending` is `true`', () => {
+    it('should return `1` if `rightSide` is invalid value and `ascending` is `true`', () => {
       const ascending: boolean = true;
 
       invalidValues.forEach(invalidValue => {
-        expect(sortValues(validParam, invalidValue, ascending)).toBe(expectedReturn);
+        expect(sortValues(validParam, invalidValue, ascending)).toBe(1);
       });
     });
 
-    it('should return `0` if `rightSide` is invalid value and `ascending` is `false`', () => {
+    it('should return `-1` if `rightSide` is invalid value and `ascending` is `false`', () => {
       const ascending: boolean = false;
 
       invalidValues.forEach(invalidValue => {
-        expect(sortValues(validParam, invalidValue, ascending)).toBe(expectedReturn);
+        expect(sortValues(validParam, invalidValue, ascending)).toBe(-1);
       });
     });
 

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -373,16 +373,19 @@ export function sortValues(leftSide: string, rightSide: string, ascending: boole
   const left = isTypeof(leftSide, 'string') ? leftSide.toLowerCase() : leftSide;
   const right = isTypeof(rightSide, 'string') ? rightSide.toLowerCase() : rightSide;
 
+  const leftIsInvalid = left === null || left === undefined || Number.isNaN(left);
+  const rightIsInvalid = right === null || right === undefined || Number.isNaN(right);
+
   if (ascending) {
-    if (left < right) {
+    if (left < right || leftIsInvalid) {
       return -1;
-    } else if (left > right) {
+    } else if (left > right || rightIsInvalid) {
       return 1;
     }
   } else if (ascending === false) {
-    if (left < right) {
+    if (left < right || leftIsInvalid) {
       return 1;
-    } else if (left > right) {
+    } else if (left > right || rightIsInvalid) {
       return -1;
     }
   }


### PR DESCRIPTION

Fixes DTHFUI-3919

**TABLE**

**DTHFUI-3919**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A ordenação com valores nulos estava incoerente.

**Qual o novo comportamento?**
Os itens com valores invalidos (null, undefined, NaN)
devem ficar no topo e em baixo após a ordenação.


**Simulação**
- Simular no Portal, e;
- Alterar algum sample e adicionar valores nulos em diferentes tipos de colunas (number, date, boolean)