### PR TITLE
feat(number): adiciona a propriedade p-icon

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
@@ -1,5 +1,8 @@
 <po-field-container [p-help]="help" [p-label]="label" [p-optional]="!required && optional">
   <div class="po-field-container-content">
+    <div *ngIf="icon" class="po-field-icon-container-left">
+      <span class="po-icon po-field-icon {{ icon }}" [class.po-field-icon-disabled]="disabled"></span>
+    </div>
     <input
       #inp
       class="po-input"
@@ -9,6 +12,7 @@
       [attr.name]="name"
       [attr.step]="step"
       [autocomplete]="autocomplete"
+      [class.po-input-icon-left]="icon"
       [class.po-input-icon-right]="clean"
       [disabled]="disabled"
       [placeholder]="placeholder"

--- a/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.html
@@ -6,6 +6,7 @@
   [p-disabled]="properties.includes('disabled')"
   [p-error-pattern]="messageErrorPattern"
   [p-help]="help"
+  [p-icon]="icon"
   [p-label]="label"
   [p-max]="max"
   [p-maxlength]="maxlength"
@@ -67,6 +68,11 @@
   <div class="po-row">
     <po-number class="po-md-6" name="step" [(ngModel)]="step" p-clean p-label="Step"> </po-number>
 
+    <po-select class="po-lg-6" name="icon" [(ngModel)]="icon" p-clean p-label="Icon" [p-options]="iconOptions">
+    </po-select>
+  </div>
+
+  <div class="po-row">
     <po-checkbox-group
       class="po-md-6"
       name="properties"

--- a/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoCheckboxGroupOption } from '@po-ui/ng-components';
+import { PoCheckboxGroupOption, PoSelectOption } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-number-labs',
@@ -10,6 +10,7 @@ export class SamplePoNumberLabsComponent implements OnInit {
   event: string;
   messageErrorPattern: string;
   help: string;
+  icon: string;
   label: string;
   max: number;
   maxlength: number;
@@ -19,6 +20,12 @@ export class SamplePoNumberLabsComponent implements OnInit {
   placeholder: string;
   properties: Array<string>;
   step: string;
+
+  public readonly iconOptions: Array<PoSelectOption> = [
+    { value: 'po-icon-finance', label: 'po-icon-finance' },
+    { value: 'po-icon-calculator', label: 'po-icon-calculator' },
+    { value: 'po-icon-finance-bitcoin', label: 'po-icon-finance-bitcoin' }
+  ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'clean', label: 'Clean' },
@@ -48,6 +55,7 @@ export class SamplePoNumberLabsComponent implements OnInit {
     this.label = undefined;
     this.placeholder = '';
     this.help = '';
+    this.icon = '';
     this.step = undefined;
     this.properties = [];
   }


### PR DESCRIPTION
**po-number**

**Fixes #437, DTHFUI-3572**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
O componente `po-number` atualmente não tem a possibilidade de adicionar um ícone, todavia a propriedade `p-icon` aparece em sua documentação.

**Qual o novo comportamento?**
Adiciona a propriedade icon para o componente ter um ícone da biblioteca de ícones.

**Simulação**
Testar com o sample labs utilizando o select de ícone ou adicionar a propriedade `p-icon` no componente `po-number`:

`<po-number name="number" p-label="PO Number" p-icon="po-icon-star"> </po-number>`