### PR TITLE
feat(number): permite usar números decimais nas propriedades min e max

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.spec.ts
@@ -48,11 +48,11 @@ describe('PoNumberComponent:', () => {
   });
 
   it('should be max and min', () => {
-    expectSettersMethod(component, 'setMax', '', 'max', undefined);
-    expectSettersMethod(component, 'setMax', '10', 'max', 10);
+    expectSettersMethod(component, 'setMax', '', 'max', '');
+    expectSettersMethod(component, 'setMax', 10, 'max', 10);
 
-    expectSettersMethod(component, 'setMin', '', 'min', undefined);
-    expectSettersMethod(component, 'setMin', '10', 'min', 10);
+    expectSettersMethod(component, 'setMin', '', 'min', '');
+    expectSettersMethod(component, 'setMin', 10, 'min', 10);
   });
 
   it('should call minFailed', () => {
@@ -96,6 +96,18 @@ describe('PoNumberComponent:', () => {
       component['invalidInputValueOnBlur'] = false;
 
       expect(component.extraValidation(new FormControl(null))).toBeNull();
+    });
+
+    it('should return null stating that there is no validation error in the value between max and min in format decimal', () => {
+      component.min = 0.6;
+      component.max = 0.9;
+      expect(component.validate(new FormControl(0.7))).toBeNull();
+    });
+
+    it('should not return null stating that there is a validation error in the value between max and min in decimal format', () => {
+      component.min = 1.6;
+      component.max = 3.9;
+      expect(component.validate(new FormControl(5))).not.toBeNull();
     });
 
     describe('getErrorPatternMessage: ', () => {

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
@@ -48,19 +48,24 @@ import { PoNumberBaseComponent } from './po-number-base.component';
   ]
 })
 export class PoNumberComponent extends PoNumberBaseComponent {
-  /** Valor mínimo. */
+  /** Valor mínimo.
+   *
+   * > Quando o valor mínimo for um número com decimais aconselha-se utilizar junto da propriedade `p-step` também passando a ela um valor decimal.
+   */
+
   min?: number;
-  @Input('p-min') set setMin(min: string) {
-    const parsedInt = parseInt(min, 10);
-    this.min = !isNaN(parsedInt) ? parsedInt : undefined;
+  @Input('p-min') set setMin(min: number) {
+    this.min = !isNaN(min) ? min : undefined;
     this.validateModel();
   }
 
-  /** Valor máximo. */
+  /** Valor máximo.
+   *
+   * > Quando o valor máximo for um número com decimais aconselha-se utilizar junto da propriedade `p-step` também passando a ela um valor decimal.
+   */
   max?: number;
-  @Input('p-max') set setMax(max: string) {
-    const parsedInt = parseInt(max, 10);
-    this.max = !isNaN(parsedInt) ? parsedInt : undefined;
+  @Input('p-max') set setMax(max: number) {
+    this.max = !isNaN(max) ? max : undefined;
     this.validateModel();
   }
 


### PR DESCRIPTION
Permitir informar valores decimais nas propriedades p-min e p-max.

Fixes DTHFUI-3795

**po-number **

**DTHFUI-3795**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente não é possível passar casas decimais para as propriedades p-min e -max, com isso não consigo validar os valores minimo:1.99 e máximo: 9.99

**Qual o novo comportamento?**
O componente aceita números decimais como mínimo e máximo

**Simulação**
<po-number 
  ...
 [p-min]="1.99"
 [p-max]="9.99"
 [p-step]="0.01">
</po-number>
