### PR TITLE
feat(decimal): cria propriedade `p-locale` para definição de formatação de separadores segundo país

### DIFF
--- a/projects/templates/src/lib/components/po-page-background/po-page-background.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-background/po-page-background.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import * as utilFunctions from './../../utils/util';
@@ -11,15 +11,22 @@ describe('PoPageBackgroundComponent:', () => {
   let component: PoPageBackgroundComponent;
   let fixture: ComponentFixture<PoPageBackgroundComponent>;
   let debugElement;
+  let languageService: PoLanguageService;
+  let spyService: jasmine.Spy;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [PoPageBackgroundComponent],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [PoPageBackgroundComponent],
+        providers: [PoLanguageService],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
+    languageService = TestBed.inject(PoLanguageService);
+    spyService = spyOn(languageService, 'getShortLanguage').and.returnValue('pt');
     fixture = TestBed.createComponent(PoPageBackgroundComponent);
     component = fixture.componentInstance;
 
@@ -91,7 +98,6 @@ describe('PoPageBackgroundComponent:', () => {
   describe('Methods:', () => {
     it('ngOnInit: should get the stored language on localstorage (or browserLanguage by default if en, pt, es or ru) and apply it to `selectedLanguageOption`', () => {
       component.ngOnInit();
-      const languageService = new PoLanguageService();
       expect(component.selectedLanguageOption).toBe(languageService.getShortLanguage());
     });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.spec.ts
@@ -10,7 +10,7 @@ describe('PoAdvancedFilterBaseComponent', () => {
   const languageService = new PoLanguageService();
 
   beforeEach(() => {
-    component = new PoAdvancedFilterBaseComponent(languageService);
+    component = new PoAdvancedFilterBaseComponent(<any>languageService);
   });
 
   it('should be created', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
@@ -27,7 +27,7 @@ describe('PoPageDynamicSearchBaseComponent:', () => {
   const languageService = new PoLanguageService();
 
   beforeEach(() => {
-    component = new MockComponent(languageService);
+    component = new MockComponent(<any>languageService);
   });
 
   it('should be created', () => {

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -1,37 +1,52 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 
-import { configureTestSuite, expectPropertiesValues } from '../../../util-test/util-expect.spec';
+import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 
 import { PoCleanComponent } from './../po-clean/po-clean.component';
 import { PoDecimalComponent } from './po-decimal.component';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
+import { PoLanguageService } from '../../../services';
 
 describe('PoDecimalComponent:', () => {
   let component: PoDecimalComponent;
   let fixture: ComponentFixture<PoDecimalComponent>;
   let nativeElement: any;
+  let languageService: PoLanguageService;
+  let inputEl: any;
+  let spyService: jasmine.Spy;
 
-  configureTestSuite(() => {
-    TestBed.configureTestingModule({
-      declarations: [PoDecimalComponent, PoFieldContainerComponent, PoCleanComponent, PoFieldContainerBottomComponent]
-    });
-  });
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          PoDecimalComponent,
+          PoFieldContainerComponent,
+          PoCleanComponent,
+          PoFieldContainerBottomComponent
+        ],
+        providers: [PoLanguageService]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
+    languageService = TestBed.inject(PoLanguageService);
+    spyService = spyOn(languageService, 'getShortLanguage').and.returnValue('pt');
     fixture = TestBed.createComponent(PoDecimalComponent);
     component = fixture.componentInstance;
     component.label = 'Label de teste';
     component.help = 'Help de teste';
     component.clean = true;
-    component['regex'] = {
-      thousand: new RegExp('\\' + '.', 'g'),
-      decimal: new RegExp('\\' + ',', 'g')
-    };
+    inputEl = component.inputEl;
 
     fixture.detectChanges();
 
     nativeElement = fixture.debugElement.nativeElement;
+  });
+
+  afterEach(() => {
+    component.inputEl = inputEl;
   });
 
   it('should be created', () => {
@@ -39,6 +54,13 @@ describe('PoDecimalComponent:', () => {
   });
 
   describe('Properties:', () => {
+    it('locale: should set decimal and thousand separator', () => {
+      component.locale = 'ru';
+
+      expect(component['decimalSeparator']).toBe(',');
+      expect(component['thousandSeparator']).toBe(' ');
+    });
+
     it('autocomplete: should return `off` if `noAutocomplete` is true', () => {
       component.noAutocomplete = true;
 
@@ -50,43 +72,43 @@ describe('PoDecimalComponent:', () => {
 
       expect(component.autocomplete).toBe('on');
     });
-  });
 
-  it('decimalsLength: should update property with default value if is invalid value.', () => {
-    const invalidValues = [undefined, null, '', true, false, 'string', [], {}, 16, -1];
-    const defaultValue = 2;
-    expectPropertiesValues(component, 'decimalsLength', invalidValues, defaultValue);
-  });
+    it('decimalsLength: should update property with default value if is invalid value.', () => {
+      const invalidValues = [undefined, null, '', true, false, 'string', [], {}, 16, -1];
+      const defaultValue = 2;
+      expectPropertiesValues(component, 'decimalsLength', invalidValues, defaultValue);
+    });
 
-  it('decimalsLength: should update property with valid values.', () => {
-    let validValues = [0, 3];
-    expectPropertiesValues(component, 'decimalsLength', validValues, validValues);
-    validValues = [3, 15];
-    component.thousandMaxlength = 1;
-    expectPropertiesValues(component, 'decimalsLength', validValues, validValues);
-  });
+    it('decimalsLength: should update property with valid values.', () => {
+      let validValues = [0, 3];
+      expectPropertiesValues(component, 'decimalsLength', validValues, validValues);
+      validValues = [3, 15];
+      component.thousandMaxlength = 1;
+      expectPropertiesValues(component, 'decimalsLength', validValues, validValues);
+    });
 
-  it('thousandMaxlength: should update property with remaining value of total limit minus `decimalsLength`.', () => {
-    component.decimalsLength = 7;
-    component.thousandMaxlength = undefined;
-    const remainingValue = 16 - component.decimalsLength;
+    it('thousandMaxlength: should update property with remaining value of total limit minus `decimalsLength`.', () => {
+      component.decimalsLength = 7;
+      component.thousandMaxlength = undefined;
+      const remainingValue = 16 - component.decimalsLength;
 
-    expect(component.decimalsLength).toEqual(7);
-    expect(component.thousandMaxlength).toEqual(remainingValue);
-  });
+      expect(component.decimalsLength).toEqual(7);
+      expect(component.thousandMaxlength).toEqual(remainingValue);
+    });
 
-  it('thousandMaxlength: should update property with default value if is invalid values.', () => {
-    const invalidValues = [undefined, null, '', true, false, 'string', [], {}, 15];
-    const defaultValue = 13;
-    expectPropertiesValues(component, 'thousandMaxlength', invalidValues, defaultValue);
-  });
+    it('thousandMaxlength: should update property with default value if is invalid values.', () => {
+      const invalidValues = [undefined, null, '', true, false, 'string', [], {}, 15];
+      const defaultValue = 13;
+      expectPropertiesValues(component, 'thousandMaxlength', invalidValues, defaultValue);
+    });
 
-  it('thousandMaxlength: should update property with valid values.', () => {
-    let validValues = [5, 8];
-    expectPropertiesValues(component, 'thousandMaxlength', validValues, validValues);
-    validValues = [13, 21];
-    component.decimalsLength = 4;
-    expectPropertiesValues(component, 'thousandMaxlength', validValues, 13);
+    it('thousandMaxlength: should update property with valid values.', () => {
+      let validValues = [5, 8];
+      expectPropertiesValues(component, 'thousandMaxlength', validValues, validValues);
+      validValues = [13, 21];
+      component.decimalsLength = 4;
+      expectPropertiesValues(component, 'thousandMaxlength', validValues, 13);
+    });
   });
 
   it('should create button clean', () => {
@@ -301,46 +323,22 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should have a call replaceCommaToDot method', () => {
-    const fakeThis = {
-      regex: {
-        decimal: ','
-      }
-    };
-
-    const valueFormatted = component['replaceCommaToDot'].call(fakeThis, '123,10');
+    const valueFormatted = component['replaceCommaToDot']('123,10');
     expect(valueFormatted).toEqual('123.10');
   });
 
   it('should have a call replaceCommaToDot method with undefined param', () => {
-    const fakeThis = {
-      regex: {
-        decimal: ','
-      }
-    };
-
-    const valueFormatted = component['replaceCommaToDot'].call(fakeThis, undefined);
+    const valueFormatted = component['replaceCommaToDot']();
     expect(valueFormatted).toEqual('');
   });
 
   it('should have a call formatValueWithoutThousandSeparator method', () => {
-    const fakeThis = {
-      regex: {
-        thousand: '.'
-      }
-    };
-
-    const valueFormatted = component['formatValueWithoutThousandSeparator'].call(fakeThis, '12345.10');
+    const valueFormatted = component['formatValueWithoutThousandSeparator']('12345.10');
     expect(valueFormatted).toEqual('1234510');
   });
 
   it('should have a call formatValueWithoutThousandSeparator method with undefined param', () => {
-    const fakeThis = {
-      regex: {
-        thousand: '.'
-      }
-    };
-
-    const valueFormatted = component['formatValueWithoutThousandSeparator'].call(fakeThis, undefined);
+    const valueFormatted = component['formatValueWithoutThousandSeparator']();
     expect(valueFormatted).toEqual('');
   });
 
@@ -777,7 +775,7 @@ describe('PoDecimalComponent:', () => {
         selectionEnd: 5
       };
 
-      expect(component['isSelectionStartDifferentSelectionEnd'](fakeTarget)).toBeTruthy();
+      expect(component['isSelectionStartDifferentSelectionEnd'](fakeTarget)).toBeTrue();
     });
 
     it('isSelectionStartDifferentSelectionEnd: should return false if have a selection', () => {
@@ -786,7 +784,7 @@ describe('PoDecimalComponent:', () => {
         selectionEnd: 1
       };
 
-      expect(component['isSelectionStartDifferentSelectionEnd'](fakeTarget)).toBeFalsy();
+      expect(component['isSelectionStartDifferentSelectionEnd'](fakeTarget)).toBeFalse();
     });
 
     it('onFocus: should called `getScreenValue` and `enter.emit`', () => {
@@ -1136,20 +1134,22 @@ describe('PoDecimalComponent:', () => {
       expect(component['callOnChange']).toHaveBeenCalledWith(undefined);
     });
 
-    it('containsMoreThanOneComma: should return `false` if param contains one comma', () => {
-      const value = '1.200,55';
+    describe('containsMoreThanOneDecimalSeparator:', () => {
+      it('should return `false` if param contains one comma', () => {
+        const value = '1.200,55';
 
-      expect(component['containsMoreThanOneComma'](value)).toBeFalsy();
-    });
+        expect(component['containsMoreThanOneDecimalSeparator'](value)).toBeFalsy();
+      });
 
-    it('containsMoreThanOneComma: should return `true` if param contains more than one comma', () => {
-      const value = '1.444,200,55';
+      it('should return `true` if param contains more than one comma', () => {
+        const value = '1.444,200,55';
 
-      expect(component['containsMoreThanOneComma'](value)).toBeTruthy();
-    });
+        expect(component['containsMoreThanOneDecimalSeparator'](value)).toBeTruthy();
+      });
 
-    it('containsMoreThanOneComma: should return `false` if param is undefined', () => {
-      expect(component['containsMoreThanOneComma'](undefined)).toBeFalsy();
+      it('should return `false` if param is undefined', () => {
+        expect(component['containsMoreThanOneDecimalSeparator'](undefined)).toBeFalsy();
+      });
     });
 
     describe('writeValueModel', () => {
@@ -1159,6 +1159,36 @@ describe('PoDecimalComponent:', () => {
 
         component.writeValueModel(value);
         expect(component.change.emit).toHaveBeenCalledWith(value);
+      });
+
+      it(`should show the value formated by locale 'pt'`, () => {
+        const value = '1234567,82';
+        const formated = '1.234.567,82';
+        const spy = spyOn(component, <any>'setViewValue');
+        spyService.and.returnValue('pt');
+        component.ngOnInit();
+        component.writeValueModel(value);
+        expect(spy).toHaveBeenCalledWith(formated);
+      });
+
+      it(`should show the value formated by locale 'ru'`, () => {
+        const value = '1234567,82';
+        const formated = '1 234 567,82';
+        const spy = spyOn(component, <any>'setViewValue');
+        spyService.and.returnValue('ru');
+        component.ngOnInit();
+        component.writeValueModel(value);
+        expect(spy).toHaveBeenCalledWith(formated);
+      });
+
+      it(`should show the value formated by locale 'en'`, () => {
+        const value = '1234567.82';
+        const formated = '1,234,567.82';
+        const spy = spyOn(component, <any>'setViewValue');
+        spyService.and.returnValue('en');
+        component.ngOnInit();
+        component.writeValueModel(value);
+        expect(spy).toHaveBeenCalledWith(formated);
       });
 
       it('shouldn`t call change.emit if param is undefined', () => {

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
@@ -8,6 +8,7 @@
   [p-help]="help"
   [p-icon]="icon"
   [p-label]="label"
+  [p-locale]="locale"
   [p-no-autocomplete]="properties?.includes('noAutocomplete')"
   [p-optional]="properties.includes('optional')"
   [p-placeholder]="placeholder"
@@ -38,7 +39,7 @@
 
   <div class="po-row">
     <po-number
-      class="po-md-6"
+      class="po-md-4"
       name="decimalsLength"
       [(ngModel)]="decimalsLength"
       p-clean
@@ -50,7 +51,7 @@
     </po-number>
 
     <po-number
-      class="po-md-6"
+      class="po-md-4"
       name="thousandMaxlength"
       [(ngModel)]="thousandMaxlength"
       p-clean
@@ -60,6 +61,16 @@
       [p-max]="maxThousandMaxlength"
     >
     </po-number>
+
+    <po-select
+      class="po-md-4"
+      name="locale"
+      [(ngModel)]="locale"
+      p-clean
+      p-help="By default is equal your browser locale"
+      p-label="Locale"
+      [p-options]="localeOptions"
+    ></po-select>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
@@ -13,9 +13,17 @@ export class SamplePoDecimalLabsComponent implements OnInit {
   help: string;
   icon: string;
   label: string;
+  locale: string;
   placeholder: string;
   properties: Array<string>;
   thousandMaxlength: number;
+
+  public readonly localeOptions: Array<PoSelectOption> = [
+    { value: 'pt', label: 'Portuguese' },
+    { value: 'en', label: 'English' },
+    { value: 'ru', label: 'Russian' },
+    { value: 'es', label: 'Spanish' }
+  ];
 
   public readonly iconOptions: Array<PoSelectOption> = [
     { value: 'po-icon-cart', label: 'po-icon-cart' },
@@ -55,6 +63,7 @@ export class SamplePoDecimalLabsComponent implements OnInit {
     this.help = undefined;
     this.icon = undefined;
     this.label = undefined;
+    this.locale = undefined;
     this.placeholder = '';
     this.thousandMaxlength = undefined;
 

--- a/projects/ui/src/lib/services/po-language/po-language.constant.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.constant.ts
@@ -1,4 +1,4 @@
-import { PoLanguage } from './po-language.interface';
+import { PoLanguage, PoNumberSeparator } from './po-language.interface';
 
 /**
  * @description
@@ -42,3 +42,37 @@ export const poLocales = poLanguageDefault.map(language => language.language);
  * @usedBy PoI18nModule
  */
 export const poLocaleDefault = 'pt';
+
+/**
+ * @description
+ *
+ * <a id="poLocaleDecimalSeparatorList"></a>
+ *
+ *
+ * A constante poLocaleDecimalSeparatorList possui os separadores de decimal por linguagens de suporte padrão do Po-UI
+ *
+ * @usedBy PoI18nModule
+ */
+export const poLocaleDecimalSeparatorList: Array<PoNumberSeparator> = [
+  { separator: '.', language: 'en' },
+  { separator: ',', language: 'es' },
+  { separator: ',', language: 'pt' },
+  { separator: ',', language: 'ru' }
+];
+
+/**
+ * @description
+ *
+ * <a id="poLocaleDecimalSeparatorList"></a>
+ *
+ *
+ * A constante poLocaleDecimalSeparatorList possui os separadores de decimal por linguagens de suporte padrão do Po-UI
+ *
+ * @usedBy PoI18nModule
+ */
+export const poLocaleThousandSeparatorList: Array<PoNumberSeparator> = [
+  { separator: ',', language: 'en' },
+  { separator: '.', language: 'es' },
+  { separator: '.', language: 'pt' },
+  { separator: ' ', language: 'ru' }
+];

--- a/projects/ui/src/lib/services/po-language/po-language.interface.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.interface.ts
@@ -21,3 +21,26 @@ export interface PoLanguage {
    */
   description?: string;
 }
+
+/**
+ * @description
+ *
+ * <a id="PoNumberSeparator"></a>
+ *
+ * Interface para os separadores numéricos das linguagens disponíveis no sistema.
+ *
+ * @usedBy PoI18nModule
+ */
+export interface PoNumberSeparator {
+  /**
+   * Código do idioma [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+   * > Exemplo: 'pt','en'
+   */
+  language?: string;
+
+  /**
+   * Separador numérico
+   *
+   */
+  separator?: string;
+}

--- a/projects/ui/src/lib/services/po-language/po-language.service.spec.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.spec.ts
@@ -137,5 +137,44 @@ describe('PoLanguageService:', () => {
 
       expect(service.languageDefault).toBeNull();
     });
+
+    describe('getNumberSeparators:', () => {
+      it(`should return language separators if language param is undefined.`, () => {
+        spyOn(service, 'getShortLanguage').and.returnValue('pt');
+        const { decimalSeparator, thousandSeparator } = service.getNumberSeparators();
+        expect(decimalSeparator).toBe(',');
+        expect(thousandSeparator).toBe('.');
+      });
+
+      it(`should return separators if language param is 'pt' .`, () => {
+        const { decimalSeparator, thousandSeparator } = service.getNumberSeparators('pt');
+        expect(decimalSeparator).toBe(',');
+        expect(thousandSeparator).toBe('.');
+      });
+
+      it(`should return separators if language param is 'en'.`, () => {
+        const { decimalSeparator, thousandSeparator } = service.getNumberSeparators('en');
+        expect(decimalSeparator).toBe('.');
+        expect(thousandSeparator).toBe(',');
+      });
+
+      it(`should return separators if language param is 'ru'.`, () => {
+        const { decimalSeparator, thousandSeparator } = service.getNumberSeparators('ru');
+        expect(decimalSeparator).toBe(',');
+        expect(thousandSeparator).toBe(' ');
+      });
+
+      it(`should return separators if language param is 'es'.`, () => {
+        const { decimalSeparator, thousandSeparator } = service.getNumberSeparators('es');
+        expect(decimalSeparator).toBe(',');
+        expect(thousandSeparator).toBe('.');
+      });
+
+      it(`should return default separators if language param is invalid.`, () => {
+        const { decimalSeparator, thousandSeparator } = service.getNumberSeparators('error');
+        expect(decimalSeparator).toBe(',');
+        expect(thousandSeparator).toBe('.');
+      });
+    });
   });
 });

--- a/projects/ui/src/lib/services/po-language/po-language.service.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.ts
@@ -1,7 +1,12 @@
 import { Injectable } from '@angular/core';
 
 import { getBrowserLanguage, getShortLanguage, isLanguage } from '../../utils/util';
-import { poLocaleDefault, poLocales } from './po-language.constant';
+import {
+  poLocaleDecimalSeparatorList,
+  poLocaleDefault,
+  poLocales,
+  poLocaleThousandSeparatorList
+} from './po-language.constant';
 
 const poDefaultLanguage = 'PO_DEFAULT_LANGUAGE';
 const poLocaleKey = 'PO_USER_LOCALE';
@@ -17,6 +22,8 @@ const poLocaleKey = 'PO_USER_LOCALE';
   providedIn: 'root'
 })
 export class PoLanguageService {
+  constructor() {}
+
   set languageDefault(language: string) {
     if (language && isLanguage(language)) {
       localStorage.setItem(poDefaultLanguage, language);
@@ -47,7 +54,6 @@ export class PoLanguageService {
    */
   getLanguage(): string {
     const language = localStorage.getItem(poLocaleKey) || this.languageDefault || getBrowserLanguage();
-
     return language && language.toLowerCase();
   }
 
@@ -117,5 +123,26 @@ export class PoLanguageService {
    */
   setLanguageDefault(language: string): void {
     this.languageDefault = language;
+  }
+
+  /**
+   * @description
+   *
+   * Método que retorna o separador
+   *
+   * @param language sigla do idioma.
+   *
+   * Esta sigla deve ser composta por duas letras representando o idioma
+   *
+   * > Caso seja informado um valor diferente deste padrão, o mesmo será ignorado.
+   */
+  getNumberSeparators(language?: string) {
+    language = language || this.getShortLanguage();
+    const decimal = poLocaleDecimalSeparatorList.find(separator => separator.language === language) ?? {};
+    const thousand = poLocaleThousandSeparatorList.find(separator => separator.language === language) ?? {};
+    const decimalSeparator = decimal.separator ?? ',';
+    const thousandSeparator = thousand.separator ?? '.';
+
+    return { decimalSeparator, thousandSeparator };
   }
 }


### PR DESCRIPTION
**po-decimal**

**DTHFUI-4311**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
A formatação do valor não respeita a configuração de idioma do usuário

**Qual o novo comportamento?**
Criada propriedade e caso ela não seja passada irá respeitar a configuração da app ou do browse.

**Simulação**

Pode ser testado no labs do portal e também no app em anexo [app.zip](https://github.com/po-ui/po-angular/files/5425392/app.zip)

