### PR TITLE
feat(dynamic-form):  adiciona propriedades as decimals-length, thousand-maxlength e icon

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -61,6 +61,29 @@ export interface PoDynamicFormField extends PoDynamicField {
   /** Máscara para o campo. */
   mask?: string;
 
+  /** Define o ícone que será exibido no início do campo.
+   * > Esta propriedade o pode ser utilizado nos campos:
+   * - Input;
+   * - Number;
+   * - Decimal;
+   * - Combo;
+   *
+   * > Veja a disponibilidade de ícones em [biblioteca de ícones](guides/icons).
+   */
+  icon?: string;
+
+  /**  Quantidade máxima de casas decimais.
+   *
+   * > Esta propriedade só pode ser utilizada quando o `type` for *currency*.
+   */
+  decimalsLength?: number;
+
+  /** Quantidade máxima de dígitos antes do separador decimal. O valor máximo permitido é 13
+   *
+   * > Esta propriedade só pode ser utilizada quando o `type` for *currency*.
+   */
+  thousandMaxlength?: number;
+
   /** Regex para validação do campo. */
   pattern?: string;
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -330,7 +330,17 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         expect(component['isNumberType']).toHaveBeenCalled();
       });
 
-      it('should return `input` if type is `number` and have a pattern', () => {
+      it('should return `input` if type is `number` and have a mask', () => {
+        const expectedValue = 'input';
+        const field = { type: 'number', property: 'code', mask: '99:99:99' };
+
+        spyOn(component, <any>'isNumberType').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isNumberType']).toHaveBeenCalled();
+      });
+
+      it('should `input` if type is `number` or `currency` or `combo` can use icon', () => {
         const expectedValue = 'input';
         const field = { type: 'number', property: 'code', pattern: '99:99:99' };
 
@@ -338,6 +348,16 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
 
         expect(component['getComponentControl'](field)).toBe(expectedValue);
         expect(component['isNumberType']).toHaveBeenCalled();
+      });
+
+      it('should return `decimal` if type is `decimal` and `isCurrencyType` can use decimalsLength', () => {
+        const expectedValue = 'decimal';
+        const field = { type: 'decimal', property: 'code' };
+
+        spyOn(component, <any>'isCurrencyType').and.returnValue(true);
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isCurrencyType']).toHaveBeenCalled();
       });
 
       it('should return `decimal` if type is `decimal` and `isCurrencyType` is `true`', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -42,6 +42,7 @@
       [p-pattern]="field.pattern"
       [p-required]="field.required"
       (p-change)="onChangeField(field)"
+      [p-icon]="field.icon"
     >
     </po-input>
 
@@ -64,6 +65,7 @@
       [p-optional]="field.optional"
       [p-required]="field.required"
       (p-change)="onChangeField(field)"
+      [p-icon]="field.icon"
     >
     </po-number>
 
@@ -75,6 +77,9 @@
       [ngClass]="field.componentClass"
       p-clean
       [p-disabled]="isDisabled(field)"
+      [p-decimals-length]="field.decimalsLength"
+      [p-thousand-maxlength]="field.thousandMaxlength"
+      [p-icon]="field.icon"
       [p-auto-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
@@ -153,6 +158,7 @@
       [p-optional]="field.optional"
       [p-required]="field.required"
       (p-change)="onChangeField(field, $event)"
+      [p-icon]="field.icon"
     >
     </po-combo>
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -51,7 +51,7 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       pattern: '[a-zA]{5}[Z0-9]{3}',
       errorMessage: 'At least 5 alphabetic and 3 numeric characters are required.'
     },
-    { property: 'email', divider: 'CONTACTS', gridColumns: 6 },
+    { property: 'email', divider: 'CONTACTS', gridColumns: 6, icon: 'po-icon-mail' },
     { property: 'phone', mask: '(99) 99999-9999', gridColumns: 6 },
     { property: 'address', gridColumns: 6 },
     {
@@ -75,7 +75,14 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
     { property: 'city', disabled: true, gridColumns: 6 },
     { property: 'entryTime', label: 'Entry time', type: 'time', divider: 'Work data', gridColumns: 6 },
     { property: 'exitTime', label: 'Exit time', type: 'time', gridColumns: 6 },
-    { property: 'wage', type: 'currency', gridColumns: 6 },
+    {
+      property: 'wage',
+      type: 'currency',
+      gridColumns: 6,
+      decimalsLength: 2,
+      thousandMaxlength: 7,
+      icon: 'po-icon-finance'
+    },
     {
       property: 'hobbies',
       divider: 'MORE INFO',


### PR DESCRIPTION
**dynamic-form**

**TIS-4**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente não possui as propriedades currency, decimals-length, thousand-maxlength e icon

**Qual o novo comportamento?**
Adiciona propriedades as currency, decimals-length, thousand-maxlength e icon

**Simulação**
<po-dynamic-form [p-fields]="fields"></po-dynamic-form>

...

fields: Array<PoDynamicFormField> = [
  ...
  {
    property: 'wage',
    label: 'Salario',
    currency: true,
    decimalsLength: 3,
    thousandMaxlength: 7,
    icon: 'po-icon-finance'
  },
  ...
];