### PR TITLE
feat(chart): adiciona propriedades label e data e deprecia value e description

### DIFF
--- a/projects/ui/src/lib/components/po-chart/po-chart-legend/po-chart-legend.component.html
+++ b/projects/ui/src/lib/components/po-chart/po-chart-legend/po-chart-legend.component.html
@@ -2,7 +2,7 @@
   <div class="po-chart-legend-container">
     <div class="po-chart-legend-item" *ngFor="let serie of series; let i = index">
       <div class="po-chart-legend-square" [style.background]="colors[i]"></div>
-      <span class="po-chart-legend-text">{{ serie.category || serie.label }}</span>
+      <span class="po-chart-legend-text">{{ serie.label || serie.category }}</span>
     </div>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-chart/po-chart-legend/po-chart-legend.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-legend/po-chart-legend.component.spec.ts
@@ -39,6 +39,24 @@ describe('PoChartLegendComponent:', () => {
   describe('Templates:', () => {
     it('should apply valid text and color values', () => {
       component.series = <any>[
+        { data: 10, label: '1' },
+        { data: 20, label: '2' }
+      ];
+      component.colors = ['red', 'green'];
+
+      fixture.detectChanges();
+
+      const legendSquare = fixture.debugElement.nativeElement.querySelectorAll('.po-chart-legend-square');
+      const legendText = fixture.debugElement.nativeElement.querySelectorAll('.po-chart-legend-text');
+
+      expect(legendSquare[0].getAttribute('style')).toBe('background: red;');
+      expect(legendText[0].textContent.trim()).toBe(component.series[0].label);
+      expect(legendSquare[1].getAttribute('style')).toBe('background: green;');
+      expect(legendText[1].textContent.trim()).toBe(component.series[1].label);
+    });
+
+    it('should apply valid text and color values when the series have value and category', () => {
+      component.series = <any>[
         { value: 10, category: '1' },
         { value: 20, category: '2' }
       ];
@@ -51,6 +69,24 @@ describe('PoChartLegendComponent:', () => {
 
       expect(legendSquare[0].getAttribute('style')).toBe('background: red;');
       expect(legendText[0].textContent.trim()).toBe(component.series[0].category);
+      expect(legendSquare[1].getAttribute('style')).toBe('background: green;');
+      expect(legendText[1].textContent.trim()).toBe(component.series[1].category);
+    });
+
+    it('should apply valid text and color values when the series have value, category, label and data', () => {
+      component.series = <any>[
+        { value: 10, label: '1' },
+        { data: 20, category: '2' }
+      ];
+      component.colors = ['red', 'green'];
+
+      fixture.detectChanges();
+
+      const legendSquare = fixture.debugElement.nativeElement.querySelectorAll('.po-chart-legend-square');
+      const legendText = fixture.debugElement.nativeElement.querySelectorAll('.po-chart-legend-text');
+
+      expect(legendSquare[0].getAttribute('style')).toBe('background: red;');
+      expect(legendText[0].textContent.trim()).toBe(component.series[0].label);
       expect(legendSquare[1].getAttribute('style')).toBe('background: green;');
       expect(legendText[1].textContent.trim()).toBe(component.series[1].category);
     });

--- a/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-circular/po-chart-circular-series.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-circular/po-chart-circular-series.interface.ts
@@ -1,9 +1,39 @@
 export interface PoCircularChartSeries {
-  /** Define o valor da categoria do objeto. */
-  category: string;
+  /**
+   * @deprecated 6.x.x
+   *
+   * @optional
+   *
+   * @description
+   *
+   * **Deprecated 6.x.x**.
+   *
+   * Define o valor da categoria do objeto.
+   *
+   * > Para definir o valor da categoria do objeto utilize a nova propriedade `label`.
+   */
+  category?: string;
 
-  /** Define o valor do objeto. */
-  value: number;
+  /**
+   * @deprecated 6.x.x
+   *
+   * @optional
+   *
+   * @description
+   *
+   * **Deprecated 6.x.x**.
+   *
+   * Define o valor do objeto.
+   *
+   * > Para definir o valor do objeto utilize a nova propriedade `data`.
+   */
+  value?: number;
+
+  /** Define o texto da série. */
+  label?: string;
+
+  /** Define o valor da série. */
+  data?: number;
 
   color?: string;
 }

--- a/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-circular/po-chart-circular.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-circular/po-chart-circular.spec.ts
@@ -97,10 +97,47 @@ describe('PoChartCircular:', () => {
 
       component.colors = PoChartColors[3];
       component['series'] = [
+        { label: '1', data: 1 },
+        { label: '2', data: 2 },
+        { label: '3', data: 3 },
+        { label: '4', data: 4 }
+      ];
+
+      component['calculateAngleRadians']();
+
+      expect(component['chartItemsEndAngleList']).toEqual(itemsEndAngle);
+    });
+
+    it('calculateAngleRadians: should set `chartItemsEndAngleList` with items end angle even if serie.category and serie.value', () => {
+      const itemsEndAngle = [0.1, 0.2, 0.3, 0.4];
+
+      spyOn(component, <any>'calculateEndAngle').and.returnValues(...itemsEndAngle);
+
+      component.colors = PoChartColors[3];
+      component['series'] = [
         { category: '1', value: 1 },
         { category: '2', value: 2 },
         { category: '3', value: 3 },
         { category: '4', value: 4 }
+      ];
+
+      component['calculateAngleRadians']();
+
+      expect(component['chartItemsEndAngleList']).toEqual(itemsEndAngle);
+    });
+
+    it(`calculateAngleRadians: should set 'chartItemsEndAngleList' with items end angle even if serie.data, serie.value,
+    serie.category and serie.label are mixed`, () => {
+      const itemsEndAngle = [0.1, 0.2, 0.3, 0.4];
+
+      spyOn(component, <any>'calculateEndAngle').and.returnValues(...itemsEndAngle);
+
+      component.colors = PoChartColors[3];
+      component['series'] = [
+        { label: '1', data: 1 },
+        { category: '2', data: 2 },
+        { category: '3', value: 3 },
+        { label: '4', value: 4 }
       ];
 
       component['calculateAngleRadians']();
@@ -402,7 +439,7 @@ describe('PoChartCircular:', () => {
       component.type = PoChartType.Pie;
       component.chartElementCategory = 'category';
       component.chartElementValue = 10;
-      const expectedParameterValue = { category: component.chartElementCategory, value: component.chartElementValue };
+      const expectedParameterValue = { label: component.chartElementCategory, data: component.chartElementValue };
 
       spyOn(component['onSerieClick'], 'next');
 
@@ -416,7 +453,7 @@ describe('PoChartCircular:', () => {
       component.type = PoChartType.Donut;
       component.chartElementCategory = 'category';
       component.chartElementValue = 10;
-      const expectedParameterValue = { category: component.chartElementCategory, value: component.chartElementValue };
+      const expectedParameterValue = { label: component.chartElementCategory, data: component.chartElementValue };
 
       spyOn(component['onSerieClick'], 'next');
 
@@ -753,6 +790,26 @@ describe('PoChartCircular:', () => {
     });
 
     it('setElementAttributes: should call renderer.setAttribute 3 times and with `data-tooltip-text`', () => {
+      const serie: PoPieChartSeries = { label: 'po', data: 2 };
+      const svgPath = '<text></text>';
+      component.type = PoChartType.Pie;
+
+      spyOn(component['renderer'], 'setAttribute');
+      spyOn(component['renderer'], 'createElement').and.returnValue(svgPath);
+      spyOn(component, <any>'getTooltipValue').and.callThrough();
+
+      component['setElementAttributes'](svgPath, serie);
+
+      expect(component['getTooltipValue']).toHaveBeenCalledWith(serie.data);
+      expect(component['renderer'].setAttribute).toHaveBeenCalledTimes(3);
+      expect(component['renderer'].setAttribute).toHaveBeenCalledWith(
+        svgPath,
+        'data-tooltip-text',
+        `${serie.label}: ${serie.data}`
+      );
+    });
+
+    it('setElementAttributes: should call renderer.setAttribute 3 times and with `data-tooltip-text` even if serie.category and serie.value', () => {
       const serie: PoPieChartSeries = { category: 'po', value: 2 };
       const svgPath = '<text></text>';
       component.type = PoChartType.Pie;
@@ -765,11 +822,39 @@ describe('PoChartCircular:', () => {
 
       expect(component['getTooltipValue']).toHaveBeenCalledWith(serie.value);
       expect(component['renderer'].setAttribute).toHaveBeenCalledTimes(3);
-      expect(component['renderer'].setAttribute).toHaveBeenCalledWith(
-        svgPath,
-        'data-tooltip-text',
-        `${serie.category}: ${serie.value}`
-      );
+      expect(component['renderer'].setAttribute).toHaveBeenCalledWith(svgPath, 'data-tooltip-text', 'po: 2');
+    });
+
+    it('setElementAttributes: should call renderer.setAttribute 3 times and with `data-tooltip-text` even if serie.category and serie.data', () => {
+      const serie: PoPieChartSeries = { category: 'po', data: 2 };
+      const svgPath = '<text></text>';
+      component.type = PoChartType.Pie;
+
+      spyOn(component['renderer'], 'setAttribute');
+      spyOn(component['renderer'], 'createElement').and.returnValue(svgPath);
+      spyOn(component, <any>'getTooltipValue').and.callThrough();
+
+      component['setElementAttributes'](svgPath, serie);
+
+      expect(component['getTooltipValue']).toHaveBeenCalledWith(serie.data);
+      expect(component['renderer'].setAttribute).toHaveBeenCalledTimes(3);
+      expect(component['renderer'].setAttribute).toHaveBeenCalledWith(svgPath, 'data-tooltip-text', 'po: 2');
+    });
+
+    it('setElementAttributes: should call renderer.setAttribute 3 times and with `data-tooltip-text` even if serie.label and serie.value', () => {
+      const serie: PoPieChartSeries = { label: 'po', value: 2 };
+      const svgPath = '<text></text>';
+      component.type = PoChartType.Pie;
+
+      spyOn(component['renderer'], 'setAttribute');
+      spyOn(component['renderer'], 'createElement').and.returnValue(svgPath);
+      spyOn(component, <any>'getTooltipValue').and.callThrough();
+
+      component['setElementAttributes'](svgPath, serie);
+
+      expect(component['getTooltipValue']).toHaveBeenCalledWith(serie.value);
+      expect(component['renderer'].setAttribute).toHaveBeenCalledTimes(3);
+      expect(component['renderer'].setAttribute).toHaveBeenCalledWith(svgPath, 'data-tooltip-text', `po: 2`);
     });
 
     it('setElementAttributes: shouldn`t call `getTooltipValue` and call `setAttribute` passing `description` as param`', () => {
@@ -886,7 +971,63 @@ describe('PoChartCircular:', () => {
     });
 
     it('createText: should create a svg text element with some attributes and add it into `svgTextElementsList`', () => {
+      const serie: PoDonutChartSeries = { label: 'po', data: 2 };
+
+      component.colors = PoChartColors[0];
+
+      spyOn(component, <any>'getFontSize');
+      spyOn(component, <any>'getTextColor');
+      spyOn(component, <any>'getPercentValue');
+      spyOn(component, <any>'setElementAttributes');
+
+      spyOn(component['renderer'], 'createElement').and.callThrough();
+      spyOn(component['renderer'], 'setAttribute');
+      spyOn(component['renderer'], 'appendChild');
+
+      component['createText'](serie);
+
+      expect(component['getFontSize']).toHaveBeenCalled();
+      expect(component['getTextColor']).toHaveBeenCalled();
+      expect(component['getPercentValue']).toHaveBeenCalled();
+      expect(component['setElementAttributes']).toHaveBeenCalled();
+
+      expect(component['renderer'].createElement).toHaveBeenCalledTimes(2);
+      expect(component['renderer'].setAttribute).toHaveBeenCalledTimes(4);
+      expect(component['renderer'].appendChild).toHaveBeenCalledTimes(2);
+
+      expect(component['svgTextElementsList'].length).toEqual(1);
+    });
+
+    it('createText: should create a svg text element with some attributes and add it into `svgTextElementsList` even serie.label and serie.value', () => {
       const serie: PoDonutChartSeries = { category: 'po', value: 2 };
+
+      component.colors = PoChartColors[0];
+
+      spyOn(component, <any>'getFontSize');
+      spyOn(component, <any>'getTextColor');
+      spyOn(component, <any>'getPercentValue');
+      spyOn(component, <any>'setElementAttributes');
+
+      spyOn(component['renderer'], 'createElement').and.callThrough();
+      spyOn(component['renderer'], 'setAttribute');
+      spyOn(component['renderer'], 'appendChild');
+
+      component['createText'](serie);
+
+      expect(component['getFontSize']).toHaveBeenCalled();
+      expect(component['getTextColor']).toHaveBeenCalled();
+      expect(component['getPercentValue']).toHaveBeenCalled();
+      expect(component['setElementAttributes']).toHaveBeenCalled();
+
+      expect(component['renderer'].createElement).toHaveBeenCalledTimes(2);
+      expect(component['renderer'].setAttribute).toHaveBeenCalledTimes(4);
+      expect(component['renderer'].appendChild).toHaveBeenCalledTimes(2);
+
+      expect(component['svgTextElementsList'].length).toEqual(1);
+    });
+
+    it(`createText: should create a svg text element with some attributes and add it into 'svgTextElementsList' even serie.label, serie.value, serie.data and serie.category are mixed`, () => {
+      const serie: PoDonutChartSeries = { category: 'po', data: 2 };
 
       component.colors = PoChartColors[0];
 
@@ -1015,10 +1156,10 @@ describe('PoChartCircular:', () => {
     });
 
     it('getSeriesWithValue: should return only series with value and color attr', () => {
-      const invalidSeries = [{ category: 'Valor 0', value: 0 }];
+      const invalidSeries = [{ label: 'Valor 0', data: 0 }];
       const series = [
-        { category: 'Valor 2', value: 2 },
-        { category: 'Valor 3', value: 3 }
+        { label: 'Valor 2', data: 2 },
+        { label: 'Valor 3', data: 3 }
       ];
       const seriesParam = [...series, ...invalidSeries];
 
@@ -1031,7 +1172,7 @@ describe('PoChartCircular:', () => {
     });
 
     it('getSeriesWithValue: should return empty array if series has value 0', () => {
-      const invalidSeries = [{ category: 'Valor 0', value: 0 }];
+      const invalidSeries = [{ label: 'Valor 0', data: 0 }];
 
       const validSeries = component['getSeriesWithValue'](invalidSeries);
 
@@ -1039,11 +1180,41 @@ describe('PoChartCircular:', () => {
     });
 
     it('getSeriesWithValue: should return empty array if series has value -1', () => {
-      const invalidSeries = [{ category: 'Valor -1', value: -1 }];
+      const invalidSeries = [{ label: 'Valor -1', data: -1 }];
 
       const validSeries = component['getSeriesWithValue'](invalidSeries);
 
       expect(validSeries).toEqual([]);
+    });
+
+    it('getSeriesWithValue: should return only series with value and color attr even with serie.value', () => {
+      const invalidSeries = [{ category: 'Valor 0', value: 0 }];
+      const series = [
+        { category: 'Valor 2', value: 2 },
+        { category: 'Valor 3', value: 3 }
+      ];
+      const seriesParam = [...series, ...invalidSeries];
+
+      component.colors = PoChartColors[seriesParam.length];
+
+      const validSeries = component['getSeriesWithValue'](seriesParam);
+
+      expect(validSeries.length).toEqual(series.length);
+    });
+
+    it('getSeriesWithValue: should return only series with value and color attr even with serie.value and serie.data', () => {
+      const invalidSeries = [{ category: 'Valor 0', value: 0 }];
+      const series = [
+        { category: 'Valor 2', value: 2 },
+        { label: 'Valor 3', data: 3 }
+      ];
+      const seriesParam = [...series, ...invalidSeries];
+
+      component.colors = PoChartColors[seriesParam.length];
+
+      const validSeries = component['getSeriesWithValue'](seriesParam);
+
+      expect(validSeries.length).toEqual(series.length);
     });
 
     it('appendGaugeBackgroundPathElement: should create a svg path and append it into `svgPathsWrapper`', () => {

--- a/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-circular/po-chart-circular.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-circular/po-chart-circular.ts
@@ -142,8 +142,9 @@ export class PoChartCircular extends PoChartDynamicTypeComponent implements OnDe
   protected getSeriesWithValue(series: Array<PoCircularChartSeries | PoChartGaugeSerie>) {
     const newSeries = [];
 
-    series.forEach((serie, index) => {
-      if (serie.value > 0) {
+    series.forEach((serie: any, index) => {
+      const value = serie.data ?? serie.value;
+      if (value > 0) {
         newSeries.push({ ...serie, color: this.colors[index] });
       }
     });
@@ -165,9 +166,10 @@ export class PoChartCircular extends PoChartDynamicTypeComponent implements OnDe
   }
 
   private calculateAngleRadians() {
-    this.series.forEach(
-      (serie, index) => (this.chartItemsEndAngleList[index] = this.calculateEndAngle(serie.value, this.totalValue))
-    );
+    this.series.forEach((serie, index) => {
+      const data = serie.data ?? serie.value;
+      this.chartItemsEndAngleList[index] = this.calculateEndAngle(data, this.totalValue);
+    });
   }
 
   private calculateCurrentEndAngle(angleCurrentPosition: number) {
@@ -247,7 +249,7 @@ export class PoChartCircular extends PoChartDynamicTypeComponent implements OnDe
   }
 
   private createText(serie: PoCircularChartSeries | PoChartGaugeSerie) {
-    const { value } = serie;
+    const data = (<any>serie).data ?? (<any>serie).value;
 
     const svgG = this.renderer.createElement('svg:g', 'svg');
     const svgText = this.renderer.createElement('svg:text', 'svg');
@@ -255,7 +257,7 @@ export class PoChartCircular extends PoChartDynamicTypeComponent implements OnDe
     const fontSize = this.getFontSize();
     const textColor = this.getTextColor(serie.color);
 
-    svgText.textContent = this.getPercentValue(value, this.totalValue) + '%';
+    svgText.textContent = this.getPercentValue(data, this.totalValue) + '%';
 
     this.renderer.setAttribute(svgText, 'class', 'po-path-item');
     this.renderer.setAttribute(svgText, 'fill', textColor);
@@ -383,7 +385,7 @@ export class PoChartCircular extends PoChartDynamicTypeComponent implements OnDe
       const { color, ...serie } = this.series[0];
       serieOnClick = serie;
     } else {
-      serieOnClick = { category: this.chartElementCategory, value: this.chartElementValue };
+      serieOnClick = { label: this.chartElementCategory, data: this.chartElementValue };
     }
 
     this.onSerieClick.next(serieOnClick);
@@ -400,7 +402,7 @@ export class PoChartCircular extends PoChartDynamicTypeComponent implements OnDe
       this.showTooltip();
       this.changeTooltipPosition(event);
 
-      serieOnEnter = { category: this.chartElementCategory, value: this.chartElementValue };
+      serieOnEnter = { label: this.chartElementCategory, data: this.chartElementValue };
     } else {
       const { color, ...serie } = this.series[0];
 
@@ -503,17 +505,19 @@ export class PoChartCircular extends PoChartDynamicTypeComponent implements OnDe
   }
 
   private setElementAttributes(svgElement, serie) {
-    const { value, category, tooltip, description } = serie;
+    const { tooltip } = serie;
+    const data = serie.data ?? serie.value;
+    const label = serie.label ?? (serie.description || serie.category);
 
-    this.renderer.setAttribute(svgElement, 'data-tooltip-value', `${value}`);
+    this.renderer.setAttribute(svgElement, 'data-tooltip-value', `${data}`);
 
     if (this.isChartGaugeType) {
-      this.renderer.setAttribute(svgElement, 'data-tooltip-description', description);
+      this.renderer.setAttribute(svgElement, 'data-tooltip-description', label);
     } else {
-      const tooltipValue = this.getTooltipValue(value);
+      const tooltipValue = this.getTooltipValue(data);
 
-      this.renderer.setAttribute(svgElement, 'data-tooltip-category', category);
-      this.renderer.setAttribute(svgElement, 'data-tooltip-text', tooltip || `${category}: ${tooltipValue}`);
+      this.renderer.setAttribute(svgElement, 'data-tooltip-category', label);
+      this.renderer.setAttribute(svgElement, 'data-tooltip-text', tooltip || `${label}: ${tooltipValue}`);
     }
   }
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-dynamic-type.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-dynamic-type.component.spec.ts
@@ -72,6 +72,26 @@ describe('PoChartDynamicTypeComponent:', () => {
     });
 
     describe('calculateTotalValue:', () => {
+      it('should return sum of data series', () => {
+        component['series'] = [{ data: 1 }, { data: 4 }, { data: 7 }];
+
+        const totalSum = 12;
+
+        component['calculateTotalValue']();
+
+        expect(component['totalValue']).toBe(totalSum);
+      });
+
+      it('should return sum of data series and value series', () => {
+        component['series'] = [{ data: 2, value: 1 }, { data: 4 }, { value: 7 }];
+
+        const totalSum = 13;
+
+        component['calculateTotalValue']();
+
+        expect(component['totalValue']).toBe(totalSum);
+      });
+
       it('should return sum of value series', () => {
         component['series'] = [{ value: 1 }, { value: 4 }, { value: 7 }];
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-dynamic-type.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-dynamic-type.component.ts
@@ -56,7 +56,7 @@ export abstract class PoChartDynamicTypeComponent {
     this.totalValue =
       this.type === PoChartType.Gauge
         ? 100
-        : this.series.reduce((previousValue, serie) => previousValue + serie.value, 0);
+        : this.series.reduce((previousValue, serie) => previousValue + (serie.data ? serie.data : serie.value), 0);
   }
 
   set series(value: Array<any>) {

--- a/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-gauge/po-chart-gauge-series.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-types/po-chart-gauge/po-chart-gauge-series.interface.ts
@@ -21,11 +21,13 @@ export interface PoChartGaugeSerie {
   description?: string;
 
   /**
+   * @optional
+   *
    * @description
    *
    * Define o valor que será exibido no gráfico, sendo possível atribuir entre 0 e 100.
    *
-   * > **Importante:**
+   * **Importante:**
    * - Valores inferiores a 0 serão convertidos para 0;
    * - Valores superiores a 100 serão convertidos para 100.
    */

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-basic/sample-po-chart-basic.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-basic/sample-po-chart-basic.component.html
@@ -1,7 +1,7 @@
 <po-chart
   [p-series]="[
-    { category: 'Angular', value: 100 },
-    { category: 'React', value: 10 }
+    { label: 'Angular', data: 100 },
+    { label: 'React', data: 10 }
   ]"
 >
 </po-chart>

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts
@@ -30,11 +30,11 @@ export class SamplePoChartCoffeeRankingComponent {
   categoriesColumn: Array<string> = ['coffee', 'chocolate', 'tea'];
 
   coffeeConsumption: Array<PoDonutChartSeries> = [
-    { category: 'Finland', value: 9.6, tooltip: 'Finland (Europe)' },
-    { category: 'Norway', value: 7.2, tooltip: 'Norway (Europe)' },
-    { category: 'Netherlands', value: 6.7, tooltip: 'Netherlands (Europe)' },
-    { category: 'Slovenia', value: 6.1, tooltip: 'Slovenia (Europe)' },
-    { category: 'Austria', value: 5.5, tooltip: 'Austria (Europe)' }
+    { label: 'Finland', data: 9.6, tooltip: 'Finland (Europe)' },
+    { label: 'Norway', data: 7.2, tooltip: 'Norway (Europe)' },
+    { label: 'Netherlands', data: 6.7, tooltip: 'Netherlands (Europe)' },
+    { label: 'Slovenia', data: 6.1, tooltip: 'Slovenia (Europe)' },
+    { label: 'Austria', data: 5.5, tooltip: 'Austria (Europe)' }
   ];
 
   participationByCountryInWorldExports: Array<PoLineChartSeries> = [
@@ -52,11 +52,11 @@ export class SamplePoChartCoffeeRankingComponent {
   ];
 
   coffeeProduction: Array<PoPieChartSeries> = [
-    { category: 'Brazil', value: 2796, tooltip: 'Brazil (South America)' },
-    { category: 'Vietnam', value: 1076, tooltip: 'Vietnam (Asia)' },
-    { category: 'Colombia', value: 688, tooltip: 'Colombia (South America)' },
-    { category: 'Indonesia', value: 682, tooltip: 'Indonesia (Asia/Oceania)' },
-    { category: 'Peru', value: 273, tooltip: 'Peru (South America)' }
+    { label: 'Brazil', data: 2796, tooltip: 'Brazil (South America)' },
+    { label: 'Vietnam', data: 1076, tooltip: 'Vietnam (Asia)' },
+    { label: 'Colombia', data: 688, tooltip: 'Colombia (South America)' },
+    { label: 'Indonesia', data: 682, tooltip: 'Indonesia (Asia/Oceania)' },
+    { label: 'Peru', data: 273, tooltip: 'Peru (South America)' }
   ];
 
   items: Array<any> = [
@@ -91,13 +91,13 @@ export class SamplePoChartCoffeeRankingComponent {
   constructor(private poAlert: PoDialogService) {}
 
   searchMore(event: any) {
-    window.open(`http://google.com/search?q=coffee+producing+${event.category}`, '_blank');
+    window.open(`http://google.com/search?q=coffee+producing+${event.label}`, '_blank');
   }
 
   showMeTheDates(event: any) {
     this.poAlert.alert({
       title: 'Statistic',
-      message: `${event.category} consuming ${event.value}kg per capita!`,
+      message: `${event.label} consuming ${event.data}kg per capita!`,
       ok: () => {}
     });
   }

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
@@ -42,24 +42,20 @@
     <div class="po-row">
       <po-input
         class="po-md-6"
-        name="category"
-        [(ngModel)]="category"
-        p-label="Category"
-        [p-disabled]="isSingleSerie"
-        [p-required]="!isSingleSerie"
+        name="label"
+        [(ngModel)]="label"
+        p-label="{{ isSingleSerie ? 'Description' : 'Label' }}"
       >
       </po-input>
 
-      <po-number class="po-md-6" name="value" [(ngModel)]="value" p-label="Value" p-required></po-number>
-
-      <po-input
+      <po-number
         class="po-md-6"
-        name="description"
-        [(ngModel)]="description"
-        p-label="Gauge Description"
-        [p-disabled]="!isSingleSerie"
+        name="data"
+        [(ngModel)]="data"
+        p-label="{{ isSingleSerie ? 'Value' : 'Data' }}"
+        p-required
       >
-      </po-input>
+      </po-number>
 
       <po-input
         class="po-md-6"
@@ -69,16 +65,6 @@
         [p-disabled]="isSingleSerie"
       >
       </po-input>
-    </div>
-
-    <div class="po-row">
-      <po-button
-        class="po-md-3"
-        p-label="Add Data"
-        [p-disabled]="chartSeries.invalid"
-        (p-click)="addData(); chartSeries.reset()"
-      >
-      </po-button>
     </div>
   </div>
 
@@ -102,10 +88,10 @@
       p-required
     >
     </po-input>
+  </div>
 
-    <div class="po-row">
-      <po-button class="po-md-4" p-label="Add Serie" (p-click)="addData(); chartSeries.reset()"> </po-button>
-    </div>
+  <div class="po-row">
+    <po-button class="po-md-4" p-label="Add Serie" (p-click)="addData(); chartSeries.reset()"> </po-button>
   </div>
 </form>
 

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
@@ -15,9 +15,8 @@ import {
   templateUrl: './sample-po-chart-labs.component.html'
 })
 export class SamplePoChartLabsComponent implements OnInit {
-  category: string;
+  label: string;
   totalValues: Array<number> = [];
-  description: string;
   event: string;
   height: number;
   multipleSeries: Array<PoPieChartSeries | PoDonutChartSeries>;
@@ -26,7 +25,7 @@ export class SamplePoChartLabsComponent implements OnInit {
   singleSerie: PoChartGaugeSerie;
   title: string;
   tooltip: string;
-  value: number;
+  data: number;
   type: PoChartType;
   lineValues: number;
   multipleValuesLabel: string = '';
@@ -72,16 +71,13 @@ export class SamplePoChartLabsComponent implements OnInit {
 
   addData() {
     if (this.isSingleSerie) {
-      this.singleSerie = { value: this.value, description: this.description };
+      this.singleSerie = { value: this.data, description: this.label };
     } else if (this.isMultipleValues) {
       const dataSeries = this.convertToArray(this.inputDataSeries);
 
       this.multipleValues = [...this.multipleValues, { label: this.multipleValuesLabel, data: dataSeries }];
     } else {
-      this.multipleSeries = [
-        ...this.multipleSeries,
-        { category: this.category, value: this.value, tooltip: this.tooltip }
-      ];
+      this.multipleSeries = [...this.multipleSeries, { label: this.label, data: this.data, tooltip: this.tooltip }];
     }
 
     this.applySeriesData();
@@ -100,7 +96,7 @@ export class SamplePoChartLabsComponent implements OnInit {
   }
 
   restore() {
-    this.category = undefined;
+    this.label = undefined;
     this.categories = undefined;
     this.event = undefined;
     this.height = undefined;
@@ -109,8 +105,7 @@ export class SamplePoChartLabsComponent implements OnInit {
     this.series = [];
     this.title = undefined;
     this.tooltip = undefined;
-    this.value = undefined;
-    this.description = undefined;
+    this.data = undefined;
     this.allCategories = [];
     this.inputDataSeries = undefined;
     this.multipleValuesLabel = undefined;


### PR DESCRIPTION
Adiciona as propriedades label e data e deprecia as propriedades value e description.

Fixes DTHFUI-4444

**PO-CHART**

**DTHFUI-4444**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente há nomenclaturas diferentes para o valor da série e o texto que será exibido.
Nos gráficos do tipo Line e Column a nomenclatura atual é `label` para o texto que representa uma série e `data` para o valor da série. Porém nos outros gráficos as nomenclaturas são diferentes.

**Qual o novo comportamento?**
Foram crias novas propriedades `label` e `data` nas interfaces `PoCircularChartSeries` e `PoChartGaugeSerie` e foram depreciadas as propriedades:
- PoCircularChartSeries.category;
- PoCircularChartSeries.value;
- PoChartGaugeSerie.description;
- PoChartGaugeSerie.value.

**Simulação**
Simular através dos samples do portal.