### PR TITLE
feat(page-breadcrumb): define literais para idiomas suportados

### DIFF
--- a/projects/ui/src/lib/components/po-breadcrumb/po-breadcrumb-favorite/po-breadcrumb-favorite.component.html
+++ b/projects/ui/src/lib/components/po-breadcrumb/po-breadcrumb-favorite/po-breadcrumb-favorite.component.html
@@ -5,6 +5,6 @@
   >
   </span>
 
-  <span class="po-hidden-sm po-breadcrumb-favorite-label" *ngIf="favorite">Desfavoritar</span>
-  <span class="po-hidden-sm po-breadcrumb-favorite-label" *ngIf="!favorite">Favoritar</span>
+  <span class="po-hidden-sm po-breadcrumb-favorite-label" *ngIf="favorite">{{ literals?.unfavorite }}</span>
+  <span class="po-hidden-sm po-breadcrumb-favorite-label" *ngIf="!favorite">{{ literals?.favorite }}</span>
 </div>

--- a/projects/ui/src/lib/components/po-breadcrumb/po-breadcrumb-favorite/po-breadcrumb-favorite.component.spec.ts
+++ b/projects/ui/src/lib/components/po-breadcrumb/po-breadcrumb-favorite/po-breadcrumb-favorite.component.spec.ts
@@ -107,7 +107,7 @@ describe('PoBreadcrumbFavoriteComponent', () => {
     const labelActive = nativeElement.querySelector('.po-breadcrumb-favorite-label');
 
     expect(starActive).toBeTruthy();
-    expect(labelActive.innerHTML).toContain('Desfavoritar');
+    expect(labelActive.innerHTML).toContain(component.literals.unfavorite);
   });
 
   it('should show the star and label with status unfavorite', () => {
@@ -118,7 +118,7 @@ describe('PoBreadcrumbFavoriteComponent', () => {
     fixture.detectChanges();
 
     expect(starActive).toBeFalsy();
-    expect(label.innerHTML).toContain('Favoritar');
+    expect(label.innerHTML).toContain(component.literals.favorite);
   });
 
   describe('Methods: ', () => {

--- a/projects/ui/src/lib/components/po-breadcrumb/po-breadcrumb-favorite/po-breadcrumb-favorite.component.ts
+++ b/projects/ui/src/lib/components/po-breadcrumb/po-breadcrumb-favorite/po-breadcrumb-favorite.component.ts
@@ -4,6 +4,26 @@ import { Subscription } from 'rxjs';
 
 import { PoBreadcrumbItem } from './../po-breadcrumb-item.interface';
 import { PoBreadcrumbFavoriteService } from './po-breadcrumb-favorite.service';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+
+export const PoBreadcrumbLiterals: Object = {
+  en: <any>{
+    favorite: 'Favorite',
+    unfavorite: 'Unfavorite'
+  },
+  es: <any>{
+    favorite: 'Favor',
+    unfavorite: 'Desfavorecer'
+  },
+  pt: <any>{
+    favorite: 'Favoritar',
+    unfavorite: 'Desfavoritar'
+  },
+  ru: <any>{
+    favorite: 'Любимый',
+    unfavorite: 'Немилость'
+  }
+};
 
 /**
  * @docsPrivate
@@ -12,6 +32,7 @@ import { PoBreadcrumbFavoriteService } from './po-breadcrumb-favorite.service';
  *
  * Componente que renderiza o serviço de favoritar do po-breadcrumb.
  */
+
 @Component({
   selector: 'po-breadcrumb-favorite',
   templateUrl: './po-breadcrumb-favorite.component.html',
@@ -19,6 +40,8 @@ import { PoBreadcrumbFavoriteService } from './po-breadcrumb-favorite.service';
 })
 export class PoBreadcrumbFavoriteComponent implements OnInit, OnDestroy {
   favorite: boolean = false;
+  literals;
+
   private getSubscription: Subscription;
   private setSubscription: Subscription;
 
@@ -31,7 +54,13 @@ export class PoBreadcrumbFavoriteComponent implements OnInit, OnDestroy {
   // Parâmetro que será enviado junto com o serviço de favoritar.
   @Input('p-params-service') paramsService: object;
 
-  constructor(private service: PoBreadcrumbFavoriteService) {}
+  constructor(private service: PoBreadcrumbFavoriteService, private languageService: PoLanguageService) {
+    const language = languageService.getShortLanguage();
+
+    this.literals = {
+      ...PoBreadcrumbLiterals[language]
+    };
+  }
 
   ngOnInit() {
     this.service.configService(this.favoriteService, this.paramsService, this.itemActive);


### PR DESCRIPTION
**BreadCrumb**

**MDO-35**
_____________________________________________________________________________

- [ X ] Código
- [ X ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Favoritar/Desfavoritar não suporta literais

**Qual o novo comportamento?**
Favoritar/Desfavoritar definir para literais suportados

**Simulação**
