### PR TITLE
feat(dialog): adiciona o evento close

### DIFF
--- a/projects/ui/src/lib/services/po-dialog/interfaces/po-dialog.interface.ts
+++ b/projects/ui/src/lib/services/po-dialog/interfaces/po-dialog.interface.ts
@@ -65,6 +65,9 @@ export interface PoDialogConfirmOptions extends PoDialogOptions {
   /** Ação de cancelamento da caixa de diálogo. */
   cancel?: Function;
 
+  /** Ação de fechamento da caixa de diálogo. */
+  close?: Function;
+
   /**
    * Objeto com as literais usadas no `po-dialog` do tipo confirmação.
    *

--- a/projects/ui/src/lib/services/po-dialog/po-dialog.component.spec.ts
+++ b/projects/ui/src/lib/services/po-dialog/po-dialog.component.spec.ts
@@ -21,7 +21,8 @@ describe('PoDialogComponent:', () => {
     title: 'Title',
     message: 'Message',
     confirm: () => {},
-    cancel: () => {}
+    cancel: () => {},
+    close: () => {}
   };
 
   configureTestSuite(() => {
@@ -99,6 +100,16 @@ describe('PoDialogComponent:', () => {
     fixture.detectChanges();
 
     expect(component.destroy).toHaveBeenCalled();
+  }));
+
+  it('Should call closeAction if has closeAction callback and was closed with X', async(() => {
+    component.closeAction = () => {};
+    spyOn(component, 'closeAction');
+
+    component.poModal.close(true);
+    fixture.detectChanges();
+
+    expect(component.closeAction).toHaveBeenCalled();
   }));
 
   it('should set var configDialog', () => {
@@ -182,7 +193,7 @@ describe('PoDialogComponent:', () => {
     });
 
     it(`open: should call 'configDialog()' with 'literals.confirm', 'dialogOptions.confirm()', 'literals.cancel',
-        and 'dialogOptions.cancel()' if 'dialogType' is 'PoDialogType.Confirm'.`, () => {
+        'dialogOptions.cancel()', and 'dialogOptions.close()' if 'dialogType' is 'PoDialogType.Confirm'.`, () => {
       component.literalsConfirm = { 'cancel': 'Cancel', 'confirm': 'Confirm' };
 
       spyOn(component, <any>'setDialogLiterals');
@@ -195,7 +206,8 @@ describe('PoDialogComponent:', () => {
         component.literalsConfirm.confirm,
         confirmOptions.confirm,
         component.literalsConfirm.cancel,
-        confirmOptions.cancel
+        confirmOptions.cancel,
+        confirmOptions.close
       );
     });
 

--- a/projects/ui/src/lib/services/po-dialog/po-dialog.component.ts
+++ b/projects/ui/src/lib/services/po-dialog/po-dialog.component.ts
@@ -56,6 +56,9 @@ export class PoDialogComponent implements OnDestroy, OnInit {
   // Objeto secondary do poModal
   secondaryAction: PoModalAction;
 
+  // Callback executado ao fechar o poModal
+  closeAction: Function;
+
   // Literais usadas nos botão de alerta do poModal
   literalsAlert: PoDialogAlertLiterals;
 
@@ -75,11 +78,15 @@ export class PoDialogComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit() {
-    this.closeSubscription = this.poModal.onXClosed.subscribe(close => this.destroy());
+    this.closeSubscription = this.poModal.onXClosed.subscribe(close => this.close(true));
   }
 
   // Fecha o poModal
-  close(): void {
+  close(xClosed = false): void {
+    if (xClosed && this.closeAction) {
+      this.closeAction();
+    }
+
     this.poModal.close();
     this.destroy();
   }
@@ -91,7 +98,7 @@ export class PoDialogComponent implements OnDestroy, OnInit {
   }
 
   // Insere os valores recebidos de this.open para o poModal
-  configDialog(primaryLabel?, primaryAction?, secondaryLabel?, secondaryAction?) {
+  configDialog(primaryLabel?, primaryAction?, secondaryLabel?, secondaryAction?, closeAction?) {
     this.primaryAction = {
       label: primaryLabel,
       action: () => {
@@ -113,6 +120,8 @@ export class PoDialogComponent implements OnDestroy, OnInit {
         }
       };
     }
+
+    this.closeAction = closeAction;
   }
 
   // Insere os valores recebidos de po-dialog.service de acordo com o tipo de diálago solicitado
@@ -134,7 +143,8 @@ export class PoDialogComponent implements OnDestroy, OnInit {
           this.literalsConfirm.confirm,
           (<PoDialogConfirmOptions>dialogOptions).confirm,
           this.literalsConfirm.cancel,
-          (<PoDialogConfirmOptions>dialogOptions).cancel
+          (<PoDialogConfirmOptions>dialogOptions).cancel,
+          (<PoDialogConfirmOptions>dialogOptions).close
         );
         break;
       }

--- a/projects/ui/src/lib/services/po-dialog/samples/sample-po-dialog-labs/sample-po-dialog-labs.component.ts
+++ b/projects/ui/src/lib/services/po-dialog/samples/sample-po-dialog-labs/sample-po-dialog-labs.component.ts
@@ -22,7 +22,8 @@ export class SamplePoDialogLabsComponent implements OnInit {
   public readonly dialogActionOptions: Array<PoCheckboxGroupOption> = [
     { label: 'Ok', value: 'ok' },
     { label: 'Cancel', value: 'cancel' },
-    { label: 'Confirm', value: 'confirm' }
+    { label: 'Confirm', value: 'confirm' },
+    { label: 'Close', value: 'close' }
   ];
 
   public readonly dialogMethodOptions: Array<PoRadioGroupOption> = [
@@ -74,7 +75,8 @@ export class SamplePoDialogLabsComponent implements OnInit {
       title: this.title,
       message: this.message,
       confirm: () => (this.actionOptions.includes('confirm') ? (this.action = 'Confirm') : undefined),
-      cancel: () => (this.actionOptions.includes('cancel') ? (this.action = 'Cancel') : undefined)
+      cancel: () => (this.actionOptions.includes('cancel') ? (this.action = 'Cancel') : undefined),
+      close: () => (this.actionOptions.includes('close') ? (this.action = 'Close') : undefined)
     });
   }
 


### PR DESCRIPTION
**po-dialog**

**651**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
O po-dialog não permite a utilização de um callback para o botão fechar (x), impossibilitando que saibamos quando o dialog é fechado por ele.

**Qual o novo comportamento?**
Foi adicionado o parâmetro `close`, que é o callback para o botão fechar.

**Simulação**
Pode ser simulado nos samples do portal.