### PR TITLE
feat(schematics): adiciona testes unitários para o @po-ui/ng-code-editor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
 
     - run: npm i
     - run: npm run test:code-editor
+    - run: npm run test:code-editor:schematics
 
   test-storage:
     name: Test storage

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:templates:schematics": "gulp build:schematics --lib templates && jasmine \"dist/ng-templates/schematics/**/*.spec.js\"",
     "test:templates:browse": "ng test templates --code-coverage --browsers=Chrome --source-map",
     "test:code-editor": "ng test code-editor --watch=false --code-coverage --browsers=ChromeHeadless --source-map",
+    "test:code-editor:schematics": "gulp build:schematics --lib code-editor && jasmine \"dist/ng-code-editor/schematics/**/*.spec.js\"",
     "test:code-editor:browse": "ng test code-editor --code-coverage --browsers=Chrome --source-map",
     "test:dev": "ng test --browsers=ChromeHeadless",
     "build:schematics": "cd ./projects/schematics && npm run build",

--- a/projects/code-editor/schematics/ng-add/index.spec.ts
+++ b/projects/code-editor/schematics/ng-add/index.spec.ts
@@ -1,0 +1,153 @@
+import { getWorkspace } from '@schematics/angular/utility/config';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
+import { WorkspaceProject } from '@schematics/angular/utility/workspace-models';
+import { Tree } from '@angular-devkit/schematics';
+
+import { getProjectFromWorkspace, getProjectTargetOptions } from '@po-ui/ng-schematics/project';
+
+import * as path from 'path';
+
+const collectionPath = path.join(__dirname, '../collection.json');
+
+describe('Schematic: ng-add', () => {
+  const runner = new SchematicTestRunner('schematics', collectionPath);
+
+  const workspaceOptions: WorkspaceOptions = {
+    name: 'workspace',
+    newProjectRoot: 'projects',
+    version: '6.0.0'
+  };
+
+  const componentOptions: any = {
+    name: 'po',
+    appName: 'po'
+  };
+
+  let appTree: UnitTestTree;
+
+  beforeEach(async () => {
+    appTree = await runner.runExternalSchematicAsync('@schematics/angular', 'workspace', workspaceOptions).toPromise();
+    appTree = await runner
+      .runExternalSchematicAsync('@schematics/angular', 'application', componentOptions, appTree)
+      .toPromise();
+  });
+
+  describe('Dependencies:', () => {
+    it('should update package.json with @po-ui/ng-code-editor dependency and run nodePackageInstall', async () => {
+      const tree = await runner.runSchematicAsync('ng-add', componentOptions, appTree).toPromise();
+
+      const packageJson = JSON.parse(getFileContent(tree, '/package.json'));
+      const dependencies = packageJson.dependencies;
+
+      expect(dependencies['@po-ui/ng-code-editor']).toBeDefined();
+      expect(Object.keys(dependencies)).toEqual(Object.keys(dependencies).sort());
+      expect(runner.tasks.some(task => task.name === 'node-package')).toBe(true);
+    });
+  });
+
+  describe('Imports:', () => {
+    it('should add the PoCodeEditorModule to the project module', async () => {
+      const poCodeEditorModuleName = 'PoCodeEditorModule';
+
+      const tree = await runner.runSchematicAsync('ng-add', componentOptions, appTree).toPromise();
+      const fileContent = getFileContent(tree, `projects/${componentOptions.appName}/src/app/app.module.ts`);
+
+      expect(fileContent).toContain(poCodeEditorModuleName);
+    });
+  });
+
+  describe('Theme configuration:', () => {
+    const defaultThemePath = './node_modules/@po-ui/style/css/po-theme-default.min.css';
+
+    it('should add default theme in styles of build project', async () => {
+      const tree = await runner.runSchematicAsync('ng-add', componentOptions, appTree).toPromise();
+
+      const workspace = getWorkspace(tree);
+      const project = getProjectFromWorkspace(workspace);
+
+      expectProjectPropertyFile(project, defaultThemePath, 'styles');
+    });
+
+    it('shouldn`t add a theme file in styles of build project multiple times', async () => {
+      writePropertiesFileToWorkspace(appTree, defaultThemePath, 'styles');
+
+      const tree = await runner.runSchematicAsync('ng-add', componentOptions, appTree).toPromise();
+
+      const workspace = getWorkspace(tree);
+      const project = getProjectFromWorkspace(workspace);
+      const styles = getProjectTargetOptions(project, 'build').styles;
+
+      expect(styles).toEqual([`projects/${componentOptions.appName}/src/styles.css`, defaultThemePath]);
+    });
+  });
+
+  describe('Assets configuration:', () => {
+    const defaultAssetsPath = {
+      'glob': '**/*',
+      'input': 'node_modules/monaco-editor/min',
+      'output': '/assets/monaco/'
+    };
+
+    it('should add assets of build project', async () => {
+      const tree = await runner.runSchematicAsync('ng-add', componentOptions, appTree).toPromise();
+
+      const workspace = getWorkspace(tree);
+      const project = getProjectFromWorkspace(workspace);
+      const assets = getProjectTargetOptions(project, 'build').assets;
+
+      const hasMonacoAssets = assets.some(
+        element => typeof element === 'object' && JSON.stringify(element) === JSON.stringify(defaultAssetsPath)
+      );
+
+      expect(hasMonacoAssets).toBe(true);
+    });
+
+    it('shouldn`t add a monaco assets file in assets of build project multiple times', async () => {
+      writePropertiesFileToWorkspace(appTree, `${defaultAssetsPath}`, 'assets');
+
+      const tree = await runner.runSchematicAsync('ng-add', componentOptions, appTree).toPromise();
+
+      const workspace = getWorkspace(tree);
+      const project = getProjectFromWorkspace(workspace);
+      const assets = getProjectTargetOptions(project, 'build').assets;
+
+      const getMonacoAssets = assets.filter(element => JSON.stringify(element) === JSON.stringify(defaultAssetsPath));
+
+      expect(getMonacoAssets.length).toBe(1);
+    });
+  });
+});
+
+/** Gets the content of a specified file from a schematic tree. */
+function getFileContent(tree: Tree, filePath: string): string {
+  const contentBuffer = tree.read(filePath);
+
+  if (!contentBuffer) {
+    throw new Error(`Cannot read "${filePath}" because it does not exist.`);
+  }
+
+  return contentBuffer.toString();
+}
+
+/** Expects the given file to be in the property of the specified workspace project. */
+function expectProjectPropertyFile(project: WorkspaceProject, filePath: string, property) {
+  expect(getProjectTargetOptions(project, 'build')[property]).toContain(
+    filePath,
+    `Expected "${filePath}" to be added to the project ${property} in the workspace.`
+  );
+}
+
+function writePropertiesFileToWorkspace(tree: Tree, filePath: string, property) {
+  const workspace = getWorkspace(tree);
+  const project = getProjectFromWorkspace(workspace);
+  const buildOptions = getProjectTargetOptions(project, 'build');
+
+  if (!buildOptions[property]) {
+    buildOptions[property] = [filePath];
+  } else {
+    buildOptions[property].push(filePath);
+  }
+
+  tree.overwrite('/angular.json', JSON.stringify(workspace, null, 2));
+}

--- a/projects/code-editor/tsconfig.schematics.json
+++ b/projects/code-editor/tsconfig.schematics.json
@@ -22,5 +22,5 @@
     "types": ["jasmine", "node"]
   },
   "include": ["schematics/**/*"],
-  "exclude": ["**/*.spec.ts", "schematics/**/*/files/**/*"]
+  "exclude": ["schematics/**/*/files/**/*"]
 }


### PR DESCRIPTION
**@po-ui/ng-code-editor**

**DTHFUI-3460**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O ng-code-editor não tinha testes unitários

**Qual o novo comportamento?**
- novos testes unitários dos schematics do ng-code-editor
- adiciona o comando na esteira do CI

**Simulação**
- entrar na branch;
- npm i
- npm run test:code-editor:schematics
- verificar o github actions
