### PR TITLE
fix(rich-text): corrige atualização do model via código

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.spec.ts
@@ -5,15 +5,17 @@ import * as ValidatorsFunctions from '../validators';
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 
 import { PoRichTextBaseComponent } from './po-rich-text-base.component';
+import { PoRichTextService } from './po-rich-text.service';
 
 @Directive()
 class PoRichTextComponent extends PoRichTextBaseComponent {}
 
 describe('PoRichTextBaseComponent:', () => {
+  const poRichTextService: PoRichTextService = new PoRichTextService();
   let component: PoRichTextComponent;
 
   beforeEach(() => {
-    component = new PoRichTextComponent();
+    component = new PoRichTextComponent(poRichTextService);
   });
 
   it('should be created', () => {
@@ -103,11 +105,14 @@ describe('PoRichTextBaseComponent:', () => {
     });
 
     it('writeValue: should set value with the received param', () => {
+      spyOn(component['richTextService'], 'emitModel');
+      const model = 'value B';
       component.value = 'value A';
 
-      component.writeValue('value B');
+      component.writeValue(model);
 
-      expect(component.value).toBe('value B');
+      expect(component.value).toBe(model);
+      expect(component['richTextService'].emitModel).toHaveBeenCalledWith(model);
     });
 
     it('updateModel: should call onChangeModel method if onChangeModel isn`t false', () => {

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
@@ -4,6 +4,7 @@ import { EventEmitter, Input, Output, Directive } from '@angular/core';
 import { convertToBoolean } from '../../../utils/util';
 import { requiredFailed } from '../validators';
 import { InputBoolean } from '../../../decorators';
+import { PoRichTextService } from './po-rich-text.service';
 
 /**
  * @description
@@ -161,6 +162,8 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
   /** Evento disparado ao modificar valor do model e que recebe como parâmetro o valor alterado. */
   @Output('p-change-model') changeModel?: EventEmitter<any> = new EventEmitter();
 
+  constructor(private richTextService: PoRichTextService) {}
+
   // Função implementada do ControlValueAccessor
   // Usada para interceptar as mudanças e não atualizar automaticamente o Model
   registerOnChange(func: any): void {
@@ -189,6 +192,8 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
 
   writeValue(value: string): void {
     this.value = value;
+
+    this.richTextService.emitModel(value);
   }
 
   // Executa a função onChange

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
@@ -4,6 +4,7 @@ import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { PoRichTextBaseComponent } from './po-rich-text-base.component';
 import { PoRichTextBodyComponent } from './po-rich-text-body/po-rich-text-body.component';
+import { PoRichTextService } from './po-rich-text.service';
 
 /* istanbul ignore next */
 const providers = [
@@ -57,8 +58,8 @@ export class PoRichTextComponent extends PoRichTextBaseComponent implements Afte
     return this.errorMessage !== '' && !this.value && this.required && this.invalid ? this.errorMessage : '';
   }
 
-  constructor(private element: ElementRef) {
-    super();
+  constructor(private element: ElementRef, richTextService: PoRichTextService) {
+    super(richTextService);
   }
 
   ngAfterViewInit() {

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+
+import { Observable } from 'rxjs';
+
+import { PoRichTextService } from './po-rich-text.service';
+
+describe('Service: PoRichText', () => {
+  let richTextService: PoRichTextService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PoRichTextService]
+    });
+
+    richTextService = TestBed.inject(PoRichTextService);
+  });
+
+  it('should ...', inject([PoRichTextService], (service: PoRichTextService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  describe('Methods:', () => {
+    it('emitModel: should call model.next with value', () => {
+      const value = 'test';
+      spyOn(richTextService['model'], 'next');
+      richTextService.emitModel('test');
+
+      expect(richTextService['model'].next).toHaveBeenCalledWith(value);
+    });
+
+    it('getModel: should call model.asObservable', () => {
+      spyOn(richTextService['model'], 'asObservable');
+      richTextService.getModel();
+
+      expect(richTextService['model'].asObservable).toHaveBeenCalled();
+    });
+
+    it('getModel: should return an instanceof Observable', () => {
+      const result = richTextService.getModel();
+
+      expect(result instanceof Observable).toBeTruthy();
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PoRichTextService {
+  private model = new Subject<string>();
+
+  emitModel(value: string) {
+    this.model.next(value);
+  }
+
+  getModel() {
+    return this.model.asObservable();
+  }
+}


### PR DESCRIPTION
**PO RICH TEXT**

**DTHFUI-3787**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao tentar atualizar o valor do rich-text via código o valor não é atualizado.

**Qual o novo comportamento?**
Corrige comportamento ao atualizar o valor do componente via código.

**Simulação**
- app.component.html:
```
<po-rich-text 
  name="richText"
  [(ngModel)]="richText">
</po-rich-text>
<po-textarea class="po-md-6" name="model" [(ngModel)]="richText" p-label="Model" p-readonly p-rows="8"> </po-textarea>
<po-button (p-click)="mudaValorRichText()" p-label="mudar o valor do rich-text"></po-button>
```
- app.component.ts:
```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  richText = 'valor inicial';

  mudaValorRichText() {
    this.richText = 'novo valor';
  }
}
```