### PR TITLE
fix(page-dynamic-table:):  corrige disparo duplicado dos recursos

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -526,7 +526,31 @@ describe('PoPageDynamicTableComponent:', () => {
       }));
 
       it(`shouldn't call 'loadData' if 'initialFilters'`, () => {
-        const fakeMetadata = { subscribe: () => 'metadata' };
+        const fakeMetadata = {
+          pipe: function () {
+            return this;
+          },
+          subscribe: () => 'metadata'
+        };
+        const fakeLoadData = { subscribe: () => 'data' };
+        const spyMetaData = spyOn(fakeMetadata, 'subscribe');
+        const spyLoadData = spyOn(fakeLoadData, 'subscribe');
+        spyOn(component, <any>'getInitialValuesFromFilter').and.returnValue({ name: 'teste' });
+        spyOn(component, <any>'loadData').and.returnValue(fakeLoadData);
+        spyOn(component, <any>'getMetadata').and.returnValue(fakeMetadata);
+
+        component['loadDataFromAPI']();
+        expect(spyMetaData).toHaveBeenCalled();
+        expect(spyLoadData).not.toHaveBeenCalled();
+      });
+
+      it(`shouldn't call 'loadData' if 'initialFilters'`, () => {
+        const fakeMetadata = {
+          pipe: function () {
+            return this;
+          },
+          subscribe: () => 'metadata'
+        };
         const fakeLoadData = { subscribe: () => 'data' };
         const spyMetaData = spyOn(fakeMetadata, 'subscribe');
         const spyLoadData = spyOn(fakeLoadData, 'subscribe');
@@ -573,6 +597,43 @@ describe('PoPageDynamicTableComponent:', () => {
         const returnedValue = component['getInitialValuesFromFilter']();
 
         expect(returnedValue).toEqual(filters);
+      });
+
+      it(`should call 'metaData' once time`, fakeAsync(() => {
+        const fakeMetadata = {
+          pipe: function () {
+            return this;
+          },
+          subscribe: () => 'metadata'
+        };
+        const fakeLoadData = { subscribe: () => 'data' };
+
+        const spyMetaData = spyOn(fakeMetadata, 'subscribe');
+
+        const filters = { name: 'teste' };
+        component.fields = [{ property: 'name', filter: true, initValue: 'teste' }, { property: 'city' }];
+        const returnedValue = component['getInitialValuesFromFilter']();
+
+        spyOn(component, <any>'getInitialValuesFromFilter').and.returnValue({ name: 'teste' });
+        spyOn(component, <any>'loadData').and.returnValue(fakeLoadData);
+        spyOn(component, <any>'getMetadata').and.returnValue(fakeMetadata);
+
+        tick();
+
+        component['loadDataFromAPI']();
+        expect(returnedValue).toEqual(filters);
+        expect(spyMetaData).toHaveBeenCalledTimes(1);
+      }));
+
+      it(`should return empty in 'metaData'`, () => {
+        component.fields = [
+          { property: 'name', filter: true },
+          { property: 'search', filter: true, initValue: '0348093615904' }
+        ];
+        const returnedValue = component['getInitialValuesFromFilter']();
+
+        component['loadDataFromAPI']();
+        expect(!Object.keys(returnedValue).length).toEqual(false);
       });
 
       it('should delete empty props', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -915,13 +915,21 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     const metadata$ = this.getMetadata(serviceApiFromRoute, onLoad);
     const data$ = this.loadData();
 
-    const initialFilters = this.getInitialValuesFromFilter();
+    this.subscriptions.add(
+      metadata$
+        .pipe(
+          switchMap(() => {
+            const initialFilters = this.getInitialValuesFromFilter();
 
-    if (Object.keys(initialFilters).length) {
-      this.subscriptions.add(metadata$.subscribe());
-    } else {
-      this.subscriptions.add(concat(metadata$, data$).subscribe());
-    }
+            if (!Object.keys(initialFilters).length) {
+              return data$;
+            }
+
+            return EMPTY;
+          })
+        )
+        .subscribe()
+    );
   }
 
   private getInitialValuesFromFilter() {
@@ -948,7 +956,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
       );
     }
 
-    return EMPTY;
+    return of(null);
   }
 
   private getPoDynamicPageOptions(onLoad: UrlOrPoCustomizationFunction): Observable<PoPageDynamicTableOptions> {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -10,6 +10,7 @@
   [p-fields]="fields"
   [p-service-api]="serviceApi"
   [p-quick-search-width]="quickSearchWidth"
+  [p-load]="onLoad.bind(this)"
 >
 </po-page-dynamic-table>
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -4,7 +4,8 @@ import { PoBreadcrumb, PoDynamicViewField, PoModalComponent } from '@po-ui/ng-co
 import {
   PoPageDynamicTableActions,
   PoPageDynamicTableCustomAction,
-  PoPageDynamicTableCustomTableAction
+  PoPageDynamicTableCustomTableAction,
+  PoPageDynamicTableOptions
 } from '@po-ui/ng-templates';
 
 import { SamplePoPageDynamicTableUsersService } from './sample-po-page-dynamic-table-users.service';
@@ -44,6 +45,7 @@ export class SamplePoPageDynamicTableUsersComponent {
     { property: 'id', key: true, visible: false, filter: true },
     { property: 'name', label: 'Name', filter: true, gridColumns: 6 },
     { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true },
+    { property: 'search', filter: true, visible: false },
     {
       property: 'birthdate',
       label: 'Birthdate',
@@ -77,6 +79,25 @@ export class SamplePoPageDynamicTableUsersComponent {
   ];
 
   constructor(private usersService: SamplePoPageDynamicTableUsersService) {}
+
+  onLoad(): PoPageDynamicTableOptions {
+    return {
+      fields: [
+        { property: 'id', key: true, visible: true, filter: true },
+        { property: 'name', label: 'Name', filter: true, gridColumns: 6 },
+        { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true },
+        { property: 'search', initValue: '0748093840433' },
+        {
+          property: 'birthdate',
+          label: 'Birthdate',
+          type: 'date',
+          gridColumns: 6,
+          visible: false,
+          allowColumnsManager: true
+        }
+      ]
+    };
+  }
 
   printPage() {
     window.print();


### PR DESCRIPTION
O componente estava disparando a requisição duas vezes quando possui filtros (initValue).

O comportamento correto é disparar a requisição dos recursos apenas quando retornar o metadata.

Fixes DTHFUI-4303

**po-page-dynamic-table**

**DTHFUI-4303**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
O componente esta disparando a requisição duas vezes quando possui filtros (initValue).

**Qual o novo comportamento?**
Corrigido, agora dispara apenas uma vez.


**Simulação**
Verificar via network do navegador.