### PR TITLE
popover/TIS3

### DIFF
--- a/projects/ui/src/lib/components/po-popover/po-popover-base.component.ts
+++ b/projects/ui/src/lib/components/po-popover/po-popover-base.component.ts
@@ -99,7 +99,7 @@ export class PoPopoverBaseComponent {
    * </po-button>
    *
    * <po-popover
-   *   [p-origin]="poButton"
+   *   [p-target]="poButton"
    *   [p-title]="PO Popover">
    * </po-popover>
    * ```
@@ -110,8 +110,26 @@ export class PoPopoverBaseComponent {
    * ```
    * @ViewChild(PoButtonComponent, {read: ElementRef}) poButton: PoButtonComponent;
    * ```
+   *
+   * Pode-se tambem informar diretamente o HTMLElement, para não ter que utilizar o ViewChild.
+   * Para utilizar o po-popover deve-se colocar uma variável no componente que vai disparar o evento
+   * de abertura, exemplo:
+   *
+   * ```
+   * <button #target>
+   *   Abrir popover
+   * </button>
+   *
+   * <po-popover
+   *     [p-target]="target"
+   *     p-trigger="click" >
+   * </po-popover>
+   * ```
+   *
+   *
+   *
    */
-  @Input('p-target') target: ElementRef;
+  @Input('p-target') target: ElementRef | HTMLElement;
 
   /** Título do popover. */
   @Input('p-title') title?: string;

--- a/projects/ui/src/lib/components/po-popover/po-popover.component.spec.ts
+++ b/projects/ui/src/lib/components/po-popover/po-popover.component.spec.ts
@@ -27,6 +27,7 @@ describe('PoPopoverComponent:', () => {
     nativeElement = fixture.debugElement.nativeElement;
 
     component.target = component.popoverElement;
+    component.targetElement = component.popoverElement.nativeElement;
   });
 
   it('should be created', () => {
@@ -39,6 +40,11 @@ describe('PoPopoverComponent:', () => {
     component.ngAfterViewInit();
     expect(component['poControlPosition'].setElements).toHaveBeenCalled();
     expect(component.setRendererListenInit).toHaveBeenCalled();
+  });
+
+  it('should set targetElement in ngAfterViewInit', () => {
+    component.ngAfterViewInit();
+    expect(component.targetElement).toBeTruthy();
   });
 
   it('should call setPopoverPosition in debounceResize', fakeAsync(() => {
@@ -71,6 +77,7 @@ describe('PoPopoverComponent:', () => {
   describe('setRendererListenInit:', () => {
     it(`should listen for 'mouseenter' `, () => {
       const fakeEvent = getFakeToSetRendererListenInit('hover', component);
+      component.targetElement = component.popoverElement.nativeElement;
 
       spyOn(fakeEvent, 'open');
 
@@ -127,6 +134,7 @@ describe('PoPopoverComponent:', () => {
   it('should open popover in togglePopup when click on target', () => {
     component.popoverElement.nativeElement.hidden = true;
     component.target = component.popoverElement;
+    component.targetElement = component.popoverElement.nativeElement;
 
     spyOn(component, 'open');
 
@@ -143,6 +151,7 @@ describe('PoPopoverComponent:', () => {
   it('should close popover in togglePopup when click on target', () => {
     component.popoverElement.nativeElement.hidden = false;
     component.target = component.popoverElement;
+    component.targetElement = component.popoverElement.nativeElement;
 
     spyOn(component, 'close');
 
@@ -162,6 +171,7 @@ describe('PoPopoverComponent:', () => {
       target: {
         nativeElement: document.head
       },
+      targetElement: document.head,
       close: () => {},
       open: () => {}
     };
@@ -294,6 +304,10 @@ describe('PoPopoverComponent:', () => {
           nativeElement: {
             contains: () => {}
           }
+        },
+        targetElement: {
+          contains: () => undefined,
+          hidden: false
         }
       };
 
@@ -321,6 +335,10 @@ describe('PoPopoverComponent:', () => {
           nativeElement: {
             contains: () => undefined
           }
+        },
+        targetElement: {
+          contains: () => undefined,
+          hidden: false
         },
         close: () => {},
         open: () => {}
@@ -379,6 +397,7 @@ function getFakeToSetRendererListenInit(trigger, component) {
     target: {
       nativeElement: document.body
     },
+    targetElement: document.body,
     open: () => {},
     close: () => {},
     togglePopup: () => {},

--- a/projects/ui/src/lib/components/po-popover/po-popover.component.ts
+++ b/projects/ui/src/lib/components/po-popover/po-popover.component.ts
@@ -41,7 +41,7 @@ import { PoPopoverBaseComponent } from './po-popover-base.component';
 export class PoPopoverComponent extends PoPopoverBaseComponent implements AfterViewInit, OnDestroy {
   arrowDirection = 'left';
   timeoutResize;
-
+  targetElement;
   eventListenerFunction: () => void;
 
   @ViewChild('popoverElement', { read: ElementRef, static: true }) popoverElement: ElementRef;
@@ -51,6 +51,7 @@ export class PoPopoverComponent extends PoPopoverBaseComponent implements AfterV
   }
 
   ngAfterViewInit(): void {
+    this.targetElement = this.target instanceof ElementRef ? this.target.nativeElement : this.target;
     this.initEventListenerFunction();
 
     this.setElementsControlPosition();
@@ -104,11 +105,11 @@ export class PoPopoverComponent extends PoPopoverBaseComponent implements AfterV
     });
 
     if (this.trigger === 'hover') {
-      this.mouseEnterListener = this.renderer.listen(this.target.nativeElement, 'mouseenter', (event: MouseEvent) => {
+      this.mouseEnterListener = this.renderer.listen(this.targetElement, 'mouseenter', (event: MouseEvent) => {
         this.open();
       });
 
-      this.mouseLeaveListener = this.renderer.listen(this.target.nativeElement, 'mouseleave', (event: MouseEvent) => {
+      this.mouseLeaveListener = this.renderer.listen(this.targetElement, 'mouseleave', (event: MouseEvent) => {
         this.close();
       });
     } else {
@@ -122,10 +123,10 @@ export class PoPopoverComponent extends PoPopoverBaseComponent implements AfterV
     if (
       !this.isHidden &&
       !this.popoverElement.nativeElement.contains(event.target) &&
-      !this.target.nativeElement.contains(event.target)
+      !this.targetElement.contains(event.target)
     ) {
       this.close();
-    } else if (this.target.nativeElement.contains(event.target)) {
+    } else if (this.targetElement.contains(event.target)) {
       this.popoverElement.nativeElement.hidden ? this.open() : this.close();
     }
   }


### PR DESCRIPTION
**popover**

**TIS-3**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente para utilizar o po-popover com elemento HTML, temos que fazer ViewChield e capturar o ElementRef

**Qual o novo comportamento?**
Permite HTMLElement como target

**Simulação**
<button #target>Abrir popover</button>

<po-popover
    [p-target]="target"
    p-trigger="click" >
</po-popover>