### PR TITLE
feat(modal): traduzir literais para os idiomas suportados

### DIFF
--- a/projects/ui/src/lib/components/po-modal/po-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-base.component.spec.ts
@@ -1,12 +1,13 @@
 import { PoModalBaseComponent } from './po-modal-base.component';
 
 import { expectPropertiesValues, expectSettersMethod } from './../../util-test/util-expect.spec';
+import { PoLanguageService } from '../../services';
 
 describe('PoModalBaseComponent:', () => {
   let component: PoModalBaseComponent;
 
   beforeEach(() => {
-    component = new PoModalBaseComponent();
+    component = new PoModalBaseComponent(new PoLanguageService());
   });
 
   it('should create component hidden', () => {
@@ -69,7 +70,7 @@ describe('PoModalBaseComponent:', () => {
 
     component.validPrimaryAction();
 
-    expect(component.primaryAction.label).toBe('Ok');
+    expect(component.primaryAction.label).toBe(component.literals.close);
     expect(component.primaryAction.action).not.toBeUndefined();
 
     spyOn(component, 'close');
@@ -80,7 +81,7 @@ describe('PoModalBaseComponent:', () => {
   it('should complete primaryAction when is undefined in validPrimaryAction', () => {
     component.primaryAction = undefined;
     component.validPrimaryAction();
-    expect(component.primaryAction.label).toBe('Ok');
+    expect(component.primaryAction.label).toBe(component.literals.close);
     expect(component.primaryAction.action).not.toBeUndefined();
 
     spyOn(component, 'close');

--- a/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
@@ -3,6 +3,9 @@ import { Input, EventEmitter, Directive } from '@angular/core';
 import { convertToBoolean } from './../../utils/util';
 import { PoModalAction } from './po-modal-action.interface';
 
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { poModalLiterals } from './po-modal.literals';
+
 /**
  * @description
  *
@@ -20,6 +23,9 @@ import { PoModalAction } from './po-modal-action.interface';
  */
 @Directive()
 export class PoModalBaseComponent {
+  language;
+  literals;
+
   private _hideClose?: boolean = false;
   private _size?: string = 'md';
 
@@ -94,6 +100,14 @@ export class PoModalBaseComponent {
   // Event emmiter para quando a modal é fechada pelo 'X'.
   public onXClosed = new EventEmitter<boolean>();
 
+  constructor(poLanguageService: PoLanguageService) {
+    this.language = poLanguageService.getShortLanguage();
+
+    this.literals = {
+      ...poModalLiterals[this.language]
+    };
+  }
+
   /** Função para fechar a modal. */
   close(xClosed = false): void {
     this.isHidden = true;
@@ -113,7 +127,7 @@ export class PoModalBaseComponent {
     if (!this.primaryAction) {
       this.primaryAction = {
         action: () => this.close(),
-        label: 'Ok'
+        label: this.literals.close
       };
     }
 
@@ -121,7 +135,7 @@ export class PoModalBaseComponent {
       this.primaryAction['action'] = () => this.close();
     }
     if (!this.primaryAction['label']) {
-      this.primaryAction['label'] = 'Ok';
+      this.primaryAction['label'] = this.literals.close;
     }
   }
 }

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.ts
@@ -3,6 +3,7 @@ import { Component, ElementRef, ViewChild } from '@angular/core';
 import { PoModalBaseComponent } from './po-modal-base.component';
 import { PoModalService } from './po-modal-service';
 import { uuid } from '../../utils/util';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 /**
  * @docsExtends PoModalBaseComponent
@@ -38,8 +39,8 @@ export class PoModalComponent extends PoModalBaseComponent {
   private id: string = uuid();
   private sourceElement;
 
-  constructor(private poModalService: PoModalService) {
-    super();
+  constructor(private poModalService: PoModalService, poLanguageService: PoLanguageService) {
+    super(poLanguageService);
   }
 
   close(xClosed = false) {

--- a/projects/ui/src/lib/components/po-modal/po-modal.literals.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.literals.ts
@@ -1,0 +1,14 @@
+export const poModalLiterals = {
+  en: {
+    close: 'Close'
+  },
+  es: {
+    close: 'Cerrar'
+  },
+  pt: {
+    close: 'Fechar'
+  },
+  ru: {
+    close: 'близко'
+  }
+};


### PR DESCRIPTION
**po-modal**

**MDO-42**
_____________________________________________________________________________

**PR Checklist**

- [ X ] Código
- [ X ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A literal "Ok", que é utilizada quando não é informada uma primaryAction não utiliza literais.

**Qual o novo comportamento?**
Alterar a literal "Ok", que é utilizada quando não é informada uma primaryAction, para "Fechar" e traduzir para os idiomas suportados (pt, en, es, ru) através do PoLanguageService.

**Simulação**
