### PR TITLE
feat(combo): adiciona a propriedade p-clean

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -1266,6 +1266,21 @@ describe('PoComboBaseComponent:', () => {
 
       expect(spyListingComboOptions).not.toHaveBeenCalled();
     });
+
+    it('clear: should call `callModelChange` and `updateSelectedValue` and `updateComboList`', () => {
+      component.clean = true;
+
+      spyOn(component, 'callModelChange');
+      spyOn(component, 'updateSelectedValue');
+      spyOn(component, 'updateComboList');
+
+      component.clear('');
+
+      expect(component.callModelChange).toHaveBeenCalled();
+      expect(component.updateSelectedValue).toHaveBeenCalled();
+      expect(component.updateComboList).toHaveBeenCalled();
+      expect(component.selectedValue).toEqual(undefined);
+    });
   });
 });
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -443,6 +443,9 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     return this._literals || poComboLiteralsDefault[this.language];
   }
 
+  /** Se verdadeiro, o campo receberá um botão para ser limpo. */
+  @Input('p-clean') @InputBoolean() clean?: boolean;
+
   /** Deve ser informada uma função que será disparada quando houver alterações no ngModel. */
   @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
 
@@ -721,6 +724,12 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     if (this.keyupSubscribe) {
       this.keyupSubscribe.unsubscribe();
     }
+  }
+
+  clear(value) {
+    this.callModelChange(value);
+    this.updateSelectedValue(null);
+    this.updateComboList();
   }
 
   protected validateModel(model: any) {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -5,8 +5,9 @@
     </div>
 
     <input
-      #inputElement
+      #inp
       class="po-input po-combo-input"
+      [ngClass]="clean && inp.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
       [class.po-input-icon-left]="icon"
       autocomplete="off"
       type="text"
@@ -21,6 +22,13 @@
     />
 
     <div class="po-field-icon-container-right">
+      <po-clean
+        [class.po-field-icon]="!disabled"
+        [class.po-field-icon-disabled]="disabled"
+        (p-change-event)="clear($event)"
+        [p-element-ref]="inputEl"
+      >
+      </po-clean>
       <span
         #iconArrow
         class="po-icon po-field-icon {{ comboIcon }}"

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -16,6 +16,7 @@ import { PoComboComponent } from './po-combo.component';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
 import { PoComboFilterService } from './po-combo-filter.service';
 import { PoComboOption } from './interfaces/po-combo-option.interface';
+import { PoCleanComponent } from '../po-clean/po-clean.component';
 
 const eventKeyBoard = document.createEvent('KeyboardEvent');
 eventKeyBoard.initEvent('keyup', true, true);
@@ -32,7 +33,7 @@ describe('PoComboComponent:', () => {
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [PoLoadingModule],
-      declarations: [PoComboComponent, PoFieldContainerComponent, PoFieldContainerBottomComponent],
+      declarations: [PoComboComponent, PoFieldContainerComponent, PoFieldContainerBottomComponent, PoCleanComponent],
       providers: [HttpClient, HttpHandler]
     });
   });
@@ -84,7 +85,7 @@ describe('PoComboComponent:', () => {
 
     spyOn(component, 'controlApplyFilter');
 
-    component.inputElement.nativeElement.dispatchEvent(eventKeyBoard);
+    component.inputEl.nativeElement.dispatchEvent(eventKeyBoard);
 
     tick(100);
 
@@ -99,7 +100,7 @@ describe('PoComboComponent:', () => {
 
     spyOn(component, 'controlApplyFilter');
 
-    component.inputElement.nativeElement.dispatchEvent(eventKeyBoard);
+    component.inputEl.nativeElement.dispatchEvent(eventKeyBoard);
 
     tick(100);
 
@@ -308,7 +309,7 @@ describe('PoComboComponent:', () => {
   it('should update value in the input', () => {
     component.setInputValue('1234567890');
     fixture.detectChanges();
-    expect(component.inputElement.nativeElement.value).toBe('1234567890');
+    expect(component.inputEl.nativeElement.value).toBe('1234567890');
   });
 
   it('should click in document', () => {
@@ -330,7 +331,7 @@ describe('PoComboComponent:', () => {
   });
 
   it('should not hide combo list when was click in input', () => {
-    component.inputElement.nativeElement.dispatchEvent(eventClick);
+    component.inputEl.nativeElement.dispatchEvent(eventClick);
 
     spyOn(component, 'controlComboVisibility');
     component.wasClickedOnToggle(eventClick);
@@ -383,32 +384,32 @@ describe('PoComboComponent:', () => {
     };
 
     it('focus: should call `focus` of combo', () => {
-      component.inputElement = {
+      component.inputEl = {
         nativeElement: {
           focus: () => {}
         }
       };
 
-      spyOn(component.inputElement.nativeElement, 'focus');
+      spyOn(component.inputEl.nativeElement, 'focus');
 
       component.focus();
 
-      expect(component.inputElement.nativeElement.focus).toHaveBeenCalled();
+      expect(component.inputEl.nativeElement.focus).toHaveBeenCalled();
     });
 
     it('focus: should`t call `focus` of combo if `disabled`', () => {
-      component.inputElement = {
+      component.inputEl = {
         nativeElement: {
           focus: () => {}
         }
       };
       component.disabled = true;
 
-      spyOn(component.inputElement.nativeElement, 'focus');
+      spyOn(component.inputEl.nativeElement, 'focus');
 
       component.focus();
 
-      expect(component.inputElement.nativeElement.focus).not.toHaveBeenCalled();
+      expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
     });
 
     describe('onKeyUp:', () => {
@@ -1120,7 +1121,7 @@ describe('PoComboComponent:', () => {
       expect(spySetElements).toHaveBeenCalledWith(
         component.containerElement.nativeElement,
         containerOffset,
-        component.inputElement,
+        component.inputEl,
         customPositions,
         isSetElementWidth
       );
@@ -1178,7 +1179,7 @@ describe('PoComboComponent:', () => {
       const spySetContainerPosition = spyOn(component, <any>'setContainerPosition');
       const spyScrollTo = spyOn(component, <any>'scrollTo');
       const spyDetectChanges = spyOn(component['changeDetector'], <any>'detectChanges');
-      const spyInputFocus = spyOn(component.inputElement.nativeElement, <any>'focus');
+      const spyInputFocus = spyOn(component.inputEl.nativeElement, <any>'focus');
 
       component['open']();
 
@@ -1294,7 +1295,7 @@ describe('PoComboComponent:', () => {
       component.isFiltering = true;
       component.filterMode = PoComboFilterMode.endsWith;
       component.safeHtml = (value: any) => value;
-      component.inputElement.nativeElement.value = 'othervalue';
+      component.inputEl.nativeElement.value = 'othervalue';
 
       expect(component.getLabelFormatted(label)).not.toBe(expectedValue);
     });
@@ -1306,7 +1307,7 @@ describe('PoComboComponent:', () => {
       component.isFiltering = true;
       component.filterMode = PoComboFilterMode.contains;
       component.safeHtml = (value: any) => value;
-      component.inputElement.nativeElement.value = 'othervalue';
+      component.inputEl.nativeElement.value = 'othervalue';
 
       expect(component.getLabelFormatted(label)).not.toBe(expectedValue);
     });
@@ -1315,7 +1316,7 @@ describe('PoComboComponent:', () => {
       component.isFiltering = true;
       component.filterMode = PoComboFilterMode.startsWith;
       component.safeHtml = (value: any) => value;
-      component.inputElement.nativeElement.value = 'val';
+      component.inputEl.nativeElement.value = 'val';
 
       expect(component.getLabelFormatted('values')).toBe('<span class="po-font-text-large-bold">val</span>ues');
     });
@@ -1324,7 +1325,7 @@ describe('PoComboComponent:', () => {
       component.isFiltering = true;
       component.filterMode = PoComboFilterMode.contains;
       component.safeHtml = (value: any) => value;
-      component.inputElement.nativeElement.value = 'lue';
+      component.inputEl.nativeElement.value = 'lue';
 
       expect(component.getLabelFormatted('values')).toBe('va<span class="po-font-text-large-bold">lue</span>s');
     });
@@ -1333,7 +1334,7 @@ describe('PoComboComponent:', () => {
       component.isFiltering = true;
       component.filterMode = PoComboFilterMode.endsWith;
       component.safeHtml = (value: any) => value;
-      component.inputElement.nativeElement.value = 'lues';
+      component.inputEl.nativeElement.value = 'lues';
 
       expect(component.getLabelFormatted('values')).toBe('va<span class="po-font-text-large-bold">lues</span>');
     });
@@ -1341,7 +1342,7 @@ describe('PoComboComponent:', () => {
     it('getLabelFormatted: should not get formatted label', () => {
       component.isFiltering = false;
       component.safeHtml = (value: any) => value;
-      component.inputElement.nativeElement.value = 'lues';
+      component.inputEl.nativeElement.value = 'lues';
 
       expect(component.getLabelFormatted('values')).toBe('values');
     });
@@ -1353,7 +1354,7 @@ describe('PoComboComponent:', () => {
       component.getInputValue = () => true;
       component.compareObjects = (a, b) => false;
       component.safeHtml = (value: any) => value;
-      component.inputElement.nativeElement.value = 'lues';
+      component.inputEl.nativeElement.value = 'lues';
 
       expect(component.getLabelFormatted('values')).toBe('values');
     });
@@ -1679,12 +1680,12 @@ describe('PoComboComponent - with service:', () => {
 
     component.debounceTime = 10;
     component.filterMinlength = 5;
-    component.inputElement.nativeElement.value = 'po';
+    component.inputEl.nativeElement.value = 'po';
     component.initInputObservable();
 
     spyOn(component, 'controlApplyFilter');
 
-    component.inputElement.nativeElement.dispatchEvent(eventKeyBoard);
+    component.inputEl.nativeElement.dispatchEvent(eventKeyBoard);
 
     tick(100);
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -119,7 +119,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   @ViewChild('containerElement', { read: ElementRef }) containerElement: ElementRef;
   @ViewChild('contentElement', { read: ElementRef }) contentElement: ElementRef;
   @ViewChild('iconArrow', { read: ElementRef, static: true }) iconElement: ElementRef;
-  @ViewChild('inputElement', { read: ElementRef, static: true }) inputElement: ElementRef;
+  @ViewChild('inp', { read: ElementRef, static: true }) inputEl: ElementRef;
 
   constructor(
     public element: ElementRef,
@@ -201,7 +201,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
    */
   focus(): void {
     if (!this.disabled) {
-      this.inputElement.nativeElement.focus();
+      this.inputEl.nativeElement.focus();
     }
   }
 
@@ -314,7 +314,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
 
   initInputObservable() {
     if (this.service) {
-      const keyupObservable = fromEvent(this.inputElement.nativeElement, 'keyup').pipe(
+      const keyupObservable = fromEvent(this.inputEl.nativeElement, 'keyup').pipe(
         filter((e: any) => this.isValidCharacterToSearch(e.keyCode)),
         map((e: any) => e.currentTarget.value),
         distinctUntilChanged(),
@@ -468,17 +468,17 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   getInputValue() {
-    return this.inputElement.nativeElement.value;
+    return this.inputEl.nativeElement.value;
   }
 
   setInputValue(value: string): void {
-    this.inputElement.nativeElement.value = value;
+    this.inputEl.nativeElement.value = value;
   }
 
   wasClickedOnToggle(event: MouseEvent): void {
     if (
       this.comboOpen &&
-      !this.inputElement.nativeElement.contains(event.target) &&
+      !this.inputEl.nativeElement.contains(event.target) &&
       !this.iconElement.nativeElement.contains(event.target) &&
       (!this.contentElement || !this.contentElement.nativeElement.contains(event.target))
     ) {
@@ -633,7 +633,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
 
     this.initializeListeners();
 
-    this.inputElement.nativeElement.focus();
+    this.inputEl.nativeElement.focus();
     this.scrollTo(this.getIndexSelectedView());
 
     this.setContainerPosition();
@@ -659,7 +659,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     this.controlPosition.setElements(
       this.containerElement.nativeElement,
       poComboContainerOffset,
-      this.inputElement,
+      this.inputEl,
       ['top', 'bottom'],
       true
     );

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -3,6 +3,7 @@
   name="combo"
   [(ngModel)]="combo"
   [p-change-on-enter]="properties.includes('changeOnEnter')"
+  [p-clean]="properties.includes('clean')"
   [p-debounce-time]="debounceTime"
   [p-disabled]="properties.includes('disabled')"
   [p-disabled-init-filter]="properties.includes('disableInitFilter')"

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
@@ -57,7 +57,8 @@ export class SamplePoComboLabsComponent implements OnInit {
     { value: 'optional', label: 'Optional' },
     { value: 'disabledInitFilter', label: 'Disabled Init Filter' },
     { value: 'required', label: 'Required' },
-    { value: 'sort', label: 'Sort' }
+    { value: 'sort', label: 'Sort' },
+    { value: 'clean', label: 'Clean' }
   ];
 
   ngOnInit() {


### PR DESCRIPTION
**po-combo**

**DTHFUI-2314**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [x] Documentação
- [X] Samples

**Qual o comportamento atual?**
Para limpar o combo, é necessário apagar todos caracteres do input.


**Qual o novo comportamento?**
Ao atribuir o valor true para a propriedade p-clean e selecionar um item no combo, será exibido um ícone X. Ao clicar neste ícone, o combo será limpo.

**Simulação**
Criar um po-combo com a propriedade p-clean, escolher alguma opção do combo e clicar no X ao lado da seta. O combo deve ser limpo e o ngModel deve ser atualizado