### PR TITLE
feat(po-login): criadas propriedades `p-languages` e `p-language-change`

### DIFF
--- a/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery-base.component.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery-base.component.ts
@@ -1,8 +1,6 @@
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { PoLanguageService } from '@po-ui/ng-components';
-
-import { poLocaleDefault } from '../../utils/util';
+import { PoLanguageService, poLocaleDefault } from '@po-ui/ng-components';
 
 import { poModalPasswordRecoveryLiterals } from './literals/i18n/po-modal-password-recovery-literals';
 import { PoModalPasswordRecoveryType } from './enums/po-modal-password-recovery-type.enum';

--- a/projects/templates/src/lib/components/po-page-background/po-page-background.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.component.spec.ts
@@ -5,7 +5,7 @@ import * as utilFunctions from './../../utils/util';
 import { expectPropertiesValues } from './../../util-test/util-expect.spec';
 
 import { PoPageBackgroundComponent } from './po-page-background.component';
-import { PoLanguageService } from '@po-ui/ng-components';
+import { PoLanguage, poLanguageDefault, PoLanguageService } from '@po-ui/ng-components';
 
 describe('PoPageBackgroundComponent:', () => {
   let component: PoPageBackgroundComponent;
@@ -73,6 +73,18 @@ describe('PoPageBackgroundComponent:', () => {
 
       expectPropertiesValues(component, 'showSelectLanguage', trueValues, true);
       expectPropertiesValues(component, 'showSelectLanguage', falseValues, false);
+    });
+
+    it('p-languages: should set property with default languages if invalid.', () => {
+      const invalidValues = [[], null, undefined];
+      const expectedValue = [poLanguageDefault];
+      expectPropertiesValues(component, 'languagesList', invalidValues, expectedValue);
+    });
+
+    it('p-languages: should set property with languages.', () => {
+      const languages: Array<PoLanguage> = [{ description: 'portugues', language: 'pt' }];
+      const validValues = [languages];
+      expectPropertiesValues(component, 'languagesList', validValues, validValues);
     });
   });
 

--- a/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
-import { PoSelectOption, PoLanguageService } from '@po-ui/ng-components';
+import { PoSelectOption, PoLanguageService, PoLanguage, poLanguageDefault } from '@po-ui/ng-components';
 
 import { convertToBoolean, isTypeof } from './../../utils/util';
 
@@ -21,18 +21,28 @@ export class PoPageBackgroundComponent implements OnInit {
   private _logo?: string;
   private _secondaryLogo?: string;
   private _showSelectLanguage?: boolean = false;
+  private _languagesList: Array<PoLanguage>;
+  private _selectLanguageOptions: Array<PoSelectOption>;
 
   selectedLanguageOption: string;
 
-  selectLanguageOptions: Array<PoSelectOption> = [
-    { label: 'English', value: 'en' },
-    { label: 'Español', value: 'es' },
-    { label: 'Português', value: 'pt' },
-    { label: 'Pусский', value: 'ru' }
-  ];
-
   /** Insere uma imagem de destaque ao lado direito do container. */
   @Input('p-background') background?: string;
+
+  /** Lista de idiomas para o combo box */
+  @Input('p-languages') set languagesList(value: Array<PoLanguage>) {
+    this._languagesList = value;
+  }
+
+  get languagesList(): Array<PoLanguage> {
+    if (this._languagesList?.length) {
+      return this._languagesList;
+    }
+    return poLanguageDefault;
+  }
+
+  /** Idioma inicial selecionado no combo */
+  @Input('p-initial-language') initialSelectLanguage?: string;
 
   /** Designa se o logotipo deve desaparecer em resoluções menores. */
   @Input('p-hide-logo') hideLogo?: boolean;
@@ -76,15 +86,23 @@ export class PoPageBackgroundComponent implements OnInit {
    * Evento disparado ao selecionar alguma opção no seletor de idiomas.
    * Para este evento será passado como parâmetro o valor de idioma selecionado.
    */
-  @Output('p-selected-language') selectedLanguage?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-selected-language') selectedLanguage?: EventEmitter<string> = new EventEmitter<string>();
 
   constructor(public poLanguageService: PoLanguageService) {}
 
   ngOnInit() {
-    this.selectedLanguageOption = this.poLanguageService.getShortLanguage();
+    this.selectedLanguageOption = this.initialSelectLanguage || this.poLanguageService.getShortLanguage();
+    this._selectLanguageOptions = this.languagesList.map<PoSelectOption>(language => ({
+      label: language.description,
+      value: language.language
+    }));
   }
 
   onChangeLanguage() {
     this.selectedLanguage.emit(this.selectedLanguageOption);
+  }
+
+  get selectLanguageOptions(): Array<PoSelectOption> {
+    return this._selectLanguageOptions;
   }
 }

--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-reason/po-page-blocked-user-reason.component.ts
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-reason/po-page-blocked-user-reason.component.ts
@@ -1,8 +1,6 @@
 import { ChangeDetectorRef, Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
-import { PoLanguageService } from '@po-ui/ng-components';
-
-import { poLocaleDefault } from '../../../utils/util';
+import { PoLanguageService, poLocaleDefault } from '@po-ui/ng-components';
 
 import { poPageBlockedUserLiterals } from './../literals/i18n/po-page-blocked-user-literals';
 import { PoPageBlockedUserReason } from '../enums/po-page-blocked-user-reason.enum';

--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user.component.ts
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user.component.ts
@@ -1,9 +1,9 @@
 import { ActivatedRoute, Router } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 
-import { PoLanguageService } from '@po-ui/ng-components';
+import { PoLanguageService, poLocaleDefault } from '@po-ui/ng-components';
 
-import { isExternalLink, poLocaleDefault } from '../../utils/util';
+import { isExternalLink } from '../../utils/util';
 
 import { PoPageBlockedUserBaseComponent } from './po-page-blocked-user-base.component';
 

--- a/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.ts
+++ b/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.ts
@@ -4,9 +4,15 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { Subscription } from 'rxjs';
 
-import { PoComponentInjectorService, PoLanguageService, PoModalAction, PoModalComponent } from '@po-ui/ng-components';
+import {
+  PoComponentInjectorService,
+  PoLanguageService,
+  PoModalAction,
+  PoModalComponent,
+  poLocaleDefault
+} from '@po-ui/ng-components';
 
-import { isExternalLink, isTypeof, poLocaleDefault } from '../../utils/util';
+import { isExternalLink, isTypeof } from '../../utils/util';
 
 import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/po-modal-password-recovery.component';
 import { PoModalPasswordRecoveryType } from '../po-modal-password-recovery/enums/po-modal-password-recovery-type.enum';

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.ts
@@ -10,10 +10,11 @@ import {
   PoDialogService,
   PoLanguageService,
   PoNotificationService,
-  PoPageAction
+  PoPageAction,
+  poLocaleDefault
 } from '@po-ui/ng-components';
 
-import * as util from '../../utils/util';
+import { convertToBoolean, mapObjectByProperties, valuesFromObject } from '../../utils/util';
 
 import { PoPageDynamicDetailActions } from './interfaces/po-page-dynamic-detail-actions.interface';
 import { PoPageDynamicDetailField } from './interfaces/po-page-dynamic-detail-field.interface';
@@ -183,7 +184,7 @@ export class PoPageDynamicDetailComponent implements OnInit, OnDestroy {
    * @default false
    */
   @Input('p-auto-router') set autoRouter(value: boolean) {
-    this._autoRouter = util.convertToBoolean(value);
+    this._autoRouter = convertToBoolean(value);
   }
 
   get autoRouter(): boolean {
@@ -288,7 +289,7 @@ export class PoPageDynamicDetailComponent implements OnInit, OnDestroy {
     const language = languageService.getShortLanguage();
 
     this.literals = {
-      ...poPageDynamicDetailLiteralsDefault[util.poLocaleDefault],
+      ...poPageDynamicDetailLiteralsDefault[poLocaleDefault],
       ...poPageDynamicDetailLiteralsDefault[language]
     };
   }
@@ -370,9 +371,9 @@ export class PoPageDynamicDetailComponent implements OnInit, OnDestroy {
   }
 
   private formatUniqueKey(item) {
-    const keys = util.mapObjectByProperties(item, this.keys);
+    const keys = mapObjectByProperties(item, this.keys);
 
-    return util.valuesFromObject(keys).join('|');
+    return valuesFromObject(keys).join('|');
   }
 
   private goBack(actionBack: PoPageDynamicDetailActions['back']) {

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -12,10 +12,11 @@ import {
   PoGridRowActions,
   PoLanguageService,
   PoNotificationService,
-  PoPageAction
+  PoPageAction,
+  poLocaleDefault
 } from '@po-ui/ng-components';
 
-import * as util from './../../utils/util';
+import { convertToBoolean, mapObjectByProperties, valuesFromObject, removeKeysProperties } from './../../utils/util';
 
 import { PoPageDynamicEditActions } from './interfaces/po-page-dynamic-edit-actions.interface';
 import { PoPageDynamicEditField } from './interfaces/po-page-dynamic-edit-field.interface';
@@ -220,7 +221,7 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
    * @default false
    */
   @Input('p-auto-router') set autoRouter(value: boolean) {
-    this._autoRouter = util.convertToBoolean(value);
+    this._autoRouter = convertToBoolean(value);
   }
 
   get autoRouter(): boolean {
@@ -366,7 +367,7 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
     const language = languageService.getShortLanguage();
 
     this.literals = {
-      ...poPageDynamicEditLiteralsDefault[util.poLocaleDefault],
+      ...poPageDynamicEditLiteralsDefault[poLocaleDefault],
       ...poPageDynamicEditLiteralsDefault[language]
     };
   }
@@ -439,9 +440,9 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
   }
 
   private formatUniqueKey(item) {
-    const keys = util.mapObjectByProperties(item, this.keys);
+    const keys = mapObjectByProperties(item, this.keys);
 
-    return util.valuesFromObject(keys).join('|');
+    return valuesFromObject(keys).join('|');
   }
 
   private goBack(
@@ -595,7 +596,7 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
   private updateModel(newResource: any = {}) {
     const dynamicNgForm = this.dynamicForm.form;
 
-    util.removeKeysProperties(this.keys, newResource);
+    removeKeysProperties(this.keys, newResource);
 
     this.model = { ...this.model, ...newResource };
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.spec.ts
@@ -1,7 +1,7 @@
 import * as utilsFunctions from './../../../utils/util';
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 import { PoLanguageService } from '../../../../../../ui/src/lib/services/po-language/po-language.service';
-
+import { poLocaleDefault } from '../../../../../../ui/src/lib/services/po-language/po-language.constant';
 import { PoAdvancedFilterBaseComponent, poAdvancedFiltersLiteralsDefault } from './po-advanced-filter-base.component';
 
 describe('PoAdvancedFilterBaseComponent', () => {
@@ -31,8 +31,6 @@ describe('PoAdvancedFilterBaseComponent', () => {
     });
 
     describe('literals:', () => {
-      const poLocaleDefault = utilsFunctions.poLocaleDefault;
-
       it('should be in portuguese if browser is setted with an unsupported language', () => {
         component['language'] = 'zw';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.ts
@@ -5,10 +5,9 @@ import {
   PoDynamicFormField,
   PoLanguageService,
   PoModalAction,
-  PoModalComponent
+  PoModalComponent,
+  poLocaleDefault
 } from '@po-ui/ng-components';
-
-import { poLocaleDefault } from '../../../utils/util';
 
 import { PoAdvancedFilterLiterals } from './po-advanced-filter-literals.interface';
 import { PoPageDynamicSearchFilters } from '../po-page-dynamic-search-filters.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
@@ -1,6 +1,7 @@
 import * as utilsFunctions from './../../utils/util';
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 import { PoLanguageService } from './../../../../../ui/src/lib/services/po-language/po-language.service';
+import { poLocaleDefault } from './../../../../../ui/src/lib/services/po-language/po-language.constant';
 
 import { PoAdvancedFilterLiterals } from './po-advanced-filter/po-advanced-filter-literals.interface';
 import { PoPageDynamicSearchLiterals } from './po-page-dynamic-search-literals.interface';
@@ -47,8 +48,6 @@ describe('PoPageDynamicSearchBaseComponent:', () => {
     });
 
     describe('p-literals:', () => {
-      const poLocaleDefault = utilsFunctions.poLocaleDefault;
-
       it('should be in portuguese if browser is setted with an unsupported language', () => {
         component['language'] = 'zw';
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
@@ -1,8 +1,15 @@
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { InputBoolean, PoBreadcrumb, PoDynamicFormField, PoLanguageService, PoPageAction } from '@po-ui/ng-components';
+import {
+  InputBoolean,
+  PoBreadcrumb,
+  PoDynamicFormField,
+  PoLanguageService,
+  PoPageAction,
+  poLocaleDefault
+} from '@po-ui/ng-components';
 
-import { convertToInt, poLocaleDefault } from '../../utils/util';
+import { convertToInt } from '../../utils/util';
 
 import { PoPageDynamicSearchLiterals } from './po-page-dynamic-search-literals.interface';
 import { poAdvancedFiltersLiteralsDefault } from './po-advanced-filter/po-advanced-filter-base.component';

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -13,7 +13,8 @@ import {
   PoPageAction,
   PoTableAction,
   PoTableColumnSort,
-  PoTableColumnSortType
+  PoTableColumnSortType,
+  poLocaleDefault
 } from '@po-ui/ng-components';
 
 import * as util from '../../utils/util';
@@ -339,7 +340,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     const language = languageService.getShortLanguage();
 
     this.literals = {
-      ...poPageDynamicTableLiteralsDefault[util.poLocaleDefault],
+      ...poPageDynamicTableLiteralsDefault[poLocaleDefault],
       ...poPageDynamicTableLiteralsDefault[language]
     };
   }

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-summary/po-page-job-scheduler-summary.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-summary/po-page-job-scheduler-summary.component.spec.ts
@@ -1,9 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { PoLanguageService } from '@po-ui/ng-components';
-
-import { poLocaleDefault } from '../../../utils/util';
+import { PoLanguageService, poLocaleDefault } from '@po-ui/ng-components';
 
 import { poPageJobSchedulerLiteralsDefault } from '../po-page-job-scheduler-literals';
 import { PoPageJobSchedulerModule } from '../po-page-job-scheduler.module';

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
@@ -11,10 +11,9 @@ import {
   PoNotificationService,
   PoPageAction,
   PoStepperItem,
-  PoStepperStatus
+  PoStepperStatus,
+  poLocaleDefault
 } from '@po-ui/ng-components';
-
-import { poLocaleDefault } from './../../utils/util';
 
 import { PoJobSchedulerInternal } from './interfaces/po-job-scheduler-internal.interface';
 import { PoPageJobSchedulerInternal } from './po-page-job-scheduler-internal';

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
@@ -8,7 +8,7 @@ import * as UtilFunctions from './../../utils/util';
 import { PoPageLoginBaseComponent, poPageLoginLiteralsDefault } from './po-page-login-base.component';
 import { PoPageLoginCustomField } from './interfaces/po-page-login-custom-field.interface';
 import { PoPageLoginService } from './po-page-login.service';
-import { PoLanguageService, poLocaleDefault } from '@po-ui/ng-components';
+import { PoLanguage, poLanguageDefault, PoLanguageService, poLocaleDefault } from '@po-ui/ng-components';
 
 const routerStub = {
   navigate: jasmine.createSpy('navigate')
@@ -289,6 +289,34 @@ describe('PoPageLoginBaseComponent: ', () => {
         spyOn(component, <any>'setLoginErrors');
         component.loginErrors = validValues;
         expect(component['setLoginErrors']).toHaveBeenCalledWith(validValues);
+      });
+    });
+
+    describe('p-languages:', () => {
+      it('should set property with default languages when the value is invalid.', () => {
+        const invalidValues = [null, undefined, NaN];
+        const expectedValues = [poLanguageDefault];
+
+        expectPropertiesValues(component, 'languagesList', invalidValues, expectedValues);
+      });
+
+      it('should set property with the language defined by the browse if the value is empty.', () => {
+        const validValues = [[]];
+        const expectedValues = [[{ description: 'Português', language: 'pt' }]];
+        spyOnProperty(component, 'language').and.returnValue('pt');
+        expectPropertiesValues(component, 'languagesList', validValues, expectedValues);
+        expect(component.showLanguage).toBeFalse();
+      });
+
+      it('should set property with the language if the value is valid.', () => {
+        const languages: Array<PoLanguage> = [
+          { description: 'português', language: 'pt' },
+          { description: 'english', language: 'en' }
+        ];
+        const validValues = [languages];
+
+        expectPropertiesValues(component, 'languagesList', validValues, validValues);
+        expect(component.showLanguage).toBeTrue();
       });
     });
 

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
@@ -3,13 +3,12 @@ import { TestBed, async } from '@angular/core/testing';
 import { throwError } from 'rxjs';
 
 import { expectPropertiesValues, getObservable } from '../../util-test/util-expect.spec';
-import { poLocaleDefault } from './../../utils/util';
 import * as UtilFunctions from './../../utils/util';
 
 import { PoPageLoginBaseComponent, poPageLoginLiteralsDefault } from './po-page-login-base.component';
 import { PoPageLoginCustomField } from './interfaces/po-page-login-custom-field.interface';
 import { PoPageLoginService } from './po-page-login.service';
-import { PoLanguageService } from '@po-ui/ng-components';
+import { PoLanguageService, poLocaleDefault } from '@po-ui/ng-components';
 
 const routerStub = {
   navigate: jasmine.createSpy('navigate')

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 
 import { convertToBoolean, convertToInt, getShortBrowserLanguage, isExternalLink, isTypeof } from './../../utils/util';
 
-import { PoLanguageService, poLocaleDefault } from '@po-ui/ng-components';
+import { PoLanguageService, poLocaleDefault, PoLanguage, poLanguageDefault } from '@po-ui/ng-components';
 
 import { PoPageLogin } from './interfaces/po-page-login.interface';
 import { PoPageLoginAuthenticationType } from './enums/po-page-login-authentication-type.enum';
@@ -193,6 +193,7 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
   private _recovery: string | PoPageLoginRecovery | Function;
   private _registerUrl: string;
   private _support: string | Function;
+  private _languagesList: Array<PoLanguage>;
 
   /**
    * @optional
@@ -834,6 +835,44 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
   }
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Coleção de idiomas que o componente irá tratar e disponibilizará para o usuário escolher.
+   *
+   * Caso essa propriedade não seja utilizada o componente mostrará no combo os idiomas que ele suporta por padrão.
+   *
+   * Caso a coleção tenha um idioma, a página estará nesse idioma e não mostrará o combo.
+   *
+   * Caso seja passado um array vazio, a página terá o idioma configurado no `i18n` e não mostrará o combo de seleção.
+   *
+   * > Se for passado um idioma não suportado, será preciso passar as literais pela propriedade `p-literals`.
+   *
+   *
+   */
+  @Input('p-languages') set languagesList(languagesList: Array<PoLanguage>) {
+    if (languagesList) {
+      if (languagesList.length) {
+        this._languagesList = languagesList;
+      } else {
+        this._languagesList = poLanguageDefault.filter(language => language.language === this.language);
+      }
+    }
+  }
+
+  get languagesList(): Array<PoLanguage> {
+    if (this._languagesList) {
+      return this._languagesList;
+    }
+    return poLanguageDefault;
+  }
+
+  get showLanguage() {
+    return this.languagesList.length > 1;
+  }
+
+  /**
    * Evento disparado quando o usuário alterar o input do campo login.
    *
    * Esse evento receberá como parâmetro uma variável do tipo `string` com o texto informado no campo.
@@ -861,6 +900,14 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
    * > Esta propriedade será ignorada se for definido valor para a propriedade `p-authentication-url`.
    */
   @Output('p-password-change') passwordChange?: EventEmitter<string> = new EventEmitter<string>();
+
+  /**
+   * Evento disparado quando o usuário alterar o idioma da página.
+   *
+   * Esse evento receberá como parâmetro um objeto do tipo `PoLanguage` com a linguagem selecionada.
+   *
+   */
+  @Output('p-language-change') languageChange?: EventEmitter<PoLanguage> = new EventEmitter<PoLanguage>();
 
   get language(): string {
     return this.selectedLanguage || getShortBrowserLanguage();

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -2,16 +2,9 @@ import { Subscription } from 'rxjs';
 import { EventEmitter, Input, OnDestroy, Output, Directive } from '@angular/core';
 import { Router } from '@angular/router';
 
-import {
-  convertToBoolean,
-  convertToInt,
-  getShortBrowserLanguage,
-  isExternalLink,
-  isTypeof,
-  poLocaleDefault
-} from './../../utils/util';
+import { convertToBoolean, convertToInt, getShortBrowserLanguage, isExternalLink, isTypeof } from './../../utils/util';
 
-import { PoLanguageService } from '@po-ui/ng-components';
+import { PoLanguageService, poLocaleDefault } from '@po-ui/ng-components';
 
 import { PoPageLogin } from './interfaces/po-page-login.interface';
 import { PoPageLoginAuthenticationType } from './enums/po-page-login-authentication-type.enum';

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
@@ -5,7 +5,9 @@
 
 <po-page-background
   #pageLogin
-  p-show-select-language
+  [p-show-select-language]="showLanguage"
+  [p-languages]="languagesList"
+  [p-initial-language]="initialSelectLanguage"
   [p-background]="background"
   [p-highlight-info]="pageLoginLiterals.highlightInfo"
   [p-logo]="logo"

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
@@ -165,14 +165,36 @@ describe('PoPageLoginComponent: ', () => {
   });
 
   describe('Methods:', () => {
-    it('ngOnInit: should call checkingForRouteMetadata', () => {
-      const activatedRoute = { snapshot: { data: {} } };
+    describe('ngOnInit:', () => {
+      it('should call checkingForRouteMetadata', () => {
+        const activatedRoute = { snapshot: { data: {} } };
 
-      spyOn(component, <any>'checkingForRouteMetadata');
+        spyOn(component, <any>'checkingForRouteMetadata');
 
-      component.ngOnInit();
+        component.ngOnInit();
 
-      expect(component['checkingForRouteMetadata']).toHaveBeenCalledWith(activatedRoute.snapshot.data);
+        expect(component['checkingForRouteMetadata']).toHaveBeenCalledWith(activatedRoute.snapshot.data);
+      });
+
+      it('should set selectedLanguage if languagesList is valid ', () => {
+        component.languagesList = [{ language: 'en', description: 'English' }];
+
+        spyOnProperty(component, 'language').and.returnValue('en');
+
+        component.ngOnInit();
+
+        expect(component.selectedLanguage).toBe('en');
+      });
+
+      it('should set selectedLanguage with a default language if languagesList is invalid ', () => {
+        component.languagesList = [{ language: 'en', description: 'English' }];
+
+        spyOnProperty(component, 'language').and.returnValue('ru');
+
+        component.ngOnInit();
+
+        expect(component.selectedLanguage).toBe('en');
+      });
     });
 
     it('ngAfterViewChecked: should call `validateArrayChanges` if has differ', () => {

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
@@ -11,10 +11,9 @@ import {
   PoLoginComponent,
   PoPasswordComponent,
   PoSelectComponent,
-  PoSwitchComponent
+  PoSwitchComponent,
+  poLocaleDefault
 } from '@po-ui/ng-components';
-
-import { poLocaleDefault } from './../../utils/util';
 
 import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/po-modal-password-recovery.component';
 import { PoModalPasswordRecoveryType } from '../po-modal-password-recovery/enums/po-modal-password-recovery-type.enum';

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
@@ -61,6 +61,7 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
   private componentRef: ComponentRef<any> = null;
   private differ: any;
   private readonly customPasswordError = { custom: false };
+  initialSelectLanguage: string;
 
   @ViewChild('loginForm', { read: NgForm, static: true }) loginForm: NgForm;
   @ViewChild('pageLogin', { read: ViewContainerRef, static: true }) pageLogin: ViewContainerRef;
@@ -89,6 +90,8 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
 
   ngOnInit() {
     this.checkingForRouteMetadata(this.activatedRoute.snapshot.data);
+    this.selectedLanguage = this.initializeLanguage();
+    this.initialSelectLanguage = this.selectedLanguage;
   }
 
   activateSupport() {
@@ -123,6 +126,7 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
   }
 
   onSelectedLanguage(language: string) {
+    this.languageChange.emit(this.languagesList.find(languageItem => languageItem.language === language));
     this.selectedLanguage = language;
   }
 
@@ -253,5 +257,10 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
   protected setPasswordErrors(errors: Array<string>) {
     const control = this.loginForm.form.controls['password'];
     this.setControlErrors('allPasswordErrors', control, errors, this.pageLoginLiterals.passwordErrorPattern);
+  }
+
+  private initializeLanguage() {
+    const language = this.languagesList.find(languageItem => languageItem.language === this.language);
+    return language?.language || this.languagesList[0].language;
   }
 }

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-automatic-service/sample-po-page-login-automatic-service.component.html
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-automatic-service/sample-po-page-login-automatic-service.component.html
@@ -9,5 +9,8 @@
   p-blocked-url="/documentation/po-page-blocked-user"
   p-logo="https://via.placeholder.com/160x64?text=MAIN+LOGO"
   p-secondary-logo="https://via.placeholder.com/80x24?text=SECONDARY+LOGO"
+  [p-languages]="languages"
+  [p-literals]="literals"
+  (p-language-change)="changeLanguage($event)"
 >
 </po-page-login>

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-automatic-service/sample-po-page-login-automatic-service.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-automatic-service/sample-po-page-login-automatic-service.component.ts
@@ -1,7 +1,38 @@
 import { Component } from '@angular/core';
+import { PoLanguage } from '@po-ui/ng-components';
+import { PoPageLoginLiterals } from '@po-ui/ng-templates';
 
 @Component({
   selector: 'sample-po-page-login-automatic-service',
   templateUrl: './sample-po-page-login-automatic-service.component.html'
 })
-export class SamplePoPageLoginAutomaticServiceComponent {}
+export class SamplePoPageLoginAutomaticServiceComponent {
+  literals: PoPageLoginLiterals;
+  japoneseLiterals: PoPageLoginLiterals = {
+    welcome: 'ようこそ',
+    loginLabel: 'ユーザー名を入力してください',
+    loginPlaceholder: 'アクセスユーザーを入力してください',
+    passwordErrorPattern: 'パスワードが必要',
+    passwordLabel: 'パスワードを入力してください',
+    passwordPlaceholder: 'パスワードを入力してください',
+    submitLabel: 'アクセスシステム',
+    submittedLabel: 'ローディング中 ...',
+    rememberUser: '自動的にログイン',
+    rememberUserHint: 'このオプションはシステムメニューで無効にできます',
+    loginHint: `ユーザーは最初の日にあなたに配達されました。
+    この情報を紛失した場合は、サポートにお問い合わせください`
+  };
+
+  languages: Array<PoLanguage> = [
+    { language: 'pt', description: 'Português' },
+    { language: 'jp', description: '日本語' }
+  ];
+
+  changeLanguage(language: PoLanguage) {
+    if (language?.language === 'jp') {
+      this.literals = { ...this.japoneseLiterals };
+    } else {
+      this.literals = {};
+    }
+  }
+}

--- a/projects/templates/src/lib/utils/util.ts
+++ b/projects/templates/src/lib/utils/util.ts
@@ -1,9 +1,5 @@
 import { ViewContainerRef } from '@angular/core';
-
-// Idiomas suportados pelas páginas
-export const poLocales = ['pt', 'en', 'es', 'ru'];
-// Idioma padrão
-export const poLocaleDefault = 'pt';
+import { poLocales, poLocaleDefault } from '@po-ui/ng-components';
 
 /**
  * Retorna o idioma atual do navegador

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
@@ -1,7 +1,8 @@
 import { DoCheck, EventEmitter, Input, IterableDiffers, Output, Directive } from '@angular/core';
 
-import { convertToBoolean, isKeyCodeEnter, poLocaleDefault, uuid } from '../../utils/util';
+import { convertToBoolean, isKeyCodeEnter, uuid } from '../../utils/util';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 
 import { PoDisclaimer } from '../po-disclaimer/po-disclaimer.interface';
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -8,6 +8,7 @@ import * as ValidatorsFunctions from '../validators';
 import { expectPropertiesValues, expectSettersMethod } from '../../../util-test/util-expect.spec';
 
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 import { PoComboBaseComponent, poComboLiteralsDefault } from './po-combo-base.component';
 import { PoComboFilter } from './interfaces/po-combo-filter.interface';
@@ -119,7 +120,7 @@ describe('PoComboBaseComponent:', () => {
 
         component.literals = {};
 
-        expect(component.literals).toEqual(poComboLiteralsDefault[Utils.poLocaleDefault]);
+        expect(component.literals).toEqual(poComboLiteralsDefault[poLocaleDefault]);
       });
 
       it('should be in english if browser is set with `en`.', () => {
@@ -147,9 +148,9 @@ describe('PoComboBaseComponent:', () => {
       });
 
       it('should accept custom literals.', () => {
-        component['language'] = Utils.poLocaleDefault;
+        component['language'] = poLocaleDefault;
 
-        const customLiterals = Object.assign({}, poComboLiteralsDefault[Utils.poLocaleDefault]);
+        const customLiterals = Object.assign({}, poComboLiteralsDefault[poLocaleDefault]);
         customLiterals.noData = 'Sem dados';
         component.literals = customLiterals;
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -1,9 +1,9 @@
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 import { EventEmitter, Input, OnInit, Output, Directive } from '@angular/core';
 
-import { convertToBoolean, isTypeof, poLocaleDefault, validValue } from '../../../utils/util';
+import { convertToBoolean, isTypeof, validValue } from '../../../utils/util';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
-
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 import { InputBoolean } from '../../../decorators';
 import { requiredFailed } from '../validators';
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -4,6 +4,7 @@ import { FormControl } from '@angular/forms';
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 import * as UtilsFunctions from '../../../utils/util';
 import * as ValidatorsFunctions from '../validators';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 import { PoDatepickerRange } from './interfaces/po-datepicker-range.interface';
 import { PoDatepickerRangeBaseComponent, poDatepickerRangeLiteralsDefault } from './po-datepicker-range-base.component';
@@ -111,7 +112,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
 
       component.literals = {};
 
-      expect(component.literals).toEqual(poDatepickerRangeLiteralsDefault[UtilsFunctions.poLocaleDefault]);
+      expect(component.literals).toEqual(poDatepickerRangeLiteralsDefault[poLocaleDefault]);
     });
 
     it('literals: should be in portuguese if browser is setted with `pt`', () => {
@@ -131,9 +132,9 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('literals: should accept custom literals', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue(UtilsFunctions.poLocaleDefault);
+      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue(poLocaleDefault);
 
-      const customLiterals = Object.assign({}, poDatepickerRangeLiteralsDefault[UtilsFunctions.poLocaleDefault]);
+      const customLiterals = Object.assign({}, poDatepickerRangeLiteralsDefault[poLocaleDefault]);
 
       customLiterals.invalidFormat = 'Incorrect format';
 
@@ -161,14 +162,9 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     it('literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue(UtilsFunctions.poLocaleDefault);
+      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
 
-      expectPropertiesValues(
-        component,
-        'literals',
-        invalidValues,
-        poDatepickerRangeLiteralsDefault[UtilsFunctions.poLocaleDefault]
-      );
+      expectPropertiesValues(component, 'literals', invalidValues, poDatepickerRangeLiteralsDefault[poLocaleDefault]);
     });
 
     it('readonly: should update with true value.', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -1,9 +1,9 @@
 import { AbstractControl, ControlValueAccessor, ValidationErrors, Validator } from '@angular/forms';
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { browserLanguage, convertToBoolean, poLocaleDefault } from './../../../utils/util';
+import { browserLanguage, convertToBoolean } from './../../../utils/util';
 import { requiredFailed } from '../validators';
-
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 import { InputBoolean } from '../../../decorators';
 import { PoDatepickerRange } from './interfaces/po-datepicker-range.interface';
 import { PoDatepickerRangeLiterals } from './interfaces/po-datepicker-range-literals.interface';

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
@@ -6,6 +6,7 @@ import { expectPropertiesValues } from '../../../../util-test/util-expect.spec';
 import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
 import { PoTableColumnSortType } from '../../../po-table/enums/po-table-column-sort-type.enum';
 import { PoLanguageService } from '../../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../../services/po-language/po-language.constant';
 
 import { poLookupLiteralsDefault, PoLookupModalBaseComponent } from './po-lookup-modal-base.component';
 import { PoLookupResponseApi } from '../interfaces/po-lookup-response-api.interface';
@@ -82,7 +83,7 @@ describe('PoLookupModalBaseComponent:', () => {
 
       component.literals = {};
 
-      expect(component.literals).toEqual(poLookupLiteralsDefault[UtilsFunctions.poLocaleDefault]);
+      expect(component.literals).toEqual(poLookupLiteralsDefault[poLocaleDefault]);
     });
 
     it('literals: should be in portuguese if browser is setted with `pt`', () => {
@@ -102,11 +103,11 @@ describe('PoLookupModalBaseComponent:', () => {
     });
 
     it('literals: should accept custom literals and call `setTableLiterals`', () => {
-      component['language'] = UtilsFunctions.poLocaleDefault;
+      component['language'] = poLocaleDefault;
 
       spyOn(component, <any>'setTableLiterals');
 
-      const customLiterals = Object.assign({}, poLookupLiteralsDefault[UtilsFunctions.poLocaleDefault]);
+      const customLiterals = Object.assign({}, poLookupLiteralsDefault[poLocaleDefault]);
 
       customLiterals.modalPrimaryActionLabel = 'Incorrect format';
 
@@ -135,14 +136,9 @@ describe('PoLookupModalBaseComponent:', () => {
     it('literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      component['language'] = UtilsFunctions.poLocaleDefault;
+      component['language'] = poLocaleDefault;
 
-      expectPropertiesValues(
-        component,
-        'literals',
-        invalidValues,
-        poLookupLiteralsDefault[UtilsFunctions.poLocaleDefault]
-      );
+      expectPropertiesValues(component, 'literals', invalidValues, poLookupLiteralsDefault[poLocaleDefault]);
     });
 
     it('title: should update property with valid values', () => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -3,7 +3,8 @@ import { EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, Directive } 
 import { Observable, Subscription, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
-import { isTypeof, poLocaleDefault } from '../../../../utils/util';
+import { isTypeof } from '../../../../utils/util';
+import { poLocaleDefault } from '../../../../services/po-language/po-language.constant';
 import { PoModalAction } from '../../../../components/po-modal';
 import { PoModalComponent } from '../../../../components/po-modal/po-modal.component';
 import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -2,14 +2,10 @@ import { Directive } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 import { expectPropertiesValues, expectSettersMethod } from '../../../util-test/util-expect.spec';
-import {
-  removeDuplicatedOptions,
-  removeUndefinedAndNullOptions,
-  sortOptionsByProperty,
-  poLocaleDefault
-} from '../../../utils/util';
+import { removeDuplicatedOptions, removeUndefinedAndNullOptions, sortOptionsByProperty } from '../../../utils/util';
 import * as UtilsFunctions from '../../../utils/util';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 import { PoMultiselectBaseComponent, poMultiselectLiteralsDefault } from './po-multiselect-base.component';
 import { PoMultiselectFilterMode } from './po-multiselect-filter-mode.enum';

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -5,11 +5,11 @@ import {
   convertToBoolean,
   removeDuplicatedOptions,
   removeUndefinedAndNullOptions,
-  sortOptionsByProperty,
-  poLocaleDefault
+  sortOptionsByProperty
 } from '../../../utils/util';
 import { requiredFailed } from './../validators';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 import { PoMultiselectFilterMode } from './po-multiselect-filter-mode.enum';
 import { PoMultiselectLiterals } from './po-multiselect-literals.interface';

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-search/po-multiselect-search.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-search/po-multiselect-search.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { expectPropertiesValues } from '../../../../util-test/util-expect.spec';
-import { poLocaleDefault } from '../../../../utils/util';
+import { poLocaleDefault } from '../../../../services/po-language/po-language.constant';
 
 import { poMultiselectLiteralsDefault } from '../po-multiselect-base.component';
 import { PoMultiselectSearchComponent } from './po-multiselect-search.component';

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
@@ -8,6 +8,7 @@ import { expectPropertiesValues, configureTestSuite } from '../../../util-test/u
 import * as utilsFunctions from '../../../utils/util';
 import * as ValidatorsFunctions from '../validators';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 import { PoUploadBaseComponent, poUploadLiteralsDefault } from './po-upload-base.component';
 import { PoUploadFile } from './po-upload-file';
@@ -567,7 +568,7 @@ describe('PoUploadBaseComponent:', () => {
 
       component.literals = {};
 
-      expect(component.literals).toEqual(poUploadLiteralsDefault[utilsFunctions.poLocaleDefault]);
+      expect(component.literals).toEqual(poUploadLiteralsDefault[poLocaleDefault]);
     });
 
     it('p-literals: should be in portuguese if browser is setted with `pt`', () => {
@@ -603,9 +604,9 @@ describe('PoUploadBaseComponent:', () => {
     });
 
     it('p-literals: should accept custom literals', () => {
-      component['language'] = utilsFunctions.poLocaleDefault;
+      component['language'] = poLocaleDefault;
 
-      const customLiterals = Object.assign({}, poUploadLiteralsDefault[utilsFunctions.poLocaleDefault]);
+      const customLiterals = Object.assign({}, poUploadLiteralsDefault[poLocaleDefault]);
 
       // Custom some literals
       customLiterals.invalidDropArea = 'Área inválida';
@@ -618,14 +619,9 @@ describe('PoUploadBaseComponent:', () => {
     it('p-literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      component['language'] = utilsFunctions.poLocaleDefault;
+      component['language'] = poLocaleDefault;
 
-      expectPropertiesValues(
-        component,
-        'literals',
-        invalidValues,
-        poUploadLiteralsDefault[utilsFunctions.poLocaleDefault]
-      );
+      expectPropertiesValues(component, 'literals', invalidValues, poUploadLiteralsDefault[poLocaleDefault]);
     });
 
     it('required: should set `required` with valid values', () => {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -1,7 +1,7 @@
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { convertToBoolean, isEquals, isIE, isMobile, poLocaleDefault } from '../../../utils/util';
+import { convertToBoolean, isEquals, isIE, isMobile } from '../../../utils/util';
 import { requiredFailed } from '../validators';
 
 import { PoUploadFile } from './po-upload-file';
@@ -11,6 +11,7 @@ import { PoUploadService } from './po-upload.service';
 import { PoUploadStatus } from './po-upload-status.enum';
 import { InputBoolean } from '../../../decorators';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 export const poUploadLiteralsDefault = {
   en: <PoUploadLiterals>{

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.spec.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { configureTestSuite } from '../../../../../util-test/util-expect.spec';
-import { poLocaleDefault } from 'projects/ui/src/lib/utils/util';
+import { poLocaleDefault } from '../../../../../services/po-language/po-language.constant';
 
 import { PoUploadDragDropAreaComponent } from './po-upload-drag-drop-area.component';
 import { poUploadLiteralsDefault } from '../../po-upload-base.component';

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.spec.ts
@@ -2,9 +2,10 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ChangeDetectorRef } from '@angular/core';
 
 import { expectSettersMethod } from './../../../../util-test/util-expect.spec';
-import { poLocaleDefault } from './../../../../utils/util';
+
 import { PoServicesModule } from './../../../../services/services.module';
 import { PoLanguageService } from './../../../../services/po-language/po-language.service';
+import { poLocaleDefault } from './../../../../services/po-language/po-language.constant';
 
 import { PoUploadFileRestrictionsComponent } from './po-upload-file-restrictions.component';
 import { poUploadLiteralsDefault } from '../po-upload-base.component';

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 
-import { formatBytes, poLocaleDefault } from '../../../../utils/util';
+import { formatBytes } from '../../../../utils/util';
 import { PoLanguageService } from '../../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../../services/po-language/po-language.constant';
 
 import { poUploadLiteralsDefault } from '../po-upload-base.component';
 

--- a/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.spec.ts
@@ -1,7 +1,7 @@
 import * as UtilsFunctions from '../../utils/util';
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
-import { poLocaleDefault } from '../../utils/util';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 
 import { PoListViewBaseComponent, poListViewLiteralsDefault } from './po-list-view-base.component';
 

--- a/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.ts
@@ -1,8 +1,8 @@
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { poLocaleDefault, convertToBoolean } from '../../utils/util';
+import { convertToBoolean } from '../../utils/util';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
-
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 import { PoListViewAction } from './interfaces/po-list-view-action.interface';
 import { PoListViewLiterals } from './interfaces/po-list-view-literals.interface';
 

--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
@@ -6,7 +6,6 @@ import {
   convertToInt,
   isExternalLink,
   isTypeof,
-  poLocaleDefault,
   validValue,
   uuid
 } from '../../utils/util';
@@ -15,6 +14,7 @@ import { PoMenuFilter } from './po-menu-filter/po-menu-filter.interface';
 import { PoMenuItem } from './po-menu-item.interface';
 import { PoMenuService } from './services/po-menu.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 
 export const poMenuLiteralsDefault = {
   en: { itemNotFound: 'Item not found.', emptyLabelError: 'Attribute PoMenuItem.label can not be empty.' },

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.spec.ts
@@ -4,6 +4,7 @@ import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 
 import * as utilsFunctions from '../../utils/util';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 
 import { PoNavbarBaseComponent, poNavbarLiteralsDefault } from './po-navbar-base.component';
 
@@ -50,7 +51,7 @@ describe('PoNavbarBaseComponent:', () => {
 
       component.literals = {};
 
-      expect(component.literals).toEqual(poNavbarLiteralsDefault[utilsFunctions.poLocaleDefault]);
+      expect(component.literals).toEqual(poNavbarLiteralsDefault[poLocaleDefault]);
     });
 
     it('literals: should be in portuguese if browser is setted with `pt`', () => {
@@ -86,9 +87,9 @@ describe('PoNavbarBaseComponent:', () => {
     });
 
     it('literals: should accept custom literals', () => {
-      component['language'] = utilsFunctions.poLocaleDefault;
+      component['language'] = poLocaleDefault;
 
-      const customLiterals = Object.assign({}, poNavbarLiteralsDefault[utilsFunctions.poLocaleDefault]);
+      const customLiterals = Object.assign({}, poNavbarLiteralsDefault[poLocaleDefault]);
 
       // Custom some literals
       customLiterals.navbarLinks = 'links';
@@ -101,14 +102,9 @@ describe('PoNavbarBaseComponent:', () => {
     it('literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      component['language'] = utilsFunctions.poLocaleDefault;
+      component['language'] = poLocaleDefault;
 
-      expectPropertiesValues(
-        component,
-        'literals',
-        invalidValues,
-        poNavbarLiteralsDefault[utilsFunctions.poLocaleDefault]
-      );
+      expectPropertiesValues(component, 'literals', invalidValues, poNavbarLiteralsDefault[poLocaleDefault]);
     });
 
     it('shadow: should update property with true if values are valid', () => {

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
@@ -1,7 +1,8 @@
 import { Input, Directive } from '@angular/core';
 
-import { convertToBoolean, poLocaleDefault } from '../../utils/util';
+import { convertToBoolean } from '../../utils/util';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 import { PoMenuComponent } from '../po-menu';
 
 import { PoNavbarIconAction } from './interfaces/po-navbar-icon-action.interface';

--- a/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.spec.ts
@@ -1,8 +1,8 @@
 import { fakeAsync, tick } from '@angular/core/testing';
 
 import { expectPropertiesValues } from './../../../util-test/util-expect.spec';
-import { poLocaleDefault } from './../../../utils/util';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 import { PoPageDetailBaseComponent, poPageDetailLiteralsDefault } from './po-page-detail-base.component';
 

--- a/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.ts
@@ -1,7 +1,7 @@
 import { Directive, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 
-import { poLocaleDefault } from './../../../utils/util';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
 import { PoPageContentComponent } from '../po-page-content/po-page-content.component';

--- a/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail.component.spec.ts
@@ -8,7 +8,7 @@ import { configureTestSuite } from './../../../util-test/util-expect.spec';
 import { PoBreadcrumbModule } from '../../po-breadcrumb/po-breadcrumb.module';
 import { PoButtonModule } from '../../po-button';
 
-import { poLocaleDefault } from './../../../utils/util';
+import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
 import { PoPageComponent } from '../po-page.component';
 import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
 import { PoPageDetailComponent } from './po-page-detail.component';

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.spec.ts
@@ -1,7 +1,7 @@
 import { tick, fakeAsync } from '@angular/core/testing';
 
 import { expectPropertiesValues } from './../../../util-test/util-expect.spec';
-import { poLocaleDefault } from './../../../utils/util';
+import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoPageEditBaseComponent, poPageEditLiteralsDefault } from './po-page-edit-base.component';

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.ts
@@ -1,6 +1,6 @@
 import { Directive, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 
-import { poLocaleDefault } from './../../../utils/util';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.spec.ts
@@ -8,7 +8,7 @@ import { configureTestSuite } from './../../../util-test/util-expect.spec';
 import { PoBreadcrumbModule } from '../../po-breadcrumb/po-breadcrumb.module';
 import { PoButtonModule } from '../../po-button';
 
-import { poLocaleDefault } from './../../../utils/util';
+import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
 import { PoPageComponent } from '../po-page.component';
 import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
 import { PoPageEditComponent } from './po-page-edit.component';

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.spec.ts
@@ -1,7 +1,7 @@
 import { Directive } from '@angular/core';
 
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
-import { poLocaleDefault } from './../../../utils/util';
+import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
 import * as UtilFunctions from './../../../utils/util';
 import { PoLanguageService } from './../../../services/po-language/po-language.service';
 

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.ts
@@ -1,6 +1,6 @@
 import { Input, Directive } from '@angular/core';
 
-import { poLocaleDefault } from './../../../utils/util';
+import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
 import { PoLanguageService } from './../../../services/po-language/po-language.service';
 
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
-import { browserLanguage, convertToBoolean, isTypeof, poLocaleDefault } from './../../../utils/util';
-
+import { browserLanguage, convertToBoolean, isTypeof } from './../../../utils/util';
+import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
 import { PoStepperOrientation } from '../enums/po-stepper-orientation.enum';
 import { PoStepperStatus } from '../enums/po-stepper-status.enum';
 

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -4,7 +4,7 @@ import * as utilsFunctions from '../../utils/util';
 import { expectPropertiesValues, expectSettersMethod } from '../../util-test/util-expect.spec';
 import { PoDateService } from '../../services/po-date/po-date.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
-import { poLocaleDefault } from '../../utils/util';
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 
 import { PoTableAction } from './interfaces/po-table-action.interface';
 import { PoTableBaseComponent, poTableLiteralsDefault } from './po-table-base.component';

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -1,8 +1,9 @@
 import { EventEmitter, Input, OnChanges, Output, Directive, SimpleChanges } from '@angular/core';
 
-import { capitalizeFirstLetter, convertToBoolean, isTypeof, sortValues, poLocaleDefault } from '../../utils/util';
+import { capitalizeFirstLetter, convertToBoolean, isTypeof, sortValues } from '../../utils/util';
 import { PoDateService } from '../../services/po-date/po-date.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 
 import { PoTableAction } from './interfaces/po-table-action.interface';
 import { PoTableColumn } from './interfaces/po-table-column.interface';

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.ts
@@ -13,11 +13,11 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { capitalizeFirstLetter, convertToInt, poLocaleDefault } from '../../../utils/util';
+import { capitalizeFirstLetter, convertToInt } from '../../../utils/util';
 import { PoCheckboxGroupOption } from '../../po-field/po-checkbox-group/interfaces/po-checkbox-group-option.interface';
 import { PoPopoverComponent } from '../../po-popover/po-popover.component';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
-
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 import { PoTableColumn } from '../interfaces/po-table-column.interface';
 
 const PoTableColumnManagerMaxColumnsDefault = 99999;

--- a/projects/ui/src/lib/services/po-dialog/po-dialog.component.ts
+++ b/projects/ui/src/lib/services/po-dialog/po-dialog.component.ts
@@ -2,7 +2,7 @@ import { Component, ComponentRef, OnDestroy, OnInit, ViewChild } from '@angular/
 
 import { Subscription } from 'rxjs';
 
-import { poLocaleDefault } from '../../utils/util';
+import { poLocaleDefault } from '../po-language/po-language.constant';
 
 import { PoLanguageService } from '../po-language/po-language.service';
 

--- a/projects/ui/src/lib/services/po-language/index.ts
+++ b/projects/ui/src/lib/services/po-language/index.ts
@@ -1,3 +1,5 @@
 export * from './po-language.service';
+export * from './po-language.interface';
+export * from './po-language.constant';
 
 export * from './po-language.module';

--- a/projects/ui/src/lib/services/po-language/po-language.constant.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.constant.ts
@@ -1,0 +1,44 @@
+import { PoLanguage } from './po-language.interface';
+
+/**
+ * @description
+ *
+ * <a id="poLanguageDefault"></a>
+ *
+ *
+ * A constante poLanguageDefault possui as linguagens de suporte padrão do Po-UI
+ *
+ * > Português, Inglês, Espanhol e Russo.
+ *
+ * @usedBy PoI18nModule
+ */
+export const poLanguageDefault: Array<PoLanguage> = [
+  { description: 'English', language: 'en' },
+  { description: 'Español', language: 'es' },
+  { description: 'Português', language: 'pt' },
+  { description: 'Pусский', language: 'ru' }
+];
+
+/**
+ * @description
+ *
+ * <a id="poLocales"></a>
+ *
+ *
+ * A constante poLocales possui somente os códigos das linguagem padrão
+ *
+ * @usedBy PoI18nModule
+ */
+export const poLocales = poLanguageDefault.map(language => language.language);
+
+/**
+ * @description
+ *
+ * <a id="poLocaleDefault"></a>
+ *
+ *
+ * A constante poLocaleDefault possui o código da linguagem padrão do Po-UI
+ *
+ * @usedBy PoI18nModule
+ */
+export const poLocaleDefault = 'pt';

--- a/projects/ui/src/lib/services/po-language/po-language.interface.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * @description
+ *
+ * <a id="poI18nLanguage"></a>
+ *
+ * Interface para descrição das linguagens disponíveis no sistema.
+ *
+ *
+ * @usedBy PoI18nModule
+ */
+export interface PoLanguage {
+  /**
+   * Código do idioma [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+   * > Exemplo: 'pt','en'
+   */
+  language?: string;
+
+  /**
+   * Descrição do idioma
+   *
+   */
+  description?: string;
+}

--- a/projects/ui/src/lib/services/po-language/po-language.service.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 
-import { getBrowserLanguage, getShortLanguage, isLanguage, poLocaleDefault, poLocales } from '../../utils/util';
+import { getBrowserLanguage, getShortLanguage, isLanguage } from '../../utils/util';
+import { poLocaleDefault, poLocales } from './po-language.constant';
 
 const poDefaultLanguage = 'PO_DEFAULT_LANGUAGE';
 const poLocaleKey = 'PO_USER_LOCALE';

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/co
 
 import { Subject } from 'rxjs';
 
-import { poLocaleDefault } from '../../../utils/util';
+import { poLocaleDefault } from '../../po-language/po-language.constant';
 
 import { PoLanguageService } from '../../po-language/po-language.service';
 

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -1,9 +1,5 @@
 import { ViewContainerRef } from '@angular/core';
-
-// Idiomas suportados pelas páginas
-export const poLocales = ['pt', 'en', 'es', 'ru'];
-// Idioma padrão
-export const poLocaleDefault = 'pt';
+import { poLocales, poLocaleDefault } from '../services/po-language/po-language.constant';
 
 /**
  * @deprecated


### PR DESCRIPTION
**PAGE-LOGIN**

**< DTHFUI-2065 >**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Não é possível alterar ou desabilitar o combo de idiomas do componente de login

**Qual o novo comportamento?**
Foram criados as seguintes propriedades/eventos para dar suporte:

- p-languages: Array<PoLanguage> = lista de idiomas exibidos no template para seleção do idioma;
- p-language-change: EventEmitter = evento que será disparado ao trocar o idioma, passa um objeto com o idioma;

**Simulação**
[app_login.zip](https://github.com/po-ui/po-angular/files/5208816/app_login.zip)