### PR TITLE
refactor(clean): remove a necessidade do ViewContainerRef[_hostLView]

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-clean/po-clean-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-clean/po-clean-base.component.spec.ts
@@ -32,31 +32,10 @@ describe('PoCleanBaseComponent', () => {
     expect(component.changeEvent.emit).toHaveBeenCalledWith('123');
   });
 
-  it('should return a boolean value if parentComponent has clean attr', () => {
-    component['parentComponent']['clean'] = true;
-
-    expect(component['hasCleanAttr']()).toBeTruthy();
-  });
-
-  it('should return disabled attr of parentComponent', () => {
-    component['parentComponent']['disabled'] = true;
-
-    expect(component['isDisabled']()).toBeTruthy();
-  });
-
-  it('should return readonly attr of parentComponent', () => {
-    component['parentComponent']['readonly'] = true;
-
-    expect(component['isReadonly']()).toBeTruthy();
-  });
-
   it('should show icon', () => {
     const fakeThis = {
       defaultValue: '',
-      getInputValue: () => 'valor',
-      hasCleanAttr: () => true,
-      isDisabled: () => false,
-      isReadonly: () => false
+      getInputValue: () => 'valor'
     };
     expect(component.showIcon.call(fakeThis)).toBeTruthy();
   });
@@ -64,42 +43,7 @@ describe('PoCleanBaseComponent', () => {
   it('shouldn`t show icon when value is equals', () => {
     const fakeThis = {
       defaultValue: '',
-      getInputValue: () => '',
-      hasCleanAttr: () => true,
-      isDisabled: () => false,
-      isReadonly: () => false
-    };
-    expect(component.showIcon.call(fakeThis)).toBeFalsy();
-  });
-
-  it('shouldn`t show icon when is disabled', () => {
-    const fakeThis = {
-      defaultValue: '',
-      getInputValue: () => 'valor',
-      hasCleanAttr: () => true,
-      isDisabled: () => true,
-      isReadonly: () => false
-    };
-    expect(component.showIcon.call(fakeThis)).toBeFalsy();
-  });
-
-  it('shouldn`t show icon when is readonly', () => {
-    const fakeThis = {
-      defaultValue: '',
-      getInputValue: () => 'valor',
-      hasCleanAttr: () => true,
-      isDisabled: () => false,
-      isReadonly: () => true
-    };
-    expect(component.showIcon.call(fakeThis)).toBeFalsy();
-  });
-
-  it('shouldn`t show icon when hasn`t clean attr', () => {
-    const fakeThis = {
-      defaultValue: '',
-      getInputValue: () => 'valor',
-      hasCleanAttr: () => false,
-      isDisabled: () => false
+      getInputValue: () => ''
     };
     expect(component.showIcon.call(fakeThis)).toBeFalsy();
   });

--- a/projects/ui/src/lib/components/po-field/po-clean/po-clean-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-clean/po-clean-base.component.ts
@@ -28,33 +28,13 @@ export abstract class PoCleanBaseComponent {
    */
   @Output('p-change-event') changeEvent: EventEmitter<any> = new EventEmitter<any>();
 
-  protected parentComponent: any;
-
   clear() {
     this.setInputValue(this.defaultValue);
     this.changeEvent.emit(this.defaultValue);
   }
 
   showIcon() {
-    return (
-      this.defaultValue !== this.getInputValue() && this.hasCleanAttr() && !this.isDisabled() && !this.isReadonly()
-    );
-  }
-
-  // Este método verifica se o componente pai possui a propriedade clean diferente de vazio,
-  // ou seja, se o po-clean deve ser usado.
-  private hasCleanAttr(): boolean {
-    return this.parentComponent.clean;
-  }
-
-  // Este método verifica se o componente pai está desabilitado.
-  private isDisabled(): boolean {
-    return this.parentComponent.disabled;
-  }
-
-  // Este método verifica se o componente pai está somente leitura.
-  private isReadonly(): boolean {
-    return this.parentComponent.readonly;
+    return this.defaultValue !== this.getInputValue();
   }
 
   abstract setInputValue(value: string): void;

--- a/projects/ui/src/lib/components/po-field/po-clean/po-clean.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-clean/po-clean.component.ts
@@ -1,6 +1,4 @@
-import { Component, ViewContainerRef } from '@angular/core';
-
-import { getParentRef } from '../../../utils/util';
+import { Component } from '@angular/core';
 
 import { PoCleanBaseComponent } from './po-clean-base.component';
 
@@ -21,11 +19,6 @@ import { PoCleanBaseComponent } from './po-clean-base.component';
   templateUrl: './po-clean.component.html'
 })
 export class PoCleanComponent extends PoCleanBaseComponent {
-  constructor(private viewRef: ViewContainerRef) {
-    super();
-    this.parentComponent = getParentRef(this.viewRef);
-  }
-
   setInputValue(value?: string) {
     if (this.inputRef && this.inputRef.nativeElement) {
       this.inputRef.nativeElement.value = value;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -22,13 +22,7 @@
     />
 
     <div class="po-field-icon-container-right">
-      <po-clean
-        [class.po-field-icon]="!disabled"
-        [class.po-field-icon-disabled]="disabled"
-        (p-change-event)="clear($event)"
-        [p-element-ref]="inputEl"
-      >
-      </po-clean>
+      <po-clean *ngIf="clean && !disabled" (p-change-event)="clear($event)" [p-element-ref]="inputEl"> </po-clean>
       <span
         #iconArrow
         class="po-icon po-field-icon {{ comboIcon }}"

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -1577,6 +1577,30 @@ describe('PoComboComponent:', () => {
 
       expect(noDataTemplateText).toEqual(noDataTemplateTextCompare);
     });
+
+    it('should show po-clean if `clean` is true and `disabled` is false', () => {
+      component.clean = true;
+      component.disabled = false;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('po-clean')).toBeTruthy();
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `disabled` is true', () => {
+      component.clean = true;
+      component.disabled = true;
+
+      fixture.detectChanges();
+      expect(nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is false', () => {
+      component.clean = false;
+
+      fixture.detectChanges();
+      expect(nativeElement.querySelector('po-clean')).toBe(null);
+    });
   });
 
   describe('Integration:', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
@@ -57,6 +57,7 @@ describe('PoDatepickerRangeComponent:', () => {
     });
 
     it('enableCleaner: should return true if `startDateInputValue` has value, `disabled` is false and `readonly` is false', () => {
+      component.clean = true;
       component.readonly = false;
       component.disabled = false;
       component.startDateInput.nativeElement.value = '23/08/2009';
@@ -66,6 +67,7 @@ describe('PoDatepickerRangeComponent:', () => {
     });
 
     it('enableCleaner: should return true if `endDateInputValue` has value, `disabled` is false and `readonly` is false', () => {
+      component.clean = true;
       component.readonly = false;
       component.disabled = false;
       component.endDateInput.nativeElement.value = '23/08/2009';
@@ -75,6 +77,7 @@ describe('PoDatepickerRangeComponent:', () => {
     });
 
     it(`enableCleaner: should return false if 'endDateInputValue' and 'startDateInputValue' have no value`, () => {
+      component.clean = true;
       component.readonly = false;
       component.disabled = false;
       component.endDateInput.nativeElement.value = '';
@@ -84,6 +87,7 @@ describe('PoDatepickerRangeComponent:', () => {
     });
 
     it(`enableCleaner: should return false if 'readonly' is true`, () => {
+      component.clean = true;
       component.readonly = true;
       component.disabled = false;
       component.endDateInput.nativeElement.value = '23/08/2009';
@@ -93,6 +97,7 @@ describe('PoDatepickerRangeComponent:', () => {
     });
 
     it(`enableCleaner: should return false if 'disabled' is true`, () => {
+      component.clean = true;
       component.readonly = false;
       component.disabled = true;
       component.endDateInput.nativeElement.value = '23/08/2009';

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -72,7 +72,7 @@ export class PoDatepickerRangeComponent extends PoDatepickerRangeBaseComponent i
   }
 
   get enableCleaner(): boolean {
-    return (this.startDateInputValue || this.endDateInputValue) && !this.disabled && !this.readonly;
+    return this.clean && (this.startDateInputValue || this.endDateInputValue) && !this.disabled && !this.readonly;
   }
 
   get endDateInputName(): string {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
@@ -16,7 +16,8 @@
     />
 
     <div class="po-field-icon-container-right">
-      <po-clean [p-element-ref]="inputEl" (p-change-event)="clear()"></po-clean>
+      <po-clean *ngIf="clean && !disabled && !readonly" [p-element-ref]="inputEl" (p-change-event)="clear()">
+      </po-clean>
 
       <span
         #iconDatepicker

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -1176,5 +1176,39 @@ describe('PoDatepickerComponent:', () => {
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-field-optional')).toBeNull();
     });
+
+    it('should show po-clean if `clean` is true and `disabled` and `readonly` are false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = false;
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBeTruthy();
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `disabled` is true', () => {
+      component.clean = true;
+      component.disabled = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `readonly` is true and `disabled` is false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is false', () => {
+      component.clean = false;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
@@ -25,7 +25,8 @@
     />
 
     <div class="po-field-icon-container-right">
-      <po-clean [p-element-ref]="inputEl" (p-change-event)="clear($event)"></po-clean>
+      <po-clean *ngIf="clean && !disabled && !readonly" [p-element-ref]="inputEl" (p-change-event)="clear($event)">
+      </po-clean>
     </div>
   </div>
 

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { FormControl } from '@angular/forms';
 
-import { expectPropertiesValues, expectSettersMethod } from '../../../util-test/util-expect.spec';
+import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 
 import { PoCleanComponent } from './../po-clean/po-clean.component';
 import { PoDecimalComponent } from './po-decimal.component';
@@ -1464,6 +1464,40 @@ describe('PoDecimalComponent:', () => {
       fixture.detectChanges();
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-field-optional')).toBeNull();
+    });
+
+    it('should show po-clean if `clean` is true and `disabled` and `readonly` are false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = false;
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBeTruthy();
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `disabled` is true', () => {
+      component.clean = true;
+      component.disabled = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `readonly` is true and `disabled` is false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is false', () => {
+      component.clean = false;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
@@ -23,7 +23,8 @@
     />
 
     <div class="po-field-icon-container-right">
-      <po-clean [p-element-ref]="inputEl" (p-change-event)="clear($event)"></po-clean>
+      <po-clean *ngIf="clean && !disabled && !readonly" [p-element-ref]="inputEl" (p-change-event)="clear($event)">
+      </po-clean>
     </div>
   </div>
 

--- a/projects/ui/src/lib/components/po-field/po-input/po-input.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input.component.spec.ts
@@ -129,5 +129,39 @@ describe('PoInputComponent: ', () => {
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-field-optional')).toBeNull();
     });
+
+    it('should show po-clean if `clean` is true and `disabled` and `readonly` are false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = false;
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBeTruthy();
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `disabled` is true', () => {
+      component.clean = true;
+      component.disabled = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `readonly` is true and `disabled` is false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is false', () => {
+      component.clean = false;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-login/po-login.component.html
+++ b/projects/ui/src/lib/components/po-field/po-login/po-login.component.html
@@ -22,7 +22,8 @@
     />
 
     <div class="po-field-icon-container-right">
-      <po-clean [p-element-ref]="inputEl" (p-change-event)="clear($event)"></po-clean>
+      <po-clean *ngIf="clean && !disabled && !readonly" [p-element-ref]="inputEl" (p-change-event)="clear($event)">
+      </po-clean>
     </div>
   </div>
 

--- a/projects/ui/src/lib/components/po-field/po-login/po-login.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-login/po-login.component.spec.ts
@@ -138,4 +138,40 @@ describe('PoLoginComponent:', () => {
       });
     });
   });
+
+  describe('Templates:', () => {
+    it('should show po-clean if `clean` is true and `disabled` and `readonly` are false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = false;
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBeTruthy();
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `disabled` is true', () => {
+      component.clean = true;
+      component.disabled = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `readonly` is true and `disabled` is false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is false', () => {
+      component.clean = false;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
@@ -26,7 +26,13 @@
     />
 
     <div class="po-field-icon-container-right">
-      <po-clean [p-default-value]="null" [p-element-ref]="inputEl" (p-change-event)="clear($event)"> </po-clean>
+      <po-clean
+        *ngIf="clean && !disabled && !readonly"
+        [p-default-value]="null"
+        [p-element-ref]="inputEl"
+        (p-change-event)="clear($event)"
+      >
+      </po-clean>
     </div>
   </div>
 

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.spec.ts
@@ -198,5 +198,39 @@ describe('PoNumberComponent:', () => {
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-field-optional')).toBeNull();
     });
+
+    it('should show po-clean if `clean` is true and `disabled` and `readonly` are false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = false;
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBeTruthy();
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `disabled` is true', () => {
+      component.clean = true;
+      component.disabled = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `readonly` is true and `disabled` is false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is false', () => {
+      component.clean = false;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.html
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.html
@@ -23,7 +23,8 @@
     />
 
     <div class="po-field-icon-container-right">
-      <po-clean class="po-icon po-field-icon" [p-element-ref]="inputEl" (p-change-event)="clear($event)"> </po-clean>
+      <po-clean *ngIf="clean && !disabled && !readonly" [p-element-ref]="inputEl" (p-change-event)="clear($event)">
+      </po-clean>
 
       <span
         *ngIf="!hidePasswordPeek && !disabled"

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.spec.ts
@@ -317,5 +317,39 @@ describe('PoNumberComponent:', () => {
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-field-optional')).toBeNull();
     });
+
+    it('should show po-clean if `clean` is true and `disabled` and `readonly` are false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = false;
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBeTruthy();
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `disabled` is true', () => {
+      component.clean = true;
+      component.disabled = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is true and `readonly` is true and `disabled` is false', () => {
+      component.clean = true;
+      component.disabled = false;
+      component.readonly = true;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+
+    it('shouldn`t show po-clean if `clean` is false', () => {
+      component.clean = false;
+
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.spec.ts
@@ -43,10 +43,6 @@ describe('PoMenuFilterComponent:', () => {
     expect(fixture.debugElement.nativeElement.querySelector('.po-icon-close')).toBeNull();
   });
 
-  it('should exists the clean variable', () => {
-    expect(component.clean).toBeTruthy();
-  });
-
   describe('Methods:', () => {
     it('filterItems: should call `filter.emit` with search param', () => {
       const search = 'menu';

--- a/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.ts
@@ -21,8 +21,6 @@ export const poMenuFilterLiteralsDefault = {
   templateUrl: './po-menu-filter.component.html'
 })
 export class PoMenuFilterComponent {
-  // Variável necessária para o po-clean identificar que deve ser criado.
-  readonly clean = true;
   public literals = {
     ...poMenuFilterLiteralsDefault[this.languageService.getLanguageDefault()],
     ...poMenuFilterLiteralsDefault[this.languageService.getShortLanguage()]

--- a/projects/ui/src/lib/utils/util.spec.ts
+++ b/projects/ui/src/lib/utils/util.spec.ts
@@ -29,8 +29,7 @@ import {
   validateDateRange,
   validateObjectType,
   validValue,
-  valuesFromObject,
-  getParentRef
+  valuesFromObject
 } from './util';
 
 import * as UtilFunctions from './util';
@@ -1406,22 +1405,6 @@ describe('Function validateObjectType:', () => {
 
     value = ['value'];
     expect(validateObjectType(value)).toBe(undefined);
-  });
-});
-
-describe('Function getParentRef:', () => {
-  it(`should return 'viewRef['_hostLView'][8]' if 'viewRef['_hostLView']' is truthy`, () => {
-    const viewRef = { _hostLView: [null, null, null, null, null, null, null, null, 'teste'] };
-    const expectedValue = ('teste' as unknown) as ViewContainerRef;
-
-    expect(getParentRef((viewRef as unknown) as ViewContainerRef)).toEqual(expectedValue);
-  });
-
-  it(`should return 'viewRef['_view']['component']' if 'viewRef['_hostLView']' is falsy`, () => {
-    const viewRef = { _view: { component: 'teste2' } };
-    const expectedValue = ('teste2' as unknown) as ViewContainerRef;
-
-    expect(getParentRef((viewRef as unknown) as ViewContainerRef)).toEqual(expectedValue);
   });
 });
 

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -563,18 +563,6 @@ export function validateObjectType(value: any) {
 }
 
 /**
- * @deprecated
- * Retorna um ViewContainerRef compatível para projetos com Ivy habilitado ou não.
- *
- * @param viewRef ViewContainerRef
- *
- * @returns ViewContainerRef
- */
-export function getParentRef(viewRef: ViewContainerRef): ViewContainerRef {
-  return viewRef['_hostLView'] ? viewRef['_hostLView'][8] : viewRef['_view']['component'];
-}
-
-/**
  * Retorna os elementos DOM capazes de receber foco.
  *
  * > Atualmente são considerados "focáveis" os elementos DOM `input`, `select`,


### PR DESCRIPTION
**COMPONENTS**

**DTHFUI-4456**
_____________________________________________________________________________

**PR Checklist**

- [x ] Código
- [ x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o novo comportamento?**
A partir da versão 11.0.X, a propriedade do ViewContainerRef
mudou de _hostView para _hostLView,
quebrando o componente <po_clean>
que era utilizado em nos seguintes campos:
- INPUT
- COMBO
- DECIMAL
- NUMBER
- PASSWORD
- LOGIN
- DATEPICKER
- DATEPICKER RANGE
- MENU-FILTER

Com isso não era possivel utilizar uma aplicação que usasse o PO UI.

No item de update para v4-rc.1, atualizamos a propriedade para [_hostLView],
porém para não utilizar propriedades privadas que possam quebrar novamente no futuro
será removido este tratamento.

A partir deste commit, os componentes serão
responsáveis por exibir ou não o clean.

**Simulação**
Gerar portal e testar todos os componentes citados, nas funcionalidades que envolvem o p-clean.