### PR TITLE
feat(menu-panel): inclui propriedade p-logo

### DIFF
--- a/projects/portal/src/styles.css
+++ b/projects/portal/src/styles.css
@@ -255,6 +255,10 @@ pre code {
   position: relative;
 }
 
+.docs-sample-container .po-wrapper-menu-panel .po-page {
+  display: inline-block;
+}
+
 .docs-sample-container po-menu + po-page-default {
   width: 80%;
 }
@@ -398,10 +402,6 @@ sample-po-menu-human-resources .po-wrapper.po-collapsed-menu .po-toolbar {
     margin-left: 60px;
     margin-top: 12px;
     position: relative;
-  }
-
-  .docs-sample-container .po-wrapper-menu-panel .po-page {
-    display: inline-block;
   }
 
   .docs-sample-container .po-wrapper .po-page {

--- a/projects/ui/src/lib/components/po-menu-panel/po-menu-panel-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu-panel/po-menu-panel-base.component.spec.ts
@@ -4,6 +4,7 @@ import { PoMenuPanelBaseComponent } from './po-menu-panel-base.component';
 
 describe('PoMenuPanelBaseComponent: ', () => {
   const component = new PoMenuPanelBaseComponent();
+  const poDefaultLogo = 'https://po-ui.io/assets/po-logos/po_black.svg';
 
   beforeEach(() => {
     component.menus = [
@@ -32,6 +33,24 @@ describe('PoMenuPanelBaseComponent: ', () => {
 
       expect(component['setMenuExtraProperties']).toHaveBeenCalled();
       expect(component['validateMenus']).toHaveBeenCalled();
+    });
+
+    it('logo: should set `logo` with default value', () => {
+      expect(component.logo).toEqual(poDefaultLogo);
+    });
+
+    it('logo: should set `logo` with the developer image url', () => {
+      const src = 'https://po-ui.io/assets/po-logos/po_color_bg.svg';
+      component.logo = src;
+      expect(component.logo).not.toEqual(poDefaultLogo);
+      expect(component.logo).toEqual(src);
+    });
+
+    it('logo: should set `logo` with default value if the url passed by the developer is undefined', () => {
+      const src = undefined;
+      component.logo = src;
+      expect(component.logo).toEqual(poDefaultLogo);
+      expect(component.logo).not.toEqual(src);
     });
   });
 

--- a/projects/ui/src/lib/components/po-menu-panel/po-menu-panel-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu-panel/po-menu-panel-base.component.ts
@@ -5,6 +5,8 @@ import { isExternalLink, uuid } from '../../utils/util';
 import { PoMenuPanelItem } from './po-menu-panel-item/po-menu-panel-item.interface';
 import { PoMenuPanelItemInternal } from './po-menu-panel-item/po-menu-panel-item-internal.interface';
 
+const poDefaultLogo = 'https://po-ui.io/assets/po-logos/po_black.svg';
+
 /**
  * @description
  *
@@ -17,6 +19,7 @@ import { PoMenuPanelItemInternal } from './po-menu-panel-item/po-menu-panel-item
 @Directive()
 export class PoMenuPanelBaseComponent {
   private _menus;
+  private _logo: string = poDefaultLogo;
 
   /** Lista dos itens do `po-menu-panel`. Se o valor estiver indefinido ou inválido, será inicializado como um array vazio. */
   @Input('p-menus') set menus(menus: Array<PoMenuPanelItem>) {
@@ -28,6 +31,23 @@ export class PoMenuPanelBaseComponent {
 
   get menus() {
     return this._menus;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Caminho para a logomarca localizada na parte superior do menu.
+   *
+   * > Caso seja indefinida será aplicada a imagem default do PO UI.
+   */
+  @Input('p-logo') set logo(src: string) {
+    this._logo = src ?? poDefaultLogo;
+  }
+
+  get logo() {
+    return this._logo;
   }
 
   private setMenuExtraProperties(menus: Array<PoMenuPanelItem>) {

--- a/projects/ui/src/lib/components/po-menu-panel/po-menu-panel.component.html
+++ b/projects/ui/src/lib/components/po-menu-panel/po-menu-panel.component.html
@@ -1,7 +1,7 @@
 <div class="po-menu-panel">
   <div class="po-menu-panel-logo-container">
     <a href="./">
-      <div class="po-menu-panel-logo"></div>
+      <img class="po-menu-panel-logo" alt="main-logo" [src]="logo" />
     </a>
   </div>
 

--- a/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-customer/sample-po-menu-panel-customer.component.html
+++ b/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-customer/sample-po-menu-panel-customer.component.html
@@ -1,7 +1,7 @@
 <div class="po-wrapper-menu-panel">
   <po-toolbar p-title="PO - Customers"></po-toolbar>
 
-  <po-menu-panel [p-menus]="menuItems"></po-menu-panel>
+  <po-menu-panel [p-menus]="menuItems" p-logo="https://po-ui.io/assets/po-logos/po_color_bg.svg"></po-menu-panel>
 
   <po-page-default [p-title]="title"></po-page-default>
 </div>

--- a/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-labs/sample-po-menu-panel-labs.component.html
+++ b/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-labs/sample-po-menu-panel-labs.component.html
@@ -1,5 +1,5 @@
 <div class="po-wrapper-menu-panel">
-  <po-menu-panel [p-menus]="menuItems"> </po-menu-panel>
+  <po-menu-panel [p-menus]="menuItems" [p-logo]="logo"> </po-menu-panel>
 
   <po-page-default p-title="PO Menu Panel">
     <div class="po-row">
@@ -7,6 +7,17 @@
     </div>
 
     <hr />
+
+    <div class="po-row">
+      <po-input
+        class="po-md-12"
+        name="logo"
+        [(ngModel)]="logo"
+        p-label="Logo"
+        p-help="Exemplo: https://po-ui.io/assets/po-logos/po_inverse.svg"
+      >
+      </po-input>
+    </div>
 
     <form #fMenuPanel="ngForm">
       <div class="po-row">

--- a/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-labs/sample-po-menu-panel-labs.component.ts
+++ b/projects/ui/src/lib/components/po-menu-panel/samples/sample-po-menu-panel-labs/sample-po-menu-panel-labs.component.ts
@@ -10,6 +10,7 @@ export class SamplePoMenuPanelLabsComponent implements OnInit {
   menuItem: PoMenuPanelItem = { icon: undefined, label: undefined };
   menuItems: Array<PoMenuPanelItem>;
   menuItemSelected: string;
+  logo: string;
 
   public readonly iconsOptions: Array<PoRadioGroupOption> = [
     { label: 'po-icon-news', value: 'po-icon-news' },
@@ -33,6 +34,7 @@ export class SamplePoMenuPanelLabsComponent implements OnInit {
   restore() {
     this.menuItems = [];
     this.menuItemSelected = undefined;
+    this.logo = undefined;
   }
 
   private onMenuItemSelected(menu: PoMenuPanelItem) {


### PR DESCRIPTION
**PO-MENU-PANEL**

**DTHFUI-4565**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Não é possível customizar a imagem do logo exibida no topo do menu.

**Qual o novo comportamento?**
Inclui propriedade p-logo que permite customizar a imagem destinada à logomarca exibida no topo do menu e também foi substituída a imagem default pela logo do PO UI.

**Simulação**
Através dos samples do Portal, possui um sample com a logo customizada.