### PR TITLE
feat(po-dynamic): adiciona espaço após os campos

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-field.interface.ts
@@ -68,6 +68,50 @@ export interface PoDynamicField {
   gridXlColumns?: number;
 
   /**
+   * Tamanho do espaçamento após o campo antes da exibição do próximo campo em telas menores (sm).
+   *
+   * Deve ser usado o sistema de **grid** do PO (1 ... 11 colunas).
+   *
+   * > Esta propriedade não funciona com a propriedade `gridColumns`. Deve-se especificar o tamanho da tela.
+   *
+   * @default `0`
+   */
+  gridSmPull?: number;
+
+  /**
+   * Tamanho do espaçamento após o campo antes da exibição do próximo campo em telas médias (md).
+   *
+   * Deve ser usado o sistema de **grid** do PO (1 ... 11 colunas).
+   *
+   * > Esta propriedade não funciona com a propriedade `gridColumns`. Deve-se especificar o tamanho da tela.
+   *
+   * @default `0`
+   */
+  gridMdPull?: number;
+
+  /**
+   * Tamanho do espaçamento após o campo antes da exibição do próximo campo em telas grandes (lg).
+   *
+   * Deve ser usado o sistema de **grid** do PO (1 ... 11 colunas).
+   *
+   * > Esta propriedade não funciona com a propriedade `gridColumns`. Deve-se especificar o tamanho da tela.
+   *
+   * @default `0`
+   */
+  gridLgPull?: number;
+
+  /**
+   * Tamanho do espaçamento após o campo antes da exibição do próximo campo em telas extra grandes (xl).
+   *
+   * Deve ser usado o sistema de **grid** do PO (1 ... 11 colunas).
+   *
+   * > Esta propriedade não funciona com a propriedade `gridColumns`. Deve-se especificar o tamanho da tela.
+   *
+   * @default `0`
+   */
+  gridXlPull?: number;
+
+  /**
    * Indica se o campo será visível.
    *
    * @default `true`

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -108,7 +108,13 @@ export class PoDynamicFormFieldsBaseComponent {
       field.gridMdColumns,
       field.gridLgColumns,
       field.gridXlColumns,
-      field.gridColumns
+      field.gridColumns,
+      {
+        smPull: field.gridSmPull,
+        mdPull: field.gridMdPull,
+        lgPull: field.gridLgPull,
+        xlPull: field.gridXlPull
+      }
     );
 
     return {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -177,7 +177,13 @@ export class PoDynamicViewBaseComponent {
       field.gridMdColumns,
       field.gridLgColumns,
       field.gridXlColumns,
-      field.gridColumns
+      field.gridColumns,
+      {
+        smPull: field.gridSmPull,
+        mdPull: field.gridMdPull,
+        lgPull: field.gridLgPull,
+        xlPull: field.gridXlPull
+      }
     );
 
     return {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic.util.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic.util.spec.ts
@@ -26,8 +26,21 @@ describe('getGridColumnsClasses:', () => {
     const mdColumns = 3;
     const lgColumns = 7;
     const xlColumns = 3;
+    const pullColumns = {
+      smPull: 0,
+      mdPull: 0,
+      lgPull: 0,
+      xlPull: 0
+    };
 
-    const classesGridColumns = getGridColumnsClasses(smColumns, mdColumns, lgColumns, xlColumns, undefined);
+    const classesGridColumns = getGridColumnsClasses(
+      smColumns,
+      mdColumns,
+      lgColumns,
+      xlColumns,
+      undefined,
+      pullColumns
+    );
 
     expect(classesGridColumns.includes(`po-sm-${smColumns}`)).toBe(true);
     expect(classesGridColumns.includes(`po-md-${mdColumns}`)).toBe(true);
@@ -38,7 +51,14 @@ describe('getGridColumnsClasses:', () => {
   it('should return classes of grid columns according to the gridColumns parameter', () => {
     const gridColumns = 6;
 
-    const classesGridColumns = getGridColumnsClasses(undefined, undefined, undefined, undefined, gridColumns);
+    const classesGridColumns = getGridColumnsClasses(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      gridColumns,
+      undefined
+    );
 
     expect(classesGridColumns.includes(`po-sm-${gridColumns}`)).toBe(true);
     expect(classesGridColumns.includes(`po-md-${gridColumns}`)).toBe(true);
@@ -47,7 +67,7 @@ describe('getGridColumnsClasses:', () => {
   });
 
   it('should return classes of grid columns according to the defaults size', () => {
-    const classesGridColumns = getGridColumnsClasses(undefined, undefined, undefined, undefined, undefined);
+    const classesGridColumns = getGridColumnsClasses(undefined, undefined, undefined, undefined, undefined, undefined);
 
     expect(classesGridColumns.includes(`po-sm-12`)).toBe(true);
     expect(classesGridColumns.includes(`po-md-6`)).toBe(true);
@@ -61,7 +81,14 @@ describe('getGridColumnsClasses:', () => {
     const smColumns = 8;
     const xlColumns = 4;
 
-    const classesGridColumns = getGridColumnsClasses(smColumns, undefined, undefined, xlColumns, gridColumns);
+    const classesGridColumns = getGridColumnsClasses(
+      smColumns,
+      undefined,
+      undefined,
+      xlColumns,
+      gridColumns,
+      undefined
+    );
 
     expect(classesGridColumns.includes(`po-sm-${smColumns}`)).toBe(true);
     expect(classesGridColumns.includes(`po-md-${gridColumns}`)).toBe(true);

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic.util.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic.util.ts
@@ -1,14 +1,18 @@
 import { PoDynamicViewField } from './po-dynamic-view/po-dynamic-view-field.interface';
 
-export function getGridColumnsClasses(smColumns, mdColumns, lgColumns, xlColumns, gridColumns) {
+export function getGridColumnsClasses(smColumns, mdColumns, lgColumns, xlColumns, gridColumns, pullColumns) {
   const systemGrid = {
     sm: smColumns || gridColumns || 12,
     md: mdColumns || gridColumns || 6,
     lg: lgColumns || gridColumns || 4,
-    xl: xlColumns || gridColumns || 3
+    xl: xlColumns || gridColumns || 3,
+    pullSm: pullColumns?.smPull || 0,
+    pullMd: pullColumns?.mdPull || 0,
+    pullLg: pullColumns?.lgPull || 0,
+    pullXl: pullColumns?.xlPull || 0
   };
 
-  return `po-sm-${systemGrid.sm} po-md-${systemGrid.md} po-lg-${systemGrid.lg} po-xl-${systemGrid.xl}`;
+  return `po-sm-${systemGrid.sm} po-pull-sm-${systemGrid.pullSm} po-md-${systemGrid.md} po-pull-md-${systemGrid.pullMd} po-lg-${systemGrid.lg} po-pull-lg-${systemGrid.pullLg} po-xl-${systemGrid.xl} po-pull-xl-${systemGrid.pullXl}`;
 }
 
 export function isVisibleField(field: { visible?: boolean }): boolean {


### PR DESCRIPTION
Foi adicionado novos css e propriedades ao dynamic-form e dynamic-view

Fixes #585

Foram adicionados as propriedades gridXXOffset.
Esta propriedade permite incluir espaço em branco após o campo.
Com esta propriedade é possível deixar apenas um campo na linha do form.

**PO-DYNAMIC**

**585**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
No componente atual não é permitido inserir espaços em branco após um campo.

**Qual o novo comportamento?**
Com as novas propriedade é possível inserir um espaçamento entre um campo e outro podendo até mesmo quebrar a linha antes do aparecimento do próximo campo.

**Simulação**
Adicionar um po-dynamic-form ou po-dynamic-view e nas propriedades inserir a propriedade grid<tamanho tela>Offset: <numero> para criar um espaçamento após o campo e no tamanho selecionado.