### PR TITLE
refactor(components): remove itens depreciados

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
@@ -21,23 +21,6 @@ export interface PoPageLoginLiterals {
   /** Texto que questiona o esquecimento da senha no popover de aviso de bloqueio. */
   forgotYourPassword?: string;
 
-  /**
-   * @deprecated 4.x.x
-   *
-   * @description
-   *
-   * **Deprecated 4.x.x**.
-   *
-   * > Removido o tratamento para concatenar o nome do produto com a palavra "Bem-vindo".
-   * Sobre a utilização:
-   * - Essa propriedade será usada apenas na ausência do texto da propriedade `p-product-name`.
-   * - Para alterar a mensagem de boas-vindas, utilize a propriedade `welcome`.
-   *
-   *
-   * Título exibido no topo da página.
-   */
-  title?: string;
-
   /** Texto do link de 'esqueci minha senha' exibido no popover de aviso de bloqueio. */
   iForgotMyPassword?: string;
 

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
@@ -16,7 +16,7 @@
 >
   <header class="po-page-login-header">
     <h1 class="po-mb-md-4 po-mb-sm-1">
-      <div class="po-page-login-header-product-name">{{ productName || literals?.title }}</div>
+      <div class="po-page-login-header-product-name">{{ productName }}</div>
       <po-tag *ngIf="environment" p-type="warning" [p-value]="environment"> </po-tag>
     </h1>
     <div class="po-page-login-header-welcome po-mb-md-4 po-mb-sm-2">{{ pageLoginLiterals.welcome }}</div>

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
@@ -83,8 +83,6 @@ describe('PoPageLoginComponent: ', () => {
 
     fixture.detectChanges();
 
-    expect(nativeElement.querySelector('.po-page-login-header').innerHTML).toContain(component.literals.title);
-
     expect(nativeElement.querySelector('po-login').innerHTML).toContain(component.literals.loginPlaceholder);
     expect(nativeElement.querySelector('po-login').innerHTML).not.toContain(component.literals.loginErrorPattern);
 
@@ -102,7 +100,6 @@ describe('PoPageLoginComponent: ', () => {
 
   it('should show custom literals', () => {
     const customLiterals: PoPageLoginLiterals = {
-      title: 'Custom title',
       loginPlaceholder: 'Custom placeholder login',
       passwordPlaceholder: 'Custom placeholder password',
       rememberUser: 'Custom remember user',
@@ -119,7 +116,6 @@ describe('PoPageLoginComponent: ', () => {
 
     fixture.detectChanges();
 
-    expect(nativeElement.querySelector('.po-page-login-header').innerHTML).toContain(customLiterals.title);
     expect(nativeElement.querySelector('po-login').innerHTML).toContain(customLiterals.loginPlaceholder);
 
     expect(nativeElement.querySelector('po-password').innerHTML).toContain(customLiterals.passwordPlaceholder);
@@ -822,11 +818,15 @@ describe('PoPageLoginComponent: ', () => {
     });
 
     it(`concatenateLiteral: should call 'concatenate' and return expected value`, () => {
-      const value = 'Portal RH';
-      const currentLiteral = 'title';
-      const defaultLiteral = 'Welcome';
+      const value = 'email@email.com.br';
+      const currentLiteral = 'loginHint';
+      const defaultLiteral = `Your login user was given to you at your first day.
+      If you don't have this information contact support`;
       const prepositionLiteral = 'to';
-      const result = { title: 'Welcome to Portal RH' };
+      const result = {
+        loginHint: `Your login user was given to you at your first day.
+      If you don't have this information contact support to email@email.com.br`
+      };
 
       spyOn(component, <any>'concatenate').and.callThrough();
 
@@ -891,32 +891,6 @@ describe('PoPageLoginComponent: ', () => {
 
       expect(productNameElement.innerText).toBe(productName);
       expect(welcomeElement.innerText).toBe(welcome);
-    });
-
-    it('should contain value of title if productName is undefined', () => {
-      const title = 'custom title';
-      component.literals = { title };
-
-      component.productName = undefined;
-
-      fixture.detectChanges();
-
-      const productNameElement = fixture.debugElement.nativeElement.querySelector('.po-page-login-header-product-name');
-
-      expect(productNameElement.innerText).toBe(title);
-    });
-
-    it('should use value of productName if title and productName are defined', () => {
-      const productName = 'custom product name';
-      component.literals = { title: 'custom title' };
-
-      component.productName = productName;
-
-      fixture.detectChanges();
-
-      const productNameElement = fixture.debugElement.nativeElement.querySelector('.po-page-login-header-product-name');
-
-      expect(productNameElement.innerText).toBe(productName);
     });
 
     it('customField po-input: should have po-input when placeholder is filled and shouldn`t have po-select and po-combo.', () => {

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-labs/sample-po-page-login-labs.component.html
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-labs/sample-po-page-login-labs.component.html
@@ -30,7 +30,7 @@
       class="po-lg-6"
       name="literals"
       [(ngModel)]="literals"
-      p-help='Ex.: {"title": "Hello", "submitLabel":"Access System", "highlightInfo": "Awesome, PO is beautiful!!!"}'
+      p-help='Ex.: {"submitLabel":"Access System", "highlightInfo": "Awesome, PO is beautiful!!!"}'
       p-label="Literals"
       (p-change)="changeLiterals()"
     >

--- a/projects/ui/src/lib/components/po-page/po-page-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-filter.interface.ts
@@ -6,30 +6,16 @@
  * Interface para o atributo `filter` do componente `po-page-list`.
  */
 export interface PoPageFilter {
-  /** Nome da ação ou a referência da mesma a ser executada. */
-  action?: string | Function;
+  /** Ação a ser executada. */
+  action?: Function;
 
   /**
    * @description
    *
-   * Nome da ação ou a referência da mesma a ser executada quando for disparado o
+   * Ação a ser executada quando for disparado o
    * evento de *click* através do rótulo **Busca Avançada**.
    */
-  advancedAction?: string | Function;
-
-  /**
-   * @deprecated 4.x.x
-   *
-   * @description
-   *
-   * ***Deprecated 4.x.x***
-   *
-   * Nome do `ngModel` do campo de filtro.
-   *
-   * > Para pegar o valor utilize o parâmetro passado pelas funções referênciadas em `action` e `advancedAction`
-   *
-   */
-  ngModel?: string;
+  advancedAction?: Function;
 
   /** Texto de instrução exibido dentro do campo de filtro. */
   placeholder?: string;

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
@@ -68,10 +68,8 @@
             class="po-input po-input-icon-right"
             name="model"
             type="text"
-            [ngModel]="parentRef[filter.ngModel]"
             [placeholder]="filter.placeholder || ''"
             (keypress)="onkeypress($event.keyCode)"
-            (ngModelChange)="changeModel($event)"
           />
         </div>
 

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
@@ -135,8 +135,7 @@ class DesktopComponent {
 
   public filter = {
     placeholder: 'Pesquise',
-    action: this.action,
-    ngModel: 'model'
+    action: this.action
   };
 
   public actions: Array<{}> = [
@@ -260,20 +259,6 @@ describe('PoPageListComponent - Desktop:', () => {
     });
   });
 
-  it('should change model in parentRef', () => {
-    const fakeThis = {
-      parentRef: {
-        modelFilter: 'filter'
-      },
-      filter: {
-        ngModel: 'modelFilter'
-      }
-    };
-
-    component.changeModel.call(fakeThis, 'new filter');
-    expect(fakeThis.parentRef.modelFilter).toBe('new filter');
-  });
-
   it('onChangeDisclaimerGroup: should call recalculateHeaderSize when have disclaimers and isRecalculate is true', () => {
     component['isRecalculate'] = true;
     const disclaimers: Array<PoDisclaimer> = [{ value: 'hotel', label: 'Hotel', property: 'hotel' }];
@@ -382,11 +367,6 @@ describe('PoPageListComponent - Desktop:', () => {
   });
 
   describe('Templates:', () => {
-    const fakeFilter = {
-      advancedAction: 'xxx',
-      ngModel: 'model'
-    };
-
     it('po-disclaimer-group: should check if the po-disclaimer-group is visible ', () => {
       component.disclaimerGroup = { change: () => {}, disclaimers: [], title: 'teste' };
 
@@ -448,7 +428,7 @@ describe('PoPageListComponent - Desktop:', () => {
 
     it('should add class `po-page-list-header-padding` if has filter and doesn`t have action.', () => {
       component.title = 'Title';
-      component.filter = fakeFilter;
+      component.filter = { action: () => {} };
       component.actions = [];
       fixture.detectChanges();
 
@@ -456,7 +436,7 @@ describe('PoPageListComponent - Desktop:', () => {
     });
 
     it('should add class `po-page-list-actions-padding` if has filter.', () => {
-      component.filter = fakeFilter;
+      component.filter = { action: () => {} };
       fixture.detectChanges();
 
       expect(nativeElement.querySelector('.po-page-list-actions-padding')).toBeTruthy();

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { callFunction, getParentRef, isExternalLink, isTypeof, openExternalLink } from '../../../utils/util';
+import { callFunction, isExternalLink, isTypeof, openExternalLink } from '../../../utils/util';
 import { PoLanguageService } from './../../../services/po-language/po-language.service';
 
 import { PoPageAction } from '../po-page-action.interface';
@@ -54,7 +54,7 @@ export class PoPageListComponent extends PoPageListBaseComponent
   dropdownActions: Array<PoPageAction>;
   isMobile: boolean;
   limitPrimaryActions: number = 3;
-  parentRef: ViewContainerRef;
+
   @ViewChild('filterInput') filterInput: ElementRef;
 
   private isRecalculate = true;
@@ -73,7 +73,6 @@ export class PoPageListComponent extends PoPageListBaseComponent
     private changeDetector: ChangeDetectorRef
   ) {
     super(languageService);
-    this.parentRef = getParentRef(viewRef);
     this.initializeListeners();
   }
 
@@ -162,10 +161,6 @@ export class PoPageListComponent extends PoPageListBaseComponent
     if (key === 13) {
       this.callActionFilter('action');
     }
-  }
-
-  changeModel(newModel): void {
-    this.parentRef[this.filter.ngModel] = newModel;
   }
 
   // Recebe evento change do disclaimer e recalcula tela

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
@@ -17,7 +17,6 @@ import { PoHttpInterceptorDetailComponent } from './po-http-interceptor-detail/p
 import { poHttpInterceptorLiterals } from './po-http-interceptor-literals';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 
-// DEPRECATED 4.x.x
 const NO_ERROR_HEADER_PARAM = 'X-PO-No-Error';
 const NO_MESSAGE_HEADER_PARAM = 'X-PO-No-Message';
 
@@ -132,7 +131,7 @@ const NO_MESSAGE_HEADER_PARAM = 'X-PO-No-Message';
  *
  * - `X-PO-No-Message`: Não exibe notificações de erro e/ou sucesso.
  *
- * - **Depreciado** `X-PO-No-Error`: não mostra notificações de erro com códigos `4xx` e `5xx`.
+ * - `X-PO-No-Error`: Não mostra notificações de erro com códigos `4xx` e `5xx`.
  *
  * ```
  * ...

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.html
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.html
@@ -17,16 +17,14 @@
     >
     </po-radio-group>
 
-    <po-switch
+    <po-radio-group
       class="po-md-6"
-      name="noMessageHeaderParam"
-      [(ngModel)]="noMessageHeaderParam"
-      p-help="Enable/disables notification"
-      p-label="X-PO-No-Message"
-      p-label-off="Off"
-      p-label-on="On"
+      name="headerParam"
+      [(ngModel)]="headerParam"
+      p-label="Disables Notifications"
+      [p-options]="headerParamOptions"
     >
-    </po-switch>
+    </po-radio-group>
   </div>
 
   <div class="po-row po-mt-1">

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.ts
@@ -1,3 +1,4 @@
+// import { PoRadioGroupOption } from './../../../../../../../dist/ng-components/lib/components/po-field/po-radio-group/po-radio-group-option.interface.d';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
@@ -9,7 +10,7 @@ import { PoRadioGroupOption } from '@po-ui/ng-components';
   templateUrl: './sample-po-http-interceptor-labs.component.html'
 })
 export class SamplePoHttpInterceptorLabsComponent implements OnDestroy, OnInit {
-  noMessageHeaderParam: boolean;
+  headerParam: string;
   requestMessage: string;
   status: string;
 
@@ -50,6 +51,11 @@ export class SamplePoHttpInterceptorLabsComponent implements OnDestroy, OnInit {
     { label: '401 - Error', value: '401' }
   ];
 
+  readonly headerParamOptions: Array<PoRadioGroupOption> = [
+    { label: 'X-PO-No-Message', value: 'No-Message' },
+    { label: 'X-PO-No-Error', value: 'No-Error' }
+  ];
+
   private apiSubscription: Subscription;
 
   constructor(private http: HttpClient) {}
@@ -68,8 +74,16 @@ export class SamplePoHttpInterceptorLabsComponent implements OnDestroy, OnInit {
     this.requestMessage = this.status === '200' ? this.successMessage : this.errorMessage;
   }
 
+  getParam() {
+    return this.headerParam === 'No-Message'
+      ? { 'X-PO-No-Message': 'true' }
+      : this.headerParam === 'No-Error'
+      ? { 'X-PO-No-Error': 'true' }
+      : {};
+  }
+
   processRequest() {
-    const headers = { 'X-PO-No-Message': (!!this.noMessageHeaderParam).toString() };
+    const headers = this.getParam();
     const body = JSON.parse(this.requestMessage);
     const params = { status: this.status || '' };
 
@@ -79,7 +93,7 @@ export class SamplePoHttpInterceptorLabsComponent implements OnDestroy, OnInit {
   }
 
   restore() {
-    this.noMessageHeaderParam = undefined;
+    this.headerParam = undefined;
     this.requestMessage = this.successMessage;
     this.status = '200';
   }


### PR DESCRIPTION
**PO-PAGE-LOGIN PO-PAGE-LIST PO-HTTP-INTERCEPTOR**

**DTHFUI-4482**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Os componentes po-page-login e o po-page-list possuem propriedades depreciadas que devem ser excluídas na versão 4.
O componente po-http-interceptor possui um parâmetro depreciado e que deverá ser mantido.

**Qual o novo comportamento?**
- po-page-login
 removida propriedade `PoPageLoginLiterals.Title`
- po-page-list
 Alteradas propriedades `PoPageFilter.action` e `PoPageFilter.advancedAction` que passam a não aceitar mais o tipo string e mantêm aceitando somente o tipo Function.
 Removida propriedade `PoPageFilter.ngModel`
- po-http-interceptor
Removida a depreciação(@deprecated) do parâmetro `X-PO-No-Error`

**Simulação**
Simular nos samples do portal.