### PR TITLE
fix(grid): corrige erro disparado ao editar uma celula

### DIFF
--- a/projects/ui/src/lib/components/po-grid/po-grid-cell-action/po-grid-cell-action.component.ts
+++ b/projects/ui/src/lib/components/po-grid/po-grid-cell-action/po-grid-cell-action.component.ts
@@ -12,13 +12,9 @@ export class PoGridCellActionComponent {
   constructor() {}
 
   onKeyDownContent(event) {
-    // console.log('onKeyDownContent: ', event);
-
     // ENTER
     if (event.keyCode === 13) {
       event.preventDefault();
-
-      // this.openActions(this.value);
 
       return;
     }

--- a/projects/ui/src/lib/components/po-grid/po-grid-cell/po-grid-cell.component.html
+++ b/projects/ui/src/lib/components/po-grid/po-grid-cell/po-grid-cell.component.html
@@ -25,14 +25,7 @@
       (keydown.arrowleft)="$event.stopPropagation()"
       (keydown.arrowright)="$event.stopPropagation()"
       (keydown)="onKeyDownInput($event)"
-      (blur)="onBlurInput($event)"
+      (blur)="onBlurInput()"
     />
-
-    <!-- <po-input
-      #inputElement class="po-grid-cell-input"
-      [(ngModel)]="editValue"
-      (keydown)="onKeyDownInput($event)"
-      (p-blur)="onBlurInput($event)">
-    </po-input> -->
   </ng-template>
 </div>

--- a/projects/ui/src/lib/components/po-grid/po-grid-cell/po-grid-cell.component.ts
+++ b/projects/ui/src/lib/components/po-grid/po-grid-cell/po-grid-cell.component.ts
@@ -95,13 +95,9 @@ export class PoGridCellComponent {
   }
 
   onKeyDownInput(event: any) {
-    // console.log('onKeyDownInput: ', event);
-
     // ENTER
     if (event.keyCode === 13) {
-      this.value = this.editValue;
-      this.editValue = undefined;
-      this.edit = false;
+      event.target.blur();
       this.changeDetectorRef.detectChanges();
       this.contentElement.nativeElement.focus();
     }

--- a/projects/ui/src/lib/components/po-grid/po-grid-cell/po-grid-cell.component.ts
+++ b/projects/ui/src/lib/components/po-grid/po-grid-cell/po-grid-cell.component.ts
@@ -44,8 +44,8 @@ export class PoGridCellComponent {
     return this._value;
   }
 
-  @ViewChild('inputElement', { static: true }) inputElement: ElementRef;
-  @ViewChild('contentElement', { static: true }) contentElement: ElementRef;
+  @ViewChild('inputElement') inputElement: ElementRef;
+  @ViewChild('contentElement') contentElement: ElementRef;
 
   constructor(private changeDetectorRef: ChangeDetectorRef) {}
 

--- a/projects/ui/src/lib/components/po-grid/po-grid-cell/po-grid-cell.component.ts
+++ b/projects/ui/src/lib/components/po-grid/po-grid-cell/po-grid-cell.component.ts
@@ -35,7 +35,7 @@ export class PoGridCellComponent {
   @Input('p-required') required?: boolean = false;
 
   @Output('p-valueChange') valueChange = new EventEmitter<any>();
-  // @Input('p-value') value?: string;
+
   @Input('p-value') set value(value: any) {
     this._value = value;
     this.valueChange.emit(this._value);
@@ -50,8 +50,6 @@ export class PoGridCellComponent {
   constructor(private changeDetectorRef: ChangeDetectorRef) {}
 
   onKeyDownContent(event: any) {
-    // console.log('onKeyDownContent: ', event);
-
     // BACKSPACE / DELETE
     if (!event.ctrlKey && (event.keyCode === 8 || event.keyCode === 46)) {
       if (this.readonly) {
@@ -79,16 +77,12 @@ export class PoGridCellComponent {
   }
 
   dblclick(event: any) {
-    // console.log('dblclick: ', event);
-
     event.preventDefault();
 
     this.onEditCell(this.value);
   }
 
-  onBlurInput(event: any) {
-    // console.log('onBlurInput: ', event);
-
+  onBlurInput() {
     this.value = this.editValue;
     this.editValue = undefined;
     this.edit = false;

--- a/projects/ui/src/lib/components/po-grid/po-grid-head/po-grid-head.component.ts
+++ b/projects/ui/src/lib/components/po-grid/po-grid-head/po-grid-head.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, ElementRef, ChangeDetectorRef } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'po-grid-head',
@@ -23,6 +23,4 @@ export class PoGridHeadComponent {
   }
 
   @Input('p-title') title?: string;
-
-  constructor(private changeDetectorRef: ChangeDetectorRef) {}
 }

--- a/projects/ui/src/lib/components/po-grid/po-grid.component.html
+++ b/projects/ui/src/lib/components/po-grid/po-grid.component.html
@@ -42,12 +42,6 @@
       </div>
     </div>
   </div>
-
-  <!-- <div class="po-grid-footer-wrapper">
-    <div class="po-grid-footer">
-      <div class="links"><a href="#">RODAPÉ</a></div>
-    </div>
-  </div> -->
 </div>
 
 <!-- Coluna com as colunas congeladas -->

--- a/projects/ui/src/lib/components/po-grid/po-grid.component.ts
+++ b/projects/ui/src/lib/components/po-grid/po-grid.component.ts
@@ -5,6 +5,8 @@ import { PoGridRowActions } from './po-grid-row-actions.interface';
 /**
  * @description
  *
+ * > Componente em desenvolvimento, podendo haver BREAKING CHANGES nas próximas versões.
+ *
  * Componente grid.
  *
  * Ações / atalhos:
@@ -128,7 +130,7 @@ export class PoGridComponent implements OnDestroy {
   }
 
   cancelRow(event: any, row: any) {
-    const el = event.path.find(element => element.id);
+    const el = this.getEventPath(event).find(element => element.id);
 
     if (!el) {
       return;
@@ -254,7 +256,7 @@ export class PoGridComponent implements OnDestroy {
   }
 
   tableClick(event: any) {
-    const el = event.path.find(element => element.id);
+    const el = this.getEventPath(event).find(element => element.id);
 
     if (!el) {
       this.selectCell(this.currencyRow, this.currencyColumn);
@@ -358,5 +360,10 @@ export class PoGridComponent implements OnDestroy {
       this.currencyColumn = col;
       nextCell.focus();
     }
+  }
+
+  private getEventPath(event) {
+    // firefox do not have support to event.path
+    return event.path || event.composedPath();
   }
 }

--- a/projects/ui/src/lib/components/po-grid/po-grid.component.ts
+++ b/projects/ui/src/lib/components/po-grid/po-grid.component.ts
@@ -177,10 +177,6 @@ export class PoGridComponent implements OnDestroy {
     let prow = +row;
     let pcol = +col;
 
-    // event.preventDefault();
-    // event.stopPropagation();
-
-    // debugger;
     if (direction === 'down') {
       if (row <= this.data.length) {
         prow++;
@@ -226,11 +222,9 @@ export class PoGridComponent implements OnDestroy {
     }
 
     if (this.currencyCell === `${prow}-${pcol}`) {
-      // console.log('vazou');
       return;
     }
 
-    // debugger;
     if (prow !== this.currencyRow && row > 0 && this.data.length >= row) {
       if (!this.isEmptyRow(row)) {
         if (!this.saveRow(row)) {
@@ -245,7 +239,6 @@ export class PoGridComponent implements OnDestroy {
 
     if (this.currencyRow !== prow) {
       this.currencyObj = Object.assign({}, this.data[prow - 1]);
-      // console.log('mudou de linha');
     }
 
     this.lastCell = event.target.id;
@@ -286,7 +279,6 @@ export class PoGridComponent implements OnDestroy {
       }
 
       this.currencyObj = Object.assign({}, this.data[prow - 1]);
-      // console.log('>>>>>>> ', prow - 1);
     }
 
     this.lastCell = this.currencyCell;
@@ -299,12 +291,9 @@ export class PoGridComponent implements OnDestroy {
   }
 
   saveRow(row: number): boolean {
-    // console.log(this.data[row - 1]);
-
     const obj = this.data[row - 1];
 
     if (!Object.keys(obj).some(prop => obj[prop] !== this.currencyObj[prop])) {
-      // console.log('tudo igual');
       return true;
     }
 
@@ -329,8 +318,6 @@ export class PoGridComponent implements OnDestroy {
     if (this.rowActions.beforeInsert && !this.rowActions.beforeInsert(obj)) {
       return false;
     }
-
-    // this.currencyObj = Object.assign({}, obj);
 
     this.data.push(obj);
     this.changeDetectorRef.detectChanges();

--- a/projects/ui/src/lib/components/po-grid/samples/sample-po-grid-basic/sample-po-grid-basic.component.ts
+++ b/projects/ui/src/lib/components/po-grid/samples/sample-po-grid-basic/sample-po-grid-basic.component.ts
@@ -19,8 +19,7 @@ export class SamplePoGridBasicComponent {
     { property: 'occupation', label: 'Cargo', width: 150 },
     { property: 'email', label: 'E-mail', width: 100, required: true },
     { property: 'status', label: 'Status', align: 'center', width: 80 },
-    { property: 'lastActivity', label: 'Última atividade', align: 'center', width: 140 },
-    { property: 'actions', label: '.', align: 'center', readonly: true, action: true }
+    { property: 'lastActivity', label: 'Última atividade', align: 'center', width: 140 }
   ];
 
   data = [
@@ -30,8 +29,7 @@ export class SamplePoGridBasicComponent {
       occupation: 'Developer',
       email: 'jhonatas.silvano@po-ui.com.br',
       status: 'Active',
-      lastActivity: '2018-12-12',
-      actions: '...'
+      lastActivity: '2018-12-12'
     },
     {
       id: 78492341,
@@ -39,8 +37,7 @@ export class SamplePoGridBasicComponent {
       occupation: 'Engineer',
       email: 'rafael.goncalvez@po-ui.com.br',
       status: 'Active',
-      lastActivity: '2018-12-10',
-      actions: '...'
+      lastActivity: '2018-12-10'
     },
     {
       id: 986434,
@@ -48,8 +45,7 @@ export class SamplePoGridBasicComponent {
       occupation: 'Developer',
       email: 'nicoli.pereira@po-ui.com.br',
       status: 'Active',
-      lastActivity: '2018-12-12',
-      actions: '...'
+      lastActivity: '2018-12-12'
     },
     {
       id: 4235652,
@@ -57,8 +53,7 @@ export class SamplePoGridBasicComponent {
       occupation: 'Developer',
       email: 'mauricio.joao@po-ui.com.br',
       status: 'Active',
-      lastActivity: '2018-11-23',
-      actions: '...'
+      lastActivity: '2018-11-23'
     },
     {
       id: 629131,
@@ -66,8 +61,7 @@ export class SamplePoGridBasicComponent {
       occupation: 'Engineer',
       email: 'leandro.oliveira@po-ui.com.br',
       status: 'Active',
-      lastActivity: '2018-11-30',
-      actions: '...'
+      lastActivity: '2018-11-30'
     }
   ];
 


### PR DESCRIPTION
**GRID**

**DTHFUI-2343**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Descrição?**
Ao entrar modo de edição em uma celula, estava disparando um erro.
Isso ocorria pois estava sendo utilizado { static: true },
Mas no caso o correto é não informa-lo, deixa-lo como false (padrão).

Avaliado que em aplicações mais simples, o ngIf =false dispara o blur do campo, portanto ao chegar no blur,
o editValue ja estava undefined, limpando o campo.
A partir deste commit ao pressionar ENTER é invocado o blur do campo, para centralizar nele o tratamento e não disparar 2x

Remove comentarios de console.log, HTML e importações não utilizadas.

**Simulação**
Rodar no portal