### PR TITLE
feat(storage): atualiza pacote do localForage

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "gulp-run": "^1.7.1",
     "highlight.js": "^10.1.2",
     "http-status-codes": "^1.4.0",
-    "localforage": "1.4.0",
+    "localforage": "1.9.0",
     "lokijs": "1.5.8",
     "monaco-editor": "0.20.0",
     "ngx-markdown": "^10.1.0",

--- a/projects/storage/package.json
+++ b/projects/storage/package.json
@@ -14,14 +14,14 @@
   "dependencies": {
     "@po-ui/ng-schematics": "0.0.0-PLACEHOLDER",
     "custom-idle-queue": "2.1.2",
-    "localforage": "1.4.0",
+    "localforage": "1.9.0",
     "lokijs": "1.5.8",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
     "@angular/core": "~10.0.3",
     "custom-idle-queue": "2.1.2",
-    "localforage": "1.4.0",
+    "localforage": "1.9.0",
     "lokijs": "1.5.8",
     "rxjs": "~6.5.5",
     "zone.js": "~0.10.3"

--- a/projects/storage/src/lib/services/po-storage.service.ts
+++ b/projects/storage/src/lib/services/po-storage.service.ts
@@ -1,6 +1,8 @@
 import { Inject, Injectable, InjectionToken } from '@angular/core';
 
 import * as LocalForage from 'localforage';
+import 'localforage';
+
 import IdleQueue from 'custom-idle-queue';
 
 import { PoLokiDriver } from '../drivers/lokijs/po-loki-driver';


### PR DESCRIPTION
**storage**

**DTHFUI-4009**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O build de projetos utilizando AppShell e que contenham pacotes do Sync e Storage instalados estava gerando erro relacionado ao LocalForage. 

**Qual o novo comportamento?**
Atualizado pacote do LocalForage. O adendo de importação do pacote adicionada em `po-storage.service.ts` soluciona o problema que impediu a atualização do mesmo quando foram atualizados todos pacotes do projeto.

A atualização também resolve o problema relacionado ao build em aplicações com AppShell.

**Simulação**
Primeiramente pegar atualização do LocalForage no PO Angular:
1 - `npm run build:storage`;
2 - Apontar o tgz gerado no pacote do storage no `package.json` do ng-sync e rodar `npm run build:sync`;

Agora monte uma aplicação com AppShell de acordo com o passo-a-passo pra utilizar o App Shell do [Angular.io](https://angular.io/guide/app-shell):
1 - `new my-app --routing`
2 - `ng generate app-shell`
3 - Adicionar os componentes do PO : `ng add @po-ui/ng-components`;
4 - Adicionar o PO-Sync: `ng add @po-ui/ng-sync`;
5 - Aplicar o tgz gerado do `po-sync` no `package.json` do projeto. 
6 - Rodar `npm install` de novo para atualizar os pacotes do storage, sync e localForage
6 - Buildar prod o Projeto com o App Shell: `ng run my-app:app-shell:production`
7 - Verificar em `dist/browser/index.html` se o app-shell foi renderizado como parte do output.
FIm.

Por conta da atualização do LocalForage, é necessário também verificar a implementação dos pacotes do sync e storage na aplicação. Para isso, pode-se verificar a interação através [dessa aplicação com AppShell utilizando pacotes do PO](https://github.com/po-ui/po-angular/files/5175621/app-with-appshell.zip)


