### PR TITLE
feat(po-decimal): inclui a propriedade `p-error-pattern`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
@@ -7,6 +7,8 @@
     <input
       #inp
       class="po-input"
+      [attr.max]="max"
+      [attr.min]="min"
       [attr.name]="name"
       [autocomplete]="autocomplete"
       [class.po-input-icon-left]="icon"
@@ -27,5 +29,5 @@
     </div>
   </div>
 
-  <po-field-container-bottom> </po-field-container-bottom>
+  <po-field-container-bottom [p-error-pattern]="getErrorPatternMessage()"> </po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
@@ -9,6 +9,9 @@
   [p-icon]="icon"
   [p-label]="label"
   [p-locale]="locale"
+  [p-error-pattern]="errorPattern"
+  [p-max]="max"
+  [p-min]="min"
   [p-no-autocomplete]="properties?.includes('noAutocomplete')"
   [p-optional]="properties.includes('optional')"
   [p-placeholder]="placeholder"
@@ -78,6 +81,15 @@
 
     <po-select class="po-md-6" name="icon" [(ngModel)]="icon" p-clean p-label="Icon" [p-options]="iconOptions">
     </po-select>
+  </div>
+
+  <div class="po-row">
+    <po-number class="po-md-6 po-lg-3" name="min" [(ngModel)]="min" p-clean p-label="Min"> </po-number>
+
+    <po-number class="po-md-6 po-lg-3" name="max" [(ngModel)]="max" p-clean p-label="Max"> </po-number>
+
+    <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern">
+    </po-input>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
@@ -17,6 +17,9 @@ export class SamplePoDecimalLabsComponent implements OnInit {
   placeholder: string;
   properties: Array<string>;
   thousandMaxlength: number;
+  errorPattern: string;
+  max: number;
+  min: number;
 
   public readonly localeOptions: Array<PoSelectOption> = [
     { value: 'pt', label: 'Portuguese' },
@@ -66,6 +69,9 @@ export class SamplePoDecimalLabsComponent implements OnInit {
     this.locale = undefined;
     this.placeholder = '';
     this.thousandMaxlength = undefined;
+    this.errorPattern = undefined;
+    this.max = undefined;
+    this.min = undefined;
 
     this.properties = [];
   }


### PR DESCRIPTION
**PO-DECIMAL**

**#325** 
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [ ] Documentação
- [X] Samples

**Qual o comportamento atual?**
As mensagens de erros não são exibidas

**Qual o novo comportamento?**
As mensagens de erros são exibidas abaixo do input, seguindo o padrões dos demais componentes com essa característica

**Simulação**
Utilizar o componente po-decimal com validação de um valor mínimo, incluir uma mensagem de erro para a propriedade p-error-pattern, ao inserir um valor inválido com a validação a mensagem de erro com o texto inserido será exibida.