### PR TITLE
fix(combo): corrige mudança para dirty caso alterar model via typescript

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -448,7 +448,7 @@ describe('PoComboBaseComponent:', () => {
 
       expect(component.getOptionFromValue).not.toHaveBeenCalled();
       expect(component.getObjectByValue).not.toHaveBeenCalled();
-      expect(component.updateSelectedValue).toHaveBeenCalledWith(null, true, true);
+      expect(component.updateSelectedValue).toHaveBeenCalledWith(null);
       expect(component.updateComboList).toHaveBeenCalled();
     });
 
@@ -475,6 +475,24 @@ describe('PoComboBaseComponent:', () => {
       component.writeValue('1');
 
       expect(component.updateSelectedValue).toHaveBeenCalled();
+    });
+
+    it('shouldn`t call `callModelChange` and `fromWriteValue` should be false after call `updateSelectedValue`', () => {
+      const newModel = 2;
+
+      component.options = [
+        { label: 'Test 1', value: 1 },
+        { label: 'Test 2', value: 2 }
+      ];
+
+      spyOn(component, 'callModelChange');
+      spyOn(component, 'updateSelectedValue').and.callThrough();
+
+      component.writeValue(newModel);
+
+      expect(component.updateSelectedValue).toHaveBeenCalled();
+      expect(component.callModelChange).not.toHaveBeenCalled();
+      expect(component['fromWriteValue']).toBe(false);
     });
   });
 
@@ -514,11 +532,12 @@ describe('PoComboBaseComponent:', () => {
       const value = 1;
 
       component.selectedValue = undefined;
+      component['fromWriteValue'] = true;
 
       const spyCallModelChange = spyOn(component, 'callModelChange');
       const spyChangeEmit = spyOn(component.change, 'emit');
 
-      component['updateModel'](value, true);
+      component['updateModel'](value);
 
       expect(spyCallModelChange).not.toHaveBeenCalled();
       expect(spyChangeEmit).toHaveBeenCalled();
@@ -776,7 +795,7 @@ describe('PoComboBaseComponent:', () => {
 
       expect(spySetInputValue).toHaveBeenCalledWith(option.label);
       expect(spyUpdateInternalVariables).toHaveBeenCalledWith(option);
-      expect(spyUpdateModel).toHaveBeenCalledWith(option.value, false);
+      expect(spyUpdateModel).toHaveBeenCalledWith(option.value);
     });
 
     it(`updateSelectedValue: should call 'setInputValue', 'updateInternalVariables' and 'updateModel' with
@@ -793,7 +812,7 @@ describe('PoComboBaseComponent:', () => {
 
       expect(spySetInputValue).toHaveBeenCalledWith(option.label);
       expect(spyUpdateInternalVariables).toHaveBeenCalledWith(option);
-      expect(spyUpdateModel).toHaveBeenCalledWith(option.value, false);
+      expect(spyUpdateModel).toHaveBeenCalledWith(option.value);
     });
 
     it(`updateSelectedValue: should call 'setInputValue', 'updateInternalVariables' and 'updateModel' with
@@ -810,7 +829,7 @@ describe('PoComboBaseComponent:', () => {
 
       expect(spySetInputValue).toHaveBeenCalledWith('');
       expect(spyUpdateInternalVariables).toHaveBeenCalledWith(option);
-      expect(spyUpdateModel).toHaveBeenCalledWith(undefined, false);
+      expect(spyUpdateModel).toHaveBeenCalledWith(undefined);
     });
 
     it(`updateSelectedValue: shouldn't call 'setInputValue' and 'updateModel' if 'changeOnEnter' is true

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -68,6 +68,10 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   private _sort?: boolean = false;
   private language: string;
 
+  // utilizado para fazer o controle de atualizar o model.
+  // não deve forçar a atualização se o gatilho for o writeValue para não deixar o campo dirty.
+  private fromWriteValue: boolean = false;
+
   protected cacheStaticOptions: Array<PoComboOption | PoComboGroup> = [];
   protected comboOptionsList: Array<PoComboOption | PoComboGroup> = [];
 
@@ -522,7 +526,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     }
   }
 
-  updateSelectedValue(option: PoComboOption | PoComboGroup, isUpdateModel: boolean = true, isWriteValue = false) {
+  updateSelectedValue(option: PoComboOption | PoComboGroup, isUpdateModel: boolean = true) {
     const optionLabel = (option && option.label) || '';
 
     this.updateInternalVariables(option);
@@ -537,7 +541,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     if (isUpdateModel) {
       const optionValue = (option && option.value) || undefined;
 
-      this.updateModel(optionValue, isWriteValue);
+      this.updateModel(optionValue);
     }
   }
 
@@ -659,6 +663,8 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
 
   // Recebe as alterações do model
   writeValue(value: any) {
+    this.fromWriteValue = true;
+
     if (validValue(value) && !this.service && this.comboOptionsList && this.comboOptionsList.length) {
       const option = this.getOptionFromValue(value, this.comboOptionsList);
       this.updateSelectedValue(option);
@@ -670,7 +676,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     if (value && this.service) {
       return this.getObjectByValue(value);
     } else {
-      this.updateSelectedValue(null, true, true);
+      this.updateSelectedValue(null);
       this.updateComboList();
     }
   }
@@ -838,9 +844,9 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     }
   }
 
-  private updateModel(value: any, fromWriteValue = false): void {
+  private updateModel(value: any): void {
     if (value !== this.selectedValue) {
-      if (!fromWriteValue) {
+      if (!this.fromWriteValue) {
         this.callModelChange(value);
       }
 
@@ -848,6 +854,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     }
 
     this.selectedValue = value;
+    this.fromWriteValue = false;
   }
 
   private updateSelectedValueWithOldOption() {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-filter.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-filter.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs';


### PR DESCRIPTION
**COMBO**

**DTHFUI-3866**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O componente estava ficando 'dirty' ao receber um valor via typescript.

**Qual o novo comportamento?**
Deve ficar dirty apenas quando o usuário digitar/selecionar algum valor.

https://angular.io/guide/form-validation#validating-input-in-template-driven-forms

**Simulação**
- Usar o projeto https://stackblitz.com/edit/po-ui-4eudxe, e, ou;
- Importar ReactiveFormsModule no app.module 
app.component.html
```
<po-page-default p-title="PO UI" [p-actions]="actions">

  <!-- REACTIVE FORM -->
  <form [formGroup]="form">

   <po-combo name="combo" p-label="PO Combo" formControlName="combo"
     [p-options]="[{ value: 'Option 1' }, { value: 'Option 2' }]"> </po-combo>

 </form>

  <!-- TEMPLATE DRIVEN FORM -->
 <!-- <form #formDriven>

   <po-combo
     name="combo"
     p-label="PO Combo"
     [(ngModel)]="combo"
     [p-options]="[{ value: 'Option 1' }, { value: 'Option 2' }]">
   </po-combo>

 </form> -->

</po-page-default>
``` 

app.component.ts
```

 @ViewChild('formDriven', { static: true, read: NgForm }) formDriven;

  constructor(){}

  readonly actions: Array<any> = [
    {
      label: "form.patchValue",
      action: this.formpatchValue.bind(this),
    },
    {
      label: "check.dirty",
      action: this.checkDirty.bind(this),
    }
  ];

  form = new FormGroup({
    combo: new FormControl(''),
  });

  combo;

  formpatchValue() {
    this.form.patchValue({
      combo: "Option 1",
    });

    // this.combo = "Option 1";

  }

  checkDirty() {

    console.log(`combo.dirty: ${this.form.get('combo').dirty}`)
    // console.log(`combo.dirty: ${this.formDriven.form.get('combo').dirty}`);
  }
```