### PR TITLE
feat(fields): implementa a função setDisabledState

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.spec.ts
@@ -103,6 +103,12 @@ describe('PoCheckboxGroupBaseComponent: ', () => {
     expect(component.change.emit).toHaveBeenCalledWith(valuesObject);
   });
 
+  it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+    const expectedValue = true;
+    component.setDisabledState(expectedValue);
+    expect(component.disabled).toBe(expectedValue);
+  });
+
   it('should update checked options list on changeValue (ngModelChange)', () => {
     component.checkedOptionsList = [].concat(valuesList);
     component.indeterminate = false;

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
@@ -235,6 +235,12 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
     }
   }
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   registerOnChange(fn: any): void {
     this.propagateChange = fn;
   }

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.spec.ts
@@ -52,6 +52,12 @@ describe('PoCheckboxBaseComponent:', () => {
       expect(component.change.emit).toHaveBeenCalledWith(component.checkboxValue);
     });
 
+    it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+      const expectedValue = true;
+      component.setDisabledState(expectedValue);
+      expect(component.disabled).toBe(expectedValue);
+    });
+
     it('changeValue: should call only `change.emit` with `checkboxValue` if propagateChange is `null`', () => {
       component.checkboxValue = true;
       component.propagateChange = null;

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -83,6 +83,12 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
     }
   }
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   registerOnChange(fn: any): void {
     this.propagateChange = fn;
   }

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -573,6 +573,12 @@ describe('PoComboBaseComponent:', () => {
       expect(component.selectedValue).toBe(value);
     });
 
+    it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+      const expectedValue = true;
+      component.setDisabledState(expectedValue);
+      expect(component.disabled).toBe(expectedValue);
+    });
+
     it(`updateSelectedValueWithOldOption: should call 'updateSelectedValue' passing oldOption found and 'true' when
       'onModelChange' is undefined`, () => {
       const oldOption = { label: '1', value: 1 };

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -709,6 +709,12 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     }
   }
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   registerOnChange(fn: any): void {
     this.onModelChange = fn;
   }

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -295,6 +295,12 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         expect(validate).toEqual(invalidDateRangeRequiredError);
       });
 
+      it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+        const expectedValue = true;
+        component.setDisabledState(expectedValue);
+        expect(component.disabled).toBe(expectedValue);
+      });
+
       it(`should call 'dateRangeObjectFailed', set 'errorMessage' as 'literals.invalidFormat'
         and return 'invalidDateRangeError'.`, () => {
         component.literals = poDatepickerRangeLiteralsDefault.pt;

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -324,6 +324,12 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   protected abstract updateScreenByModel(dateRange: PoDatepickerRange);
 
   // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
+  // Função implementada do ControlValueAccessor
   // Usada para interceptar as mudanças e não atualizar automaticamente o Model
   registerOnChange(func: any): void {
     this.onChangeModel = func;

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -175,6 +175,12 @@ describe('PoDatepickerBaseComponent:', () => {
     expect(component.callOnChange).toHaveBeenCalledWith('');
   });
 
+  it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+    const expectedValue = true;
+    component.setDisabledState(expectedValue);
+    expect(component.disabled).toBe(expectedValue);
+  });
+
   it('should be call callOnChange with minDate', () => {
     spyOn(component, 'callOnChange');
     component.minDate = '2000-01-01';

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -381,6 +381,12 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   }
 
   // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
+  // Função implementada do ControlValueAccessor
   // Usada para interceptar as mudanças e não atualizar automaticamente o Model
   registerOnChange(func: any): void {
     this.onChangeModel = func;

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
@@ -267,6 +267,12 @@ describe('PoInputBase:', () => {
       expect(component['validatorChange']).toHaveBeenCalledWith();
     });
 
+    it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+      const expectedValue = true;
+      component.setDisabledState(expectedValue);
+      expect(component.disabled).toBe(expectedValue);
+    });
+
     it('registerOnValidatorChange: should register validatorChange function', () => {
       const registerOnValidatorChangeFn = () => {};
 

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -343,6 +343,12 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
   abstract focus(): void;
 
   // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
+  // Função implementada do ControlValueAccessor
   // Usada para interceptar as mudanças e não atualizar automaticamente o Model
   registerOnChange(func: any): void {
     this.onChangePropagate = func;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -305,6 +305,12 @@ describe('PoLookupBaseComponent:', () => {
       expect(component['setViewValue']).toHaveBeenCalled();
     });
 
+    it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+      const expectedValue = true;
+      component.setDisabledState(expectedValue);
+      expect(component.disabled).toBe(expectedValue);
+    });
+
     it('cleanModel: should call `cleanViewValue` when execute the method `cleanModel`.', () => {
       spyOn(component, <any>'cleanViewValue');
       spyOn(component, 'callOnChange');

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -360,6 +360,12 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
     }
   }
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   registerOnValidatorChange(fn: () => void) {
     this.validatorChange = fn;
   }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -186,6 +186,12 @@ describe('PoMultiselectBaseComponent:', () => {
     expect(component.visibleOptionsDropdown.length).toBe(1);
   });
 
+  it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+    const expectedValue = true;
+    component.setDisabledState(expectedValue);
+    expect(component.disabled).toBe(expectedValue);
+  });
+
   it('should call onModelChange and eventChange', () => {
     const fakeThis = {
       onModelChange: v => {},

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -446,6 +446,12 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
     }
   }
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   registerOnChange(fn: any): void {
     this.onModelChange = fn;
   }

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.spec.ts
@@ -177,6 +177,12 @@ describe('PoRadioGroupBase: ', () => {
       expect(component['getGridSystemColumns'](columns, maxColumns)).toBe(4);
     });
 
+    it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+      const expectedValue = true;
+      component.setDisabledState(expectedValue);
+      expect(component.disabled).toBe(expectedValue);
+    });
+
     it('getGridSystemColumns: should return `6 grid system columns` if `columns` aren`t between columns range', () => {
       const columns = 7;
       const maxColumns = 4;

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
@@ -167,6 +167,12 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
     this.value = changedValue;
   }
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   registerOnChange(fn: any) {
     this.onChangePropagate = fn;
   }

--- a/projects/ui/src/lib/components/po-field/po-select/po-select-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select-base.component.spec.ts
@@ -1,4 +1,4 @@
-import { Directive } from '@angular/core';
+import { ChangeDetectorRef, Directive } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
@@ -164,6 +164,18 @@ describe('PoSelectBaseComponent:', () => {
       component['validateModel']();
 
       expect(component['onValidatorChange']).toHaveBeenCalled();
+    });
+
+    it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+      component.changeDetector = <any>{ detectChanges: () => {} };
+
+      spyOn(component.changeDetector, 'detectChanges');
+
+      const expectedValue = true;
+      component.setDisabledState(expectedValue);
+      expect(component.disabled).toBe(expectedValue);
+
+      expect(component.changeDetector.detectChanges).toHaveBeenCalled();
     });
 
     it('validateModel: shouldn`t call `onValidatorChange` when it is false.', () => {

--- a/projects/ui/src/lib/components/po-field/po-select/po-select-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select-base.component.ts
@@ -201,6 +201,13 @@ export abstract class PoSelectBaseComponent implements ControlValueAccessor, Val
     return null;
   }
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+    this.changeDetector.detectChanges();
+  }
+
   registerOnChange(fn: any): void {
     this.onModelChange = fn;
   }

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.spec.ts
@@ -122,6 +122,12 @@ describe('PoSwitchBaseComponent:', () => {
     expect(component.change.emit).not.toHaveBeenCalled();
   });
 
+  it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+    const expectedValue = true;
+    component.setDisabledState(expectedValue);
+    expect(component.disabled).toBe(expectedValue);
+  });
+
   it('should updated switchValue on writeValue', () => {
     component.switchValue = true;
 

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
@@ -138,6 +138,12 @@ export class PoSwitchBaseComponent implements ControlValueAccessor {
     }
   }
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   registerOnChange(fn: any): void {
     this.propagateChange = fn;
   }

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
@@ -176,6 +176,12 @@ describe('PoTextareaBase:', () => {
         expect(ValidatorsFunctions.requiredFailed).toHaveBeenCalled();
       });
 
+      it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+        const expectedValue = true;
+        component.setDisabledState(expectedValue);
+        expect(component.disabled).toBe(expectedValue);
+      });
+
       it('should return minlenght obj if `minlengpoailed` is true.', () => {
         const invalidMinlenghtError = {
           minlength: {

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -233,6 +233,12 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
     }
   }
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   // Funções `registerOnChange`, `registerOnTouched` e `registerOnValidatorChange` implementadas referentes ao ControlValueAccessor
   // usadas para interceptar as mudanças e não atualizar automaticamente o Model
   registerOnChange(func: any): void {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
@@ -183,6 +183,12 @@ describe('PoUploadBaseComponent:', () => {
         component.isMultiple = true;
       });
 
+      it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+        const expectedValue = true;
+        component.setDisabledState(expectedValue);
+        expect(component.disabled).toBe(expectedValue);
+      });
+
       it(`should return false if 'fileRestrictions' is undefined.`, () => {
         component.fileRestrictions = undefined;
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -515,6 +515,12 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
 
   abstract sendFeedback(): void;
 
+  // Função implementada do ControlValueAccessor
+  // Usada para interceptar os estados de habilitado via forms api
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   registerOnChange(fn: any): void {
     this.onModelChange = fn;
   }


### PR DESCRIPTION
Implementa a função setDisabledStates nos seguintes componentes de entrada:
 - Checkbox group
- Checkbox
- Combo
- Datepicker range
- Datepicker
- Decimal
- Email
- Input
- Login
- Lookup
- Number
- Multiselect
- Password
- Radio-Group
- Select
- Switch
- Textarea
- Upload
- Url

Fixes DTHFUI-2733, #238

**fields**

**DTHFUI-2733, #238**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao desabilitar um FormGroup ou até mesmo um FormControl através do formControl.disabled || .enable, os campos não estavam sendo desabilitado.

**Qual o novo comportamento?**
Ao desabilitar um FormGroup ou até mesmo um FormControl através do formControl.disabled || .enable, estão funcionando


**Simulação**

https://stackblitz.com/edit/portinariui-8p5nen