### PR TITLE
build(actions): cria ação de publicação dos pacotes

### DIFF
--- a/.github/workflows/publish_po_angular_ci.yml
+++ b/.github/workflows/publish_po_angular_ci.yml
@@ -1,0 +1,132 @@
+name: PO-UI Publish
+
+# URL para os pacotes po-ui no npm
+env:
+  SCHEMATICS_NPM_PATH: po-ui/ng-schematics
+  STORAGE_NPM_PATH: po-ui/ng-storage
+  SYNC_NPM_PATH: po-ui/ng-sync
+  COMPONENTS_NPM_PATH: po-ui/ng-components
+  TEMPLATES_NPM_PATH: po-ui/ng-templates
+  CODE_EDITOR_NPM_PATH: po-ui/ng-code-editor
+
+on:
+  workflow_dispatch:
+  
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+
+    - run: npm install
+    - run: npm run build
+
+    # Pega a última versão dos pacotes publicados no npm e armazena em variáveis
+    - run: echo ::set-env name=SCHEMATICS_LAST_PUBLISHED_VERSION::$(npm view @${{ env.SCHEMATICS_NPM_PATH }} dist-tags.next)
+    - run: echo ::set-env name=STORAGE_LAST_PUBLISHED_VERSION::$(npm view @${{ env.STORAGE_NPM_PATH }} dist-tags.next)
+    - run: echo ::set-env name=SYNC_LAST_PUBLISHED_VERSION::$(npm view @${{ env.SYNC_NPM_PATH }} dist-tags.next)
+    - run: echo ::set-env name=COMPONENTS_LAST_PUBLISHED_VERSION::$(npm view @${{ env.COMPONENTS_NPM_PATH }} dist-tags.next)
+    - run: echo ::set-env name=TEMPLATES_LAST_PUBLISHED_VERSION::$(npm view @${{ env.TEMPLATES_NPM_PATH }} dist-tags.next)
+    - run: echo ::set-env name=CODE_EDITOR_LAST_PUBLISHED_VERSION::$(npm view @${{ env.CODE_EDITOR_NPM_PATH }} dist-tags.next)
+
+    # Pega a versão no package.json
+    - name: Get package.json version.
+      id: package-version
+      uses: martinbeentjes/npm-get-version-action@master
+
+    # PUBLISH NG-SCHEMATICS
+    - name: ng-schematics - publish
+      # Se a versão remota for igual à versão que será publicada então ele pula o publish deste pacote e tenta publicar os demais pacotes
+      if: (!contains(env.PACKAGE_VERSION, env.SCHEMATICS_LAST_PUBLISHED_VERSION))
+      run: npm publish dist/ng-schematics
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-schematics - add "latest" tag
+    
+      if: (!contains(env.PACKAGE_VERSION, env.SCHEMATICS_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.SCHEMATICS_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    # PUBLISH NG-STORAGE
+    - name: ng-storage - publish
+      if: (!contains(env.PACKAGE_VERSION, env.STORAGE_LAST_PUBLISHED_VERSION))
+      run: npm publish dist/ng-storage
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-storage - add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.STORAGE_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.STORAGE_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+    # PUBLISH NG-SYNC
+    - name: ng-sync - publish 
+      if: (!contains(env.PACKAGE_VERSION, env.SYNC_LAST_PUBLISHED_VERSION))
+      run: npm publish dist/ng-sync
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-sync - add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.SYNC_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.SYNC_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+    # PUBLISH NG-COMPONENTS
+    - name: ng-components - publish
+      if: (!contains(env.PACKAGE_VERSION, env.COMPONENTS_LAST_PUBLISHED_VERSION))
+      run: npm publish dist/ng-components
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-components - add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.COMPONENTS_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.COMPONENTS_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+    # PUBLISH NG-TEMPLATES
+    - name: ng-templates - publish
+      if: (!contains(env.PACKAGE_VERSION, env.TEMPLATES_LAST_PUBLISHED_VERSION))
+      run: npm publish dist/ng-templates
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-templates - add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.TEMPLATES_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.TEMPLATES_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+    # PUBLISH NG-CODE-EDITOR
+    - name: ng-code-editor publish
+      if: (!contains(env.PACKAGE_VERSION, env.CODE_EDITOR_LAST_PUBLISHED_VERSION))
+      run: npm publish dist/ng-code-editor
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-code-editor add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.CODE_EDITOR_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.CODE_EDITOR_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      

--- a/projects/code-editor/package.json
+++ b/projects/code-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@po-ui/ng-code-editor",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "dev",
+  "tag": "next",
   "description": "PO UI - Code Editor",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@po-ui/ng-schematics",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "dev",
+  "tag": "next",
   "description": "PO UI - Schematics",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/storage/package.json
+++ b/projects/storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@po-ui/ng-storage",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "dev",
+  "tag": "next",
   "description": "PO UI - Storage",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/sync/package.json
+++ b/projects/sync/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@po-ui/ng-sync",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "dev",
+  "tag": "next",
   "description": "PO UI - Sync",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/templates/package.json
+++ b/projects/templates/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@po-ui/ng-templates",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "dev",
+  "tag": "next",
   "description": "PO UI - Templates",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@po-ui/ng-components",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "dev",
+  "tag": "next",
   "description": "PO UI - Components",
   "author": "PO UI",
   "license": "MIT",


### PR DESCRIPTION
**build**

**DTHFUI-4136**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
N/A

**Qual o novo comportamento?**
Adiciona no github actions uma ação para publicar o pacote de forma automatizada.
Substitui a tag `dev` do package.json para `next`, para a partir dali o pacote ser publicado utilizando a tag next e latest.

**Simulação**
Para chegar em um teste mais próximo, pode ser utilizado o repositório [para testes](https://github.com/samir-ayoub/po-angular-test-github-actions). Utilize esse repositório para subir as versões e executar as actions.

Altere para uma nova versão executando `npm run release`
`git commit` e `git push`

Acesse abra a aba actions do repositório, clique em `PO-UI - publish`, posteriormente em `Run Workflow` veja a execução do fluxo de trabalho.

Favor testar também versão com tags -rc e -next executando `npm run release -- --release-as major --prerelease rc`

Verificar também nossa [doc sobre o processo de release](https://docs.google.com/document/d/1-eQpYVVBZLpkgZEuZ4a2ycXtS2-pcCwuB2QOS97D-zM/edit#)
