### PR TITLE
feat(lookup): adicionar evento p-change

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -157,7 +157,10 @@ describe('PoLookupBaseComponent:', () => {
 
   it('should not be called the onChangePropate event', () => {
     const fakeThis = {
-      onChangePropagate: ''
+      onChangePropagate: '',
+      change: {
+        emit: () => {}
+      }
     };
 
     spyOn<any>(component, 'onChangePropagate');
@@ -207,6 +210,16 @@ describe('PoLookupBaseComponent:', () => {
       expect(component.setViewValue).toHaveBeenCalledWith('123 - teste', objectSelected);
     }
   ));
+
+  it('callOnChange: should call change.emit with value', () => {
+    const objectSelected = { value: 1495832652942, label: 'Kakaroto' };
+    component.fieldValue = 'value';
+
+    spyOn(component.change, 'emit');
+
+    component.selectValue(objectSelected);
+    expect(component.change.emit).toHaveBeenCalledWith(1495832652942);
+  });
 
   it('call writeValue with invalid Id', inject([LookupFilterService], (lookupFilterService: LookupFilterService) => {
     component.service = lookupFilterService;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -38,6 +38,7 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
   protected keysDescription: Array<any>;
   protected oldValue: string = '';
   protected valueToModel;
+  protected oldValueToModel = null;
 
   private onChangePropagate: any = null;
   // tslint:disable-next-line
@@ -327,6 +328,16 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
    */
   @Output('p-selected') selected: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   *  Evento que será disparado ao alterar o model.
+   *  Por parâmetro será passado o novo valor.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
+
   constructor(private defaultService: PoLookupFilterService) {}
 
   ngOnDestroy() {
@@ -378,6 +389,13 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
     if (this.onChangePropagate) {
       this.onChangePropagate(value);
     }
+
+    if (this.oldValueToModel !== this.valueToModel) {
+      this.change.emit(this.valueToModel);
+    }
+
+    // Armazenar o valor antigo do model
+    this.oldValueToModel = this.valueToModel;
   }
 
   searchById(value: string) {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -17,6 +17,7 @@
   [p-required]="properties.includes('required')"
   (p-error)="changeEvent('p-error')"
   (p-selected)="changeEvent('p-selected')"
+  (p-change)="changeEvent('p-change')"
 >
 </po-lookup>
 


### PR DESCRIPTION
O evento p-change será disparado ao alterar o ngModel. É uma função que será disparada quando houver alterações.

Fixes TIS-1

**po-lookup**

**TIS-1**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Não havia o evento change no componente

**Qual o novo comportamento?**
Criação do evento p-change, que deverá ser disparado toda vez que o model for alterado.

**Simulação**
Esta correção pode ser validada utilizando o sample labs no portal.
