### PR TITLE
feat(lookup): inclusão da propriedade de busca avançada 

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -7,6 +7,7 @@ import { PoButtonGroupModule } from '../po-button-group/index';
 import { PoButtonModule } from '../po-button/index';
 import { PoCheckboxGroupModule } from './po-checkbox-group/po-checkbox-group.module';
 import { PoContainerModule } from '../po-container/index';
+import { PoDisclaimerGroupModule } from './../po-disclaimer-group/po-disclaimer-group.module';
 import { PoDisclaimerModule } from './../po-disclaimer/po-disclaimer.module';
 import { PoFieldContainerModule } from './po-field-container/po-field-container.module';
 import { PoLoadingModule } from '../po-loading/index';
@@ -71,6 +72,7 @@ import { PoUrlComponent } from './po-url/po-url.component';
     PoButtonModule,
     PoCheckboxGroupModule,
     PoContainerModule,
+    PoDisclaimerGroupModule,
     PoDisclaimerModule,
     PoFieldContainerModule,
     PoLoadingModule,

--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-advanced-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-advanced-filter.interface.ts
@@ -1,0 +1,8 @@
+import { PoDynamicFormField } from './../../../po-dynamic/po-dynamic-form/po-dynamic-form-field.interface';
+
+/**
+ * @docsExtends PoDynamicFormField
+ *
+ * @usedBy PoLookupComponent
+ */
+export interface PoLookupAdvancedFilter extends PoDynamicFormField {}

--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-filtered-items-params.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-filtered-items-params.interface.ts
@@ -33,4 +33,11 @@ export interface PoLookupFilteredItemsParams {
    * - Coluna ascendente será informada da seguinte forma: `<colunaOrdenada>`, por exemplo `name`.
    */
   order?: string;
+
+  /**
+   *
+   * Valores informados nos campos de busca avançada, que serão utilizados para filtrar a lista de itens.
+   *
+   */
+  advancedFilters?: { [key: string]: any };
 }

--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-literals.interface.ts
@@ -29,4 +29,24 @@ export interface PoLookupLiterals {
 
   /** Texto exibido no título da modal. */
   modalTitle?: string;
+
+  /**
+   * Texto do link de busca avançada.
+   *
+   * Importante
+   * Caso seja passado uma literal muito comprida poderá quebrar o layout.
+   */
+  modalAdvancedSearch?: string;
+
+  /** Texto exibido no título da modal de busca avançada. */
+  modalAdvancedSearchTitle?: string;
+
+  /** Texto exibido no label do botão de ação primária da modal de busca avançada. */
+  modalAdvancedSearchPrimaryActionLabel?: string;
+
+  /** Texto exibido no label do botão de ação secundária da modal de busca avançada. */
+  modalAdvancedSearchSecondaryActionLabel?: string;
+
+  /** Texto exibido no título do disclaimer. */
+  modalDisclaimerGroupTitle?: string;
 }

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs';
 import { convertToBoolean, isTypeof } from '../../../utils/util';
 import { requiredFailed } from '../validators';
 
+import { PoLookupAdvancedFilter } from './interfaces/po-lookup-advanced-filter.interface';
 import { PoLookupColumn } from './interfaces/po-lookup-column.interface';
 import { PoLookupFilter } from './interfaces/po-lookup-filter.interface';
 import { PoLookupFilterService } from './services/po-lookup-filter.service';
@@ -82,7 +83,12 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
    *    modalTableNoData: 'No data',
    *    modalTableLoadingData: 'Loading data',
    *    modalTableLoadMoreData: 'Load more',
-   *    modalTitle: 'Select a user'
+   *    modalTitle: 'Select a user',
+   *    modalAdvancedSearch: 'Advanced search',
+   *    modalAdvancedSearchTitle: 'Advanced search',
+   *    modalAdvancedSearchPrimaryActionLabel: 'Filter',
+   *    modalAdvancedSearchSecondaryActionLabel: 'Return',
+   *    modalDisclaimerGroupTitle: 'Presenting results filtered by:'
    *  };
    * ```
    *
@@ -280,10 +286,32 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
   }
 
   /**
+   *
    * @optional
    *
    * @description
    *
+   * Lista de objetos dos campos que serão criados na busca avançada.
+   *
+   * > Caso não seja passado um objeto ou então ele esteja em branco o link de busca avançada ficará escondido.
+   *
+   * Exemplo de URL com busca avançada:
+   *
+   * ```
+   * url + ?page=1&pageSize=20&name=Tony%20Stark&nickname=Homem%20de%20Ferro
+   * ```
+   *
+   * Caso algum parâmetro seja uma lista, a concatenação é feita utilizando vírgula.
+   * Exemplo:
+   *
+   * ```
+   * url + ?page=1&pageSize=20&name=Tony%20Stark,Peter%20Parker,Gohan
+   * ```
+   *
+   */
+  @Input('p-advanced-filters') advancedFilters: Array<PoLookupAdvancedFilter>;
+
+  /**
    * Evento será disparado quando ocorrer algum erro na requisição de busca do item.
    * Será passado por parâmetro o objeto de erro retornado.
    */

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
@@ -1,7 +1,6 @@
 import { Directive } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
 
-import * as UtilsFunctions from '../../../../utils/util';
 import { expectPropertiesValues } from '../../../../util-test/util-expect.spec';
 import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
 import { PoTableColumnSortType } from '../../../po-table/enums/po-table-column-sort-type.enum';
@@ -14,6 +13,7 @@ import { PoLookupResponseApi } from '../interfaces/po-lookup-response-api.interf
 @Directive()
 class PoLookupModalComponent extends PoLookupModalBaseComponent {
   openModal(): void {}
+  destroyDynamicForm(): void {}
 }
 
 describe('PoLookupModalBaseComponent:', () => {
@@ -38,6 +38,8 @@ describe('PoLookupModalBaseComponent:', () => {
       { value: 4, label: 'Suco Natural' },
       { value: 5, label: 'Suco em lata' }
     ];
+
+    component.ngOnInit();
   });
 
   it('should init modal with items', () => {
@@ -235,6 +237,27 @@ describe('PoLookupModalBaseComponent:', () => {
       expect(component.filterService.getFilteredItems).toHaveBeenCalledWith({ filter, page, pageSize, filterParams });
     });
 
+    it('getAdvancedFilters: should return a new object of the disclaimer', () => {
+      const expectedValue = { propertyTest: 'valueTest', propertyArrayTest: 'valueTest01,valueTest02' };
+      const disclaimerGroup = {
+        title: 'titleTest',
+        disclaimers: [
+          { property: 'propertyTest', value: 'valueTest' },
+          { property: 'propertyArrayTest', value: ['valueTest01', 'valueTest02'] }
+        ]
+      };
+      const advancedFilters = component['getAdvancedFilters'](disclaimerGroup.disclaimers);
+
+      expect(advancedFilters).toEqual(expectedValue);
+    });
+
+    it('getAdvancedFilters: should return undefined if advancedParams length is equal to 0', () => {
+      const emptyAdvancedParams = [];
+      const advancedFilters = component['getAdvancedFilters'](emptyAdvancedParams);
+
+      expect(advancedFilters).toBeUndefined();
+    });
+
     it('search: should call `getFilteredItems` if `searchValue` it`s truthy.', () => {
       component.searchValue = 'Suco';
 
@@ -421,6 +444,53 @@ describe('PoLookupModalBaseComponent:', () => {
       expect(component.items.length).toBe(2);
       expect(component.hasNext).toBeFalsy();
       expect(component.isLoading).toBeFalsy();
+    });
+
+    it('onChangeDisclaimerGroup: should call searchFilteredItems if searchValue is empty', () => {
+      component.searchValue = undefined;
+      const spySearch = spyOn(component, <any>'searchFilteredItems');
+
+      component.onChangeDisclaimerGroup();
+
+      expect(spySearch).toHaveBeenCalled();
+    });
+
+    it('onChangeDisclaimerGroup: should not call searchFilteredItems if searchValue is not empty', () => {
+      component.searchValue = 'hasValue';
+      const spySearch = spyOn(component, <any>'searchFilteredItems');
+
+      component.onChangeDisclaimerGroup();
+
+      expect(spySearch).not.toHaveBeenCalled();
+    });
+
+    it('createDisclaimer: should call initializeData if dynamicFormValue is empty', () => {
+      const spyInitializeData = spyOn(component, <any>'initializeData');
+      component.dynamicFormValue = {};
+      component.createDisclaimer();
+
+      expect(spyInitializeData).toHaveBeenCalled();
+    });
+
+    it('createDisclaimer: should call addDisclaimer if dynamicFormValue is not empty', () => {
+      const spyAddDisclaimer = spyOn(component, <any>'addDisclaimer');
+      component.dynamicFormValue = { name: 'nameTest' };
+      component.createDisclaimer();
+
+      expect(spyAddDisclaimer).toHaveBeenCalled();
+    });
+
+    it('addDisclaimer: should create disclaimer and disclaimerGroup.disclaimer with parameters', () => {
+      const expectedValueDisclaimer = { property: 'propertyTest', value: 'valueTest' };
+      const expectedValueDisclaimerGroup = {
+        title: 'titleTest',
+        disclaimers: [{ property: 'propertyTest', value: 'valueTest' }]
+      };
+
+      component.addDisclaimer('valueTest', 'propertyTest');
+
+      expect(component.disclaimer).toEqual(expectedValueDisclaimer);
+      expect(component.disclaimerGroup.disclaimers).toEqual(expectedValueDisclaimerGroup.disclaimers);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -2,43 +2,70 @@
   p-click-out="false"
   p-hide-close="false"
   p-size="lg"
-  [p-primary-action]="primaryAction"
-  [p-secondary-action]="secondaryAction"
-  [p-title]="title"
+  [p-primary-action]="isAdvancedFilter ? primaryActionAdvancedFilter : primaryAction"
+  [p-secondary-action]="isAdvancedFilter ? secondaryActionAdvancedFilter : secondaryAction"
+  [p-title]="isAdvancedFilter ? advancedFilterModalTitle : title"
 >
-  <po-field-container class="po-lookup-header po-md-6 po-pull-right" [p-optional]="false">
-    <div class="po-field-container-content">
-      <input
-        #inpsearch
-        class="po-input po-input-icon-right"
-        name="contentSearch"
-        [(ngModel)]="searchValue"
-        [placeholder]="literals.modalPlaceholder"
-        type="text"
-      />
+  <div [hidden]="isAdvancedFilter">
+    <po-field-container class="po-lookup-header po-pull-right" [p-optional]="false">
+      <div class="po-lookup-filter-content">
+        <div class="po-field-icon-container-right">
+          <span #iconLookup class="po-icon po-field-icon po-icon-search" (click)="search()"> </span>
+        </div>
 
-      <div class="po-field-icon-container-right">
-        <span #iconLookup class="po-icon po-field-icon po-icon-search" (click)="search()"> </span>
+        <input
+          #inpsearch
+          class="po-input po-input-icon-right"
+          name="contentSearch"
+          [(ngModel)]="searchValue"
+          [placeholder]="literals.modalPlaceholder"
+          type="text"
+        />
       </div>
-    </div>
-  </po-field-container>
 
-  <div class="po-row po-lookup-container-table" [style.height.px]="containerHeight">
-    <po-table
+      <div *ngIf="advancedFilters && advancedFilters.length > 0" class="po-lookup-advanced-search">
+        <span
+          class="po-lookup-advanced-search-link"
+          tabindex="0"
+          (click)="onAdvancedFilter()"
+          (keydown.enter)="onAdvancedFilter()"
+          tabindex="0"
+        >
+          {{ literals.modalAdvancedSearch }}
+        </span>
+      </div>
+    </po-field-container>
+
+    <!-- DISCLAIMER -->
+    <po-disclaimer-group
       class="po-md-12"
-      p-selectable="true"
-      p-hide-detail="true"
-      p-single-select="true"
-      p-sort="true"
-      [p-columns]="columns"
-      [p-height]="tableHeight"
-      [p-items]="items"
-      [p-literals]="tableLiterals"
-      [p-loading]="isLoading"
-      [p-show-more-disabled]="!hasNext"
-      (p-show-more)="showMoreEvent()"
-      (p-sort-by)="sortBy($event)"
+      *ngIf="!!disclaimerGroup"
+      [p-disclaimers]="disclaimerGroup?.disclaimers"
+      [p-title]="disclaimerGroup?.title"
+      (p-change)="onChangeDisclaimerGroup()"
     >
-    </po-table>
+    </po-disclaimer-group>
+
+    <div class="po-row po-lookup-container-table" [style.height.px]="containerHeight">
+      <po-table
+        class="po-md-12"
+        p-selectable="true"
+        p-hide-detail="true"
+        p-single-select="true"
+        p-sort="true"
+        [p-columns]="columns"
+        [p-height]="tableHeight"
+        [p-items]="items"
+        [p-literals]="tableLiterals"
+        [p-loading]="isLoading"
+        [p-show-more-disabled]="!hasNext"
+        (p-show-more)="showMoreEvent()"
+        (p-sort-by)="sortBy($event)"
+      >
+      </po-table>
+    </div>
+  </div>
+  <div [hidden]="!isAdvancedFilter">
+    <ng-container #container> </ng-container>
   </div>
 </po-modal>

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -342,8 +342,8 @@ describe('PoLookupComponent:', () => {
         component.label = 'Estabelecimento';
         component.literals = undefined;
 
-        const { service, columns, filterParams, literals } = component;
-        const params = { service, columns, filterParams, title: component.label, literals };
+        const { advancedFilters, service, columns, filterParams, literals } = component;
+        const params = { advancedFilters, service, columns, filterParams, title: component.label, literals };
 
         spyOn(component['poLookupModalService'], 'openModal');
         spyOn(component, <any>'isAllowedOpenModal').and.returnValue(true);

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -135,9 +135,16 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
 
   openLookup(): void {
     if (this.isAllowedOpenModal()) {
-      const { service, columns, filterParams, literals } = this;
+      const { advancedFilters, service, columns, filterParams, literals } = this;
 
-      this.poLookupModalService.openModal({ service, columns, filterParams, title: this.label, literals });
+      this.poLookupModalService.openModal({
+        advancedFilters,
+        service,
+        columns,
+        filterParams,
+        title: this.label,
+        literals
+      });
 
       if (!this.modalSubscription) {
         this.modalSubscription = this.poLookupModalService.selectValueEvent.subscribe(element => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero/sample-po-lookup-hero.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero/sample-po-lookup-hero.component.html
@@ -19,6 +19,7 @@
       [p-columns]="columns"
       [p-field-format]="fieldFormat"
       [p-filter-service]="service"
+      [p-advanced-filters]="advancedFilters"
       [p-literals]="{ 'modalTitle': 'Heroes available for mission' }"
     >
     </po-lookup>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero/sample-po-lookup-hero.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero/sample-po-lookup-hero.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 import { PoLookupColumn, PoSelectOption } from '@po-ui/ng-components';
 
-import { PoNotificationService } from '@po-ui/ng-components';
+import { PoNotificationService, PoDynamicFormField } from '@po-ui/ng-components';
 
 import { SamplePoLookupService } from '../sample-po-lookup.service';
 
@@ -30,6 +30,11 @@ export class SamplePoLookupHeroComponent {
     { label: 'Spaceship', value: 'spaceship' },
     { label: 'Submarine', value: 'submarine' },
     { label: 'Truck', value: 'truck' }
+  ];
+
+  advancedFilters: Array<PoDynamicFormField> = [
+    { property: 'nickname', divider: 'Hero Informations', optional: true, gridColumns: 6, label: 'Hero' },
+    { property: 'name', optional: true, gridColumns: 6 }
   ];
 
   constructor(public service: SamplePoLookupService, public notification: PoNotificationService) {}

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -10,6 +10,7 @@
   [p-help]="help"
   [p-label]="label"
   [p-literals]="customLiterals"
+  [p-advanced-filters]="customAdvancedFilters"
   [p-no-autocomplete]="properties.includes('noAutocomplete')"
   [p-optional]="properties.includes('optional')"
   [p-placeholder]="placeholder"
@@ -106,6 +107,19 @@
       (p-change)="onChangeProperties($event)"
     >
     </po-checkbox-group>
+  </div>
+
+  <div class="po-row">
+    <po-textarea
+      class="po-md-6"
+      name="advancedFilters"
+      [(ngModel)]="advancedFilters"
+      (p-change)="changeAdvancedFilters()"
+      p-help='Ex.: [{"property":"name","divider":"PERSONAL DATA","required":true,"gridColumns":6},{"property":"id","optional":true,"gridColumns":6}]'
+      p-label="Advanced Filters"
+      p-rows="4"
+    >
+    </po-textarea>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
@@ -5,6 +5,7 @@ import {
   PoLookupColumn,
   PoLookupFilter,
   PoLookupLiterals,
+  PoDynamicFormField,
   PoSelectOption
 } from '@po-ui/ng-components';
 
@@ -30,6 +31,8 @@ export class SamplePoLookupLabsComponent implements OnInit {
   lookup: any;
   placeholder: string;
   properties: Array<string>;
+  advancedFilters: string;
+  customAdvancedFilters: Array<PoDynamicFormField>;
 
   private readonly columnsDefinition = {
     id: <PoLookupColumn>{ property: 'id', label: 'Id' },
@@ -91,6 +94,14 @@ export class SamplePoLookupLabsComponent implements OnInit {
     }
   }
 
+  changeAdvancedFilters() {
+    try {
+      this.customAdvancedFilters = JSON.parse(this.advancedFilters);
+    } catch {
+      this.customAdvancedFilters = undefined;
+    }
+  }
+
   restore() {
     this.columnsName = ['id', 'name'];
     this.customLiterals = undefined;
@@ -107,6 +118,7 @@ export class SamplePoLookupLabsComponent implements OnInit {
     this.lookup = undefined;
     this.placeholder = '';
     this.properties = [];
+    this.customAdvancedFilters = [];
   }
 
   updateColumns() {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup.service.ts
@@ -12,8 +12,8 @@ export class SamplePoLookupService implements PoLookupFilter {
   constructor(private httpClient: HttpClient) {}
 
   getFilteredItems(filteredParams: PoLookupFilteredItemsParams): Observable<any> {
-    const { page, pageSize } = filteredParams;
-    const params = { ...filteredParams, page: page.toString(), pageSize: pageSize.toString() };
+    const { filterParams, advancedFilters, ...restFilteredItemsParams } = filteredParams;
+    const params = { ...restFilteredItemsParams, ...filterParams, ...advancedFilters };
 
     return this.httpClient.get(this.url, { params });
   }

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.ts
@@ -26,11 +26,12 @@ export class PoLookupFilterService implements PoLookupFilter {
   constructor(private httpClient: HttpClient) {}
 
   getFilteredItems(filteredItemsParams: PoLookupFilteredItemsParams): Observable<any> {
-    const { filterParams, ...restFilteredItemsParams } = filteredItemsParams;
+    const { filterParams, advancedFilters, ...restFilteredItemsParams } = filteredItemsParams;
 
     const validatedFilterParams = this.validateParams(filterParams);
+    const validatedAdvancedFilters = this.validateParams(advancedFilters);
 
-    const params = { ...restFilteredItemsParams, ...validatedFilterParams };
+    const params = { ...restFilteredItemsParams, ...validatedFilterParams, ...validatedAdvancedFilters };
 
     return this.httpClient.get(this.url, { headers: this.headers, params });
   }

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
@@ -33,6 +33,7 @@ describe('PoLookupModalService:', () => {
   let lookupFilterService: LookupFilterService;
   let poLookupModalService: PoLookupModalService;
   const params = {
+    advancedFilters: [],
     service: undefined,
     columns: [],
     filterParams: undefined,

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, ComponentRef, EventEmitter } from '@angular/core';
 
+import { PoDynamicFormField } from './../../../po-dynamic/po-dynamic-form/po-dynamic-form-field.interface';
 import { PoComponentInjectorService } from '../../../../services/po-component-injector/po-component-injector.service';
 import { PoLookupColumn } from '../../../../components/po-field/po-lookup/interfaces/po-lookup-column.interface';
 import { PoLookupFilter } from '../../../../components/po-field/po-lookup/interfaces/po-lookup-filter.interface';
@@ -22,6 +23,7 @@ export class PoLookupModalService {
   /**
    * Método responsável por abrir a modal de busca das informações.
    *
+   * @param advancedFilters {Array<PoDynamicFormField>} Objeto utilizado para criar o busca avançada.
    * @param service {PoLookupFilter} Serviço responsável por realizar a busca no serviço dos dados.
    * @param columns {Array<PoLookupColumn>} Definição das colunas na modal de busca.
    * @param filterParams {any} Valor que será repassado aos métodos do serviço para auxiliar no filtro dos dados.
@@ -29,15 +31,17 @@ export class PoLookupModalService {
    * @param literals {PoLookupLiterals} Literais utilizadas no componente.
    */
   openModal(params: {
+    advancedFilters: Array<PoDynamicFormField>;
     service: PoLookupFilter;
     columns: Array<PoLookupColumn>;
     filterParams: any;
     title: string;
     literals: PoLookupLiterals;
   }): void {
-    const { service, columns, filterParams, title, literals } = params;
+    const { advancedFilters, service, columns, filterParams, title, literals } = params;
 
     this.componentRef = this.poComponentInjector.createComponentInApplication(PoLookupModalComponent);
+    this.componentRef.instance.advancedFilters = advancedFilters;
     this.componentRef.instance.title = title;
     this.componentRef.instance.columns = columns;
     this.componentRef.instance.filterService = service;


### PR DESCRIPTION
**PO-LOOKUP**

**DTHFUI-487**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**

O componente atual não possui um busca avançada configurável, limitando os campos que podem ser pesquisados ou tendo que fazer o filtro simples pesquisar por todos os campos da tabela.


**Qual o novo comportamento?**

Adicionado uma nova propriedade, p-advanced-filters, onde permite configurar um array de PoDynamicFormField para criar uma nova tela de busca avançada, permitindo filtrar pelos campos inseridos nessa propriedade.


**Simulação**

- Arquivos necessários para simular com o app:  [app.zip](https://github.com/po-ui/po-angular/files/5245400/app.zip)

- Para o estilo do botão de busca avançada ficar correto deve-se pegar as alterações do PR do po-style (**po-style\dist\style\css\po-theme-default.min.css**) que se encontra abaixo e colocar em **po-angular\node_modules\@po-ui\style\css\po-theme-default.min.css**.

- Para os samples, **labs** e **PO Lookup - Hero** , funcionarem corretamente a API deve ser atualizada, PR do po-sample-api se encontra abaixo.

PR API: https://github.com/po-ui/po-sample-api/pull/17
PR Style: https://github.com/po-ui/po-style/pull/157