### PR TITLE
feat(combo): cria props para melhorar a usabilidade para apis paginadas

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -1,19 +1,17 @@
+import { Directive, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
-import { EventEmitter, Input, OnInit, Output, Directive } from '@angular/core';
-
-import { convertToBoolean, isTypeof, validValue } from '../../../utils/util';
-import { PoLanguageService } from '../../../services/po-language/po-language.service';
-import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 import { InputBoolean } from '../../../decorators';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { convertToBoolean, isTypeof, validValue } from '../../../utils/util';
 import { requiredFailed } from '../validators';
-
 import { PoComboFilter } from './interfaces/po-combo-filter.interface';
-import { PoComboFilterMode } from './po-combo-filter-mode.enum';
-import { PoComboFilterService } from './po-combo-filter.service';
 import { PoComboGroup } from './interfaces/po-combo-group.interface';
 import { PoComboLiterals } from './interfaces/po-combo-literals.interface';
-import { PoComboOption } from './interfaces/po-combo-option.interface';
 import { PoComboOptionGroup } from './interfaces/po-combo-option-group.interface';
+import { PoComboOption } from './interfaces/po-combo-option.interface';
+import { PoComboFilterMode } from './po-combo-filter-mode.enum';
+import { PoComboFilterService } from './po-combo-filter.service';
 
 const PO_COMBO_DEBOUNCE_TIME_DEFAULT = 400;
 const PO_COMBO_FIELD_LABEL_DEFAULT = 'label';
@@ -456,6 +454,29 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * @default `false`
    */
   @Input('p-emit-object-value') @InputBoolean() emitObjectValue?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Se falso a seta do dropdown será visível e clicável.
+   *
+   * @default `false`
+   */
+  @Input('p-hide-arrow') @InputBoolean() shouldHideDropDownArrow?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Se verdadeiro as opções de seleção irão ser abertas toda vez que o usuário clicar no componente. Se falso as opções só
+   * aparecerão quando algo for escrito no input.
+   *
+   * @default `true`
+   */
+  @Input('p-open-options-on-click') @InputBoolean() shouldOpenOptionsOnClick?: boolean = true;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -15,13 +15,13 @@
       [disabled]="disabled"
       [placeholder]="placeholder"
       [required]="required"
-      (click)="toggleComboVisibility()"
+      (click)="onInputClick()"
       (keyup)="onKeyUp($event)"
       (keyup.enter)="searchOnEnter($event.target.value)"
       (keydown)="onKeyDown($event)"
     />
 
-    <div class="po-field-icon-container-right">
+    <div class="po-field-icon-container-right" [hidden]="shouldHideDropDownArrow">
       <po-clean
         [class.po-field-icon]="!disabled"
         [class.po-field-icon-disabled]="disabled"

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -1,22 +1,17 @@
-import { By } from '@angular/platform-browser';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { Observable, throwError } from 'rxjs';
-
-import { changeBrowserInnerWidth, configureTestSuite } from './../../../util-test/util-expect.spec';
-
 import { PoLoadingModule } from '../../po-loading/po-loading.module';
-
-import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
+import { PoCleanComponent } from '../po-clean/po-clean.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
-
-import { PoComboComponent } from './po-combo.component';
+import { changeBrowserInnerWidth, configureTestSuite } from './../../../util-test/util-expect.spec';
+import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
+import { PoComboOption } from './interfaces/po-combo-option.interface';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
 import { PoComboFilterService } from './po-combo-filter.service';
-import { PoComboOption } from './interfaces/po-combo-option.interface';
-import { PoCleanComponent } from '../po-clean/po-clean.component';
+import { PoComboComponent } from './po-combo.component';
 
 const eventKeyBoard = document.createEvent('KeyboardEvent');
 eventKeyBoard.initEvent('keyup', true, true);
@@ -373,6 +368,19 @@ describe('PoComboComponent:', () => {
 
     expect(spyAdjustContainerPosition).toHaveBeenCalled();
   }));
+
+  it('should hide the dropdown arrow if `shouldHideDropDownArrow` is true', () => {
+    const componentElement: HTMLElement = fixture.componentInstance.element.nativeElement;
+
+    const fieldIconContainerRight: HTMLElement = componentElement.querySelector('.po-field-icon-container-right');
+
+    expect(fieldIconContainerRight.hidden).toEqual(false);
+
+    component.shouldHideDropDownArrow = true;
+    fixture.detectChanges();
+
+    expect(fieldIconContainerRight.hidden).toEqual(true);
+  });
 
   describe('Methods:', () => {
     const fakeEvent = {
@@ -1558,6 +1566,22 @@ describe('PoComboComponent:', () => {
       const noDataTemplate = nativeElement.querySelector('.po-combo-container-no-data');
 
       expect(noDataTemplate).toBeNull();
+    });
+
+    it('shouldn´t open combo container on click if `shouldOpenOptionsOnClick` is false', () => {
+      component.visibleOptions = [{ label: '1', value: '1' }];
+      component.shouldOpenOptionsOnClick = false;
+
+      fixture.detectChanges();
+
+      const comboInput = nativeElement.querySelector('.po-combo-input');
+      comboInput.dispatchEvent(eventClick);
+
+      fixture.detectChanges();
+
+      const noDataTemplate = nativeElement.querySelector('.po-combo-container');
+
+      expect(noDataTemplate.hidden).toBeTrue();
     });
 
     it('should display `literals.noData` in Spanish if browser language is `es`.', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -12,21 +12,18 @@ import {
   SimpleChanges,
   ViewChild
 } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
-
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { fromEvent, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map, tap } from 'rxjs/operators';
-
 import { PoControlPositionService } from '../../../services/po-control-position/po-control-position.service';
-import { PoKeyCodeEnum } from './../../../enums/po-key-code.enum';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
-
+import { PoKeyCodeEnum } from './../../../enums/po-key-code.enum';
+import { PoComboGroup } from './interfaces/po-combo-group.interface';
+import { PoComboOption } from './interfaces/po-combo-option.interface';
 import { PoComboBaseComponent } from './po-combo-base.component';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
 import { PoComboFilterService } from './po-combo-filter.service';
-import { PoComboGroup } from './interfaces/po-combo-group.interface';
-import { PoComboOption } from './interfaces/po-combo-option.interface';
 import { PoComboOptionTemplateDirective } from './po-combo-option-template/po-combo-option-template.directive';
 
 const poComboContainerOffset = 8;
@@ -419,6 +416,12 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
       const visibleOption = this.visibleOptions[index];
 
       this.updateSelectedValue(visibleOption, visibleOption.value !== currentViewValue && !this.changeOnEnter);
+    }
+  }
+
+  onInputClick(): void {
+    if (this.shouldOpenOptionsOnClick) {
+      this.toggleComboVisibility();
     }
   }
 


### PR DESCRIPTION
**PoCombo**

#657
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando usado o combo com um serviço paginado a "setinha" para baixo do lado direito do componente traz ao usuário a impressão de que se trata de um select. Ao clicar na setinha é feito a busca da primeira página e geralmente o registro não se encontra ali. O usuário não vê como intuitivo que ele deve escrever para buscar mais resultados até que ele encontre aquele registro que procura.

Mesmo utilizando o atributo p-disabled-init-filter a confusão persiste pois ao clicar na setinha a mensagem "Nenhum registro foi encontrado" é mostrada. E mesmo que ele busque um registro e consiga achá-lo sempre ao clicar na setinha virá de novo com a primeira página carregada.

**Qual o novo comportamento?**
Foi criado dois novos atributos **p-hide-arrow** e **p-open-options-on-click**. O **p-hide-arrow** esconde a setinha de dropdown que remete ao usuário que o componente é um "select". O **p-open-options-on-click** se setado como falso não abre a lista de opções quando o input é clicado, somente quando se escreve no input.
