### PR TITLE
feat(page-dynamic-search): adiciona propriedade p-quick-search-width

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
@@ -121,6 +121,18 @@ describe('PoPageDynamicSearchBaseComponent:', () => {
         expect(component.literals).toEqual(poPageDynamicSearchLiteralsDefault['pt']);
       });
     });
+
+    it('p-quick-search-width: should update property p-quick-search-width with valid values.', () => {
+      const validValues = [105, 1, 98, 0];
+
+      expectPropertiesValues(component, 'quickSearchWidth', validValues, validValues);
+    });
+
+    it('p-quick-search-width: should update property p-quick-search-width with invalid values for undefined.', () => {
+      const invalidValues = [null, undefined, '', ' ', {}, [], false, true];
+
+      expectPropertiesValues(component, 'quickSearchWidth', invalidValues, undefined);
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
@@ -2,7 +2,7 @@ import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
 import { InputBoolean, PoBreadcrumb, PoDynamicFormField, PoLanguageService, PoPageAction } from '@po-ui/ng-components';
 
-import { poLocaleDefault } from '../../utils/util';
+import { convertToInt, poLocaleDefault } from '../../utils/util';
 
 import { PoPageDynamicSearchLiterals } from './po-page-dynamic-search-literals.interface';
 import { poAdvancedFiltersLiteralsDefault } from './po-advanced-filter/po-advanced-filter-base.component';
@@ -55,6 +55,7 @@ export const poPageDynamicSearchLiteralsDefault = {
 export abstract class PoPageDynamicSearchBaseComponent {
   private _filters: Array<PoDynamicFormField> = [];
   private _literals: PoPageDynamicSearchLiterals;
+  private _quickSearchWidth: number;
 
   advancedFilterLiterals: PoAdvancedFilterLiterals;
 
@@ -212,6 +213,23 @@ export abstract class PoPageDynamicSearchBaseComponent {
 
   /** Título da página. */
   @Input('p-title') title: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Largura do campo de busca, utilizando o *Grid System*,
+   * e limitado ao máximo de 6 colunas. O tamanho mínimo é controlado
+   * conforme resolução de tela para manter a consistência do layout.
+   */
+  @Input('p-quick-search-width') set quickSearchWidth(value: number) {
+    this._quickSearchWidth = convertToInt(value);
+  }
+
+  get quickSearchWidth(): number {
+    return this._quickSearchWidth;
+  }
 
   /**
    * @description

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-options.interface.ts
@@ -56,4 +56,11 @@ export interface PoPageDynamicSearchOptions {
    * é apenas nos `disclaimers`.
    */
   concatFilters?: boolean;
+
+  /**
+   * Largura do campo de busca, utilizando o *Grid System*,
+   * e limitado ao máximo de 6 colunas. O tamanho mínimo é controlado
+   * conforme resolução de tela para manter a consistência do layout.
+   */
+  quickSearchWidth?: number;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -48,6 +48,13 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(typeof component.filterSettings.advancedAction).toBe('function');
     });
 
+    it('get filterSettings: should apply `quickSearchWidth` value to `filterSettings.width`', () => {
+      const filterWidth = 3;
+      component.quickSearchWidth = filterWidth;
+
+      expect(component.filterSettings.width).toBe(filterWidth);
+    });
+
     describe('onAction:', () => {
       let fakethis;
 
@@ -460,6 +467,7 @@ describe('PoPageDynamicSearchComponent:', () => {
         };
         component.filters = [{ property: 'filter1' }, { property: 'filter2' }];
         component.title = 'Original Title';
+        component.quickSearchWidth = 3;
 
         component.onLoad = () => {
           return {
@@ -472,7 +480,8 @@ describe('PoPageDynamicSearchComponent:', () => {
               { label: 'Feature 3', url: '/new-feature3' }
             ],
             filters: [{ property: 'filter1' }, { property: 'filter3' }],
-            keepFilters: true
+            keepFilters: true,
+            quickSearchWidth: 6
           };
         };
 
@@ -489,6 +498,7 @@ describe('PoPageDynamicSearchComponent:', () => {
           items: [{ label: 'Test' }, { label: 'Test2' }]
         });
         expect(component.keepFilters).toBeTrue();
+        expect(component.quickSearchWidth).toBe(6);
       }));
     });
   });

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -54,7 +54,8 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
   private readonly _filterSettings: PoPageFilter = {
     action: this.onAction.bind(this),
     advancedAction: this.onAdvancedAction.bind(this),
-    placeholder: this.literals.searchPlaceholder
+    placeholder: this.literals.searchPlaceholder,
+    width: this.quickSearchWidth
   };
 
   @ViewChild(PoAdvancedFilterComponent, { static: true }) poAdvancedFilter: PoAdvancedFilterComponent;
@@ -74,7 +75,10 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
   get filterSettings() {
     this._filterSettings.advancedAction = this.filters.length === 0 ? undefined : this.onAdvancedAction.bind(this);
 
-    return Object.assign({}, this._filterSettings, { placeholder: this.literals.searchPlaceholder });
+    return Object.assign({}, this._filterSettings, {
+      placeholder: this.literals.searchPlaceholder,
+      width: this.quickSearchWidth
+    });
   }
 
   ngOnInit() {
@@ -270,7 +274,8 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
       breadcrumb: this.breadcrumb,
       filters: this.filters,
       keepFilters: this.keepFilters,
-      concatFilters: this.concatFilters
+      concatFilters: this.concatFilters,
+      quickSearchWidth: this.quickSearchWidth
     };
 
     const pageOptionSchema: PoPageDynamicOptionsSchema<PoPageDynamicSearchOptions> = {
@@ -296,6 +301,9 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
         },
         {
           nameProp: 'concatFilters'
+        },
+        {
+          nameProp: 'quickSearchWidth'
         }
       ]
     };

--- a/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.html
@@ -5,6 +5,7 @@
   [p-filters]="filters"
   [p-literals]="literals"
   [p-load]="onLoadFields.bind(this)"
+  [p-quick-search-width]="quickSearchWidth"
   (p-change-disclaimers)="onChangeDisclaimers($event)"
   (p-quick-search)="onQuickSearch($event)"
   (p-advanced-search)="onAdvancedSearch($event)"

--- a/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
@@ -22,6 +22,7 @@ import { SamplePoPageDynamicSearchHiringProcessesService } from './sample-po-pag
 export class SamplePoPageDynamicSearchHiringProcessesComponent implements OnInit {
   hiringProcesses: Array<object>;
   hiringProcessesColumns: Array<PoTableColumn>;
+  quickSearchWidth: number = 6;
 
   private jobDescriptionOptions: Array<PoSelectOption>;
   private statusOptions: Array<PoSelectOption>;

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-options.interface.ts
@@ -91,4 +91,11 @@ export interface PoPageDynamicTableOptions {
    * ```
    */
   tableCustomActions?: Array<PoPageDynamicTableCustomTableAction>;
+
+  /**
+   * Largura do campo de busca, utilizando o *Grid System*,
+   * e limitado ao máximo de 6 colunas. O tamanho mínimo é controlado
+   * conforme resolução de tela para manter a consistência do layout.
+   */
+  quickSearchWidth?: number;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -4,6 +4,7 @@
   [p-filters]="filters"
   [p-keep-filters]="keepFilters"
   [p-concat-filters]="concatFilters"
+  [p-quick-search-width]="quickSearchWidth"
   [p-title]="title"
   (p-advanced-search)="onAdvancedSearch($event)"
   (p-change-disclaimers)="onChangeDisclaimers($event)"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -69,6 +69,18 @@ describe('PoPageDynamicTableComponent:', () => {
 
       expectPropertiesValues(component, 'actions', validValues, validValues);
     });
+
+    it('p-quick-search-width: should update property p-quick-search-width with valid values.', () => {
+      const validValues = [105, 1, 98, 0];
+
+      expectPropertiesValues(component, 'quickSearchWidth', validValues, validValues);
+    });
+
+    it('p-quick-search-width: should update property p-quick-search-width with invalid values for undefined.', () => {
+      const invalidValues = [null, undefined, '', ' ', {}, [], false, true];
+
+      expectPropertiesValues(component, 'quickSearchWidth', invalidValues, undefined);
+    });
   });
 
   describe('Methods:', () => {
@@ -135,9 +147,11 @@ describe('PoPageDynamicTableComponent:', () => {
         };
         component.fields = [{ property: 'filter1' }, { property: 'filter2' }];
         component.title = 'Original Title';
+        component.quickSearchWidth = 3;
 
         component.onLoad = () => {
           return {
+            quickSearchWidth: 6,
             title: 'New Title',
             breadcrumb: {
               items: [{ label: 'Test' }, { label: 'Test2' }]
@@ -160,6 +174,7 @@ describe('PoPageDynamicTableComponent:', () => {
 
         tick();
 
+        expect(component.quickSearchWidth).toBe(6);
         expect(component.title).toBe('New Title');
         expect(component.actions).toEqual({
           detail: '/new_datail',
@@ -185,6 +200,7 @@ describe('PoPageDynamicTableComponent:', () => {
         component.breadcrumb = <any>{};
         component.fields = [];
         component.title = '';
+        component.quickSearchWidth = undefined;
 
         const activatedRoute: any = {
           snapshot: {
@@ -202,6 +218,7 @@ describe('PoPageDynamicTableComponent:', () => {
             items: [{ label: 'Home' }, { label: 'Hiring processes' }]
           },
           title: 'Original Title',
+          quickSearchWidth: 6,
           pageCustomActions: [{ label: 'Custom Action', action: 'endpoint/' }],
           tableCustomActions: [{ label: 'Details', action: 'endpoint/' }],
           keepFilters: true,
@@ -229,6 +246,7 @@ describe('PoPageDynamicTableComponent:', () => {
         expect(component.tableCustomActions).toEqual([{ label: 'Details', action: 'endpoint/' }]);
         expect(component.keepFilters).toBe(true);
         expect(component.concatFilters).toBe(true);
+        expect(component.quickSearchWidth).toBe(6);
       }));
     });
 
@@ -454,7 +472,8 @@ describe('PoPageDynamicTableComponent:', () => {
           actions: undefined,
           breadcrumb: undefined,
           fields: [],
-          title: 'Title'
+          title: 'Title',
+          quickSearchWidth: 4
         };
 
         spyOn(component['poPageDynamicService'], 'getMetadata').and.returnValue(of(response));
@@ -468,6 +487,7 @@ describe('PoPageDynamicTableComponent:', () => {
         expect(component.autoRouter).toEqual(response.autoRouter);
         expect(component.fields).toEqual(response.fields);
         expect(component.title).toEqual(response.title);
+        expect(component.quickSearchWidth).toEqual(response.quickSearchWidth);
       }));
 
       it('should call `getMetadata` and set properties', fakeAsync(() => {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -122,6 +122,7 @@ type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicTableOptions);
 export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent implements OnInit, OnDestroy {
   private _actions: PoPageDynamicTableActions = {};
   private _pageCustomActions: Array<PoPageDynamicTableCustomAction> = [];
+  private _quickSearchWidth: number;
   private _tableCustomActions: Array<PoPageDynamicTableCustomTableAction> = [];
 
   hasNext = false;
@@ -306,6 +307,23 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   @Input('p-concat-filters')
   concatFilters: boolean = false;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Largura do campo de busca, utilizando o *Grid System*,
+   * e limitado ao máximo de 6 colunas. O tamanho mínimo é controlado
+   * conforme resolução de tela para manter a consistência do layout.
+   */
+  @Input('p-quick-search-width') set quickSearchWidth(value: number) {
+    this._quickSearchWidth = util.convertToInt(value);
+  }
+
+  get quickSearchWidth(): number {
+    return this._quickSearchWidth;
+  }
+
   constructor(
     private router: Router,
     private activatedRoute: ActivatedRoute,
@@ -458,6 +476,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
           this.tableCustomActions = response.tableCustomActions || this.tableCustomActions;
           this.keepFilters = response.keepFilters || this.keepFilters;
           this.concatFilters = response.concatFilters || this.concatFilters;
+          this.quickSearchWidth = response.quickSearchWidth || this.quickSearchWidth;
         }),
         switchMap(() => this.loadOptionsOnInitialize(onLoad))
       );
@@ -939,7 +958,8 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
       keepFilters: this.keepFilters,
       concatFilters: this.concatFilters,
       pageCustomActions: this.pageCustomActions,
-      tableCustomActions: this.tableCustomActions
+      tableCustomActions: this.tableCustomActions,
+      quickSearchWidth: this.quickSearchWidth
     };
 
     const pageOptionSchema: PoPageDynamicOptionsSchema<PoPageDynamicTableOptions> = {
@@ -961,6 +981,9 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
         },
         {
           nameProp: 'keepFilters'
+        },
+        {
+          nameProp: 'quickSearchWidth'
         },
         {
           nameProp: 'concatFilters'

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -9,6 +9,7 @@
   [p-breadcrumb]="breadcrumb"
   [p-fields]="fields"
   [p-service-api]="serviceApi"
+  [p-quick-search-width]="quickSearchWidth"
 >
 </po-page-dynamic-table>
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -19,6 +19,7 @@ export class SamplePoPageDynamicTableUsersComponent {
 
   readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
   detailedUser;
+  quickSearchWidth: number = 3;
 
   readonly actions: PoPageDynamicTableActions = {
     new: '/documentation/po-page-dynamic-edit',


### PR DESCRIPTION
**page-dynamic-search**
**page-dynamic-table**

**DTHFUI-4118**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
O componente `po-page-list` possui propriedade para definição de largura do campo de busca porém não recebe o repasse para tal no template `page-dynamic-search`.

**Qual o novo comportamento?**
O desenvolvedor agora pode definir uma largura para o campo de busca rápida nos templates `page-dynamic-search` e `page-dynamic-table`.

**Simulação**
Samples de uso dos templates.
