### PR TITLE
fix(password): sobrescreve a propriedade autocomplete

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -14,7 +14,7 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
   valueBeforeChange: any;
   timeoutChange: any;
 
-  get autocomplete() {
+  get autocomplete(): string {
     return this.noAutocomplete ? 'off' : 'on';
   }
 

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -72,6 +72,8 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    *
    * Define a propriedade nativa `autocomplete` do campo como `off`.
    *
+   * > No componente `po-password` será definido como `new-password`.
+   *
    * @default `false`
    */
   @Input('p-no-autocomplete') set noAutocomplete(value: boolean) {

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.spec.ts
@@ -109,6 +109,18 @@ describe('PoNumberComponent:', () => {
       expect(component.visiblePassword).toBe(true);
       expect(component.type).toEqual(expectedValue);
     });
+
+    it('autocomplete: should return `new-password` if `noAutocomplete` is true', () => {
+      component.noAutocomplete = true;
+
+      expect(component.autocomplete).toBe('new-password');
+    });
+
+    it('autocomplete: should return `on` if `noAutocomplete` is false', () => {
+      component.noAutocomplete = false;
+
+      expect(component.autocomplete).toBe('on');
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.ts
@@ -70,6 +70,10 @@ export class PoPasswordComponent extends PoInputGeneric {
     return this._hidePasswordPeek;
   }
 
+  get autocomplete(): string {
+    return this.noAutocomplete ? 'new-password' : 'on';
+  }
+
   /* istanbul ignore next */
   constructor(el: ElementRef) {
     super(el);


### PR DESCRIPTION
**PO-PASSWORD**

**#633**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O campo é preenchido automaticamente com a senha salva mesmo com o autocomplete desabilitado.

**Qual o novo comportamento?**
O campo não é mais completado automaticamente devido à utilização da propriedade `autocomplete="new-password"`.

**Simulação**
Utilizar o componente `po-password` em um formulário qualquer com a propriedade `p-no-autocomplete` ativada, digitar uma senha, fazer o submit do formulário e aceitar quando o navegador oferecer para salvar a senha. Ao voltar para o formulário, o `po-password` não será mais preenchido automaticamente.