### PR TITLE
feat(lookup): permite informar propriedade p/ exibir descrição formatada 

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -160,8 +160,27 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
    * }
    * ```
    * > Esta propriedade sobrepõe o valor da propriedade `p-field-label` na descrição do campo.
+   *
+   * Pode-se informar uma lista de propriedades que deseja exibir como descrição do campo, Por exemplo:
+   * ```
+   * <po-lookup
+   *  ...
+   *  [p-field-format]="['id','nickname']"
+   *  ...
+   * >
+   *
+   * Objeto retornado:
+   *   {
+   *      id:123,
+   *      name: 'Kakaroto',
+   *      nickname: 'Goku',
+   *   }
+   * Apresentação no campo: 123 - Goku
+   * ```
+   *
+   * > Será utilizado ` - ` como separador.
    */
-  @Input('p-field-format') fieldFormat?: (value) => string;
+  @Input('p-field-format') fieldFormat?: ((value) => string) | Array<string>;
 
   /**
    * Lista das colunas da tabela.

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -324,6 +324,34 @@ describe('PoLookupComponent:', () => {
       expect(component.inputEl.nativeElement.value).toBe('123 - teste');
     });
 
+    it('setInputValueWipoieldFormat: should set input value and old value with formatedField  if fieldFormat is array', () => {
+      component.fieldFormat = ['label', 'value'];
+      component['setInputValueWipoieldFormat'](objectSelected);
+      expect(component['oldValue']).toBe('teste - 123');
+      expect(component.inputEl.nativeElement.value).toBe('teste - 123');
+    });
+
+    it('formatFields: shouldformat the return based on the array sent by fieldFormat, even if the array contains an invalid property ', () => {
+      component.fieldFormat = ['label', 'cnpj'];
+      expect(component['formatFields'](objectSelected, component.fieldFormat)).toBe('teste');
+    });
+
+    it('formatFields: should format the return based on the default fieldValue sent if fieldFormat is an invalid value', () => {
+      component.fieldValue = 'value';
+      expect(component['formatFields'](objectSelected, 'abc')).toBe(123);
+    });
+
+    it('formatFields: should formats the return based on the array sent by fieldFormat ', () => {
+      component.fieldFormat = ['label', 'value'];
+      expect(component['formatFields'](objectSelected, component.fieldFormat)).toBe('teste - 123');
+    });
+
+    it('formatFields: should format the return based on the default fieldValue sent if the fieldFormat is undefined', () => {
+      component.fieldFormat = ['label', 'value'];
+      component.fieldValue = 'value';
+      expect(component['formatFields'](objectSelected, undefined)).toBe(123);
+    });
+
     it('setInputValueWipoieldFormat: should set `oldValue` and `inputValue` to `` ', () => {
       component.fieldFormat = valueFormated => `${valueFormated.value} - ${valueFormated.label}`;
       component['oldValue'] = '';

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -181,10 +181,35 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
 
     return !!(this.service && !this.disabled);
   }
+  private formatFields(objectSelected, properties) {
+    let formatedField;
+    if (Array.isArray(properties)) {
+      for (const property of properties) {
+        if (objectSelected && objectSelected[property]) {
+          if (!formatedField) {
+            formatedField = objectSelected[property];
+          } else {
+            formatedField = formatedField + ' - ' + objectSelected[property];
+          }
+        }
+      }
+    }
+
+    if (!formatedField) {
+      formatedField = objectSelected[this.fieldValue];
+    }
+    return formatedField;
+  }
 
   private setInputValueWipoieldFormat(objectSelected: any) {
     const isEmpty = Object.keys(objectSelected).length === 0;
-    const fieldFormated = this.fieldFormat(objectSelected);
+    let fieldFormated;
+
+    if (Array.isArray(this.fieldFormat)) {
+      fieldFormated = this.formatFields(objectSelected, this.fieldFormat);
+    } else {
+      fieldFormated = this.fieldFormat(objectSelected);
+    }
 
     this.oldValue = isEmpty ? '' : fieldFormated;
     this.inputEl.nativeElement.value = isEmpty ? '' : fieldFormated;

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero-reactive-form/sample-po-lookup-hero-reactive-form.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero-reactive-form/sample-po-lookup-hero-reactive-form.component.html
@@ -17,7 +17,7 @@
       p-label="Hero"
       p-required
       [p-columns]="columns"
-      [p-field-format]="fieldFormat"
+      [p-field-format]="['nickname', 'label']"
       [p-filter-service]="service"
       [p-literals]="{ 'modalTitle': 'Heroes available for mission' }"
     >

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -89,12 +89,22 @@
 
   <div class="po-row">
     <po-input
-      class="po-lg-6"
+      class="po-lg-12"
       name="literals"
       [(ngModel)]="literals"
       p-help='Ex.: { "modalTitle": "Select a register", "modalPrimaryActionLabel": "Select", "modalPlaceholder": "Search Value" }'
       p-label="Literals"
       (p-change)="changeLiterals()"
+    >
+    </po-input>
+
+    <po-input
+      name="formatField"
+      [(ngModel)]="formatField"
+      class="po-lg-6"
+      p-label="Field Format"
+      p-help='Ex.: ["id", "name"]'
+      (p-change)="onFieldFormatChange($event)"
     >
     </po-input>
 
@@ -105,7 +115,6 @@
       p-columns="3"
       p-label="Properties"
       [p-options]="propertiesOptions"
-      (p-change)="onChangeProperties($event)"
     >
     </po-checkbox-group>
   </div>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
@@ -21,7 +21,8 @@ export class SamplePoLookupLabsComponent implements OnInit {
   columnsName: Array<string>;
   customLiterals: PoLookupLiterals;
   event: string;
-  fieldFormat: (objectSelected) => string;
+  fieldFormat: Array<string>;
+  formatField: string;
   fieldLabel: string;
   fieldValue: string;
   filterService: PoLookupFilter | string;
@@ -58,7 +59,6 @@ export class SamplePoLookupLabsComponent implements OnInit {
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'disabled', label: 'Disabled' },
-    { value: 'fieldFormat', label: 'Field format' },
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'required', label: 'Required' }
@@ -82,14 +82,10 @@ export class SamplePoLookupLabsComponent implements OnInit {
     }
   }
 
-  fieldFormatFn(objectSelected) {
-    return `${objectSelected.id} - ${objectSelected.name}`;
-  }
-
-  onChangeProperties(properties: Array<string>) {
-    if (properties.includes('fieldFormat')) {
-      this.fieldFormat = this.fieldFormatFn;
-    } else {
+  onFieldFormatChange(event) {
+    try {
+      this.fieldFormat = JSON.parse(event);
+    } catch {
       this.fieldFormat = undefined;
     }
   }
@@ -109,7 +105,8 @@ export class SamplePoLookupLabsComponent implements OnInit {
 
     this.fieldLabel = 'name';
     this.fieldValue = 'id';
-
+    this.fieldFormat = undefined;
+    this.formatField = undefined;
     this.event = undefined;
     this.filterService = undefined;
     this.label = undefined;


### PR DESCRIPTION
**po-lookup**

**DTHFUI-4540**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Apenas realizava formatação dos campos através de função

**Qual o novo comportamento?**
Aceita também, array de strings para formatação do campo.

**Simulação**

{ email: jhony@gmail.com, name: undefined }

['email', 'name']

Apresentação do campo: "jhony@gmail.com"