### PR TITLE
fix(menu): corrige pesquisa para usar itens com subItems vazio

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
@@ -265,6 +265,19 @@ export abstract class PoMenuBaseComponent {
     menus.forEach(menu => this.validateMenu(menu));
   }
 
+  protected setMenuType(menuItem: PoMenuItem): string {
+    if (menuItem.subItems && menuItem.subItems.length > 0 && this._level < this.maxLevel) {
+      return 'subItems';
+    }
+    if (!menuItem.link) {
+      return 'noLink';
+    }
+    if (isExternalLink(menuItem.link)) {
+      return 'externalLink';
+    }
+    return 'internalLink';
+  }
+
   private processSubItems(menu) {
     menu.subItems.forEach((menuItem, index, menuItems) => {
       const previousItem = menuItems[index - 1];
@@ -307,19 +320,6 @@ export abstract class PoMenuBaseComponent {
     parent['badgeAlert'] = childHasBadgeAlert || (childHasBadge && !childHasSubItems);
 
     return parent;
-  }
-
-  private setMenuType(menuItem: PoMenuItem): string {
-    if (menuItem.subItems && menuItem.subItems.length > 0 && this._level < this.maxLevel) {
-      return 'subItems';
-    }
-    if (!menuItem.link) {
-      return 'noLink';
-    }
-    if (isExternalLink(menuItem.link)) {
-      return 'externalLink';
-    }
-    return 'internalLink';
   }
 
   private validateMenu(menuItem: PoMenuItem): void {

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
@@ -530,6 +530,81 @@ describe('PoMenuComponent:', () => {
     );
   });
 
+  it('should find items that have action or link', fakeAsync(() => {
+    const items = [
+      { label: 'Test AA', link: 'test/' },
+      { label: 'Test AB', link: 'test/' },
+      { label: 'Test ABC' },
+      { label: 'Test BB', link: 'test/' }
+    ];
+
+    const itemsFound = [
+      { label: 'Test AA', link: 'test/' },
+      { label: 'Test AB', link: 'test/' }
+    ];
+
+    const label = 'Test A';
+
+    component.menus = items;
+    component.filteredItems = [];
+
+    component.debounceFilter(label);
+
+    tick(500);
+
+    expect(component.filteredItems).toEqual(itemsFound);
+  }));
+
+  it('should find items and subItems that have action or link', fakeAsync(() => {
+    const action = () => {};
+
+    const items = [
+      { label: 'Test AA', link: 'test/' },
+      {
+        label: 'Test AB',
+        link: 'test/',
+        subItems: [
+          {
+            label: 'Test ABB',
+            link: 'test/',
+            subItems: [
+              { label: 'Test ABBC', action },
+              { label: 'Test ABBCD', action },
+              { label: 'Test ABBCE', action }
+            ]
+          },
+          { label: 'Test AABB', action },
+          { label: 'Test AABBB' }
+        ]
+      },
+      { label: 'Test ABD' },
+      { label: 'Test ABF', link: 'test/', subItems: [] },
+      { label: 'Test BB', link: 'test/' }
+    ];
+
+    const itemsFound = [
+      { label: 'Test AA', link: 'test/' },
+      { label: 'Test AB', link: 'test/', type: 'internalLink' },
+      { label: 'Test ABB', link: 'test/', type: 'internalLink' },
+      { label: 'Test ABBC', action },
+      { label: 'Test ABBCD', action },
+      { label: 'Test ABBCE', action },
+      { label: 'Test AABB', action },
+      { label: 'Test ABF', link: 'test/', subItems: [] }
+    ];
+
+    const label = 'Test A';
+
+    component.menus = items;
+    component.filteredItems = [];
+
+    component.debounceFilter(label);
+
+    tick(500);
+
+    expect(component.filteredItems).toEqual(itemsFound);
+  }));
+
   describe('Templates:', () => {
     it('should show collapse button if `enableCollapseButton` is enabled', () => {
       component.allowCollapseMenu = true;

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.ts
@@ -427,11 +427,22 @@ export class PoMenuComponent extends PoMenuBaseComponent implements OnDestroy, O
 
   private findItems(menus: Array<PoMenuItem>, filter: string, filteredItems: Array<any>) {
     menus.forEach(menu => {
-      if (
-        (menu.label.toLowerCase().includes(filter) && !menu.subItems) ||
-        (menu.subItems && this.findItems(menu.subItems, filter, filteredItems))
-      ) {
-        filteredItems.push(menu);
+      const hasAction = menu.action || menu.link;
+      const labelHasFilter = menu.label.toLowerCase().includes(filter);
+
+      if (labelHasFilter && hasAction) {
+        const newMenu = { ...menu };
+
+        if (newMenu.subItems?.length) {
+          delete newMenu.subItems;
+          newMenu['type'] = this.setMenuType(newMenu);
+        }
+
+        filteredItems.push(newMenu);
+      }
+
+      if (menu.subItems) {
+        this.findItems(menu.subItems, filter, filteredItems);
       }
     });
   }


### PR DESCRIPTION
**Po Menu**

**DTHFUI-4158**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Não estava buscando os itens que tinham `subItems: []`, mas se tivesse actions ou link definidos.

**Qual o novo comportamento?**
Agora busca todos os itens que contenham itens link ou actions definidos, conforme documentação. 

**Simulação**
- Usar o sample labs para criar os itens;
- Ou usar essa simulação:
```
  menus = [
    { label: 'angular', link: '/', subItems: [] }, // encontra
    { label: 'react', action: () => {}, subItems: [ // encontra
      { label: 'sub react sem nada' }, // não encontra
      { label: 'sub react action', action: () => {}, subItems: [] }, // encontra
      { label: 'sub react sem subitems', link: '/' }, // encontra
    ] },
    { label: 'vue sem nada' }, // não encontra
    { label: 'angular action', action: () => {}, subItems: [] }, // encontra
    { label: 'angular sem subitems', link: '/' }, //  encontra
  ];

<po-menu p-filter [p-menus]="menus"></po-menu>
```

**Obs.: testar com vários níveis.** 