### PR TITLE
docs(breadcrumb|page): altera endpoint utilizado nos samples

### DIFF
--- a/projects/ui/src/lib/components/po-breadcrumb/samples/sample-po-breadcrumb-labs/sample-po-breadcrumb-labs.component.html
+++ b/projects/ui/src/lib/components/po-breadcrumb/samples/sample-po-breadcrumb-labs/sample-po-breadcrumb-labs.component.html
@@ -41,8 +41,9 @@
       name="favoriteService"
       [(ngModel)]="favoriteService"
       p-clean
-      p-help="Ex.: https://thf.totvs.com.br/sample/api/favorite"
+      p-help="Ex.: https://po-sample-api.herokuapp.com/v1/favorite"
       p-label="Favorite service"
+      [p-disabled]="!breadcrumbItems?.length"
     >
     </po-input>
 
@@ -53,9 +54,12 @@
       p-clean
       p-help="Ex.: { id: 14, user: 'dev.po' }"
       p-label="Params service"
+      [p-disabled]="!breadcrumbItems?.length"
     >
     </po-input>
   </div>
+
+  <hr />
 
   <div class="po-row">
     <po-button

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
@@ -51,7 +51,7 @@
       name="breadcrumbFavorite"
       [(ngModel)]="breadcrumb.favorite"
       p-clean
-      p-help="https://thf.totvs.com.br/sample/api/favorite"
+      p-help="https://po-sample-api.herokuapp.com/v1/favorite"
       p-label="Breadcrumb favorite"
     >
     </po-input>

--- a/projects/ui/src/lib/components/po-page/po-page-detail/samples/sample-po-page-detail-labs/sample-po-page-detail-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/samples/sample-po-page-detail-labs/sample-po-page-detail-labs.component.html
@@ -26,7 +26,7 @@
           name="breadcrumbFavorite"
           [(ngModel)]="breadcrumb.favorite"
           p-clean
-          p-help="https://thf.totvs.com.br/sample/api/favorite"
+          p-help="https://po-sample-api.herokuapp.com/v1/favorite"
           p-label="Breadcrumb favorite"
         >
         </po-input>

--- a/projects/ui/src/lib/components/po-page/po-page-edit/samples/sample-po-page-edit-labs/sample-po-page-edit-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/samples/sample-po-page-edit-labs/sample-po-page-edit-labs.component.html
@@ -36,7 +36,7 @@
           name="breadcrumbFavorite"
           [(ngModel)]="breadcrumb.favorite"
           p-clean
-          p-help="https://thf.totvs.com.br/sample/api/favorite"
+          p-help="https://po-sample-api.herokuapp.com/v1/favorite"
           p-label="Breadcrumb favorite"
         >
         </po-input>

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.html
@@ -61,7 +61,7 @@
       name="breadcrumbFavorite"
       [(ngModel)]="breadcrumb.favorite"
       p-clean
-      p-help="https://thf.totvs.com.br/sample/api/favorite"
+      p-help="https://po-sample-api.herokuapp.com/v1/favorite"
       p-label="Breadcrumb favorite"
     >
     </po-input>


### PR DESCRIPTION
Altera a URL do endpoint favorite utilizado nos samples dos componentes:
- Breadcrumb
- PageList
- PageDefault
- PageEdit
- PageDetail

Fixes DTHFUI-2669

**breadcrumb|page**

**DTHFUI-2669**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
Link antigo das APIs

**Qual o novo comportamento?**
Inclusão dos links novos da API

**Simulação**
