### PR TITLE
fix(po-decimal): incluido p-error-pattern

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
@@ -27,5 +27,5 @@
     </div>
   </div>
 
-  <po-field-container-bottom> </po-field-container-bottom>
+  <po-field-container-bottom [p-error-pattern]="getErrorPatternMessage()"> </po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -1286,6 +1286,48 @@ describe('PoDecimalComponent:', () => {
     it('isValueBetweenAllowed: should return `false` if is value below allowed.', () => {
       expect(component['isValueBetweenAllowed'](-1, 9)).toBe(false);
     });
+
+    describe('getErrorPatternMessage: ', () => {
+      it('should return errorPattern value if errorPattern has value and containsInvalidClass returns true and show the properly message in template', () => {
+        const fakeThis = {
+          errorPattern: 'erro',
+          hasInvalidClass: () => true
+        };
+
+        expect(component.getErrorPatternMessage.call(fakeThis)).toBe('erro');
+
+        component.errorPattern = 'MENSAGEM DE ERRO';
+        component.hasInvalidClass = () => true;
+        fixture.detectChanges();
+        const content = fixture.debugElement.nativeElement
+          .querySelector('.po-field-container-bottom-text-error')
+          .innerHTML.toString();
+
+        expect(content.indexOf('MENSAGEM DE ERRO') > -1).toBeTruthy();
+      });
+
+      it('should return empty string if errorPattern is empty', () => {
+        component.errorPattern = '';
+
+        const expectedResult = component.getErrorPatternMessage();
+
+        expect(expectedResult).toBe('');
+        expect(fixture.debugElement.nativeElement.querySelector('.po-field-container-bottom-text-error')).toBeNull();
+      });
+
+      it('should return empty string if errorPattern has value but containsInvalidClass returns false', () => {
+        component.inputEl.nativeElement.value = '';
+        component.errorPattern = 'error';
+        component.inputEl.nativeElement.classList.add('ng-invalid');
+        component.inputEl.nativeElement.classList.add('ng-dirty');
+        component['invalidInputValueOnBlur'] = false;
+
+        const expectedResult = component.getErrorPatternMessage();
+
+        expect(expectedResult).toBe('');
+        expect(fixture.debugElement.nativeElement.querySelector('.po-field-container-bottom-text-error')).toBeNull();
+      });
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -312,6 +312,10 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
     }
   }
 
+  getErrorPatternMessage() {
+    return this.errorPattern !== '' && this.hasInvalidClass() ? this.errorPattern : '';
+  }
+
   // reponsável por adicionar 0 antes da virgula (decimalSeparator).
   private addZeroBefore(value) {
     const isDecimalSeparator = value === this.decimalSeparator;


### PR DESCRIPTION
**PO-DECIMAL**

**#325** 
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
As mensagens de erros não são exibidas

**Qual o novo comportamento?**
As mensagens de erros são exibidas abaixo do input, seguindo o padrões dos demais componentes com essa caracteristica

**Simulação**
Utilizar o componente po-decimal com validação de um valor mínimo, incluir uma mensagem de erro para a propriedade p-error-pattern, ao inserir um valor inválido com a validação a mensagem de erro com o texto inserido será exibida.