### PR TITLE
fix(number): permitir apenas números

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -19,7 +19,8 @@ import { PoMask } from './po-mask';
  *
  * - Caso o input tenha um [(ngModel)] sem o atributo name, ocorrerá um erro de angular.
  * Então você precisa informar o atributo name ou o atributo [ngModelOptions]="{standalone: true}".
- * Exemplo: [(ngModel)]="pessoa.nome" [ngModelOptions]="{standalone: true}"
+ * Exemplo: [(ngModel)]="pessoa.nome" [ngModelOptions]="{standalone: true}".
+ *
  */
 @Directive()
 export abstract class PoInputBaseComponent implements ControlValueAccessor, Validator {

--- a/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.spec.ts
@@ -111,6 +111,147 @@ describe('PoNumberBaseComponent', () => {
     expect(fakeThis.eventOnBlur).toHaveBeenCalledWith(fakeEvent);
   });
 
+  it('onKeyDown: shouldn`t allow invalid keys and should call `preventDefault`', () => {
+    const fakeKeyboardEvent = {
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      key: 'e'
+    };
+
+    spyOn(fakeKeyboardEvent, 'preventDefault');
+    spyOn(fakeKeyboardEvent, 'stopPropagation');
+    spyOn(component, <any>'isKeyAllowed').and.returnValue(false);
+
+    component.onKeyDown(fakeKeyboardEvent);
+
+    expect(fakeKeyboardEvent.preventDefault).toHaveBeenCalled();
+    expect(fakeKeyboardEvent.stopPropagation).toHaveBeenCalled();
+    expect(component['isKeyAllowed']).toHaveBeenCalledWith(fakeKeyboardEvent);
+  });
+
+  it('onKeyDown: shouldn`t call `preventDefault`', () => {
+    const fakeKeyboardEvent = {
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      key: '1'
+    };
+
+    spyOn(fakeKeyboardEvent, 'preventDefault');
+    spyOn(fakeKeyboardEvent, 'stopPropagation');
+    spyOn(component, <any>'isKeyAllowed').and.returnValue(true);
+
+    component.onKeyDown(fakeKeyboardEvent);
+
+    expect(fakeKeyboardEvent.preventDefault).not.toHaveBeenCalled();
+    expect(fakeKeyboardEvent.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it('isKeyAllowed: should return false if is a letter', () => {
+    const fakeKeyboardEvent = {
+      key: 'e'
+    };
+    spyOn(component, <any>'isShortcut').and.returnValue(false);
+    spyOn(component, <any>'isControlKeys').and.returnValue(false);
+    spyOn(component, <any>'isInvalidKey').and.returnValue(true);
+
+    const result = component['isKeyAllowed'](fakeKeyboardEvent);
+    expect(result).toBeFalse();
+  });
+
+  it('isKeyAllowed: should return true if isn`t a letter', () => {
+    const fakeKeyboardEvent = {
+      key: '1'
+    };
+    spyOn(component, <any>'isShortcut').and.returnValue(false);
+    spyOn(component, <any>'isControlKeys').and.returnValue(false);
+    spyOn(component, <any>'isInvalidKey').and.returnValue(false);
+
+    const result = component['isKeyAllowed'](fakeKeyboardEvent);
+    expect(result).toBeTrue();
+  });
+
+  it('isShortcut: should return true if is an copy event', () => {
+    const fakeKeyboardEvent = {
+      keyCode: 67,
+      ctrlKey: true
+    };
+
+    const result = component['isShortcut'](fakeKeyboardEvent);
+    expect(result).toBeTrue();
+  });
+
+  it('isShortcut: should return true if is a paste event', () => {
+    const fakeKeyboardEvent = {
+      keyCode: 86,
+      metaKey: true
+    };
+
+    const result = component['isShortcut'](fakeKeyboardEvent);
+    expect(result).toBeTrue();
+  });
+
+  it('isShortcut: should return true if is a select all event', () => {
+    const fakeKeyboardEvent = {
+      keyCode: 65,
+      metaKey: true
+    };
+
+    const result = component['isShortcut'](fakeKeyboardEvent);
+    expect(result).toBeTrue();
+  });
+
+  it('isShortcut: should return true if is a cut event', () => {
+    const fakeKeyboardEvent = {
+      keyCode: 88,
+      metaKey: true
+    };
+
+    const result = component['isShortcut'](fakeKeyboardEvent);
+    expect(result).toBeTrue();
+  });
+
+  it('isShortcut: should return false if isn`t a allowed shortcut', () => {
+    const fakeKeyboardEvent = {
+      keyCode: 66,
+      metaKey: false
+    };
+
+    const result = component['isShortcut'](fakeKeyboardEvent);
+    expect(result).toBeFalse();
+  });
+
+  it('isControlKeys: should return true if is a control key', () => {
+    const fakeKeyboardEvent = {
+      key: 'Backspace'
+    };
+
+    const result = component['isControlKeys'](fakeKeyboardEvent);
+    expect(result).toBeTrue();
+  });
+
+  it('isControlKeys: should return false if isn`t a control key', () => {
+    const fakeKeyboardEvent = {
+      key: 'e'
+    };
+
+    const result = component['isControlKeys'](fakeKeyboardEvent);
+    expect(result).toBeFalse();
+  });
+
+  it('isInvalidKey: should return true if is invalid', () => {
+    const key = 'e';
+
+    const result = component['isInvalidKey'](key);
+    expect(result).toBeTrue();
+  });
+
+  it('isInvalidKey: should return false if is valid', () => {
+    const key = '1';
+
+    const result = component['isInvalidKey'](key);
+    expect(result).toBeFalse();
+  });
+
   it('eventOnInput: should call "callOnChange" if doesn`t contain mask and set invalidInputValueOnBlur with false', () => {
     fakeEvent.target.value = '1234567890';
     const fakeThis = {

--- a/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
@@ -40,6 +40,13 @@ export abstract class PoNumberBaseComponent extends PoInputGeneric {
     this.eventOnBlur(event);
   }
 
+  onKeyDown(event) {
+    if (!this.isKeyAllowed(event)) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+  }
+
   validMaxLength(maxlength: number, value: string) {
     if (maxlength && value.length > maxlength) {
       const substringValue = value.toString().substring(0, maxlength);
@@ -84,5 +91,43 @@ export abstract class PoNumberBaseComponent extends PoInputGeneric {
 
   private formatNumber(value) {
     return value ? Number(value) : null;
+  }
+
+  private isKeyAllowed(event): boolean {
+    return this.isShortcut(event) || this.isControlKeys(event) || !this.isInvalidKey(event.key);
+  }
+
+  private isInvalidKey(key) {
+    const validatesKey = new RegExp(/[a-zA-Z:;=_´`^~"'?!@#$%¨&*()><{}çÇ\[\]/\\|]+/);
+    return validatesKey.test(key);
+  }
+
+  private isShortcut(event): boolean {
+    const key = event.keyCode;
+    const ctrl = event.ctrlKey || event.metaKey;
+    const keyA = key === 65;
+    const keyC = key === 67;
+    const keyX = key === 88;
+    const keyV = key === 86;
+
+    return (ctrl && keyC) || (ctrl && keyV) || (ctrl && keyA) || (ctrl && keyX);
+  }
+
+  private isControlKeys(event) {
+    const controlKeys = [
+      'Backspace',
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'ArrowDown',
+      'Left',
+      'Right',
+      'Up',
+      'Down',
+      'Tab',
+      'Delete'
+    ];
+
+    return controlKeys.indexOf(event.key) !== -1;
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
@@ -18,6 +18,7 @@
       (blur)="onBlur($event)"
       (focus)="eventOnFocus($event)"
       (input)="eventOnInput($event)"
+      (keydown)="onKeyDown($event)"
     />
 
     <div class="po-field-icon-container-right">

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
@@ -10,7 +10,7 @@ import { PoNumberBaseComponent } from './po-number-base.component';
  *
  * @description
  *
- * po-number é um input específico para receber apenas números.
+ * O `po-number` é um input específico para receber apenas números.
  * É possível configurar um valor mínimo, máximo e um step com p-min, p-max e p-step,
  * respectivamente.
  *


### PR DESCRIPTION
**PO-NUMBER**

**DTHFUI-591**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Possibilita utilizar a letra `e` no Chrome e também possibilita utilizar todas as letras no Firefox e I.E.

**Qual o novo comportamento?**
Restringe o comportamento do componente a aceitar somente números em todos os navegadores suportados.

**Simulação**
Pode ser simulado nos samples do portal.