### PR TITLE
fix(ui/templates): ajusta declaracao incorreta dos event emitter

### DIFF
--- a/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.component.ts
@@ -83,10 +83,14 @@ export class PoPageBackgroundComponent implements OnInit {
   }
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento disparado ao selecionar alguma opção no seletor de idiomas.
    * Para este evento será passado como parâmetro o valor de idioma selecionado.
    */
-  @Output('p-selected-language') selectedLanguage?: EventEmitter<string> = new EventEmitter<string>();
+  @Output('p-selected-language') selectedLanguage: EventEmitter<string> = new EventEmitter<string>();
 
   constructor(public poLanguageService: PoLanguageService) {}
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
@@ -239,19 +239,33 @@ export abstract class PoPageDynamicSearchBaseComponent {
   }
 
   /**
+   * @optional
+   *
    * @description
    *
    * Evento disparado ao executar a pesquisa avançada, o mesmo irá repassar um objeto com os valores preenchidos no modal de pesquisa.
    *
    * > Campos não preenchidos não irão aparecer no objeto passado por parâmetro.
    */
-  @Output('p-advanced-search') advancedSearch?: EventEmitter<any> = new EventEmitter();
+  @Output('p-advanced-search') advancedSearch: EventEmitter<any> = new EventEmitter();
 
-  /** Evento disparado ao remover um ou todos os disclaimers pelo usuário. */
-  @Output('p-change-disclaimers') changeDisclaimers?: EventEmitter<any> = new EventEmitter();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao remover um ou todos os disclaimers pelo usuário.
+   */
+  @Output('p-change-disclaimers') changeDisclaimers: EventEmitter<any> = new EventEmitter();
 
-  /** Evento disparado ao realizar uma busca pelo campo de pesquisa rápida, o mesmo será chamado repassando o valor digitado. */
-  @Output('p-quick-search') quickSearch?: EventEmitter<string> = new EventEmitter();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao realizar uma busca pelo campo de pesquisa rápida, o mesmo será chamado repassando o valor digitado.
+   */
+  @Output('p-quick-search') quickSearch: EventEmitter<string> = new EventEmitter();
 
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -873,13 +873,17 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
   }
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento disparado quando o usuário alterar o input do campo login.
    *
    * Esse evento receberá como parâmetro uma variável do tipo `string` com o texto informado no campo.
    *
    * > Esta propriedade será ignorada se for definido valor para a propriedade `p-authentication-url`.
    */
-  @Output('p-login-change') loginChange?: EventEmitter<string> = new EventEmitter<string>();
+  @Output('p-login-change') loginChange: EventEmitter<string> = new EventEmitter<string>();
 
   /**
    * Evento disparado ao submeter o formulário de login (apertando `Enter` dentro dos campos ou pressionando o botão de confirmação).
@@ -893,21 +897,29 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
   @Output('p-login-submit') loginSubmit = new EventEmitter<PoPageLogin>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento disparado quando o usuário alterar o input do campo password.
    *
    * Esse evento receberá como parâmetro uma variável do tipo `string` com o texto informado no campo.
    *
    * > Esta propriedade será ignorada se for definido valor para a propriedade `p-authentication-url`.
    */
-  @Output('p-password-change') passwordChange?: EventEmitter<string> = new EventEmitter<string>();
+  @Output('p-password-change') passwordChange: EventEmitter<string> = new EventEmitter<string>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento disparado quando o usuário alterar o idioma da página.
    *
    * Esse evento receberá como parâmetro um objeto do tipo `PoLanguage` com a linguagem selecionada.
    *
    */
-  @Output('p-language-change') languageChange?: EventEmitter<PoLanguage> = new EventEmitter<PoLanguage>();
+  @Output('p-language-change') languageChange: EventEmitter<PoLanguage> = new EventEmitter<PoLanguage>();
 
   get language(): string {
     return this.selectedLanguage || getShortBrowserLanguage();

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
@@ -89,23 +89,37 @@ export class PoDisclaimerGroupBaseComponent implements DoCheck {
   /** Título do grupo de *disclaimers*. */
   @Input('p-title') title?: string;
 
-  /** Função que será disparada quando a lista de *disclaimers* for modificada. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função que será disparada quando a lista de *disclaimers* for modificada.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Função que será disparada quando um *disclaimer* for removido da lista de *disclaimers* pelo usuário.
    *
    * Recebe como parâmetro um objeto conforme a interface `PoDisclaimerGroupRemoveAction`.
    */
-  @Output('p-remove') remove?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-remove') remove: EventEmitter<any> = new EventEmitter<any>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Função que será disparada quando todos os *disclaimers* forem removidos da lista de *disclaimers* pelo usuário,
    * utilizando o botão "remover todos".
    *
    * Recebe como parâmetro uma lista contendo todos os `disclaimers` removidos.
    */
-  @Output('p-remove-all') removeAll?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-remove-all') removeAll: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(differs: IterableDiffers, languageService: PoLanguageService) {
     const language = languageService.getShortLanguage();

--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.ts
@@ -51,10 +51,14 @@ export class PoDisclaimerBaseComponent {
   }
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento disparado ao fechar o disclaimer.
    * Para este evento será passado como parâmetro um objeto com value, label e property.
    */
-  @Output('p-close-action') closeAction?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-close-action') closeAction: EventEmitter<any> = new EventEmitter<any>();
 
   /**
    * @description

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
@@ -194,11 +194,23 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
     return this._required;
   }
 
-  // Função para atualizar o `ngModel` do componente, necessário quando não for utilizado dentro da tag form.
-  @Output('ngModelChange') ngModelChange?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função para atualizar o `ngModel` do componente, necessário quando não for utilizado dentro da tag form.
+   */
+  @Output('ngModelChange') ngModelChange: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Evento disparado ao alterar valor do campo */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao alterar valor do campo
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
   changeValue() {
     const value = this.checkIndeterminate();

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -59,8 +59,14 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
   /** Texto de exibição do *checkbox*. */
   @Input('p-label') label?: string;
 
-  /** Evento disparado quando o valor do *checkbox* for alterado. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado quando o valor do *checkbox* for alterado.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
   changeValue() {
     if (this.propagateChange) {

--- a/projects/ui/src/lib/components/po-field/po-clean/po-clean-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-clean/po-clean-base.component.ts
@@ -17,11 +17,16 @@ export abstract class PoCleanBaseComponent {
   @Input('p-default-value') defaultValue?: string = '';
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   *
    * Evento disparado quando executada ação do po-clean.
    * Este evento deve ser usado para avisar para o componente que está usando o po-clean, que o botão foi disparado,
    * e provavelmente será preciso emitir o evento para atualizar o model.
    */
-  @Output('p-change-event') changeEvent?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-change-event') changeEvent: EventEmitter<any> = new EventEmitter<any>();
 
   protected parentComponent: any;
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -446,11 +446,23 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   /** Se verdadeiro, o campo receberá um botão para ser limpo. */
   @Input('p-clean') @InputBoolean() clean?: boolean;
 
-  /** Deve ser informada uma função que será disparada quando houver alterações no ngModel. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Deve ser informada uma função que será disparada quando houver alterações no ngModel.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
-  // Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
-  @Output('ngModelChange') ngModelChange?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
+   */
+  @Output('ngModelChange') ngModelChange: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -326,7 +326,7 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    *
    * Evento disparado ao alterar valor do campo.
    */
-  @Output('p-change') onChange?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-change') onChange: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(protected poDateService: PoDateService) {}
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -306,11 +306,23 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
     return this._locale || getShortBrowserLanguage();
   }
 
-  /** Evento disparado ao sair do campo. */
-  @Output('p-blur') onblur?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao sair do campo.
+   */
+  @Output('p-blur') onblur: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Evento disparado ao alterar valor do campo. */
-  @Output('p-change') onchange?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao alterar valor do campo.
+   */
+  @Output('p-change') onchange: EventEmitter<any> = new EventEmitter<any>();
 
   constructor() {}
 

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -260,17 +260,41 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    */
   @Input('p-optional') optional: boolean;
 
-  /** Evento disparado ao sair do campo. */
-  @Output('p-blur') blur?: EventEmitter<any> = new EventEmitter();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao sair do campo.
+   */
+  @Output('p-blur') blur: EventEmitter<any> = new EventEmitter();
 
-  /** Evento disparado ao entrar do campo. */
-  @Output('p-enter') enter?: EventEmitter<any> = new EventEmitter();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao entrar do campo.
+   */
+  @Output('p-enter') enter: EventEmitter<any> = new EventEmitter();
 
-  /** Evento disparado ao alterar valor e deixar o campo. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao alterar valor e deixar o campo.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter();
 
-  /** Evento disparado ao alterar valor do model. */
-  @Output('p-change-model') changeModel?: EventEmitter<any> = new EventEmitter();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao alterar valor do model.
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
 
   type: string;
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -280,16 +280,24 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
   }
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento será disparado quando ocorrer algum erro na requisição de busca do item.
    * Será passado por parâmetro o objeto de erro retornado.
    */
-  @Output('p-error') onError?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-error') onError: EventEmitter<any> = new EventEmitter<any>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento será disparado quando ocorrer alguma seleção.
    * Será passado por parâmetro o objeto com o valor selecionado.
    */
-  @Output('p-selected') selected?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-selected') selected: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(private defaultService: PoLookupFilterService) {}
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -300,8 +300,14 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
     return this._filterMode;
   }
 
-  /** Pode ser informada uma função que será disparada quando houver alterações no ngModel. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Pode ser informada uma função que será disparada quando houver alterações no ngModel.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
   protected clickOutListener: () => void;
   protected resizeListener: () => void;

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
@@ -142,8 +142,14 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
    */
   @Input('p-optional') optional: boolean;
 
-  /** Evento ao alterar valor do campo. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento ao alterar valor do campo.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
   // Deve retornar o valor elemento que contém o valor passado por parâmetro
   abstract getElementByValue(value: any): any;

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
@@ -156,11 +156,23 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
     return this._required;
   }
 
-  /** Evento disparado ao deixar o campo e que recebe como parâmetro o valor alterado. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao deixar o campo e que recebe como parâmetro o valor alterado.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter();
 
-  /** Evento disparado ao modificar valor do model e que recebe como parâmetro o valor alterado. */
-  @Output('p-change-model') changeModel?: EventEmitter<any> = new EventEmitter();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao modificar valor do model e que recebe como parâmetro o valor alterado.
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
 
   constructor(private richTextService: PoRichTextService) {}
 

--- a/projects/ui/src/lib/components/po-field/po-select/po-select-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select-base.component.ts
@@ -96,11 +96,23 @@ export abstract class PoSelectBaseComponent implements ControlValueAccessor, Val
     return this._options;
   }
 
-  /** Deve ser informada uma função que será disparada quando houver alterações no ngModel. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Deve ser informada uma função que será disparada quando houver alterações no ngModel.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
-  // Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
-  @Output('ngModelChange') ngModelChange?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
+   */
+  @Output('ngModelChange') ngModelChange: EventEmitter<any> = new EventEmitter<any>();
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
@@ -99,11 +99,23 @@ export class PoSwitchBaseComponent implements ControlValueAccessor {
     return this._disabled;
   }
 
-  /** Evento disparado ao alterar valor do campo. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao alterar valor do campo.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
-  // Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
-  @Output('ngModelChange') ngModelChange?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
+   */
+  @Output('ngModelChange') ngModelChange: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(private changeDetector: ChangeDetectorRef) {}
 

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -181,17 +181,41 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
     return this._rows;
   }
 
-  /** Evento disparado ao sair do campo. */
-  @Output('p-blur') blur?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao sair do campo.
+   */
+  @Output('p-blur') blur: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Evento disparado ao entrar do campo. */
-  @Output('p-enter') enter?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao entrar do campo.
+   */
+  @Output('p-enter') enter: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Evento disparado ao alterar valor e deixar o campo. */
-  @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao alterar valor e deixar o campo.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Evento disparado ao alterar valor do model. */
-  @Output('p-change-model') changeModel?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao alterar valor do model.
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter<any>();
 
   callOnChange(value: any) {
     // Quando o input não possui um formulário, então esta função não é registrada

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -465,6 +465,10 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
   }
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Função que será executada no momento de realizar o envio do arquivo,
    * onde será possível adicionar informações ao parâmetro que será enviado na requisição.
    * É passado por parâmetro um objeto com o arquivo e a propiedade data nesta propriedade pode ser informado algum dado,
@@ -474,22 +478,36 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *   event.data = {id: 'id do usuario'};
    * ```
    */
-  @Output('p-upload') onUpload?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-upload') onUpload: EventEmitter<any> = new EventEmitter<any>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento será disparado quando ocorrer algum erro no envio do arquivo.
    * > Por parâmetro será passado o objeto do retorno que é do tipo `HttpErrorResponse`.
    */
-  @Output('p-error') onError?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-error') onError: EventEmitter<any> = new EventEmitter<any>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento será disparado quando o envio do arquivo for realizado com sucesso.
    * > Por parâmetro será passado o objeto do retorno que é do tipo `HttpResponse`.
    */
-  @Output('p-success') onSuccess?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-success') onSuccess: EventEmitter<any> = new EventEmitter<any>();
 
-  // Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da *tag* `form`.
-  @Output('ngModelChange') ngModelChange?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da *tag* `form`.
+   */
+  @Output('ngModelChange') ngModelChange: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(protected uploadService: PoUploadService, languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();

--- a/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.ts
@@ -220,18 +220,26 @@ export class PoListViewBaseComponent {
   }
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Recebe uma ação, que será executada quando clicar no botão "Carregar mais resultados".
    *
    * > Caso nenhuma ação for definida o mesmo não ficará visível.
    */
-  @Output('p-show-more') showMore?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-show-more') showMore: EventEmitter<any> = new EventEmitter<any>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Ação que será executada ao clicar no título.
    *
    * Ao ser disparado, o método inserido na ação irá receber como parâmetro o item da lista clicado.
    */
-  @Output('p-title-action') titleAction?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-title-action') titleAction: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -439,30 +439,58 @@ export abstract class PoTableBaseComponent implements OnChanges {
    */
   @Input('p-max-columns') maxColumns?: number;
 
-  /** Evento executado quando todas as linhas são selecionadas por meio do *checkbox* que seleciona todas as linhas. */
-  @Output('p-all-selected') allSelected?: EventEmitter<any> = new EventEmitter<any>();
-
-  /** Evento executado quando a seleção das linhas é desmarcada por meio do *checkbox* que seleciona todas as linhas. */
-  @Output('p-all-unselected') allUnselected?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   * Evento executado quando todas as linhas são selecionadas por meio do *checkbox* que seleciona todas as linhas.
+   */
+  @Output('p-all-selected') allSelected: EventEmitter<any> = new EventEmitter<any>();
 
   /**
+   * @optional
+   *
+   * @description
+   * Evento executado quando a seleção das linhas é desmarcada por meio do *checkbox* que seleciona todas as linhas.
+   */
+  @Output('p-all-unselected') allUnselected: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Evento executado ao colapsar uma linha do `po-table`.
    *
    * > Como parâmetro o componente envia o item colapsado.
    */
-  @Output('p-collapsed') collapsed?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-collapsed') collapsed: EventEmitter<any> = new EventEmitter<any>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento executado ao expandir uma linha do `po-table`.
    *
    * > Como parâmetro o componente envia o item expandido.
    */
-  @Output('p-expanded') expanded?: EventEmitter<any> = new EventEmitter<any>();
-
-  /** Evento executado ao selecionar uma linha do `po-table`. */
-  @Output('p-selected') selected?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-expanded') expanded: EventEmitter<any> = new EventEmitter<any>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento executado ao selecionar uma linha do `po-table`.
+   */
+  @Output('p-selected') selected: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Recebe uma ação de clique para o botão "Carregar mais resultados", caso nenhuma ação for definida o mesmo
    * não é visível.
    *
@@ -471,9 +499,13 @@ export abstract class PoTableBaseComponent implements OnChanges {
    * - column (`PoTableColumn`): objeto da coluna que está ordenada.
    * - type (`PoTableColumnSortType`): tipo da ordenação.
    */
-  @Output('p-show-more') showMore?: EventEmitter<PoTableColumnSort> = new EventEmitter<PoTableColumnSort>();
+  @Output('p-show-more') showMore: EventEmitter<PoTableColumnSort> = new EventEmitter<PoTableColumnSort>();
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Evento executado ao ordenar colunas da tabela.
    *
    * Recebe um objeto `{ column, type }` onde:
@@ -481,10 +513,15 @@ export abstract class PoTableBaseComponent implements OnChanges {
    * - column (`PoTableColumn`): objeto da coluna que foi clicada/ordenada.
    * - type (`PoTableColumnSortType`): tipo da ordenação.
    */
-  @Output('p-sort-by') sortBy?: EventEmitter<PoTableColumnSort> = new EventEmitter<PoTableColumnSort>();
+  @Output('p-sort-by') sortBy: EventEmitter<PoTableColumnSort> = new EventEmitter<PoTableColumnSort>();
 
-  /** Evento executado ao desmarcar a seleção de uma linha do `po-table`. */
-  @Output('p-unselected') unselected?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   * Evento executado ao desmarcar a seleção de uma linha do `po-table`.
+   */
+  @Output('p-unselected') unselected: EventEmitter<any> = new EventEmitter<any>();
 
   get hasColumns(): boolean {
     return this.columns && this.columns.length > 0;

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.ts
@@ -42,9 +42,13 @@ export class PoTableDetailComponent {
   @Input('p-selectable') isSelectable?: boolean = false;
 
   /**
+   * @optional
+   *
+   * @description
+   *
    * Ação executada ao selecionar ou desmarcar a seleção de uma linha de detalhe do `po-table`.
    */
-  @Output('p-select-row') selectRow?: EventEmitter<any> = new EventEmitter<any>();
+  @Output('p-select-row') selectRow: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(private decimalPipe: DecimalPipe) {}
 

--- a/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
@@ -172,5 +172,5 @@ export class PoTagBaseComponent {
    *
    * Ação que será executada ao clicar sobre o `po-tag` e que receberá como parâmetro um objeto contendo o seu valor e tipo.
    */
-  @Output('p-click') click?: EventEmitter<any> = new EventEmitter<PoTagItem>();
+  @Output('p-click') click: EventEmitter<any> = new EventEmitter<PoTagItem>();
 }

--- a/projects/ui/src/lib/components/po-widget/po-widget-base.component.ts
+++ b/projects/ui/src/lib/components/po-widget/po-widget-base.component.ts
@@ -174,23 +174,57 @@ export abstract class PoWidgetBaseComponent {
     return this._title;
   }
 
-  /** Ação que será executada quando o usuário clicar sobre a área total do `po-widget`. */
-  @Output('p-click') click?: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Ação que será executada quando o usuário clicar sobre a área total do `po-widget`.
+   */
+  @Output('p-click') click: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
-  /** Função que será disparada com o valor do `p-disabled` quando esta propriedade for alterada. */
-  @Output('p-on-disabled') onDisabled?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função que será disparada com o valor do `p-disabled` quando esta propriedade for alterada.
+   */
+  @Output('p-on-disabled') onDisabled: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Função que será chamada na primeira ação. */
-  @Output('p-primary-action') primaryAction?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função que será chamada na primeira ação.
+   */
+  @Output('p-primary-action') primaryAction: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Função que será chamada na segunda ação. */
-  @Output('p-secondary-action') secondaryAction?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função que será chamada na segunda ação.
+   */
+  @Output('p-secondary-action') secondaryAction: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Função chamada ao clicar no ícone de configuração */
-  @Output('p-setting') setting?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   * Função chamada ao clicar no ícone de configuração
+   */
+  @Output('p-setting') setting: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Função que será chamada ao clicar no título. */
-  @Output('p-title-action') titleAction?: EventEmitter<any> = new EventEmitter<any>();
+  /**
+   * @optional
+   *
+   * @description
+   * Função que será chamada ao clicar no título.
+   */
+  @Output('p-title-action') titleAction: EventEmitter<any> = new EventEmitter<any>();
 
   abstract setHeight(height: number);
 }


### PR DESCRIPTION
Ajusta a declaração incorreta nos projetos ui e templates dos eventemitter.

**< DTHFUI-4309 >**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não permite o uso do po-ui com strict mode ativo

**Qual o novo comportamento?**
Permite o uso do po-ui com strict mode ativo

**Simulação**
ng new strict-po --strict=true --skipTests=true --skipInstall=true
#altera o package.json conforme guia de instalação
npm i
ng add @po-ui/ng-components
cria a function fn no home component ts
inclui no home component html <po-table (p-show-more)="fn()"></po-table>
ng build --prod

no console, Object is possibly 'undefined' 