### PR TITLE
feat(datepicker-range): traduz as literais para os idiomas suportados

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -7,7 +7,9 @@ import * as ValidatorsFunctions from '../validators';
 import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 import { PoDatepickerRange } from './interfaces/po-datepicker-range.interface';
-import { PoDatepickerRangeBaseComponent, poDatepickerRangeLiteralsDefault } from './po-datepicker-range-base.component';
+import { PoDatepickerRangeBaseComponent } from './po-datepicker-range-base.component';
+import { poDatepickerRangeLiteralsDefault } from './po-datepicker-range.literals';
+import { PoLanguageService } from '../../../services';
 
 describe('PoDatepickerRangeBaseComponent:', () => {
   @Directive()
@@ -32,7 +34,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     validateDate: () => {}
   };
 
-  const component = new PoDatepickerRangeComponent(mockedService);
+  const component = new PoDatepickerRangeComponent(mockedService, new PoLanguageService());
 
   it('should be created', () => {
     expect(component instanceof PoDatepickerRangeBaseComponent).toBeTruthy();
@@ -100,7 +102,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('literals: should return literals default if `_literals` is undefined', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component['_literals'] = undefined;
 
@@ -108,7 +110,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('zw');
+      component['language'] = 'zw';
 
       component.literals = {};
 
@@ -116,7 +118,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('pt');
+      component['language'] = 'pt';
 
       component.literals = {};
 
@@ -124,7 +126,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('literals: should be in english if browser is setted with `en`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('en');
+      component['language'] = 'en';
 
       component.literals = {};
 
@@ -132,7 +134,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('literals: should accept custom literals', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       const customLiterals = Object.assign({}, poDatepickerRangeLiteralsDefault[poLocaleDefault]);
 
@@ -144,7 +146,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('es');
+      component['language'] = 'es';
 
       component.literals = {};
 
@@ -152,7 +154,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('literals: should be in russian if browser is setted with `ru`', () => {
-      spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('ru');
+      component['language'] = 'ru';
 
       component.literals = {};
 
@@ -162,7 +164,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     it('literals: should update property with default literals if is setted with invalid values', () => {
       const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(UtilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      component['language'] = poLocaleDefault;
 
       expectPropertiesValues(component, 'literals', invalidValues, poDatepickerRangeLiteralsDefault[poLocaleDefault]);
     });

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -1,32 +1,16 @@
 import { AbstractControl, ControlValueAccessor, ValidationErrors, Validator } from '@angular/forms';
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { browserLanguage, convertToBoolean } from './../../../utils/util';
+import { convertToBoolean } from './../../../utils/util';
 import { requiredFailed } from '../validators';
-import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 import { InputBoolean } from '../../../decorators';
+import { PoDateService } from './../../../services/po-date/po-date.service';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
+
 import { PoDatepickerRange } from './interfaces/po-datepicker-range.interface';
 import { PoDatepickerRangeLiterals } from './interfaces/po-datepicker-range-literals.interface';
-import { PoDateService } from './../../../services/po-date/po-date.service';
-
-export const poDatepickerRangeLiteralsDefault = {
-  en: <PoDatepickerRangeLiterals>{
-    invalidFormat: 'Date in invalid format',
-    startDateGreaterThanEndDate: 'Start date greater than end date'
-  },
-  es: <PoDatepickerRangeLiterals>{
-    invalidFormat: 'Fecha en formato no válido',
-    startDateGreaterThanEndDate: 'Fecha de inicio mayor que fecha final'
-  },
-  pt: <PoDatepickerRangeLiterals>{
-    invalidFormat: 'Data no formato inválido',
-    startDateGreaterThanEndDate: 'Data inicial maior que data final'
-  },
-  ru: <PoDatepickerRangeLiterals>{
-    invalidFormat: 'Дата в неверном формате',
-    startDateGreaterThanEndDate: 'Дата начала больше даты окончания'
-  }
-};
+import { poDatepickerRangeLiteralsDefault } from './po-datepicker-range.literals';
 
 /**
  * @description
@@ -81,6 +65,8 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   private _readonly: boolean = false;
   private _required?: boolean = false;
   private _startDate?;
+
+  private language;
   private onChangeModel: any;
   private validatorChange: any;
 
@@ -212,22 +198,23 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    * </po-datepicker-range>
    * ```
    *
-   * > O objeto padrão de literais será traduzido de acordo com o idioma do browser (pt, en, es).
+   * > O objeto padrão de literais será traduzido de acordo com o idioma do
+   * [`PoI18nService`](/documentation/po-i18n) ou do browser.
    */
   @Input('p-literals') set literals(value: PoDatepickerRangeLiterals) {
     if (value instanceof Object && !(value instanceof Array)) {
       this._literals = {
         ...poDatepickerRangeLiteralsDefault[poLocaleDefault],
-        ...poDatepickerRangeLiteralsDefault[browserLanguage()],
+        ...poDatepickerRangeLiteralsDefault[this.language],
         ...value
       };
     } else {
-      this._literals = poDatepickerRangeLiteralsDefault[browserLanguage()];
+      this._literals = poDatepickerRangeLiteralsDefault[this.language];
     }
   }
 
   get literals() {
-    return this._literals || poDatepickerRangeLiteralsDefault[browserLanguage()];
+    return this._literals || poDatepickerRangeLiteralsDefault[this.language];
   }
 
   /**
@@ -328,7 +315,9 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    */
   @Output('p-change') onChange: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(protected poDateService: PoDateService) {}
+  constructor(protected poDateService: PoDateService, languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
 
   protected abstract resetDateRangeInputValidation(): void;
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -5,6 +5,7 @@ import { PoDatepickerRange } from './interfaces/po-datepicker-range.interface';
 import { PoDatepickerRangeBaseComponent } from './po-datepicker-range-base.component';
 import { PoDateService } from './../../../services/po-date/po-date.service';
 import { PoMask } from '../po-input/po-mask';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 const arrowLeftKey = 37;
 const arrowRightKey = 39;
@@ -123,9 +124,10 @@ export class PoDatepickerRangeComponent extends PoDatepickerRangeBaseComponent i
   constructor(
     private changeDetector: ChangeDetectorRef,
     poDateService: PoDateService,
-    poDatepickerRangeElement: ElementRef
+    poDatepickerRangeElement: ElementRef,
+    poLanguageService: PoLanguageService
   ) {
-    super(poDateService);
+    super(poDateService, poLanguageService);
     this.poDatepickerRangeElement = poDatepickerRangeElement;
   }
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.literals.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.literals.ts
@@ -1,0 +1,20 @@
+import { PoDatepickerRangeLiterals } from './interfaces/po-datepicker-range-literals.interface';
+
+export const poDatepickerRangeLiteralsDefault = {
+  en: <PoDatepickerRangeLiterals>{
+    invalidFormat: 'Date in invalid format',
+    startDateGreaterThanEndDate: 'Start date greater than end date'
+  },
+  es: <PoDatepickerRangeLiterals>{
+    invalidFormat: 'Fecha en formato no válido',
+    startDateGreaterThanEndDate: 'Fecha de inicio mayor que fecha final'
+  },
+  pt: <PoDatepickerRangeLiterals>{
+    invalidFormat: 'Data no formato inválido',
+    startDateGreaterThanEndDate: 'Data inicial maior que data final'
+  },
+  ru: <PoDatepickerRangeLiterals>{
+    invalidFormat: 'Дата в неверном формате',
+    startDateGreaterThanEndDate: 'Дата начала больше даты окончания'
+  }
+};


### PR DESCRIPTION
**po-datepicker-range**

**MDO-40**
_____________________________________________________________________________

**traduzir literais no po-datepicker-range para os idiomas suportados**

- [ X ] Código
- [ X ] Testes unitários
- [ X ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
serviço utiliza tradução do Browser

**Qual o novo comportamento?**
Utilizar o serviço de tradução (PoLanguageService) para traduzir as literais do componente PoDatepickerRange.

**Simulação**
