### PR TITLE
feat(po-decimal): inclui as propriedades `p-error-pattern`, `p-min` e `p-max`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
@@ -27,5 +27,5 @@
     </div>
   </div>
 
-  <po-field-container-bottom> </po-field-container-bottom>
+  <po-field-container-bottom [p-error-pattern]="getErrorPatternMessage()"> </po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
@@ -7,6 +7,8 @@
     <input
       #inp
       class="po-input"
+      [attr.max]="max"
+      [attr.min]="min"
       [attr.name]="name"
       [autocomplete]="autocomplete"
       [class.po-input-icon-left]="icon"

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { FormControl } from '@angular/forms';
 
-import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
+import { expectPropertiesValues, expectSettersMethod } from '../../../util-test/util-expect.spec';
 
 import { PoCleanComponent } from './../po-clean/po-clean.component';
 import { PoDecimalComponent } from './po-decimal.component';
@@ -108,6 +109,46 @@ describe('PoDecimalComponent:', () => {
       validValues = [13, 21];
       component.decimalsLength = 4;
       expectPropertiesValues(component, 'thousandMaxlength', validValues, 13);
+    });
+
+    it('p-min: should update property with valid values', () => {
+      let validValues = [undefined, undefined];
+      expectPropertiesValues(component, 'min', validValues, validValues);
+
+      validValues = [19.9];
+      component.decimalsLength = 2;
+      expectPropertiesValues(component, 'min', validValues, 19.9);
+    });
+
+    it('p-min: should update property with `undefined` if values are invalid.', () => {
+      component.min = <any>'one';
+      expect(component.min).toBeUndefined();
+    });
+
+    it('p-min: should call min failed', () => {
+      component.min = 4;
+
+      expect(component.validate(new FormControl('2'))).not.toBeNull();
+    });
+
+    it('p-max: should update property with valid values', () => {
+      let validValues = [undefined, undefined];
+      expectPropertiesValues(component, 'max', validValues, validValues);
+
+      validValues = [49.99];
+      component.decimalsLength = 2;
+      expectPropertiesValues(component, 'max', validValues, 49.99);
+    });
+
+    it('p-max: should update property with `undefined` if values are invalid.', () => {
+      component.max = <any>'one';
+      expect(component.max).toBeUndefined();
+    });
+
+    it('p-max: should call max failed', () => {
+      component.max = 5;
+
+      expect(component.validate(new FormControl('10'))).not.toBeNull();
     });
   });
 
@@ -311,7 +352,11 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should return null in extraValidation()', () => {
-    expect(component.extraValidation(null)).toBeNull();
+    component.errorPattern = 'Valor Inválido';
+    component.min = 0;
+    component.max = 0;
+
+    expect(component.extraValidation(new FormControl(null))).toBeNull();
   });
 
   it('should have a call getScreenValue method', () => {

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -1316,6 +1316,48 @@ describe('PoDecimalComponent:', () => {
     it('isValueBetweenAllowed: should return `false` if is value below allowed.', () => {
       expect(component['isValueBetweenAllowed'](-1, 9)).toBe(false);
     });
+
+    describe('getErrorPatternMessage: ', () => {
+      it('should return errorPattern value if errorPattern has value and containsInvalidClass returns true and show the properly message in template', () => {
+        const fakeThis = {
+          errorPattern: 'erro',
+          hasInvalidClass: () => true
+        };
+
+        expect(component.getErrorPatternMessage.call(fakeThis)).toBe('erro');
+
+        component.errorPattern = 'MENSAGEM DE ERRO';
+        component.hasInvalidClass = () => true;
+        fixture.detectChanges();
+        const content = fixture.debugElement.nativeElement
+          .querySelector('.po-field-container-bottom-text-error')
+          .innerHTML.toString();
+
+        expect(content.indexOf('MENSAGEM DE ERRO') > -1).toBeTruthy();
+      });
+
+      it('should return empty string if errorPattern is empty', () => {
+        component.errorPattern = '';
+
+        const expectedResult = component.getErrorPatternMessage();
+
+        expect(expectedResult).toBe('');
+        expect(fixture.debugElement.nativeElement.querySelector('.po-field-container-bottom-text-error')).toBeNull();
+      });
+
+      it('should return empty string if errorPattern has value but containsInvalidClass returns false', () => {
+        component.inputEl.nativeElement.value = '';
+        component.errorPattern = 'error';
+        component.inputEl.nativeElement.classList.add('ng-invalid');
+        component.inputEl.nativeElement.classList.add('ng-dirty');
+        component['invalidInputValueOnBlur'] = false;
+
+        const expectedResult = component.getErrorPatternMessage();
+
+        expect(expectedResult).toBe('');
+        expect(fixture.debugElement.nativeElement.querySelector('.po-field-container-bottom-text-error')).toBeNull();
+      });
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -343,6 +343,10 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
     }
   }
 
+  getErrorPatternMessage() {
+    return this.errorPattern !== '' && this.hasInvalidClass() ? this.errorPattern : '';
+  }
+
   // responsável por adicionar 0 antes da virgula (decimalSeparator).
   private addZeroBefore(value) {
     const isDecimalSeparator = value === this.decimalSeparator;

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -1,6 +1,9 @@
 import { AfterViewInit, Component, ElementRef, forwardRef, Input, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
+
+import { minFailed, maxFailed } from '../validators';
+
 import { convertToInt } from '../../../utils/util';
 import { PoInputBaseComponent } from '../po-input/po-input-base.component';
 
@@ -69,6 +72,8 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
   private _decimalsLength?: number = poDecimalDefaultDecimalsLength;
   private _thousandMaxlength?: number = poDecimalDefaultThousandMaxlength;
   private _locale?: string;
+  private _min?: number;
+  private _max?: number;
 
   private decimalSeparator: string;
   private fireChange: boolean = false;
@@ -174,6 +179,52 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
     this.setNumbersSeparators();
   }
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Valor mínimo.
+   */
+  @Input('p-min') set min(value: number) {
+    if (!isNaN(value)) {
+      this._min = value;
+
+      this.validateModel();
+    } else if (!value) {
+      this._min = undefined;
+
+      this.validateModel();
+    }
+  }
+
+  get min(): number {
+    return this._min;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Valor máximo.
+   */
+  @Input('p-max') set max(value: number) {
+    if (!isNaN(value)) {
+      this._max = value;
+
+      this.validateModel();
+    } else if (!value) {
+      this._max = undefined;
+
+      this.validateModel();
+    }
+  }
+
+  get max(): number {
+    return this._max;
+  }
+
   constructor(private el: ElementRef, private poLanguageService: PoLanguageService) {
     super();
     this.isKeyboardAndroid = !!navigator.userAgent.match(/Android/i);
@@ -203,7 +254,26 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
     this.controlChangeEmitter();
   }
 
-  extraValidation(c: AbstractControl): { [key: string]: any } {
+  extraValidation(abstractControl: AbstractControl): { [key: string]: any } {
+    // Verifica se já possui algum error pattern padrão.
+    this.errorPattern = this.errorPattern !== 'Valor Inválido' ? this.errorPattern : '';
+
+    if (minFailed(this.min, abstractControl.value)) {
+      return {
+        min: {
+          valid: false
+        }
+      };
+    }
+
+    if (maxFailed(this.max, abstractControl.value)) {
+      return {
+        max: {
+          valid: false
+        }
+      };
+    }
+
     return null;
   }
 

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
@@ -9,6 +9,7 @@
   [p-icon]="icon"
   [p-label]="label"
   [p-locale]="locale"
+  [p-error-pattern]="errorPattern"
   [p-no-autocomplete]="properties?.includes('noAutocomplete')"
   [p-optional]="properties.includes('optional')"
   [p-placeholder]="placeholder"
@@ -78,6 +79,11 @@
 
     <po-select class="po-md-6" name="icon" [(ngModel)]="icon" p-clean p-label="Icon" [p-options]="iconOptions">
     </po-select>
+  </div>
+
+  <div class="po-row">
+    <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern">
+    </po-input>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
@@ -10,6 +10,8 @@
   [p-label]="label"
   [p-locale]="locale"
   [p-error-pattern]="errorPattern"
+  [p-max]="max"
+  [p-min]="min"
   [p-no-autocomplete]="properties?.includes('noAutocomplete')"
   [p-optional]="properties.includes('optional')"
   [p-placeholder]="placeholder"
@@ -82,6 +84,10 @@
   </div>
 
   <div class="po-row">
+    <po-number class="po-md-6 po-lg-3" name="min" [(ngModel)]="min" p-clean p-label="Min"> </po-number>
+
+    <po-number class="po-md-6 po-lg-3" name="max" [(ngModel)]="max" p-clean p-label="Max"> </po-number>
+
     <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern">
     </po-input>
   </div>

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
@@ -17,6 +17,7 @@ export class SamplePoDecimalLabsComponent implements OnInit {
   placeholder: string;
   properties: Array<string>;
   thousandMaxlength: number;
+  errorPattern: string;
 
   public readonly localeOptions: Array<PoSelectOption> = [
     { value: 'pt', label: 'Portuguese' },
@@ -66,6 +67,7 @@ export class SamplePoDecimalLabsComponent implements OnInit {
     this.locale = undefined;
     this.placeholder = '';
     this.thousandMaxlength = undefined;
+    this.errorPattern = undefined;
 
     this.properties = [];
   }

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
@@ -18,6 +18,8 @@ export class SamplePoDecimalLabsComponent implements OnInit {
   properties: Array<string>;
   thousandMaxlength: number;
   errorPattern: string;
+  max: number;
+  min: number;
 
   public readonly localeOptions: Array<PoSelectOption> = [
     { value: 'pt', label: 'Portuguese' },
@@ -68,6 +70,8 @@ export class SamplePoDecimalLabsComponent implements OnInit {
     this.placeholder = '';
     this.thousandMaxlength = undefined;
     this.errorPattern = undefined;
+    this.max = undefined;
+    this.min = undefined;
 
     this.properties = [];
   }


### PR DESCRIPTION
**PO-DECIMAL**

**#325** 
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
As mensagens de erros não são exibidas

**Qual o novo comportamento?**
As mensagens de erros são exibidas abaixo do input, seguindo o padrões dos demais componentes com essa característica

**Simulação**
Utilizar o componente po-decimal com validação de um valor mínimo para a propriedade p-min ou um valor máximo através da propriedade p-max, inserir uma mensagem de erro para a propriedade p-error-pattern, ao inserir um valor inválido com a validação a mensagem de erro com o texto inserido será exibida.