### PR TITLE
fix(rich-text): corrige compartilhamento do ngModel

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
@@ -6,6 +6,7 @@ import * as UtilsFunction from '../../../../utils/util';
 import { configureTestSuite } from './../../../../util-test/util-expect.spec';
 
 import { PoRichTextBodyComponent } from './po-rich-text-body.component';
+import { PoRichTextService } from '../po-rich-text.service';
 
 describe('PoRichTextBodyComponent:', () => {
   let component: PoRichTextBodyComponent;
@@ -14,7 +15,8 @@ describe('PoRichTextBodyComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      declarations: [PoRichTextBodyComponent]
+      declarations: [PoRichTextBodyComponent],
+      providers: [PoRichTextService]
     });
   });
 

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
@@ -19,6 +19,9 @@ const providers = [
     // tslint:disable-next-line
     useExisting: forwardRef(() => PoRichTextComponent),
     multi: true
+  },
+  {
+    provide: PoRichTextService
   }
 ];
 

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.service.ts
@@ -2,9 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { Subject } from 'rxjs';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable()
 export class PoRichTextService {
   private model = new Subject<string>();
 


### PR DESCRIPTION
**PO-RICH-TEXT**

**DTHFUI-4248**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O componente está compartilhando o ngModel quando tem mais de um `po-rich-text` por tela.

**Qual o novo comportamento?**
Corrigido o compartilhamento do model.

**Simulação**
- Nos próprios samples do portal que na master todos mostram a receita do último sample e agora está como deveria.
- Teste no app:
app.component.html:
```
<div class="po-row">
  <po-rich-text
    class="po-md-6"
    p-label="Componente 1"
    name="teste"
    [(ngModel)]="teste">
  </po-rich-text>
  
  <po-info class="po-md-6" p-label="Model Componente 1" [p-value]="teste"> </po-info>
</div>

<po-divider></po-divider>

<div class="po-row">
  <po-rich-text
    class="po-md-6"
    p-label="Componente 2"
    name="recipe"
    [(ngModel)]="recipe">
  </po-rich-text>
  
  <po-info class="po-md-6" p-label="Model Componente 2" [p-value]="recipe"> </po-info>
</div>

<po-divider></po-divider>

<po-button
  class="po-md-12"
  (p-click)="changeModel()"
  p-label="Alterar conteudo" >
</po-button>
```
app.component.ts:
```
  teste = `Conteúdo inicial do Componente 1`;
  recipe = `Conteúdo inicial do Componente 2`;

  changeModel() {
    this.teste += ` Conteúdo alterado do Componente 1`;
    this.recipe += ` Conteúdo alterado do Componente 2`;
  }
```

