### PR TITLE
fix(page-dynamic-search): corrige filtro para tipo combo

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.spec.ts
@@ -102,12 +102,36 @@ describe('PoAdvancedFilterBaseComponent', () => {
   });
 
   describe('Methods:', () => {
-    it('getValuesFromForm: should return all items that property isn´t undefined or ``.', () => {
-      component.filter = { name: 'name', birthdate: 'Birthdate', age: '', Adress: undefined };
+    describe('getValuesFromForm', () => {
+      it('should return an object containing filter and optionsService key values if optionsServiceChosenOptions has length', () => {
+        component.filter = { name: 'name', birthdate: 'Birthdate', age: '', city: 12345 };
+        component.optionsServiceChosenOptions = [{ label: 'Vancouver', value: 12345 }];
 
-      const filteredItems = { name: 'name', birthdate: 'Birthdate' };
+        const expectedReturnValue = { filter: component.filter, optionsService: component.optionsServiceChosenOptions };
 
-      expect(component['getValuesFromForm']()).toEqual(filteredItems);
+        component['getValuesFromForm']();
+
+        expect(component['getValuesFromForm']()).toEqual(expectedReturnValue);
+      });
+
+      it('should return an object with undefined to optionService if optionsServiceChosenOptions doesn`t have length', () => {
+        component.filter = { name: 'name', birthdate: 'Birthdate', age: '', city: 12345 };
+        component.optionsServiceChosenOptions = [];
+
+        const expectedReturnValue = { filter: component.filter, optionsService: undefined };
+
+        component['getValuesFromForm']();
+
+        expect(component['getValuesFromForm']()).toEqual(expectedReturnValue);
+      });
+
+      it('should return the items that do not have undefined or empty property values.', () => {
+        component.filter = { name: 'name', birthdate: 'Birthdate', age: '', Adress: undefined };
+
+        const filteredItems = { filter: { name: 'name', birthdate: 'Birthdate' }, optionsService: undefined };
+
+        expect(component['getValuesFromForm']()).toEqual(filteredItems);
+      });
     });
 
     it('primaryAction: should emit `searchEvent` and call `getValuesFromForm` and `poModal.close`', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.ts
@@ -6,7 +6,8 @@ import {
   PoLanguageService,
   PoModalAction,
   PoModalComponent,
-  poLocaleDefault
+  poLocaleDefault,
+  PoComboOption
 } from '@po-ui/ng-components';
 
 import { PoAdvancedFilterLiterals } from './po-advanced-filter-literals.interface';
@@ -49,6 +50,8 @@ export class PoAdvancedFilterBaseComponent {
 
   private _filters: Array<PoDynamicFormField> = [];
   private _literals: PoAdvancedFilterLiterals;
+
+  protected optionsServiceChosenOptions: Array<PoComboOption> = [];
 
   filter = {};
   language: string = poLocaleDefault;
@@ -118,12 +121,21 @@ export class PoAdvancedFilterBaseComponent {
 
   // Retorna os models dos campos preenchidos
   private getValuesFromForm() {
+    let optionServiceOptions: Array<PoComboOption>;
+
     Object.keys(this.filter).forEach(property => {
       if (this.filter[property] === undefined || this.filter[property] === '') {
         delete this.filter[property];
+        return;
       }
     });
 
-    return this.filter;
+    if (this.optionsServiceChosenOptions.length) {
+      optionServiceOptions = this.optionsServiceChosenOptions.filter((optionItem: PoComboOption) => {
+        return Object.values(this.filter).includes(optionItem.value);
+      });
+    }
+
+    return { filter: this.filter, optionsService: optionServiceOptions };
   }
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.ts
@@ -1,6 +1,7 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Subscription } from 'rxjs';
 
-import { PoDynamicFormComponent, PoLanguageService } from '@po-ui/ng-components';
+import { PoComboOption, PoDynamicFormComponent, PoLanguageService } from '@po-ui/ng-components';
 
 import { PoAdvancedFilterBaseComponent } from './po-advanced-filter-base.component';
 import { PoPageDynamicSearchFilters } from '../po-page-dynamic-search-filters.interface';
@@ -21,11 +22,21 @@ import { PoPageDynamicSearchFilters } from '../po-page-dynamic-search-filters.in
   selector: 'po-advanced-filter',
   templateUrl: './po-advanced-filter.component.html'
 })
-export class PoAdvancedFilterComponent extends PoAdvancedFilterBaseComponent {
+export class PoAdvancedFilterComponent extends PoAdvancedFilterBaseComponent implements OnDestroy, OnInit {
+  private subscription = new Subscription();
+
   @ViewChild(PoDynamicFormComponent, { static: true }) poDynamicForm: PoDynamicFormComponent;
 
   constructor(languageService: PoLanguageService) {
     super(languageService);
+  }
+
+  ngOnInit() {
+    this.optionsServiceSubscribe();
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
   }
 
   open() {
@@ -34,7 +45,26 @@ export class PoAdvancedFilterComponent extends PoAdvancedFilterBaseComponent {
     this.poModal.open();
   }
 
+  private getOptionsServiceItem(optionServiceObject: PoComboOption) {
+    const objectItem = this.optionsServiceChosenOptions.map(option => option.value).indexOf(optionServiceObject.value);
+
+    if (objectItem === -1) {
+      this.optionsServiceChosenOptions = [...this.optionsServiceChosenOptions, optionServiceObject];
+    }
+  }
+
   private getInitialValuesFromFilter(filters: Array<PoPageDynamicSearchFilters>) {
     return filters.reduce((result, item) => Object.assign(result, { [item.property]: item.initValue }), {});
+  }
+
+  // Se inscreve para receber valores referentes a campos do tipo combo.
+  private optionsServiceSubscribe() {
+    this.subscription.add(
+      this.poDynamicForm.getObjectValue().subscribe(optionServiceObject => {
+        if (optionServiceObject) {
+          this.getOptionsServiceItem(optionServiceObject);
+        }
+      })
+    );
   }
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -29,6 +29,9 @@ export class PoDynamicFormFieldsBaseComponent {
 
   @Output('p-fieldsChange') fieldsChange = new EventEmitter<any>();
 
+  // Evento disparado se existir optionsService em visibleField. Necessário resgatar referência do objeto selecionado para quando se tratar de recebimento de opções via serviço.
+  @Output('p-object-value') objectValue = new EventEmitter<any>();
+
   // valor que será utilizado para iniciar valor no componente.
   @Input('p-value') set value(value: any) {
     this._value = value && isTypeof(value, 'object') ? value : {};

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -141,6 +141,7 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      p-emit-object-value
       [p-auto-focus]="field.focus"
       [p-disabled]="isDisabled(field)"
       [p-field-label]="field.fieldLabel"
@@ -151,7 +152,7 @@
       [p-label]="field.label"
       [p-optional]="field.optional"
       [p-required]="field.required"
-      (p-change)="onChangeField(field)"
+      (p-change)="onChangeField(field, $event)"
     >
     </po-combo>
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -245,6 +245,28 @@ describe('PoDynamicFormFieldsComponent: ', () => {
           fakeVisibleField
         );
       });
+
+      it('should emit `objectValue` if `visibleField` has `optionsService` property', async () => {
+        const fakeVisibleField = { property: 'test1', optionsService: 'url.com' };
+        const objectValue = { label: 'Vancouver', value: 12343 };
+
+        const spyObjectValue = spyOn(component.objectValue, 'emit');
+
+        await component.onChangeField(fakeVisibleField, objectValue);
+
+        expect(spyObjectValue).toHaveBeenCalledWith(objectValue);
+      });
+
+      it('shouldn`t emit `objectValue` if `visibleField` doesn`t have the `optionsService` property', async () => {
+        const fakeVisibleField = { property: 'test1' };
+        const objectValue = { label: 'Vancouver', value: 12343 };
+
+        const spyObjectValue = spyOn(component.objectValue, 'emit');
+
+        await component.onChangeField(fakeVisibleField, objectValue);
+
+        expect(spyObjectValue).not.toHaveBeenCalled();
+      });
     });
 
     it('applyFieldValidation: should merge fields and validatedFields and apply new value to `fields` and `value``', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -50,9 +50,13 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
     return field.disabled || this.disabledForm;
   }
 
-  async onChangeField(visibleField: PoDynamicFormField) {
+  async onChangeField(visibleField: PoDynamicFormField, objectValue?: any) {
     const { property } = visibleField;
     const isChangedValueField = this.previousValue[property] !== this.value[property];
+
+    if (visibleField.optionsService) {
+      this.objectValue.emit(objectValue);
+    }
 
     if (isChangedValueField) {
       const { changedField, changedFieldIndex } = this.getField(property);

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.html
@@ -15,6 +15,7 @@
       [p-validate]="validate"
       [p-validate-fields]="validateFields"
       [p-value]="value"
+      (p-object-value)="sendObjectValue($event)"
       (p-form-validate)="validateForm($event)"
     >
     </po-dynamic-form-fields>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { NgForm } from '@angular/forms';
 
 import { configureTestSuite } from './../../../util-test/util-expect.spec';
-import { of, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 
 import { PoDynamicFormBaseComponent } from './po-dynamic-form-base.component';
 import { PoDynamicFormComponent } from './po-dynamic-form.component';
@@ -504,6 +504,30 @@ describe('PoDynamicFormComponent:', () => {
       component['loadDataOnInitialize']();
 
       expect(spyApplyFormUpdatesOnLoad).toHaveBeenCalled();
+    });
+
+    it('getObjectValue: should call comboOptionSubject.asObservable', () => {
+      const spyComboOptionSubjectObservable = spyOn(component['comboOptionSubject'], 'asObservable');
+
+      component.getObjectValue();
+
+      expect(spyComboOptionSubjectObservable).toHaveBeenCalled();
+    });
+
+    it('getObjectValue: should return  an instanceof Observable', () => {
+      const result = component.getObjectValue();
+
+      expect(result instanceof Observable).toBeTruthy();
+    });
+
+    it('sendObjectValue: should call comboOptionSubject.next with value', () => {
+      const value = 'test';
+
+      const spyComboOptionSubjectNext = spyOn(component['comboOptionSubject'], 'next');
+
+      component.sendObjectValue('test');
+
+      expect(spyComboOptionSubjectNext).toHaveBeenCalledWith(value);
     });
   });
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectorRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 
-import { Subscription } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 
 import { PoDynamicFormBaseComponent } from './po-dynamic-form-base.component';
 import { PoDynamicFormField } from './po-dynamic-form-field.interface';
@@ -38,6 +38,7 @@ export class PoDynamicFormComponent extends PoDynamicFormBaseComponent implement
 
   private onLoadSubscription: Subscription;
   private sendFormSubscription: Subscription;
+  private comboOptionSubject = new Subject<any>();
 
   @ViewChild('dynamicForm') set form(value: NgForm) {
     // necessario para nao ocorrer o ExpressionChangedAfterItHasBeenCheckedError
@@ -102,6 +103,14 @@ export class PoDynamicFormComponent extends PoDynamicFormBaseComponent implement
    */
   focus(property: string) {
     this.fieldsComponent.focus(property);
+  }
+
+  getObjectValue(): Observable<any> {
+    return this.comboOptionSubject.asObservable();
+  }
+
+  sendObjectValue(objectValue: any) {
+    this.comboOptionSubject.next(objectValue);
   }
 
   validateForm(field: PoDynamicFormField) {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -516,7 +516,7 @@ describe('PoComboBaseComponent:', () => {
     it('updateModel: should call `change.emit` passing `value` as param', () => {
       const value = 1;
 
-      component.objectValue = false;
+      component.emitObjectValue = false;
 
       spyOn(component, 'callModelChange');
       spyOn(component.change, 'emit');
@@ -526,10 +526,10 @@ describe('PoComboBaseComponent:', () => {
       expect(component.change.emit).toHaveBeenCalledWith(value);
     });
 
-    it('updateModel: should call `change.emit` passing `selectedOption` as param if `objectValue` is true', () => {
+    it('updateModel: should call `change.emit` passing `selectedOption` as param if `emitObjectValue` is true', () => {
       const value = 1;
 
-      component.objectValue = true;
+      component.emitObjectValue = true;
       component.selectedOption = { label: '1', value: '1' };
 
       spyOn(component, 'callModelChange');

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -509,8 +509,35 @@ describe('PoComboBaseComponent:', () => {
       component['updateModel'](value);
 
       expect(component.callModelChange).toHaveBeenCalledWith(value);
-      expect(component.change.emit).toHaveBeenCalledWith(value);
+      expect(component.change.emit).toHaveBeenCalled();
       expect(component.selectedValue).toBe(value);
+    });
+
+    it('updateModel: should call `change.emit` passing `value` as param', () => {
+      const value = 1;
+
+      component.objectValue = false;
+
+      spyOn(component, 'callModelChange');
+      spyOn(component.change, 'emit');
+
+      component['updateModel'](value);
+
+      expect(component.change.emit).toHaveBeenCalledWith(value);
+    });
+
+    it('updateModel: should call `change.emit` passing `selectedOption` as param if `objectValue` is true', () => {
+      const value = 1;
+
+      component.objectValue = true;
+      component.selectedOption = { label: '1', value: '1' };
+
+      spyOn(component, 'callModelChange');
+      spyOn(component.change, 'emit');
+
+      component['updateModel'](value);
+
+      expect(component.change.emit).toHaveBeenCalledWith(component.selectedOption);
     });
 
     it('updateModel: shouldn`t call `callModelChange` and `change.emit` if `selectedValue` is equal value param', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -451,7 +451,20 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @description
    *
-   * Deve ser informada uma função que será disparada quando houver alterações no ngModel.
+   * Se verdadeiro, o evento `p-change` receberá como argumento o `PoComboOption` referente à opção selecionada.
+   *
+   * @default `false`
+   */
+  @Input('p-object-value') @InputBoolean() objectValue?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Deve ser informada uma função que será disparada quando houver alterações no ngModel. A função receberá como argumento o model modificado.
+   *
+   * > Pode-se optar pelo recebimento do objeto selecionado ao invés do model através da propriedade `p-object-value`.
    */
   @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
@@ -871,7 +884,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
         this.callModelChange(value);
       }
 
-      this.change.emit(value);
+      this.change.emit(this.objectValue ? this.selectedOption : value);
     }
 
     this.selectedValue = value;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -455,7 +455,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @default `false`
    */
-  @Input('p-object-value') @InputBoolean() objectValue?: boolean = false;
+  @Input('p-emit-object-value') @InputBoolean() emitObjectValue?: boolean = false;
 
   /**
    * @optional
@@ -464,7 +464,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * Deve ser informada uma função que será disparada quando houver alterações no ngModel. A função receberá como argumento o model modificado.
    *
-   * > Pode-se optar pelo recebimento do objeto selecionado ao invés do model através da propriedade `p-object-value`.
+   * > Pode-se optar pelo recebimento do objeto selecionado ao invés do model através da propriedade `p-emit-object-value`.
    */
   @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
@@ -884,7 +884,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
         this.callModelChange(value);
       }
 
-      this.change.emit(this.objectValue ? this.selectedOption : value);
+      this.change.emit(this.emitObjectValue ? this.selectedOption : value);
     }
 
     this.selectedValue = value;


### PR DESCRIPTION
**page-dynamic-search**

**DTHFUI-2726**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando um dos filters usa o combo, o mesmo exibe os valores selecionados e não a descrição que o usuário usou para fazer o filtro.

**Qual o novo comportamento?**
- Criada nova propriedade `p-emit-object-value` em  **po-combo** para que o usuário opte por receber o objeto selecionado ao invés do model no evento `p-change`;
- Quando o usuário usar um combo para fazer um filtro, o disclaimer deve exibir a descrição do item selecionado e não o valor "interno". 

**Simulação**
No sample `SamplePoPageDynamicSearchHiringProcessesComponent`, substitua por favor na linha 41 por esse objeto: 
`{ property: 'city', optionsService: 'http://demo4398968.mockable.io/city', gridColumns: 6 }`.

Fazer as verificações de filtragem. Lembrando que o initValue não se aplica adequadamente para campo do tipo **combo**