### PR TITLE
Table/tis 6

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -904,6 +904,28 @@ describe('PoTableBaseComponent:', () => {
       expect(component.collapsed.emit).toHaveBeenCalled();
     });
 
+    it('autoCollapse: should all items collapsed and expand seleted item', () => {
+      component.items = [
+        {
+          $showDetail: true,
+          id: 11234,
+          country: 'Brazil',
+          destination: 'Rio de Janeiro',
+          detail: [{ package: 'Basic', tour: 'City tour by public bus and visit to the main museums.' }]
+        },
+        {
+          $showDetail: false,
+          id: 23334,
+          country: 'Brazil',
+          destination: 'Joinville',
+          detail: [{ package: 'Intermediary', tour: 'Tour city.' }]
+        }
+      ];
+      component.autoCollapse = true;
+      component.toggleDetail(component.items[1]);
+      expect(component.items[0].$showDetail).toBe(false);
+    });
+
     it('expand: should set showDetail to true', () => {
       const currentRow = {
         id: 1,
@@ -1328,6 +1350,14 @@ describe('PoTableBaseComponent:', () => {
 
     it('p-loading-show-more: should update property `p-loading-show-more` with invalid values.', () => {
       expectPropertiesValues(component, 'loadingShowMore', booleanInvalidValues, false);
+    });
+
+    it('p-auto-collapse: should update property `p-auto-collapse` with valid values.', () => {
+      expectPropertiesValues(component, 'autoCollapse', booleanValidTrueValues, true);
+    });
+
+    it('p-auto-collapse: should update property `p-auto-collapse` with invalid values.', () => {
+      expectPropertiesValues(component, 'autoCollapse', booleanInvalidValues, false);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -354,6 +354,17 @@ export abstract class PoTableBaseComponent implements OnChanges {
    *
    * @description
    *
+   * Permite fechar um detalhe ou row template automaticamente, ao abrir outro item.
+   *
+   * @default `false`
+   */
+  @Input('p-auto-collapse') @InputBoolean() autoCollapse?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Permite que seja adicionado o estado de carregamento no botão "Carregar mais resultados".
    *
    * @default `false`
@@ -647,8 +658,22 @@ export abstract class PoTableBaseComponent implements OnChanges {
   }
 
   toggleDetail(row: any) {
-    this.setShowDetail(row, !row.$showDetail);
+    const rowShowDetail = row.$showDetail;
+    if (this.autoCollapse) {
+      this.collapseAllItems(this.items);
+    }
+
+    this.setShowDetail(row, !rowShowDetail);
     this.emitExpandEvents(row);
+  }
+
+  private collapseAllItems(items: Array<{ [key: string]: any }>) {
+    for (const item of items) {
+      if (item.$showDetail) {
+        this.setShowDetail(item, false);
+        this.emitExpandEvents(item);
+      }
+    }
   }
 
   toggleRowAction(row: any) {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -24,6 +24,7 @@
   (p-selected)="changeEvent('p-selected')"
   (p-show-more)="showMore()"
   (p-unselected)="changeEvent('p-unselected')"
+  [p-auto-collapse]="properties.includes('autoCollapse')"
 >
 </po-table>
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -83,6 +83,7 @@ export class SamplePoTableLabsComponent implements OnInit {
     { label: 'Loading show more', value: 'loadingShowMore' },
     { label: 'Hide detail', value: 'hideDetail' },
     { label: 'Loading', value: 'loading' },
+    { label: 'Auto collapse', value: 'autoCollapse' },
     { label: 'Hide columns manager', value: 'hideColumnsManager' }
   ];
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.component.html
@@ -1,4 +1,11 @@
-<po-table p-hide-columns-manager p-sort="true" [p-columns]="columns" [p-items]="items" [p-striped]="true">
+<po-table
+  p-hide-columns-manager
+  p-sort="true"
+  p-auto-collapse
+  [p-columns]="columns"
+  [p-items]="items"
+  [p-striped]="true"
+>
   <ng-template
     p-table-row-template
     let-rowItem


### PR DESCRIPTION
**po-table**

**DTHFUI-2435 e #167**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
ao clicar um uma row que está fechada, essa será expandida, mas a linha anterior que está expandida não é retraída automaticamente, forçando o usuário fechar todas manualmente.

**Qual o novo comportamento?**
Ao clicar em uma nova linha para expandir, todas as outras são retraídas. Necessário setar o atributo 'p-auto-collapse'


**Simulação**
Exemplo de tabela com Detail:

<po-table 
   p-auto-collapse
   [p-items]="items"
   [p-columns]="columns">
</po-table>


// TS
items = [
  {
     id: 11234,
     country: 'Brazil',
     destination: 'Rio de Janeiro',
     detail: [{ package: 'Basic', tour: 'City tour by public bus and visit to the main museums.' }]
   },
  { 
    id: 23334,
    country: 'Brazil',
    destination: 'Joinville',
    detail: [ { package: 'Intermediary', tour: 'Tour city.' } ] 
  }
];

columns = [
      { property: 'country', width: '150px' },
      { property: 'destination', width: '150px' },
      { property: 'id', label: 'Flight Number', type: 'number', width: '150px' },
      { property: 'detail', label: 'Details', type: 'detail', detail: {
            columns: [
              { property: 'package' },
              { property: 'tour' }
            ],
            typeHeader: 'top'
          }
      }
];