### PR TITLE
fix(combo): adiciona tratamento para retorno de erro HTTP na pesquisa

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-filter.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-filter.service.spec.ts
@@ -97,6 +97,24 @@ describe('PoComboFilterService ', () => {
   });
 
   describe('Methods:', () => {
+    it('getFilteredData: should contains X-PO-NO-MESSAGE in headers request', done => {
+      const urlWithParams = 'http://mockurl.com?filter=test';
+      const parsedParams: Array<PoComboOption> = [{ label: 'value1', value: 'value1' }];
+
+      spyOn(comboService, <any>'parseToArrayComboOption').and.returnValue(parsedParams);
+      spyOnProperty(comboService, 'url', 'get').and.returnValue('http://mockurl.com');
+
+      comboService.getFilteredData({ value: 'test' }).subscribe(response => {
+        expect(response).toEqual(parsedParams);
+        done();
+      });
+
+      const req = httpMock.expectOne((request: HttpRequest<any>) => request.urlWithParams === urlWithParams);
+      expect(req.request.headers.get('X-PO-No-Message')).toBe('true');
+
+      req.flush({});
+    });
+
     it('getFilteredData: should concatenate url with filter params', done => {
       const urlWithParams = 'http://mockurl.com?param1=value1&param2=value2&filter=test';
       const parsedParams: Array<PoComboOption> = [{ label: 'value1', value: 'value1' }];
@@ -181,6 +199,25 @@ describe('PoComboFilterService ', () => {
       });
 
       httpMock.expectOne(`http://mockurl.com?filter=`).flush({ items });
+    });
+
+    it('getObjectByValue: should contains X-PO-NO-MESSAGE in headers request', done => {
+      const filteredObject: PoComboOption = { label: 'value1', value: 'value1' };
+      const param = 'angular';
+      const urlWithParams = 'http://mockurl.com/angular';
+
+      spyOn(comboService, <any>'parseToComboOption').and.returnValue(filteredObject);
+      spyOnProperty(comboService, 'url', 'get').and.returnValue('http://mockurl.com');
+
+      comboService.getObjectByValue(param).subscribe(response => {
+        expect(response).toEqual(filteredObject);
+        done();
+      });
+
+      const req = httpMock.expectOne((request: HttpRequest<any>) => request.urlWithParams === urlWithParams);
+      expect(req.request.headers.get('X-PO-No-Message')).toBe('true');
+
+      req.flush({});
     });
 
     it('getObjectByValue: should add filter params', done => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-filter.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-filter.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs';
@@ -25,6 +25,10 @@ export class PoComboFilterService implements PoComboFilter {
 
   private messages = [];
 
+  readonly headers: HttpHeaders = new HttpHeaders({
+    'X-PO-No-Message': 'true'
+  });
+
   get url(): string {
     return this._url;
   }
@@ -38,7 +42,7 @@ export class PoComboFilterService implements PoComboFilter {
     const params = { ...filterParamsValidated, filter: value };
 
     return this.http
-      .get(`${this.url}`, { responseType: 'json', params: params })
+      .get(`${this.url}`, { responseType: 'json', params, headers: this.headers })
       .pipe(map((response: PoResponse) => this.parseToArrayComboOption(response.items)));
   }
 
@@ -46,7 +50,7 @@ export class PoComboFilterService implements PoComboFilter {
     const filterParamsValidated = validateObjectType(filterParams);
 
     return this.http
-      .get(`${this.url}/${value}`, { params: filterParamsValidated })
+      .get(`${this.url}/${value}`, { params: filterParamsValidated, headers: this.headers })
       .pipe(map(item => this.parseToComboOption(item)));
   }
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -146,8 +146,6 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
       this.initializeListeners();
     } else {
       this._isServerSearching = value;
-
-      this.removeListeners();
     }
   }
 
@@ -346,9 +344,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
 
     const param = { property: this.fieldLabel, value };
 
-    this.filterSubscription = this.service
-      .getFilteredData(param, this.filterParams)
-      .subscribe(items => this.setOptionsByApplyFilter(value, items));
+    this.filterSubscription = this.service.getFilteredData(param, this.filterParams).subscribe(
+      items => this.setOptionsByApplyFilter(value, items),
+      error => this.onErrorFilteredData()
+    );
   }
 
   setOptionsByApplyFilter(value, items) {
@@ -373,9 +372,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     if (!this.selectedValue) {
       this.isProcessingGetObjectByValue = true;
 
-      this.getSubscription = this.service
-        .getObjectByValue(value, this.filterParams)
-        .subscribe(item => this.updateOptionByFilteredValue(item));
+      this.getSubscription = this.service.getObjectByValue(value, this.filterParams).subscribe(
+        item => this.updateOptionByFilteredValue(item),
+        error => this.onErrorGetObjectByValue()
+      );
     }
   }
 
@@ -606,6 +606,18 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     });
 
     window.addEventListener('scroll', this.onScroll, true);
+  }
+
+  private onErrorGetObjectByValue() {
+    this.updateOptionByFilteredValue(null);
+  }
+
+  private onErrorFilteredData() {
+    this.isServerSearching = false;
+
+    this.updateComboList([]);
+
+    this.controlComboVisibility(true);
   }
 
   private onScroll = (): void => {


### PR DESCRIPTION
**COMBO**

**DTHFUI-3653**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao ocorrer um erro na pequisa, utilizando serviço, o componente ficava no estado de carregando e apresentava notificações de erro.

Também ficava preso no estado de carregando, não sendo possível fechar o popup.

**Qual o novo comportamento?**
Ao ocorrer algum erro na pesquisa, apresenta-se "Dado não encontrado" e omite as notificações de erro.

**Simulação**
- Utilizar Sample Labs e passar um serviço inexistente,