### PR TITLE
docs(popup): corrige caminho da imagem no sample Email

### DIFF
--- a/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-email/sample-po-popup-email.component.html
+++ b/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-email/sample-po-popup-email.component.html
@@ -29,7 +29,7 @@
         >
         </po-textarea>
 
-        <img class="po-lg-2 sample-logo-po" src="../../../assets/graphics/po.jpg" />
+        <img class="po-lg-2 sample-logo-po" src="./assets/graphics/po.png" />
       </div>
 
       <div class="po-row">


### PR DESCRIPTION
**PO-POPUP**

**DTHFUI-4561**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
A imagem do Po UI não está aparecendo.

**Qual o novo comportamento?**
Foi corrigido o caminho e a extensão do arquivo e agora a imagem abre corretamente.

**Simulação**
Sample Email do portal.