### PR TITLE
fix(i18n): correção para uso do componente PoI18n nos testes unitários

### DIFF
--- a/projects/ui/src/lib/services/po-i18n/index.ts
+++ b/projects/ui/src/lib/services/po-i18n/index.ts
@@ -3,5 +3,5 @@ export * from './interfaces/po-i18n-config-default.interface';
 export * from './interfaces/po-i18n-literals.interface';
 export * from './po-i18n.pipe';
 export * from './po-i18n.service';
-
+export * from './po-i18n-config-injection-token';
 export * from './po-i18n.module';

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
@@ -84,6 +84,9 @@ import { PoI18nLiterals } from './interfaces/po-i18n-literals.interface';
  *
  * Abaixo segue um exemplo de *setup* inicial de teste unitário do *AppComponent* que utiliza o `PoI18nService`:
  *
+ * > Atenção: não declarar o `PoI18nService` no providers do TestBed pois a biblioteca realiza a injeção de dependência de forma dinâmica.
+ * > Se o serviço for declarado o teste não fará a injeção e o teste apresentará erros.
+ *
  * ```
  * import { async, TestBed } from '@angular/core/testing';
  * import { HttpClientTestingModule } from '@angular/common/http/testing';

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
@@ -10,7 +10,7 @@ import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
  * @docsExtends PoI18nBaseService
  */
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class PoI18nService extends PoI18nBaseService {}
 
 // Função usada para retornar instância para o módulo po-i18n.module


### PR DESCRIPTION
**I18n**

**DTHFUI-4113**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [ ] Samples

**Qual o comportamento atual?**
No desenvolvimento de testes unitarios em componentes que utilizam o PoI18n apresenta erros de "default is not a function" e dependencia ciclica.

**Qual o novo comportamento?**
Foi exportado o arquivo po-i18n-config-injection-token e declarado
a propriedade provideIn do serviço.
Também foi incluído aviso na documentação.

**Simulação**
- Utilizar o projeto em anexo, buildar o ng component e colar no node_module do projeto
[taf-thf.zip](https://github.com/po-ui/po-angular/files/5163958/taf-thf.zip)
