### PR TITLE
feat(dynamic-form): permite formatar descrição do campo no lookup

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -179,7 +179,10 @@ export interface PoDynamicFormField extends PoDynamicField {
   errorMessage?: string;
 
   /**
-   * Formato de exibição da data.
+   * Formato de exibição no campo.
+   *
+   * Ao utilizar esta propriedade com o `type` *PoDynamicFieldType.Date* ou *PoDynamicFieldType.DateTime*,
+   * pode ser utilizada para formatação de exibição da data:
    *
    * Valores válidos:
    *
@@ -187,9 +190,11 @@ export interface PoDynamicFormField extends PoDynamicField {
    * - mm/dd/yyyy
    * - yyyy/mm/dd
    *
-   * > Esta propriedade pode ser utilizada quando o `type` for *PoDynamicFieldType.Date* ou *PoDynamicFieldType.DateTime*.
+   *
+   * Também pode-se utilizar em conjunto com `searchService`, informando uma lista de propriedades que será utilizado
+   * para formatação da exibição no campo, por exemplo: ["id", "name"].
    */
-  format?: string;
+  format?: string | Array<string>;
 
   /**
    * Nome da propriedade do objeto retornado que será utilizado como descrição do campo.

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -178,6 +178,7 @@
       [p-filter-service]="field.searchService"
       [p-auto-focus]="field.focus"
       [p-help]="field.help"
+      [p-field-format]="field.format"
       [p-label]="field.label"
       [p-optional]="field.optional"
       [p-required]="field.required"

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -103,6 +103,7 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
         { property: 'nickname', label: 'Hero' },
         { property: 'label', label: 'Name' }
       ],
+      format: ['id', 'nickname'],
       fieldLabel: 'nickname',
       fieldValue: 'email'
     }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
@@ -3,7 +3,7 @@ import { CurrencyPipe, DatePipe, DecimalPipe, TitleCasePipe } from '@angular/com
 
 import { PoTimePipe } from '../../../pipes/po-time/po-time.pipe';
 
-import { PoDynamicFormField } from './../po-dynamic-form/po-dynamic-form-field.interface';
+import { PoDynamicViewField } from './../po-dynamic-view/po-dynamic-view-field.interface';
 import { PoDynamicViewBaseComponent } from './po-dynamic-view-base.component';
 import { PoDynamicViewService } from './po-dynamic-view.service';
 
@@ -55,7 +55,7 @@ export class PoDynamicViewComponent extends PoDynamicViewBaseComponent implement
     }
   }
 
-  private async getValuesAndFieldsFromLoad(): Promise<{ value?: any; fields?: Array<PoDynamicFormField> }> {
+  private async getValuesAndFieldsFromLoad(): Promise<{ value?: any; fields?: Array<PoDynamicViewField> }> {
     let valueAndFieldsFromLoad;
 
     if (typeof this.load === 'string') {
@@ -75,7 +75,7 @@ export class PoDynamicViewComponent extends PoDynamicViewBaseComponent implement
     return this.value && this.fields.length ? this.getConfiguredFields() : this.getValueFields();
   }
 
-  private setFieldOnLoad(fieldOnLoad: PoDynamicFormField) {
+  private setFieldOnLoad(fieldOnLoad: PoDynamicViewField) {
     const index = this.fields.findIndex(field => field.property === fieldOnLoad.property);
 
     if (index >= 0) {
@@ -85,7 +85,7 @@ export class PoDynamicViewComponent extends PoDynamicViewBaseComponent implement
     }
   }
 
-  private setFieldsOnLoad(fields: Array<PoDynamicFormField>) {
+  private setFieldsOnLoad(fields: Array<PoDynamicViewField>) {
     if (fields) {
       fields.forEach(fieldOnLoad => {
         this.setFieldOnLoad(fieldOnLoad);

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.service.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.service.ts
@@ -1,13 +1,13 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
-import { PoDynamicFormField } from '../po-dynamic-form/po-dynamic-form-field.interface';
+import { PoDynamicViewField } from '../po-dynamic-view/po-dynamic-view-field.interface';
 
 @Injectable()
 export class PoDynamicViewService {
   constructor(private http: HttpClient) {}
 
-  onLoad(url: string, value): Promise<{ value?: any; fields?: Array<PoDynamicFormField> }> {
+  onLoad(url: string, value): Promise<{ value?: any; fields?: Array<PoDynamicViewField> }> {
     return this.http.post(url, value).toPromise();
   }
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic.util.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic.util.spec.ts
@@ -2,7 +2,7 @@ import { isVisibleField, getGridColumnsClasses } from './po-dynamic.util';
 
 describe('isVisibleField:', () => {
   it('should return `true` if not contain visible property', () => {
-    const field = { property: 'name' };
+    const field: any = { property: 'name' };
 
     expect(isVisibleField(field)).toBe(true);
   });

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic.util.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic.util.ts
@@ -11,7 +11,7 @@ export function getGridColumnsClasses(smColumns, mdColumns, lgColumns, xlColumns
   return `po-sm-${systemGrid.sm} po-md-${systemGrid.md} po-lg-${systemGrid.lg} po-xl-${systemGrid.xl}`;
 }
 
-export function isVisibleField(field: PoDynamicViewField): boolean {
+export function isVisibleField(field: { visible?: boolean }): boolean {
   const containsVisible = 'visible' in field;
 
   return containsVisible ? field.visible : true;


### PR DESCRIPTION
Permite passar através da propriedade PoDynamicFormField.format, uma lista de propriedades
para formatação do campo.

Fixes DTHFUI-3797

**po-dynamic-form**

**DTHFUI-3797**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não é possível alterar a formatação do campo lookup no através do dynamic-form.

**Qual o novo comportamento?**
Permite informar uma lista de propriedades para formatação do campo  lookup através do  dynamic-form.

**Simulação**
<po-dynamic-form
  #dynamicForm
  p-auto-focus="name"
  [p-fields]="fields"
  [p-value]="person"
>
</po-dynamic-form>

-- TS

 person = {};
 
  fields: Array<PoDynamicFormField> = [
    {
      property: 'favoriteHero',
      gridColumns: 6,
      gridSmColumns: 12,
      label: 'Favorite hero',
      optional: true,
      format: ['id','nickname'],
      searchService: 'http://localhost:3000/v1/people',
      columns: [
        { property: 'nickname', label: 'Hero' },
        { property: 'label', label: 'Name' }
      ],
      fieldLabel: 'nickname',
      fieldValue: 'email'
    }
  ];




