### PR TITLE
feat(dialog): permite informar conteúdo HTML na mensagem

### DIFF
--- a/projects/ui/src/lib/services/po-dialog/interfaces/po-dialog.interface.ts
+++ b/projects/ui/src/lib/services/po-dialog/interfaces/po-dialog.interface.ts
@@ -10,11 +10,13 @@ import { PoDialogConfirmLiterals } from './po-dialog-confirm-literals.interface'
  *
  * Interface para o título e a mensagem do serviço po-dialog.
  */
-interface PoDialogOptions {
+export interface PoDialogOptions {
   /** Título da caixa de diálogo. */
   title: string;
 
-  /** Mensagem da caixa de diálogo. */
+  /** Mensagem da caixa de diálogo.
+   * > Pode-se informar um conteúdo HTML na mensagem.
+   */
   message: string;
 }
 

--- a/projects/ui/src/lib/services/po-dialog/po-dialog.component.html
+++ b/projects/ui/src/lib/services/po-dialog/po-dialog.component.html
@@ -1,3 +1,3 @@
 <po-modal [p-title]="title" [p-primary-action]="primaryAction" [p-secondary-action]="secondaryAction">
-  {{ message }}
+  <div [innerHtml]="message"></div>
 </po-modal>

--- a/projects/ui/src/lib/services/po-dialog/samples/sample-po-dialog-cancel-credit-card/sample-po-dialog-cancel-credit-card.component.ts
+++ b/projects/ui/src/lib/services/po-dialog/samples/sample-po-dialog-cancel-credit-card/sample-po-dialog-cancel-credit-card.component.ts
@@ -63,7 +63,7 @@ export class SamplePoDialogCancelCreditCardComponent implements OnDestroy, OnIni
   openConfirmDialog() {
     this.poDialog.confirm({
       title: 'Confirm',
-      message: `Hi ${this.name},  do you confirm the cancellation of the card number ${this.cardNumber} ?`,
+      message: `<p>Hi <b>${this.name}</b>.</p> <p> Do you confirm the cancellation of the card number  <i class="po-icon po-icon-credit-payment"></i> <b>${this.cardNumber}<b>? </p>`,
       confirm: () => this.confirmCancelation()
     });
   }


### PR DESCRIPTION
Permite informar mensagem com conteúdo HTML para que seja possível trabalhar com quebras de linhas, espaçamentos, ícones e etc.

Fixes DTHFUI-4423, #656

**po-dialog**

**DTHFUI-4423, #656**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não permite informar conteúdo HTML na mensagem.

**Qual o novo comportamento?**
Permite informar mensagem com conteúdo HTML para que seja possível trabalhar com quebras de linhas, espaçamentos, ícones e etc.

**Simulação**
``` 
<button (click)="open()">Abrir</button>

...

constructor(private dialog: PoDialogService) {}

show() {
    const message = 'Olá <b>Fulano</b> <p> Seu e-mail é: <i class="po-icon po-icon-mail"></i> fulano@gmail.com ?</p>';

    this.dialog.confirm({
      title: 'Confirmação',
      message,
      confirm: () => console.log('confirm')
    });
}
``` 