### PR TITLE
field-container: traduz literais para os idiomas suportados

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-literals.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-literals.ts
@@ -1,0 +1,14 @@
+export const poFieldContainerLiterals = {
+  en: {
+    optional: '(Optional)'
+  },
+  es: {
+    optional: '(Opcional)'
+  },
+  pt: {
+    optional: '(Opcional)'
+  },
+  ru: {
+    optional: '(Пожеланию)'
+  }
+};

--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.html
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.html
@@ -1,7 +1,7 @@
 <div class="po-field-container">
   <div class="po-field-container-title">
     <span class="po-field-title">{{ label }}</span>
-    <span class="po-field-optional" *ngIf="optional && (label || help)">{{ getOptionalText() }}</span>
+    <span class="po-field-optional" *ngIf="optional && (label || help)">{{ literals.optional }}</span>
   </div>
 
   <div class="po-field-help" *ngIf="help">{{ help }}</div>

--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.spec.ts
@@ -1,12 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import {
-  configureTestSuite,
-  expectBrowserLanguageMethod,
-  expectPropertiesValues
-} from './../../../util-test/util-expect.spec';
+import { configureTestSuite, expectPropertiesValues } from './../../../util-test/util-expect.spec';
 
 import { PoFieldContainerComponent } from './po-field-container.component';
+import { poFieldContainerLiterals } from './po-field-container-literals';
 
 describe('PoFieldContainerComponent:', () => {
   let component: PoFieldContainerComponent;
@@ -21,29 +18,11 @@ describe('PoFieldContainerComponent:', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PoFieldContainerComponent);
     component = fixture.componentInstance;
+    component.literals = poFieldContainerLiterals['en'];
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should get pt optional literal', () => {
-    expectBrowserLanguageMethod('pt', component, 'getOptionalText', '(Opcional)');
-  });
-
-  it('should get es optional literal', () => {
-    expectBrowserLanguageMethod('es', component, 'getOptionalText', '(Opcional)');
-  });
-
-  it('should get en optional literal', () => {
-    expectBrowserLanguageMethod('en', component, 'getOptionalText', '(Optional)');
-  });
-
-  it('should get not existent optional literal', () => {
-    expectBrowserLanguageMethod('al', component, 'getOptionalText', '(Opcional)');
-  });
-  it('should get default optional literal', () => {
-    expectBrowserLanguageMethod('', component, 'getOptionalText', '(Opcional)');
   });
 
   describe('Properties: ', () => {
@@ -127,6 +106,18 @@ describe('PoFieldContainerComponent:', () => {
       fixture.detectChanges();
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-field-optional')).toBeNull();
+    });
+
+    it('should show optional and verify literal.optional', () => {
+      component.optional = true;
+      component.label = 'label';
+
+      fixture.detectChanges();
+
+      const fieldOptionalHtml = fixture.debugElement.nativeElement.querySelector('.po-field-optional');
+
+      expect(fieldOptionalHtml).toBeTruthy();
+      expect(fieldOptionalHtml.innerHTML).toBe(component.literals.optional);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
-import { convertToBoolean, getShortBrowserLanguage } from '../../../utils/util';
+import { convertToBoolean } from '../../../utils/util';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poFieldContainerLiterals } from './po-field-container-literals';
 
 /**
  * @docsPrivate
@@ -13,6 +15,8 @@ import { convertToBoolean, getShortBrowserLanguage } from '../../../utils/util';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PoFieldContainerComponent {
+  literals;
+
   private _optional: boolean = false;
 
   /** Label do campo. */
@@ -30,15 +34,11 @@ export class PoFieldContainerComponent {
     return this._optional;
   }
 
-  getOptionalText() {
-    const browserLanguage = getShortBrowserLanguage();
+  constructor(languageService: PoLanguageService) {
+    const language = languageService.getShortLanguage();
 
-    const optional = {
-      pt: '(Opcional)',
-      en: '(Optional)',
-      es: '(Opcional)'
+    this.literals = {
+      ...poFieldContainerLiterals[language]
     };
-
-    return optional[browserLanguage];
   }
 }


### PR DESCRIPTION
**po-field-container**

**MDO-39**
_____________________________________________________________________________

**PR Checklist**

- [ X ] Código
- [ X ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A literal "Opcional" utilizado no po-field-container não traduz para os idiomas suportados.

**Qual o novo comportamento?**
A literal "Opcional" deverá utilizar no po-field-container as literais para os idiomas suportados.

**Simulação**
