### PR TITLE
feat(page-dynamic-table): ordena a ação de excluir por ultimo na tabela

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -2242,5 +2242,22 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(routerNavigateSpy).not.toHaveBeenCalled();
       expect(customActionServiceSpy).toHaveBeenCalled();
     });
+
+    it('should set "Excluir" button in last item of action', () => {
+      component.actions = {
+        remove: true,
+        new: '/documentation/po-page-dynamic-edit',
+        edit: 'edit/:id',
+        duplicate: 'duplicate/:id'
+      };
+
+      component.tableCustomActions = [
+        { label: 'Details', action: () => alert('DETALHES') },
+        { label: 'teste', action: () => alert('teste') }
+      ];
+
+      const tableActions = visibleTableActions();
+      expect(tableActions[tableActions.length - 1].label).toBe(component.literals.tableActionDelete);
+    });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -129,7 +129,6 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   hasNext = false;
   items = [];
   literals;
-
   pageActions: Array<PoPageAction> = [];
   tableActions: Array<PoTableAction> = [];
 
@@ -201,6 +200,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
    * @description
    *
    * Ações da página e da tabela.
+   * > Caso utilizar a ação padrão de excluir, a mesma será exibida por último na tabela.
    */
   @Input('p-actions') set actions(value: PoPageDynamicTableActions) {
     this._actions = value && typeof value === 'object' && Object.keys(value).length > 0 ? value : {};
@@ -258,6 +258,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
    *  { label: 'Details', action: this.details.bind(this) }
    * ];
    * ```
+   * > Caso utilizar a ação padrão de excluir, a mesma será exibida por último na tabela.
    */
   @Input('p-table-custom-actions') set tableCustomActions(value: Array<PoPageDynamicTableCustomTableAction>) {
     this._tableCustomActions = Array.isArray(value) ? value : [];
@@ -1026,6 +1027,13 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   }
 
   private updateTableActions() {
-    this.tableActions = [...this._defaultTableActions, ...this._customTableActions];
+    const tableActionDelete = this._defaultTableActions.find(
+      tableAction => tableAction.label === this.literals.tableActionDelete
+    );
+    const defaultTableActionsWithoutActionDelete = this._defaultTableActions.filter(
+      tableAction => tableAction.label !== this.literals.tableActionDelete
+    );
+
+    this.tableActions = [...defaultTableActionsWithoutActionDelete, ...this._customTableActions, tableActionDelete];
   }
 }


### PR DESCRIPTION
A ação de "Excluir" é ser a ultima ação a ser apresentada nas ações da tabela.

Fixes DTHFUI-4413

**po-page-dynamic-table**

**DTHFUI-4413**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A ação de "Excluir" 'não é a última ação a ser apresentada nas ações da tabela.

**Qual o novo comportamento?**
A ação de "Excluir" passa a ser a ultima ação a ser apresentada nas ações da tabela.

**Simulação**
// HTML
<po-page-dynamic-table
  p-title="TITULO"
  p-service-api="https://po-sample-api.herokuapp.com/v1/people"
  [p-fields]="fields"
  [p-actions]="actions"
  [p-table-custom-actions]="tableCustomActions">
</po-page-dynamic-table>

// TS
readonly actions = {
    new: '/documentation/po-page-dynamic-edit',
    remove: true,
  };

  readonly tableCustomActions = [
    { label: 'Details', action: () => alert('DETALHES') }
  ];

  readonly fields = [
    { property: 'id', key: true },
    { property: 'name', label: 'Name' },
    { property: 'birthdate', label: 'Birthdate', type: 'date' }
  ];
