### PR TITLE
feat(widget): adiciona hint no titulo

### DIFF
--- a/projects/ui/src/lib/components/po-widget/po-widget-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-widget/po-widget-base.component.spec.ts
@@ -123,6 +123,18 @@ describe('PoWidgetBaseComponent:', () => {
       expect(component.setHeight).toHaveBeenCalled();
     });
 
+    it('p-hint: should update property with valid values.', () => {
+      const validValues = ['test', 'value', 'false', '0'];
+
+      expectPropertiesValues(component, 'hint', validValues, validValues);
+    });
+
+    it('p-hint: should update property with empty string when invalid values.', () => {
+      const validValues = [3, null, undefined];
+
+      expectPropertiesValues(component, 'hint', validValues, '');
+    });
+
     it('p-disabled: should update property with true if valid values and call `onDisabled.emit`', () => {
       const validValues = [true, '', 'true'];
 

--- a/projects/ui/src/lib/components/po-widget/po-widget-base.component.ts
+++ b/projects/ui/src/lib/components/po-widget/po-widget-base.component.ts
@@ -25,6 +25,7 @@ export abstract class PoWidgetBaseComponent {
   private _primary?: boolean = false;
   private _primaryLabel?: string;
   private _title?: string;
+  private _hint?: string;
 
   containerHeight?: string = 'auto';
 
@@ -172,6 +173,23 @@ export abstract class PoWidgetBaseComponent {
 
   get title(): string {
     return this._title;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Dica do titulo do `po-widget`.
+   *
+   * @default `false`
+   */
+  @Input('p-hint') set hint(value: string) {
+    this._hint = isTypeof(value, 'string') ? value : '';
+  }
+
+  get hint(): string {
+    return this._hint;
   }
 
   /**

--- a/projects/ui/src/lib/components/po-widget/po-widget.component.html
+++ b/projects/ui/src/lib/components/po-widget/po-widget.component.html
@@ -8,7 +8,12 @@
   (click)="onClick($event)"
 >
   <div *ngIf="hasTitleHelpOrSetting()" class="po-widget-header">
-    <span *ngIf="showTitleAction; else noTitleAction" class="po-widget-title-action" (click)="runTitleAction($event)">
+    <span
+      *ngIf="showTitleAction; else noTitleAction"
+      class="po-widget-title-action"
+      (click)="runTitleAction($event)"
+      [title]="hint"
+    >
       {{ title }}
     </span>
     <ng-template #noTitleAction>{{ title }}</ng-template>

--- a/projects/ui/src/lib/components/po-widget/samples/sample-po-widget-labs/sample-po-widget-labs.component.html
+++ b/projects/ui/src/lib/components/po-widget/samples/sample-po-widget-labs/sample-po-widget-labs.component.html
@@ -4,6 +4,7 @@
   [p-disabled]="properties.includes('disabled')"
   [p-height]="height"
   [p-help]="help"
+  [p-hint]="hint"
   [p-no-shadow]="properties.includes('noShadow')"
   [p-primary]="properties.includes('primaryWidget')"
   [p-primary-label]="primaryLabel"
@@ -30,6 +31,8 @@
   <po-input class="po-md-4" name="title" [(ngModel)]="title" p-label="Title"> </po-input>
 
   <po-input class="po-md-4" name="help" [(ngModel)]="help" p-label="Help"> </po-input>
+
+  <po-input class="po-md-4" name="hint" [(ngModel)]="hint" p-label="Hint"> </po-input>
 
   <po-number class="po-md-4" name="height" [(ngModel)]="height" p-label="Height"> </po-number>
 

--- a/projects/ui/src/lib/components/po-widget/samples/sample-po-widget-labs/sample-po-widget-labs.component.ts
+++ b/projects/ui/src/lib/components/po-widget/samples/sample-po-widget-labs/sample-po-widget-labs.component.ts
@@ -16,6 +16,7 @@ export class SamplePoWidgetLabsComponent implements OnInit {
   properties: Array<string>;
   secondaryLabel: string;
   title: string;
+  hint: string;
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'disabled', label: 'Disabled' },
@@ -37,6 +38,7 @@ export class SamplePoWidgetLabsComponent implements OnInit {
     this.content = '';
     this.height = undefined;
     this.help = '';
+    this.hint = '';
     this.title = undefined;
     this.primaryLabel = undefined;
     this.properties = [];


### PR DESCRIPTION
cria propriedade p-hint para ser apresentada no titulo do componente

Fixes #109, DTHFUI-2107

**po-widget**

**#109**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não existe

**Qual o novo comportamento?**
Quando tiver um título e a propriedade `p-hint` possuir valor, ao passar o mouse no título do `po-widget` será apresentado o valor da propriedade.
Foi utilizado o atributo `title` do `html`, conforme sugerido na issue.

**Simulação**
É possível validar através do sample labs (documentation/po-widget)



A issue fez um ano, então nada mais justo que um bolinho :tada:
![](https://media.giphy.com/media/26Ff7AANuS6stRqec/giphy.gif)