### PR TITLE
docs: ajusta documentação da propriedade 'p-change-visible-columns' do 'po-table'

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -527,7 +527,7 @@ export abstract class PoTableBaseComponent implements OnChanges {
    * @optional
    *
    * @description
-   * Evento disparado ao alterar as colunas visíveis no gerenciador de colunas e fechar o popover do gerenciador.
+   * Evento disparado ao fechar o popover do gerenciador de colunas após alterar as colunas visíveis.
    *
    * O componente envia como parâmetro um array de string com as colunas visíveis atualizadas.
    * Por exemplo: ["idCard", "name", "hireStatus", "age"].


### PR DESCRIPTION
Fixes DTHFUI-3699

**PO-TABLE**

**DTHFUI-3699**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A documentação da propriedade 'p-change-visible-columns' não está muito clara sobre o momento em que o evento será disparado.

**Qual o novo comportamento?**
Ajustada a documentação para melhor entendimento da funcionalidade

**Simulação**
Verificar no portal.