### PR TITLE
feat(chart): altera propriedade `axisXGridLines` para `gridLines`

### DIFF
--- a/docs/guides/migration-poui-v4.md
+++ b/docs/guides/migration-poui-v4.md
@@ -37,6 +37,7 @@ Para realizar a migração, execute o comando abaixo:
 ``` ng update @po-ui/ng-components --next```
 
 O `ng update` ajudará nas alterações necessárias para seu projeto seguir atualizado, que são elas:
+  - Modificada propriedade contida na interface `PoChartAxisOptions` de `axisXGridLines` para `gridLines`;
   - Atualizar as versões dos pacotes:
     - `@po-ui/ng-componentes`;
     - `@po-ui/ng-templates`;
@@ -81,6 +82,16 @@ Remoção das propriedades, onde passam a valer as novas definições, veja a ta
           </td>
           <td class="po-table-column">
             Será enviado por parâmetro na função <i>PoPageFilter.onAction</i> o valor de pesquisa.
+          </td>
+        </tr>
+        <tr class="po-table-row">
+          <td class="po-table-column">
+          <a href="/documentation/po-chart"><strong>PoChartAxisOptions</strong></a>
+          </td>
+          <td class="po-table-column">axisXGridLines
+          </td>
+          <td class="po-table-column">
+            gridLines
           </td>
         </tr>
       </tbody>

--- a/projects/ui/schematics/ng-update/v4/changes.ts
+++ b/projects/ui/schematics/ng-update/v4/changes.ts
@@ -1,4 +1,12 @@
 import { UpdateDependencies } from '@po-ui/ng-schematics/package-config';
+import { ReplaceChanges } from '@po-ui/ng-schematics/replace/replace';
+
+export const replaceChanges: Array<ReplaceChanges> = [
+  {
+    replace: 'axisXGridLines',
+    replaceWith: 'gridLines'
+  }
+];
 
 export const updateDepedenciesVersion: UpdateDependencies = {
   dependencies: [

--- a/projects/ui/schematics/ng-update/v4/index.ts
+++ b/projects/ui/schematics/ng-update/v4/index.ts
@@ -1,16 +1,77 @@
 import { chain, Tree, SchematicContext } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
+import { ReplaceChanges } from '@po-ui/ng-schematics/replace';
+import { getWorkspaceConfigGracefully } from '@po-ui/ng-schematics/project';
 import { updatePackageJson } from '@po-ui/ng-schematics/package-config';
 
-import { updateDepedenciesVersion } from './changes';
+import { replaceChanges, updateDepedenciesVersion } from './changes';
 
 export default function () {
-  return chain([updatePackageJson('0.0.0-PLACEHOLDER', updateDepedenciesVersion), postUpdate()]);
+  return chain([updatePackageJson('0.0.0-PLACEHOLDER', updateDepedenciesVersion), createUpgradeRule(), postUpdate()]);
 }
 
 function postUpdate() {
   return (_: Tree, context: SchematicContext) => {
     context.addTask(new NodePackageInstallTask());
   };
+}
+
+function createUpgradeRule() {
+  return (tree: Tree, context: SchematicContext) => {
+    const logger = context.logger;
+    const workspace = getWorkspaceConfigGracefully(tree);
+
+    if (workspace === null) {
+      logger.error('Não foi possível encontrar o arquivo de configuração de workspace.');
+      return;
+    }
+
+    const projectNames = Object.keys(workspace.projects);
+    for (const projectName of projectNames) {
+      const project = workspace.projects[projectName];
+      const entryFolderProject = project.projectType === 'library' ? 'lib' : 'app';
+      const sourceDir = `${project.sourceRoot}/${entryFolderProject}`;
+
+      applyUpdateInContent(tree, sourceDir);
+    }
+  };
+}
+
+function applyUpdateInContent(tree: Tree, path: string) {
+  const directory = tree.getDir(path);
+  if (directory.subfiles.length) {
+    directory.subfiles.forEach(file => {
+      const filePath = path + '/' + file;
+      const content = tree.read(filePath)!.toString('utf-8');
+      if (!content) {
+        return;
+      }
+
+      let updated = content;
+
+      if (file.endsWith('.ts')) {
+        updated = replaceWithChanges(replaceChanges, updated);
+
+        if (updated !== content) {
+          tree.overwrite(filePath, updated);
+        }
+      }
+    });
+  }
+
+  if (directory.subdirs.length) {
+    directory.subdirs.forEach(subDir => {
+      applyUpdateInContent(tree, path + '/' + subDir);
+    });
+  }
+}
+
+function replaceWithChanges(replaces: Array<ReplaceChanges>, content: string = '') {
+  replaces.forEach(({ replace, replaceWith }) => {
+    const regex = new RegExp(replace, 'gi');
+    content = content.replace(regex, <string>replaceWith);
+  });
+
+  return content;
 }

--- a/projects/ui/src/lib/components/po-chart/helpers/po-chart-default-values.constant.ts
+++ b/projects/ui/src/lib/components/po-chart/helpers/po-chart-default-values.constant.ts
@@ -5,7 +5,7 @@ export const PoChartPadding = 24;
 export const PoChartAxisXLabelArea = 72;
 
 // Quantidade de linhas do eixo X
-export const PoChartAxisXGridLines = 5;
+export const PoChartGridLines = 5;
 
 // Padding top para área interna de plotagem do grid para evitar overflow no hover dos pontos do gráfico do tipo linha;
 export const PoChartPlotAreaPaddingTop = 8;

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-axis-options.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-axis-options.interface.ts
@@ -7,14 +7,16 @@
  */
 export interface PoChartAxisOptions {
   /**
-   * Número de linhas exibidas no eixo X dos gráficos do tipo `Line` e `Column`.
-   * Para gráficos do tipo `Bar` define-se as linhas do eixo Y.
+   * Define a quantidade de linhas exibidas no grid.
+   * Para os gráficos dos tipos `Line` e `Column`, as linhas modificadas serão as horizontais (eixo X).
+   * Já para gráficos do tipo `Bar`, tratará as linhas verticais (eixo Y).
    *
-   * - Valor padrão: '5';
-   * - Valor mínimo permitido: '2';
-   * - Máximo Máximo permitido: '10';
+   * A propriedade contém as seguintes diretrizes para seu correto funcionamento:
+   * - Quantidade padrão de linhas: '5';
+   * - Quantidade mínima permitida: '2';
+   * - Quantidade máxima permitida: '10';
    */
-  axisXGridLines?: number;
+  gridLines?: number;
 
   /**
    * Define o alcance de valor máximo exibido no eixo Y.

--- a/projects/ui/src/lib/components/po-chart/po-chart-base.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-base.component.ts
@@ -165,7 +165,7 @@ export abstract class PoChartBaseComponent {
    *    axis: {
    *      minRange: 0,
    *      maxRange: 100,
-   *      axisXGridLines: 5,
+   *      gridLines: 5,
    *    },
    *  };
    * ```

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.spec.ts
@@ -62,7 +62,7 @@ describe('PoChartAxisComponent', () => {
         const fakeAxisOptions: PoChartAxisOptions = {
           minRange: 0,
           maxRange: 100,
-          axisXGridLines: 5
+          gridLines: 5
         };
         const fakeMinMaxAxisValues: PoChartMinMaxValues = {
           minValue: 1,
@@ -121,7 +121,7 @@ describe('PoChartAxisComponent', () => {
         component.categories = fakeCategories;
 
         expect(component['setAxisXCoordinates']).toHaveBeenCalledWith(
-          component['axisXGridLines'],
+          component['gridLines'],
           fakeSeriesLength,
           fakeContainerSize,
           fakeMinMaxAxisValues,
@@ -158,7 +158,7 @@ describe('PoChartAxisComponent', () => {
         component.categories = fakeCategories;
 
         expect(component['setAxisXCoordinates']).toHaveBeenCalledWith(
-          component['axisXGridLines'],
+          component['gridLines'],
           fakeSeriesLength,
           fakeContainerSize,
           fakeMinMaxAxisValues,
@@ -194,7 +194,7 @@ describe('PoChartAxisComponent', () => {
     describe('p-options: ', () => {
       it('should call `checkAxisOptions` and `setAxisYCoordinates` if type is Bar', () => {
         const fakeSeriesLength = 0;
-        const fakeAxisXGridLines = 5;
+        const fakeGridLines = 5;
         const fakeMinMaxAxisValues: PoChartMinMaxValues = {
           minValue: 1,
           maxValue: 3
@@ -202,7 +202,7 @@ describe('PoChartAxisComponent', () => {
         const fakeAxisOptions: PoChartAxisOptions = {
           minRange: 0,
           maxRange: 100,
-          axisXGridLines: 5
+          gridLines: 5
         };
         const fakeContainerSize = {
           svgWidth: 500,
@@ -219,13 +219,13 @@ describe('PoChartAxisComponent', () => {
 
         component.type = PoChartType.Bar;
         component['minMaxAxisValues'] = fakeMinMaxAxisValues;
-        component['axisXGridLines'] = fakeAxisXGridLines;
+        component['gridLines'] = fakeGridLines;
         component.containerSize = fakeContainerSize;
         component.axisOptions = fakeAxisOptions;
 
         expect(component['checkAxisOptions']).toHaveBeenCalledWith(fakeAxisOptions);
         expect(component['setAxisYCoordinates']).toHaveBeenCalledWith(
-          component['axisXGridLines'],
+          component['gridLines'],
           fakeSeriesLength,
           fakeContainerSize,
           fakeMinMaxAxisValues,
@@ -235,7 +235,7 @@ describe('PoChartAxisComponent', () => {
 
       it('should call `checkAxisOptions` and `setAxisXCoordinates` if type is different than Bar', () => {
         const fakeSeriesLength = 0;
-        const fakeAxisXGridLines = 5;
+        const fakeGridLines = 5;
         const fakeMinMaxAxisValues: PoChartMinMaxValues = {
           minValue: 1,
           maxValue: 3
@@ -243,7 +243,7 @@ describe('PoChartAxisComponent', () => {
         const fakeAxisOptions: PoChartAxisOptions = {
           minRange: 0,
           maxRange: 100,
-          axisXGridLines: 5
+          gridLines: 5
         };
         const fakeContainerSize = {
           svgWidth: 500,
@@ -260,13 +260,13 @@ describe('PoChartAxisComponent', () => {
 
         component.type = PoChartType.Line;
         component['minMaxAxisValues'] = fakeMinMaxAxisValues;
-        component['axisXGridLines'] = fakeAxisXGridLines;
+        component['gridLines'] = fakeGridLines;
         component.containerSize = fakeContainerSize;
         component.axisOptions = fakeAxisOptions;
 
         expect(component['checkAxisOptions']).toHaveBeenCalledWith(fakeAxisOptions);
         expect(component['setAxisXCoordinates']).toHaveBeenCalledWith(
-          component['axisXGridLines'],
+          component['gridLines'],
           fakeSeriesLength,
           fakeContainerSize,
           fakeMinMaxAxisValues,
@@ -294,7 +294,7 @@ describe('PoChartAxisComponent', () => {
 
   describe('Methods', () => {
     it(`setAxisXCoordinates: should call 'calculateAxisXCoordinates' and 'calculateAxisXLabelCoordinates' passing 'seriesLength' as argument if type is Bar`, () => {
-      const axisXGridLines = 5;
+      const gridLines = 5;
       const seriesLength = 3;
       const containerSize = {
         svgWidth: 500,
@@ -313,7 +313,7 @@ describe('PoChartAxisComponent', () => {
       const spyCalculateAxisXCoordinates = spyOn(component, <any>'calculateAxisXCoordinates');
       const spyCalculateAxisXLabelCoordinates = spyOn(component, <any>'calculateAxisXLabelCoordinates');
 
-      component['setAxisXCoordinates'](axisXGridLines, seriesLength, containerSize, minMaxAxisValues, type);
+      component['setAxisXCoordinates'](gridLines, seriesLength, containerSize, minMaxAxisValues, type);
 
       expect(spyCalculateAxisXCoordinates).toHaveBeenCalledWith(seriesLength + 1, containerSize);
       expect(spyCalculateAxisXLabelCoordinates).toHaveBeenCalledWith(
@@ -324,8 +324,8 @@ describe('PoChartAxisComponent', () => {
       );
     });
 
-    it(`setAxisXCoordinates: should call 'calculateAxisXCoordinates' and 'calculateAxisXLabelCoordinates' passing 'axisXGridLines' as argument if type is Bar`, () => {
-      const axisXGridLines = 5;
+    it(`setAxisXCoordinates: should call 'calculateAxisXCoordinates' and 'calculateAxisXLabelCoordinates' passing 'gridLines' as argument if type is Bar`, () => {
+      const gridLines = 5;
       const seriesLength = 3;
       const containerSize = {
         svgWidth: 500,
@@ -344,15 +344,10 @@ describe('PoChartAxisComponent', () => {
       const spyCalculateAxisXCoordinates = spyOn(component, <any>'calculateAxisXCoordinates');
       const spyCalculateAxisXLabelCoordinates = spyOn(component, <any>'calculateAxisXLabelCoordinates');
 
-      component['setAxisXCoordinates'](axisXGridLines, seriesLength, containerSize, minMaxAxisValues, type);
+      component['setAxisXCoordinates'](gridLines, seriesLength, containerSize, minMaxAxisValues, type);
 
-      expect(spyCalculateAxisXCoordinates).toHaveBeenCalledWith(axisXGridLines, containerSize);
-      expect(spyCalculateAxisXLabelCoordinates).toHaveBeenCalledWith(
-        axisXGridLines,
-        containerSize,
-        minMaxAxisValues,
-        type
-      );
+      expect(spyCalculateAxisXCoordinates).toHaveBeenCalledWith(gridLines, containerSize);
+      expect(spyCalculateAxisXLabelCoordinates).toHaveBeenCalledWith(gridLines, containerSize, minMaxAxisValues, type);
     });
 
     it('calculateAxisXLabelCoordinates: should apply value to `axisXLabelCoordinates`', () => {
@@ -419,8 +414,8 @@ describe('PoChartAxisComponent', () => {
       expect(component['generateAverageOfLabels'](minMaxAxisValues, amountOfAxisLines)).toEqual(expectedResult);
     });
 
-    it(`setAxisYCoordinates: should call 'calculateAxisYCoordinates' and 'calculateAxisYLabelCoordinates' passing 'axisXGridLines' as argument if type is Bar`, () => {
-      const axisXGridLines = 5;
+    it(`setAxisYCoordinates: should call 'calculateAxisYCoordinates' and 'calculateAxisYLabelCoordinates' passing 'gridLines' as argument if type is Bar`, () => {
+      const gridLines = 5;
       const seriesLength = 3;
       const containerSize = {
         svgWidth: 500,
@@ -439,19 +434,14 @@ describe('PoChartAxisComponent', () => {
       const spyCalculateAxisYCoordinates = spyOn(component, <any>'calculateAxisYCoordinates');
       const spyCalculateAxisYLabelCoordinates = spyOn(component, <any>'calculateAxisYLabelCoordinates');
 
-      component['setAxisYCoordinates'](axisXGridLines, seriesLength, containerSize, minMaxAxisValues, type);
+      component['setAxisYCoordinates'](gridLines, seriesLength, containerSize, minMaxAxisValues, type);
 
-      expect(spyCalculateAxisYCoordinates).toHaveBeenCalledWith(axisXGridLines, containerSize, type);
-      expect(spyCalculateAxisYLabelCoordinates).toHaveBeenCalledWith(
-        axisXGridLines,
-        containerSize,
-        minMaxAxisValues,
-        type
-      );
+      expect(spyCalculateAxisYCoordinates).toHaveBeenCalledWith(gridLines, containerSize, type);
+      expect(spyCalculateAxisYLabelCoordinates).toHaveBeenCalledWith(gridLines, containerSize, minMaxAxisValues, type);
     });
 
     it(`setAxisYCoordinates: should call 'calculateAxisYCoordinates' and 'calculateAxisYLabelCoordinates' passing 'seriesLength' as argument if type is Bar`, () => {
-      const axisXGridLines = 5;
+      const gridLines = 5;
       const seriesLength = 3;
       const containerSize = {
         svgWidth: 500,
@@ -470,7 +460,7 @@ describe('PoChartAxisComponent', () => {
       const spyCalculateAxisYCoordinates = spyOn(component, <any>'calculateAxisYCoordinates');
       const spyCalculateAxisYLabelCoordinates = spyOn(component, <any>'calculateAxisYLabelCoordinates');
 
-      component['setAxisYCoordinates'](axisXGridLines, seriesLength, containerSize, minMaxAxisValues, type);
+      component['setAxisYCoordinates'](gridLines, seriesLength, containerSize, minMaxAxisValues, type);
 
       expect(spyCalculateAxisYCoordinates).toHaveBeenCalledWith(seriesLength, containerSize, type);
       expect(spyCalculateAxisYLabelCoordinates).toHaveBeenCalledWith(
@@ -842,17 +832,17 @@ describe('PoChartAxisComponent', () => {
     });
 
     it('isValidGridLinesLengthOption: should return true', () => {
-      const fakeAxisXGridLines = 5;
+      const fakeGridLines = 5;
 
-      const result = component['isValidGridLinesLengthOption'](fakeAxisXGridLines);
+      const result = component['isValidGridLinesLengthOption'](fakeGridLines);
 
       expect(result).toBeTrue();
     });
 
     it('isValidGridLinesLengthOption: should return true', () => {
-      const fakeAxisXGridLines = 11;
+      const fakeGridLines = 11;
 
-      const result = component['isValidGridLinesLengthOption'](fakeAxisXGridLines);
+      const result = component['isValidGridLinesLengthOption'](fakeGridLines);
 
       expect(result).toBeFalse();
     });
@@ -949,11 +939,11 @@ describe('PoChartAxisComponent', () => {
         expect(component['minMaxAxisValues']).toEqual(expectedValue);
       });
 
-      it('should apply `options.axisXGridLines` value to `axisXGridLines`', () => {
+      it('should apply `options.gridLines` value to `gridLines`', () => {
         const fakeOptions: PoChartAxisOptions = {
           maxRange: 4,
           minRange: 0,
-          axisXGridLines: 2
+          gridLines: 2
         };
 
         component['acceptNegativeValues'] = true;
@@ -962,14 +952,14 @@ describe('PoChartAxisComponent', () => {
 
         component['checkAxisOptions'](fakeOptions);
 
-        expect(component['axisXGridLines']).toEqual(fakeOptions.axisXGridLines);
+        expect(component['gridLines']).toEqual(fakeOptions.gridLines);
       });
 
-      it('should apply `PoChartAxisXGridLines` value to `axisXGridLines`', () => {
+      it('should apply `PoChartridLines` value to `gridLines`', () => {
         const fakeOptions: PoChartAxisOptions = {
           maxRange: 4,
           minRange: 0,
-          axisXGridLines: 1
+          gridLines: 1
         };
         const expectedValue = 5;
 
@@ -979,14 +969,14 @@ describe('PoChartAxisComponent', () => {
 
         component['checkAxisOptions'](fakeOptions);
 
-        expect(component['axisXGridLines']).toEqual(expectedValue);
+        expect(component['gridLines']).toEqual(expectedValue);
       });
 
       it('should apply 0 to the `minValue` if `hasAxisSideSpacing` is false and `minValue < 0`', () => {
         const fakeOptions: PoChartAxisOptions = {
           maxRange: 4,
           minRange: -100,
-          axisXGridLines: 1
+          gridLines: 1
         };
 
         const expectedValue = {
@@ -1071,40 +1061,40 @@ describe('PoChartAxisComponent', () => {
 
       it('amountOfAxisXLines: should return `seriesLength` plus 1 if chart type is `Bar` and seriesLength is greater than 1', () => {
         const seriesLength = 2;
-        const axisXGridLines = 5;
+        const gridLines = 5;
         const type = PoChartType.Bar;
 
-        const expectedResult = component['amountOfAxisXLines'](seriesLength, axisXGridLines, type);
+        const expectedResult = component['amountOfAxisXLines'](seriesLength, gridLines, type);
 
         expect(expectedResult).toBe(3);
       });
 
       it('amountOfAxisXLines: should return `2` if chart type is `Bar` and seriesLength is 1', () => {
         const seriesLength = 1;
-        const axisXGridLines = 5;
+        const gridLines = 5;
         const type = PoChartType.Bar;
 
-        const expectedResult = component['amountOfAxisXLines'](seriesLength, axisXGridLines, type);
+        const expectedResult = component['amountOfAxisXLines'](seriesLength, gridLines, type);
 
         expect(expectedResult).toBe(2);
       });
 
-      it('amountOfAxisXLines: should return `1` if chart type isn`t `Bar` and axisXGridLines value is zero', () => {
+      it('amountOfAxisXLines: should return `1` if chart type isn`t `Bar` and gridLines value is zero', () => {
         const seriesLength = 1;
-        const axisXGridLines = 0;
+        const gridLines = 0;
         const type = PoChartType.Line;
 
-        const expectedResult = component['amountOfAxisXLines'](seriesLength, axisXGridLines, type);
+        const expectedResult = component['amountOfAxisXLines'](seriesLength, gridLines, type);
 
         expect(expectedResult).toBe(1);
       });
 
-      it('amountOfAxisXLines: should return `axisXGridLines` if chart type isn`t `Bar` and axisXGridLines is different of zero', () => {
+      it('amountOfAxisXLines: should return `gridLines` if chart type isn`t `Bar` and gridLines is different of zero', () => {
         const seriesLength = 1;
-        const axisXGridLines = 5;
+        const gridLines = 5;
         const type = PoChartType.Line;
 
-        const expectedResult = component['amountOfAxisXLines'](seriesLength, axisXGridLines, type);
+        const expectedResult = component['amountOfAxisXLines'](seriesLength, gridLines, type);
 
         expect(expectedResult).toBe(5);
       });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 
 import {
   PoChartAxisXLabelArea,
-  PoChartAxisXGridLines,
+  PoChartGridLines,
   PoChartPadding,
   PoChartPlotAreaPaddingTop
 } from '../../helpers/po-chart-default-values.constant';
@@ -25,7 +25,7 @@ export class PoChartAxisComponent {
   axisYCoordinates: Array<PoChartPathCoordinates>;
   axisYLabelCoordinates: Array<PoChartAxisLabelCoordinates>;
 
-  private axisXGridLines: number = PoChartAxisXGridLines;
+  private gridLines: number = PoChartGridLines;
   private minMaxAxisValues: PoChartMinMaxValues;
   private seriesLength: number = 0;
   private hasAxisSideSpacing: boolean;
@@ -59,20 +59,8 @@ export class PoChartAxisComponent {
       this.seriesLength = this.mathsService.seriesGreaterLength(this.series);
       this.minMaxAxisValues = this.mathsService.calculateMinAndMaxValues(this._series);
       this.checkAxisOptions(this.axisOptions);
-      this.setAxisXCoordinates(
-        this.axisXGridLines,
-        this.seriesLength,
-        this.containerSize,
-        this.minMaxAxisValues,
-        this.type
-      );
-      this.setAxisYCoordinates(
-        this.axisXGridLines,
-        this.seriesLength,
-        this.containerSize,
-        this.minMaxAxisValues,
-        this.type
-      );
+      this.setAxisXCoordinates(this.gridLines, this.seriesLength, this.containerSize, this.minMaxAxisValues, this.type);
+      this.setAxisYCoordinates(this.gridLines, this.seriesLength, this.containerSize, this.minMaxAxisValues, this.type);
     } else {
       this._series = [];
       this.cleanUpCoordinates();
@@ -87,16 +75,10 @@ export class PoChartAxisComponent {
     this._categories = value;
 
     if (this.type === PoChartType.Bar) {
-      this.setAxisXCoordinates(
-        this.axisXGridLines,
-        this.seriesLength,
-        this.containerSize,
-        this.minMaxAxisValues,
-        this.type
-      );
+      this.setAxisXCoordinates(this.gridLines, this.seriesLength, this.containerSize, this.minMaxAxisValues, this.type);
     } else {
       this.setAxisYCoordinates(
-        this.axisXGridLines,
+        this.gridLines,
         this.seriesLength,
         this._containerSize,
         this.minMaxAxisValues,
@@ -113,20 +95,8 @@ export class PoChartAxisComponent {
     this._containerSize = value;
 
     this.checkAxisOptions(this.axisOptions);
-    this.setAxisXCoordinates(
-      this.axisXGridLines,
-      this.seriesLength,
-      this._containerSize,
-      this.minMaxAxisValues,
-      this.type
-    );
-    this.setAxisYCoordinates(
-      this.axisXGridLines,
-      this.seriesLength,
-      this._containerSize,
-      this.minMaxAxisValues,
-      this.type
-    );
+    this.setAxisXCoordinates(this.gridLines, this.seriesLength, this._containerSize, this.minMaxAxisValues, this.type);
+    this.setAxisYCoordinates(this.gridLines, this.seriesLength, this._containerSize, this.minMaxAxisValues, this.type);
   }
 
   get containerSize() {
@@ -139,21 +109,9 @@ export class PoChartAxisComponent {
     this.checkAxisOptions(this._axisOptions);
 
     if (this.type === PoChartType.Bar) {
-      this.setAxisYCoordinates(
-        this.axisXGridLines,
-        this.seriesLength,
-        this.containerSize,
-        this.minMaxAxisValues,
-        this.type
-      );
+      this.setAxisYCoordinates(this.gridLines, this.seriesLength, this.containerSize, this.minMaxAxisValues, this.type);
     } else {
-      this.setAxisXCoordinates(
-        this.axisXGridLines,
-        this.seriesLength,
-        this.containerSize,
-        this.minMaxAxisValues,
-        this.type
-      );
+      this.setAxisXCoordinates(this.gridLines, this.seriesLength, this.containerSize, this.minMaxAxisValues, this.type);
     }
   }
 
@@ -164,36 +122,36 @@ export class PoChartAxisComponent {
   constructor(private mathsService: PoChartMathsService) {}
 
   private setAxisXCoordinates(
-    axisXGridLines: number,
+    gridLines: number,
     seriesLength: number,
     containerSize: PoChartContainerSize,
     minMaxAxisValues: PoChartMinMaxValues,
     type: PoChartType
   ) {
-    const amountOfAxisXLines = this.amountOfAxisXLines(seriesLength, axisXGridLines, type);
+    const amountOfAxisXLines = this.amountOfAxisXLines(seriesLength, gridLines, type);
     this.calculateAxisXCoordinates(amountOfAxisXLines, containerSize);
 
     if (seriesLength) {
-      const amountOfAxisLabels = type === PoChartType.Bar ? seriesLength : axisXGridLines;
+      const amountOfAxisLabels = type === PoChartType.Bar ? seriesLength : gridLines;
       this.calculateAxisXLabelCoordinates(amountOfAxisLabels, containerSize, minMaxAxisValues, type);
     }
   }
 
-  private amountOfAxisXLines(seriesLength: number, axisXGridLines: number, type: PoChartType): number {
+  private amountOfAxisXLines(seriesLength: number, gridLines: number, type: PoChartType): number {
     if (type === PoChartType.Bar) {
       return seriesLength <= 1 ? 2 : seriesLength + 1;
     }
-    return axisXGridLines === 0 ? 1 : axisXGridLines;
+    return gridLines === 0 ? 1 : gridLines;
   }
 
   private setAxisYCoordinates(
-    axisXGridLines: number,
+    gridLines: number,
     seriesLength: number,
     containerSize: PoChartContainerSize,
     minMaxAxisValues: PoChartMinMaxValues,
     type: PoChartType
   ) {
-    const amountOfAxisY = type === PoChartType.Bar ? axisXGridLines : seriesLength;
+    const amountOfAxisY = type === PoChartType.Bar ? gridLines : seriesLength;
 
     this.calculateAxisYCoordinates(amountOfAxisY, containerSize, type);
 
@@ -396,10 +354,8 @@ export class PoChartAxisComponent {
 
     this.minMaxAxisValues = this.checksMinAndMaxValues(options, minMaxSeriesValues);
 
-    this.axisXGridLines =
-      options.axisXGridLines && this.isValidGridLinesLengthOption(options.axisXGridLines)
-        ? options.axisXGridLines
-        : PoChartAxisXGridLines;
+    this.gridLines =
+      options.gridLines && this.isValidGridLinesLengthOption(options.gridLines) ? options.gridLines : PoChartGridLines;
   }
 
   private checksMinAndMaxValues(
@@ -433,8 +389,8 @@ export class PoChartAxisComponent {
     this.seriesLength = 0;
   }
 
-  private isValidGridLinesLengthOption(axisXGridLines: number): boolean {
-    return axisXGridLines >= 2 && axisXGridLines <= 10;
+  private isValidGridLinesLengthOption(gridLines: number): boolean {
+    return gridLines >= 2 && gridLines <= 10;
   }
 
   private getAxisXLabels(type: PoChartType, minMaxAxisValues: PoChartMinMaxValues, amountOfAxisX: number) {

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-base.component.spec.ts
@@ -337,7 +337,7 @@ describe('PoChartBarBaseComponent', () => {
     });
 
     it('p-options: should update property if valid values', () => {
-      const validValues = [{}, { axisXGridLines: 5 }];
+      const validValues = [{}, { gridLines: 5 }];
 
       expectPropertiesValues(component, 'options', validValues, validValues);
     });
@@ -352,7 +352,7 @@ describe('PoChartBarBaseComponent', () => {
       const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
       const spyCalculateSeriesPathsCoordinatesn = spyOn(component, <any>'calculateSeriesPathsCoordinates');
 
-      component.options = { axisXGridLines: 5, maxRange: 100, minRange: 0 };
+      component.options = { gridLines: 5, maxRange: 100, minRange: 0 };
 
       expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
       expect(spyCalculateSeriesPathsCoordinatesn).toHaveBeenCalledWith(

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
@@ -353,7 +353,7 @@ describe('PoChartLineComponent', () => {
     });
 
     it('p-options: should update property if valid values', () => {
-      const validValues = [{}, { axisXGridLines: 5 }];
+      const validValues = [{}, { gridLines: 5 }];
 
       expectPropertiesValues(component, 'options', validValues, validValues);
     });
@@ -368,7 +368,7 @@ describe('PoChartLineComponent', () => {
       const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
       const spySeriePathPointsDefinition = spyOn(component, <any>'seriePathPointsDefinition');
 
-      component.options = { axisXGridLines: 5, maxRange: 100, minRange: 0 };
+      component.options = { gridLines: 5, maxRange: 100, minRange: 0 };
 
       expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
       expect(spySeriePathPointsDefinition).toHaveBeenCalledWith(

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts
@@ -98,7 +98,7 @@ export class SamplePoChartCoffeeRankingComponent {
   consumptionPerCapitaOptions: PoChartOptions = {
     axis: {
       maxRange: 100,
-      axisXGridLines: 2
+      gridLines: 2
     }
   };
 
@@ -106,7 +106,7 @@ export class SamplePoChartCoffeeRankingComponent {
     axis: {
       minRange: 0,
       maxRange: 40,
-      axisXGridLines: 5
+      gridLines: 5
     }
   };
 
@@ -114,7 +114,7 @@ export class SamplePoChartCoffeeRankingComponent {
     axis: {
       minRange: 0,
       maxRange: 100,
-      axisXGridLines: 5
+      gridLines: 5
     }
   };
 

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
@@ -133,10 +133,10 @@
 
     <po-number
       class="po-md-4"
-      name="axisXGridLines"
-      [(ngModel)]="options.axis.axisXGridLines"
+      name="gridLines"
+      [(ngModel)]="options.axis.gridLines"
       p-help="Example: 6"
-      p-label="axisXGridLines"
+      p-label="gridLines"
       (p-blur)="addOptions()"
     >
     </po-number>

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
@@ -36,7 +36,7 @@ export class SamplePoChartLabsComponent implements OnInit {
     axis: {
       minRange: undefined,
       maxRange: undefined,
-      axisXGridLines: undefined
+      gridLines: undefined
     }
   };
 
@@ -116,7 +116,7 @@ export class SamplePoChartLabsComponent implements OnInit {
       axis: {
         minRange: undefined,
         maxRange: undefined,
-        axisXGridLines: undefined
+        gridLines: undefined
       }
     };
   }

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
@@ -47,44 +47,44 @@ describe('PoChartMathsService', () => {
       expect(service.calculateMinAndMaxValues(series, acceptNegativeValues)).toEqual(expectedResult);
     });
 
-    it('range: should call `getAxisXGridLineArea` and return a list of values according with axisXGridLabels default value', () => {
+    it('range: should call `getGridLineArea` and return a list of values according with gridLabels default value', () => {
       const minMaxValues = { minValue: 0, maxValue: 200 };
       const expectedResult = [0, 50, 100, 150, 200];
-      const axisXGridLines = 5;
+      const gridLines = 5;
 
-      const spyGetAxisXGridLineArea = spyOn(service, <any>'getAxisXGridLineArea').and.callThrough();
+      const spygetGridLineArea = spyOn(service, <any>'getGridLineArea').and.callThrough();
 
       expect(service.range(minMaxValues)).toEqual(expectedResult);
-      expect(spyGetAxisXGridLineArea).toHaveBeenCalledWith(minMaxValues, axisXGridLines);
+      expect(spygetGridLineArea).toHaveBeenCalledWith(minMaxValues, gridLines);
     });
 
-    it('range: return a list of values according with axisXGridLabels passed value', () => {
+    it('range: return a list of values according with gridLabels passed value', () => {
       const minMaxValues = { minValue: 0, maxValue: 200 };
       const expectedResult = [0, 100, 200];
-      const axisXGridLines = 3;
+      const gridLines = 3;
 
-      const spyGetAxisXGridLineArea = spyOn(service, <any>'getAxisXGridLineArea').and.callThrough();
+      const spyGetGridLineArea = spyOn(service, <any>'getGridLineArea').and.callThrough();
 
-      expect(service.range(minMaxValues, axisXGridLines)).toEqual(expectedResult);
-      expect(spyGetAxisXGridLineArea).toHaveBeenCalledWith(minMaxValues, axisXGridLines);
+      expect(service.range(minMaxValues, gridLines)).toEqual(expectedResult);
+      expect(spyGetGridLineArea).toHaveBeenCalledWith(minMaxValues, gridLines);
     });
 
     it('range: should return only one item if minValue and maxValue have same value', () => {
       const minMaxValues = { minValue: 1, maxValue: 1 };
       const expectedResult = [1];
 
-      const axisXGridLines = 5;
+      const gridLines = 5;
 
-      expect(service.range(minMaxValues, axisXGridLines)).toEqual(expectedResult);
+      expect(service.range(minMaxValues, gridLines)).toEqual(expectedResult);
     });
 
     it('range: should return 6 itens', () => {
       const minMaxValues = { minValue: 19, maxValue: 100 };
       const expectedResult = [19, 35.2, 51.4, 67.6, 83.8, 100];
 
-      const axisXGridLines = 6;
+      const gridLines = 6;
 
-      expect(service.range(minMaxValues, axisXGridLines)).toEqual(expectedResult);
+      expect(service.range(minMaxValues, gridLines)).toEqual(expectedResult);
     });
 
     it('calculateSideSpacing: should return value referring to space between label x and serie`s plot', () => {

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
@@ -75,13 +75,13 @@ export class PoChartMathsService {
    * Calcula e retorna uma lista de valores referentes aos textos dos eixos X em relação à quantidade de linhas horizontais.
    *
    * @param minMaxValues Objeto contendo os valores mínimo e máximo de todas as séries.
-   * @param axisXGridLines Quantidade de linhas horizontais. Valor default é 5.
+   * @param gridLines Quantidade de linhas horizontais. Valor default é 5.
    */
-  range(minMaxValues: PoChartMinMaxValues, axisXGridLines: number = 5) {
+  range(minMaxValues: PoChartMinMaxValues, gridLines: number = 5) {
     const { minValue, maxValue } = minMaxValues;
 
     const result = [];
-    const step = this.getAxisXGridLineArea(minMaxValues, axisXGridLines);
+    const step = this.getGridLineArea(minMaxValues, gridLines);
 
     for (let index = minValue; index <= maxValue; index = (index * 10 + step * 10) / 10) {
       result.push(index);
@@ -106,9 +106,9 @@ export class PoChartMathsService {
     return (notABoolean && isInteger) || (notABoolean && isFloat);
   }
 
-  // Cálculo que retorna o valor obtido da quantidade de AXISXGRIDL INES em relação ao alcance dos valores mínimos e máximos das séries (maxMinValues)
-  private getAxisXGridLineArea(minMaxValues: PoChartMinMaxValues, axisXGridLines: number) {
-    const percentageValue = this.getFractionFromInt(axisXGridLines - 1);
+  // Cálculo que retorna o valor obtido de gridLines em relação ao alcance dos valores mínimos e máximos das séries (maxMinValues)
+  private getGridLineArea(minMaxValues: PoChartMinMaxValues, gridLines: number) {
+    const percentageValue = this.getFractionFromInt(gridLines - 1);
     const { minValue, maxValue } = minMaxValues;
     const result = (percentageValue * (maxValue - minValue)) / 100;
 
@@ -127,7 +127,7 @@ export class PoChartMathsService {
     return isNaN(result) ? 0 : result;
   }
 
-  // Retorna a fração do número passado referente à quantidade de linhas no eixo X (axisXGridLines)
+  // Retorna a fração do número passado referente à quantidade de linhas no eixo X (gridLines)
   private getFractionFromInt(value: number) {
     return (1 / value) * (100 / 1);
   }


### PR DESCRIPTION
**chart**

**DTHFUI-4576**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente a propriedade designada para quantidade de linhas do grid se chama `axisXGridLines`. É preciso definir um nome mais genérico já que, no caso de gráficos do tipo barra, as linhas modificadas são relacionadas com o eixo Y.

**Qual o novo comportamento?**
- Modificada a propriedade axisGridLines para gridLines.
- Incluída modificação na migração do ng-update.

**Simulação**
- Samples do Portal para teste da propriedade;

- Buildar os pacotes com a versão 4.0.0-rc.1 e publica-los localmente com verdaccio. (não esqueça de publicar style e tslint na mesma versão para não dar erro na hora de migrar o projeto).
Utilizar o Po Conference Web incluindo um componente po-chart e adicionar em p-options um objeto contendo axisXGridLines.
Migrar da v3x para v4x utilizando a documentação e verificar a modificação dad propriedade após a atualização.

