### PR TITLE
fix(combo): efetua disparo do getObjectByValue caso alterar valor

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -1688,14 +1688,33 @@ describe('PoComboComponent - with service:', () => {
     expect(component.controlComboVisibility).toHaveBeenCalledWith(false);
   });
 
-  it('shouldn`t call updateOptionByFilteredValue if not exists selectedValue', () => {
+  it('should call updateOptionByFilteredValue if selectedValue is different of value parameter', () => {
     component.service = getFakeService([{ label: 'label', value: 1 }]);
     component.selectedValue = 'po';
 
     spyOn(component, 'updateOptionByFilteredValue');
-
     component.getObjectByValue('value');
 
+    expect(component.updateOptionByFilteredValue).toHaveBeenCalled();
+  });
+
+  it('shouldn`t call updateOptionByFilteredValue if selectedValue exists and is equal to the value', () => {
+    component.service = getFakeService([{ label: 'label', value: 1 }]);
+    component.selectedValue = 1;
+
+    spyOn(component, 'updateOptionByFilteredValue');
+
+    component.getObjectByValue(1);
+    expect(component.updateOptionByFilteredValue).not.toHaveBeenCalled();
+  });
+
+  it('should not call updateOptionByFilteredValue if the selectedOption label exists and is equal to the value', () => {
+    component.service = getFakeService([{ label: 'label', value: 1 }]);
+    component.selectedValue = 1;
+    component.selectedOption = { label: 'label', value: 1 };
+
+    spyOn(component, 'updateOptionByFilteredValue');
+    component.getObjectByValue('label');
     expect(component.updateOptionByFilteredValue).not.toHaveBeenCalled();
   });
 
@@ -1787,22 +1806,6 @@ describe('PoComboComponent - with service:', () => {
       component.getObjectByValue.apply(fakeThis, [param]);
 
       expect(fakeThis.service.getObjectByValue).toHaveBeenCalledWith(param, filterParams);
-    });
-
-    it('getObjectByValue: should not call PoComboFilterService.getObjectByValue() if selectedValue is valid', () => {
-      const param = 'value';
-      const fakeThis = {
-        service: {
-          getObjectByValue: () => {}
-        },
-        selectedValue: 'valid'
-      };
-
-      spyOn(fakeThis.service, 'getObjectByValue');
-
-      component.getObjectByValue.apply(fakeThis, [param]);
-
-      expect(fakeThis.service.getObjectByValue).not.toHaveBeenCalled();
     });
 
     it('ngAfterViewInit: should call `focus` if `autoFocus` is true.', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -369,7 +369,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   getObjectByValue(value) {
-    if (!this.selectedValue) {
+    if (this.selectedValue !== value && this.selectedOption?.label !== value) {
       this.isProcessingGetObjectByValue = true;
 
       this.getSubscription = this.service.getObjectByValue(value, this.filterParams).subscribe(


### PR DESCRIPTION
Ao alterar o valor do model do campo, que contenha serviço, e o mesmo estiver selecionado,  é efetuada a busca novamente pelo "id" via getObjectByValue.

Fixes  DTHFUI-4312

**po-combo**

**DTHFUI-4312**
_____________________________________________________________________________

**PR Checklist**

- [x ] Código
- [x ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao alterar o valor do model do campo, que contenha serviço, e o mesmo estiver selecionado, não é efetuada a busca novamente pelo "id" via getObjectByValue.

**Qual o novo comportamento?**
A busca via getObjectByValue  acontecer quando o seu model for alterado, mesmo estando já selecionado.

**Simulação**
https://stackblitz.com/edit/po-ui-3sm5jy
- Selecionar a opção "São Paulo" no combo "Estado"
- O combo "Pessoa" não realiza a busca atraves do getObjectByValue, mesmo com o model alterado.