### PR TITLE
feat(sync): permite o sincronismo e o envio de arquivos (File) ao servidor 

### DIFF
--- a/docs/guides/sync-fundamentals.md
+++ b/docs/guides/sync-fundamentals.md
@@ -699,6 +699,46 @@ this.poSync.insertHttpCommand(poHttpRequestData).then(commandId => {
 });
 ```
 
+Também é possível fazer o envio de arquivo (File) para o servidor utilizando o `Content-Type: multipart/form-data`. Para isso, deve ser informado no `body` o `rawFile`, conforme exemplo abaixo:
+
+``` typescript
+public insertFileHttpCommand(file: File) {
+  const requestData: PoHttpRequestData = {
+    url: 'http://my-server/api/v1/upload';,
+    method: PoHttpRequestType.POST,
+    headers: Array<PoHttpHeaderOption> = [{ name: 'Authorization', value: 'Basic ' + btoa('13' + ':' + '13') }],
+    body: file.rawFile,
+    formField: 'files',
+  };
+
+  this.poSync.insertHttpCommand(requestData).then(commandId => {
+    // Evento HTTP adicionado na fila de eventos e retornado o ID do evento em "commandId"
+  });
+}
+```
+> Caso não seja passado nenhum valor para a propriedade `formField` será aplicado o valor padrão `file`.
+
+> Para o envio de arquivos recomendamos o uso prioritário do `lokijs` nas configurações do `PoStorageModule` por sua maior capacidade de armazenamento.
+A configuração deve ser feita no `app.module.ts` da sua aplicação, por exemplo:
+
+``` typescript
+...
+@NgModule({
+  ...
+  imports: [
+    ...
+    PoStorageModule.forRoot({ // import do módulo Po Storage,
+      name: 'mystorage',
+      storeName: '_mystore',
+      driverOrder: ['lokijs', 'indexeddb', 'localstorage', 'websql']
+    }),
+    PoSyncModule, // import do módulo Po Sync
+  ],
+  ...
+})
+export class AppModule {}
+```
+
 <a id="custom-request-id"></a>
 ### Criação de identificador customizado para eventos da fila
 

--- a/projects/sync/src/lib/services/po-http-client/interfaces/po-http-request-data.interface.ts
+++ b/projects/sync/src/lib/services/po-http-client/interfaces/po-http-request-data.interface.ts
@@ -20,4 +20,16 @@ export interface PoHttpRequestData {
 
   /** Corpo da requisição. */
   body?: any;
+
+  /** Nome da propriedade que conterá o arquivo enviado para o servidor */
+  formField?: string;
+
+  // Tipo do body
+  bodyType?: string;
+
+  // MimeType da requisição caso seja um arquivo
+  mimeType?: string;
+
+  // Nome do arquivo
+  fileName?: string;
 }

--- a/projects/sync/src/lib/utils/utils.spec.ts
+++ b/projects/sync/src/lib/utils/utils.spec.ts
@@ -59,4 +59,89 @@ describe('Utils:', () => {
 
     expect(utilsFunctions.getObjectEntries(object)).toEqual(objectEntries);
   });
+
+  describe('toBase64:', () => {
+    function handleThrowError(testFunction) {
+      return testFunction
+        .then(response => () => response)
+        .catch(error => () => {
+          throw error;
+        });
+    }
+
+    it(`should resolve of promise if file is defined.`, async () => {
+      const file = new File([''], 'filename', { type: 'text/html' });
+
+      const result = await utilsFunctions.toBase64(file);
+
+      expect(result).toBeDefined();
+    });
+
+    it(`should return a error if file is invalid.`, async () => {
+      const file = <any>'invalid file';
+
+      const result = await handleThrowError(utilsFunctions.toBase64(file));
+
+      expect(result).toThrow();
+    });
+  });
+
+  describe('toFile:', () => {
+    let result;
+    let promiseHelper;
+
+    const url = 'http://teste.com.br';
+    const fileName = 'meu_arquivo.png';
+    const mimeType = 'image/png';
+
+    beforeEach(() => {
+      const fetchPromise = new Promise((resolve, reject) => {
+        promiseHelper = {
+          resolve: resolve,
+          reject: reject
+        };
+      });
+      spyOn(window, 'fetch').and.returnValue(<any>fetchPromise);
+      result = utilsFunctions.toFile(url, fileName, mimeType);
+    });
+
+    it('should call fetch with url', () => {
+      expect(window.fetch).toHaveBeenCalledWith(url);
+    });
+
+    it('should return a promise', () => {
+      expect(result).toEqual(jasmine.any(Promise));
+    });
+
+    describe('on successful fetch', () => {
+      const file = new File([''], 'filename', { type: 'text/html' });
+
+      beforeEach(() => {
+        const response = new Response(file);
+        promiseHelper.resolve(response);
+      });
+
+      it('should return a file', done => {
+        result.then(response => {
+          expect(response).toEqual(file);
+          done();
+        });
+      });
+    });
+
+    describe('on unsuccessful fetch', () => {
+      const errorObj = { msg: 'failed!' };
+
+      beforeEach(() => {
+        promiseHelper.reject(errorObj);
+      });
+
+      it('should return an error', done => {
+        result.catch(error => {
+          expect(error).toEqual(errorObj);
+          done();
+        });
+      });
+    });
+  });
 });

--- a/projects/sync/src/lib/utils/utils.ts
+++ b/projects/sync/src/lib/utils/utils.ts
@@ -47,3 +47,27 @@ export const validateArray = (value: object) => {
     throw new Error(`${paramName} cannot be empty array`);
   }
 };
+
+/**
+ * Recebe um arquivo e converte para uma string base64
+ *
+ * @param Objeto do tipo file.
+ */
+export const toBase64 = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result as string);
+    /* istanbul ignore next */
+    reader.onerror = error => reject(error);
+  });
+
+/**
+ * Recebe uma string base64 e converte para um arquivo
+ *
+ * @param string base64.
+ */
+export const toFile = (url: string, fileName: string, mimeType: string) =>
+  fetch(url)
+    .then(result => result.arrayBuffer())
+    .then(buffer => new File([buffer], fileName, { type: mimeType }));


### PR DESCRIPTION
**PO-SYNC**

**DTHFUI-4575**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Não é possível realizar o envio e sincronismo de arquivos (File).

**Qual o novo comportamento?**
Permite o sincronismo e envio de arquivos (File) ao servidor com o content-type: multipart/form-data.

**Simulação**
Simular através do aplicativo anexado na issue. Baixar o zip, descompactar, substituir o caminho do tgz no package.json e rodar o npm i. Para subir a aplicação utilize o ng serve.

**Importante baixar o arquivo `atualizado`**

Para testar também pode ser usada a API criada no 'po-sample-api-conference', basta utilizar a [PR](https://github.com/po-ui/po-sample-conference/pull/14) criada para subir a API e susbtituir a url da imagem no aplicativo por `urlImage = 'http://localhost:3000/gallery/photo/file'`.