### PR TITLE
feat(table): inclui evento `p-change-visible-columns`

### DIFF
--- a/projects/ui/src/lib/components/po-popover/po-popover-base.component.ts
+++ b/projects/ui/src/lib/components/po-popover/po-popover-base.component.ts
@@ -1,4 +1,4 @@
-import { ElementRef, Input, Directive } from '@angular/core';
+import { ElementRef, EventEmitter, Input, Directive, Output } from '@angular/core';
 
 import { convertToBoolean } from '../../utils/util';
 import { PO_CONTROL_POSITIONS } from './../../services/po-control-position/po-control-position.constants';
@@ -135,6 +135,9 @@ export class PoPopoverBaseComponent {
   get trigger(): string {
     return this._trigger;
   }
+
+  /** Evento disparado ao fechar o popover. */
+  @Output('p-close') closePopover = new EventEmitter<any>();
 
   protected clickoutListener: () => void;
   protected mouseEnterListener: () => void;

--- a/projects/ui/src/lib/components/po-popover/po-popover.component.spec.ts
+++ b/projects/ui/src/lib/components/po-popover/po-popover.component.spec.ts
@@ -203,12 +203,14 @@ describe('PoPopoverComponent:', () => {
     expect(fakeThis.setElementsControlPosition).toHaveBeenCalled();
   }));
 
-  it('should close popover', () => {
+  it('should close popover and call `closePopover.emit`', () => {
+    spyOn(component.closePopover, 'emit');
     component.isHidden = false;
 
     component.close();
 
     expect(component.isHidden).toBeTruthy();
+    expect(component.closePopover.emit).toHaveBeenCalled();
   });
 
   it('should set opacity', () => {

--- a/projects/ui/src/lib/components/po-popover/po-popover.component.ts
+++ b/projects/ui/src/lib/components/po-popover/po-popover.component.ts
@@ -1,4 +1,13 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, Renderer2, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  OnDestroy,
+  Output,
+  Renderer2,
+  ViewChild
+} from '@angular/core';
 
 import { PoControlPositionService } from './../../services/po-control-position/po-control-position.service';
 import { PoPopoverBaseComponent } from './po-popover-base.component';
@@ -55,6 +64,7 @@ export class PoPopoverComponent extends PoPopoverBaseComponent implements AfterV
 
   close(): void {
     this.isHidden = true;
+    this.closePopover.emit();
   }
 
   debounceResize() {

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -523,6 +523,17 @@ export abstract class PoTableBaseComponent implements OnChanges {
    */
   @Output('p-unselected') unselected: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao alterar as colunas visíveis no gerenciador de colunas e fechar o popover do gerenciador.
+   *
+   * O componente envia como parâmetro um array de string com as colunas visíveis atualizadas.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   */
+  @Output('p-change-visible-columns') changeVisibleColumns = new EventEmitter<Array<string>>();
+
   get hasColumns(): boolean {
     return this.columns && this.columns.length > 0;
   }

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.html
@@ -1,4 +1,4 @@
-<po-popover #popover *ngIf="target" [p-target]="target" p-position="bottom-left">
+<po-popover #popover *ngIf="target" [p-target]="target" p-position="bottom-left" (p-close)="emitVisibleColumns()">
   <div class="po-table-column-manager-header">
     <div class="po-table-column-manager-header-title">{{ literals.columnsManager }}</div>
 

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
@@ -170,6 +170,167 @@ describe('PoTableColumnManagerComponent:', () => {
       expect(component.visibleColumnsChange.emit).toHaveBeenCalledWith(visibleColumnsChange);
     });
 
+    it(`onChangeVisibleColumns: should call 'updatesControlValues'`, () => {
+      spyOn(component, <any>'updatesControlValues');
+      const checkedColumns = ['initial'];
+
+      component.onChangeVisibleColumns(checkedColumns);
+
+      expect(component['updatesControlValues']).toHaveBeenCalledWith(checkedColumns);
+    });
+
+    it(`updatesControlValues: should set 'lastValueCheckedColumns' with 'checkedColumns' if 'lastValueCheckedColumns' is 'undefined'`, () => {
+      component['lastValueCheckedColumns'] = undefined;
+      const checkedColumns = ['initial'];
+
+      component['updatesControlValues'](checkedColumns);
+
+      expect(component['lastValueCheckedColumns']).toEqual(checkedColumns);
+    });
+
+    it(`updatesControlValues: should set 'selectedColumns' with 'checkedColumns' if 'lastValueCheckedColumns' isn't 'undefined'`, () => {
+      component['lastValueCheckedColumns'] = ['teste'];
+      const checkedColumns = ['initial'];
+
+      component['updatesControlValues'](checkedColumns);
+
+      expect(component['selectedColumns']).toEqual(checkedColumns);
+    });
+
+    it(`updatesControlValues: shouldn't set 'selectedColumns' with 'checkedColumns' if 'lastValueCheckedColumns' and 'checkedColumns' are 'undefined'`, () => {
+      component['lastValueCheckedColumns'] = undefined;
+      const checkedColumns = undefined;
+
+      component['updatesControlValues'](checkedColumns);
+
+      expect(component['selectedColumns']).toEqual(undefined);
+    });
+
+    it(`emitVisibleColumns: should set 'lastEmittedValue' if 'isUpdate' is true`, () => {
+      spyOn(component.changeVisibleColumns, 'emit');
+      spyOn(component, <any>'isUpdate').and.returnValue(true);
+      component['selectedColumns'] = ['initial'];
+
+      component.emitVisibleColumns();
+
+      expect(component.changeVisibleColumns.emit).toHaveBeenCalledWith(component['selectedColumns']);
+      expect(component['lastEmittedValue']).toEqual(['initial']);
+    });
+
+    it(`emitVisibleColumns: should set 'lastEmittedValue' if 'isFirstTime' is true`, () => {
+      spyOn(component.changeVisibleColumns, 'emit');
+      spyOn(component, <any>'isUpdate').and.returnValue(false);
+      spyOn(component, <any>'isFirstTime').and.returnValue(true);
+      component['selectedColumns'] = ['initial'];
+
+      component.emitVisibleColumns();
+
+      expect(component.changeVisibleColumns.emit).toHaveBeenCalledWith(component['selectedColumns']);
+      expect(component['lastEmittedValue']).toEqual(['initial']);
+    });
+
+    it(`isUpdate: should return true if it's an update`, () => {
+      spyOn(component, <any>'columnsAreEquals').and.returnValue(false);
+      component['selectedColumns'] = ['initial'];
+      component['lastEmittedValue'] = ['teste'];
+
+      const result = component['isUpdate'](component['selectedColumns'], component['lastEmittedValue']);
+
+      expect(result).toBeTrue();
+    });
+
+    it(`isUpdate: should return true if it's an update and 'columnsAreEquals' is false`, () => {
+      spyOn(component, <any>'columnsAreEquals').and.returnValue(false);
+      component['selectedColumns'] = ['initial', 'teste'];
+      component['lastEmittedValue'] = ['teste', 'initial'];
+
+      const result = component['isUpdate'](component['selectedColumns'], component['lastEmittedValue']);
+
+      expect(result).toBeTrue();
+    });
+
+    it(`isUpdate: should return false if 'columnsAreEquals' is true`, () => {
+      spyOn(component, <any>'columnsAreEquals').and.returnValue(true);
+      component['selectedColumns'] = ['initial', 'teste'];
+      component['lastEmittedValue'] = ['initial', 'teste'];
+
+      const result = component['isUpdate'](component['selectedColumns'], component['lastEmittedValue']);
+
+      expect(result).toBeFalse();
+    });
+
+    it(`isFirstTime: should return true if it's a first access`, () => {
+      spyOn(component, <any>'columnsAreEquals').and.returnValue(false);
+      component['selectedColumns'] = ['initial'];
+      component['lastValueCheckedColumns'] = ['teste'];
+      component['lastEmittedValue'] = undefined;
+
+      const result = component['isFirstTime'](
+        component['selectedColumns'],
+        component['lastEmittedValue'],
+        component['lastValueCheckedColumns']
+      );
+
+      expect(result).toBeTrue();
+    });
+
+    it(`isFirstTime: should return false if 'columnsAreEquals' is true`, () => {
+      spyOn(component, <any>'columnsAreEquals').and.returnValue(true);
+      component['selectedColumns'] = ['initial'];
+      component['lastValueCheckedColumns'] = ['initial'];
+      component['lastEmittedValue'] = undefined;
+
+      const result = component['isFirstTime'](
+        component['selectedColumns'],
+        component['lastEmittedValue'],
+        component['lastValueCheckedColumns']
+      );
+
+      expect(result).toBeFalse();
+    });
+
+    it(`isFirstTime: should return true if 'columnsAreEquals' is false`, () => {
+      spyOn(component, <any>'columnsAreEquals').and.returnValue(false);
+      component['selectedColumns'] = ['initial', 'teste'];
+      component['lastValueCheckedColumns'] = ['teste', 'initial'];
+      component['lastEmittedValue'] = undefined;
+
+      const result = component['isFirstTime'](
+        component['selectedColumns'],
+        component['lastEmittedValue'],
+        component['lastValueCheckedColumns']
+      );
+
+      expect(result).toBeTrue();
+    });
+
+    it(`columnsAreEquals: should return true if the current value is equal to the old value`, () => {
+      const oldValue = ['initial', 'teste'];
+      const newValue = ['teste', 'initial'];
+
+      const result = component['columnsAreEquals'](oldValue, newValue);
+
+      expect(result).toBeTrue();
+    });
+
+    it(`columnsAreEquals: should return false if the current value is different from the old value`, () => {
+      const oldValue = ['initial', 'teste'];
+      const newValue = ['initial'];
+
+      const result = component['columnsAreEquals'](oldValue, newValue);
+
+      expect(result).toBeFalse();
+    });
+
+    it(`columnsAreEquals: should return false if 'oldValue' is undefined`, () => {
+      const oldValue = undefined;
+      const newValue = ['initial'];
+
+      const result = component['columnsAreEquals'](oldValue, newValue);
+
+      expect(result).toBeFalsy();
+    });
+
     it('restore: should call `updateColumnsOptions` with `defaultColumns`', () => {
       spyOn(component, <any>'updateColumnsOptions');
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -372,5 +372,6 @@
   [p-max-columns]="maxColumns"
   [p-target]="columnManagerTarget"
   (p-visible-columns-change)="onVisibleColumnsChange($event)"
+  (p-change-visible-columns)="onChangeVisibleColumns($event)"
 >
 </po-table-column-manager>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1521,6 +1521,15 @@ describe('PoTableComponent:', () => {
 
       expect(spyStopPropagation).not.toHaveBeenCalled();
     });
+
+    it('onChangeVisibleColumns: should call `changeVisibleColumns.emit`', () => {
+      spyOn(component.changeVisibleColumns, 'emit');
+      const fakeColumns = ['name', 'age'];
+
+      component.onChangeVisibleColumns(fakeColumns);
+
+      expect(component.changeVisibleColumns.emit).toHaveBeenCalledWith(fakeColumns);
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -310,6 +310,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     }
   }
 
+  onChangeVisibleColumns(columns: Array<string>) {
+    this.changeVisibleColumns.emit(columns);
+  }
+
   onVisibleColumnsChange(columns: Array<PoTableColumn>) {
     this.columns = columns;
 


### PR DESCRIPTION
**PO-TABLE E PO-POPOVER**

**DTHFUI-3699**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Hoje não é possível saber quais colunas que o usuário configurou para ficar visível.

**Qual o novo comportamento?**
Criado evento `p-change-visible-columns` que será disparado ao alterar as colunas visíveis no gerenciador de colunas e fechar o popover do gerenciador.

**Simulação**
- app.component.html:
```
<po-table
  [p-columns]="hiringProcessesColumns"
  [p-items]="hiringProcesses"
  (p-change-visible-columns)="myOnChangeVisibleColumns($event)"
>
</po-table>
```

- app.component.ts:
```
  hiringProcesses: Array<object>;
  hiringProcessesColumns: Array<PoTableColumn>;


  constructor() {}

  ngOnInit() {
    this.hiringProcesses = this.getItems();
    this.hiringProcessesColumns = this.getColumns();

  }

  myOnChangeVisibleColumns(event) {
    console.log('visible columns', event);
  }

  getColumns(): Array<PoTableColumn> {
    return [
      {
        property: 'hireStatus',
        label: 'Status',
        type: 'subtitle',
        subtitles: [
          { value: '1', color: 'success', label: 'Hired', content: '1' },
          { value: '2', color: 'warning', label: 'Progress', content: '2' },
          { value: '3', color: 'danger', label: 'Canceled', content: '3' }
        ]
      },
      { property: 'idCard', label: 'Identity card', type: 'string' },
      { property: 'name', label: 'Name' },
      { property: 'age', label: 'Age' },
      { property: 'city', label: 'City' },
      { property: 'jobDescription', label: 'Job description', type: 'string' }
    ];
  }

  getHireStatus() {
    return [
      { value: '1', label: 'Hired' },
      { value: '2', label: 'Progress' },
      { value: '3', label: 'Canceled' }
    ];
  }

  getItems() {
    return [
      {
        hireStatus: '1',
        name: 'James Johnson',
        city: 'Ontario',
        age: 24,
        idCard: 'AB34lxi90',
        job: 'abc',
        jobDescription: 'Systems Analyst'
      },
      {
        hireStatus: '2',
        name: 'Brian Brown',
        city: 'Buffalo',
        age: 23,
        idCard: 'HG56lds54',
        job: 'def',
        jobDescription: 'Trainee'
      },
    ];
  }

  getJobs() {
    return [
      { value: 'abc', label: 'Systems Analyst' },
      { value: 'def', label: 'Trainee' },
    ];
  }
```
