### PR TITLE
Datepicker/tis 21

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.spec.ts
@@ -85,7 +85,7 @@ describe('PoCalendarComponent:', () => {
     });
 
     it('p-locale: should update with valid values and call `initializeLanguage`', () => {
-      const validValues = ['pt', 'es', 'en'];
+      const validValues = ['pt', 'es', 'en', 'ru'];
 
       spyOn(component, 'initializeLanguage');
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.spec.ts
@@ -27,6 +27,8 @@ describe('PoCalendarComponent:', () => {
     component = fixture.componentInstance;
     nativeElement = fixture.debugElement.nativeElement;
     fixture.detectChanges();
+
+    component['shortLanguage'] = 'pt';
   });
 
   it('should be created', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.ts
@@ -22,7 +22,7 @@ import { poLocales } from '../../../../services/po-language/po-language.constant
 export class PoCalendarComponent {
   private _dateEnd: Date;
   private _dateStart: Date;
-  private _locale: string;
+  private _locale: string = this.languageService.getShortLanguage();
   private _selectedDate?: Date;
 
   currentYear: number;
@@ -45,6 +45,7 @@ export class PoCalendarComponent {
   private isMobile: any = isMobile;
   private lastDisplay: string;
   private today: Date = new Date();
+  private shortLanguage: string;
 
   @ViewChild('days', { read: ElementRef, static: true }) elDays: ElementRef;
   @ViewChild('months', { read: ElementRef, static: true }) elMonths: ElementRef;
@@ -82,10 +83,7 @@ export class PoCalendarComponent {
    *
    * Idioma do calendário.
    *
-   * Valores válidos:
-   *  - `pt`
-   *  - `en`
-   *  - `es`
+   * > O locale padrão sera recuperado com base no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
    */
   @Input('p-locale') set locale(locale: string) {
     this._locale = poLocales.includes(locale) ? locale : this.shortLanguage;
@@ -137,7 +135,13 @@ export class PoCalendarComponent {
   @Output('p-selected-dateChange') selectedDateChange = new EventEmitter<Date>();
   @Output('p-submit') submit = new EventEmitter<Date>();
 
-  constructor(private poCalendarService: PoCalendarService, private poCalendarLangService: PoCalendarLangService) {}
+  constructor(
+    private poCalendarService: PoCalendarService,
+    private poCalendarLangService: PoCalendarLangService,
+    private languageService: PoLanguageService
+  ) {
+    this.shortLanguage = languageService.getShortLanguage();
+  }
 
   close() {
     this.overlayInvisible = true;

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.ts
@@ -4,8 +4,8 @@ import { isMobile, setYearFrom0To100, validateDateRange } from '../../../../util
 import { PoCalendarLangService } from './po-calendar.lang.service';
 import { PoCalendarService } from './po-calendar.service';
 
-const poCalendarLocaleDefault = 'pt';
-const poCalendarLocales = ['pt', 'en', 'es'];
+import { PoLanguageService } from '../../../../services/po-language/po-language.service';
+import { poLocales } from '../../../../services/po-language/po-language.constant';
 
 /**
  * @docsPrivate
@@ -88,7 +88,7 @@ export class PoCalendarComponent {
    *  - `es`
    */
   @Input('p-locale') set locale(locale: string) {
-    this._locale = poCalendarLocales.includes(locale) ? locale : poCalendarLocaleDefault;
+    this._locale = poLocales.includes(locale) ? locale : this.shortLanguage;
     this.initializeLanguage();
   }
   get locale() {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.lang.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.lang.service.spec.ts
@@ -21,6 +21,9 @@ describe('PoCalendarLangService', () => {
     service.setLanguage('es');
     expect(service.lang).toBe('es');
 
+    service.setLanguage('ru');
+    expect(service.lang).toBe('ru');
+
     service.setLanguage('rs');
     expect(service.lang).toBe('pt');
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.lang.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.lang.service.ts
@@ -1,118 +1,141 @@
 import { Injectable } from '@angular/core';
 
+import { poLocales, poLocaleDefault } from '../../../../services/po-language/po-language.constant';
+
 @Injectable()
 export class PoCalendarLangService {
-  months = [
+  private months = [
     {
       pt: 'Janeiro',
       en: 'January',
-      es: 'Enero'
+      es: 'Enero',
+      ru: 'Январь'
     },
     {
       pt: 'Fevereiro',
       en: 'February',
-      es: 'Febrero'
+      es: 'Febrero',
+      ru: 'Февраль'
     },
     {
       pt: 'Março',
       en: 'March',
-      es: 'Marzo'
+      es: 'Marzo',
+      ru: 'Март'
     },
     {
       pt: 'Abril',
       en: 'April',
-      es: 'Abril'
+      es: 'Abril',
+      ru: 'Апрель'
     },
     {
       pt: 'Maio',
       en: 'May',
-      es: 'Mayo'
+      es: 'Mayo',
+      ru: 'Май'
     },
     {
       pt: 'Junho',
       en: 'June',
-      es: 'Junio'
+      es: 'Junio',
+      ru: 'Июнь'
     },
     {
       pt: 'Julho',
       en: 'July',
-      es: 'Julio'
+      es: 'Julio',
+      ru: 'Июль'
     },
     {
       pt: 'Agosto',
       en: 'August',
-      es: 'Agosto'
+      es: 'Agosto',
+      ru: 'Август'
     },
     {
       pt: 'Setembro',
       en: 'September',
-      es: 'Setiembre'
+      es: 'Setiembre',
+      ru: 'Сентябрь'
     },
     {
       pt: 'Outubro',
       en: 'October',
-      es: 'Octubre'
+      es: 'Octubre',
+      ru: 'Октябрь'
     },
     {
       pt: 'Novembro',
       en: 'November',
-      es: 'Noviembre'
+      es: 'Noviembre',
+      ru: 'Ноябрь'
     },
     {
       pt: 'Dezembro',
       en: 'December',
-      es: 'Diciembre'
+      es: 'Diciembre',
+      ru: 'Декабрь'
     }
   ];
 
-  shortWeekDays = [
+  private shortWeekDays = [
     {
       pt: 'Dom',
       en: 'Sun',
-      es: 'Dom'
+      es: 'Dom',
+      ru: 'Вс'
     },
     {
       pt: 'Seg',
       en: 'Mon',
-      es: 'Lun'
+      es: 'Lun',
+      ru: 'Пн'
     },
     {
       pt: 'Ter',
       en: 'Tue',
-      es: 'Mar'
+      es: 'Mar',
+      ru: 'Вт'
     },
     {
       pt: 'Qua',
       en: 'Wed',
-      es: 'Mié'
+      es: 'Mié',
+      ru: 'Ср'
     },
     {
       pt: 'Qui',
       en: 'Thu',
-      es: 'Jue'
+      es: 'Jue',
+      ru: 'Чт'
     },
     {
       pt: 'Sex',
       en: 'Fri',
-      es: 'Vie'
+      es: 'Vie',
+      ru: 'Пт'
     },
     {
       pt: 'Sáb',
       en: 'Sat',
-      es: 'Sáb'
+      es: 'Sáb',
+      ru: 'Сб'
     }
   ];
 
   wordMonth = {
     pt: 'Mês',
     en: 'Month',
-    es: 'Mes'
+    es: 'Mes',
+    ru: 'Месяц'
   };
 
   wordYear = {
     pt: 'Ano',
     en: 'Year',
-    es: 'Año'
+    es: 'Año',
+    ru: 'Год'
   };
 
   lang = 'pt';
@@ -122,7 +145,7 @@ export class PoCalendarLangService {
   setLanguage(lang: string) {
     if (lang && lang.length >= 2) {
       lang = lang.toLowerCase().slice(0, 2);
-      this.lang = lang === 'pt' || lang === 'en' || lang === 'es' ? lang : 'pt';
+      this.lang = poLocales.includes(lang) ? lang : poLocaleDefault;
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -117,10 +117,11 @@ describe('PoDatepickerBaseComponent:', () => {
   });
 
   it('should be update property p-locale', () => {
-    expectPropertiesValues(component, 'locale', '', getShortBrowserLanguage());
+    expectPropertiesValues(component, 'locale', '', languageService.getShortLanguage());
     expectPropertiesValues(component, 'locale', ['pt', 'x'], 'pt');
     expectPropertiesValues(component, 'locale', 'en', 'en');
     expectPropertiesValues(component, 'locale', 'es', 'es');
+    expectPropertiesValues(component, 'locale', 'ru', 'ru');
   });
 
   it('should transform a String to Date', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -10,6 +10,7 @@ import { expectSettersMethod, expectPropertiesValues } from '../../../util-test/
 import { PoDatepickerBaseComponent } from './po-datepicker-base.component';
 import { PoDatepickerIsoFormat } from './enums/po-datepicker-iso-format.enum';
 import { PoMask } from '../po-input/po-mask';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 @Directive()
 class PoDatepickerComponent extends PoDatepickerBaseComponent {
@@ -19,14 +20,17 @@ class PoDatepickerComponent extends PoDatepickerBaseComponent {
 
 describe('PoDatepickerBaseComponent:', () => {
   let component: PoDatepickerComponent;
+  let languageService: PoLanguageService;
+  languageService = new PoLanguageService();
 
   beforeEach(() => {
-    component = new PoDatepickerComponent();
+    component = new PoDatepickerComponent(languageService);
+    component['shortLanguage'] = 'pt';
   });
 
   it('should be created', () => {
     expect(component instanceof PoDatepickerBaseComponent).toBeTruthy();
-    expect(component.locale).toBe(getShortBrowserLanguage());
+    expect(component.locale).toBe(component['shortLanguage']);
   });
 
   it('should be update property p-disabled', () => {
@@ -117,7 +121,7 @@ describe('PoDatepickerBaseComponent:', () => {
   });
 
   it('should be update property p-locale', () => {
-    expectPropertiesValues(component, 'locale', '', languageService.getShortLanguage());
+    expectPropertiesValues(component, 'locale', '', 'pt');
     expectPropertiesValues(component, 'locale', ['pt', 'x'], 'pt');
     expectPropertiesValues(component, 'locale', 'en', 'en');
     expectPropertiesValues(component, 'locale', 'es', 'es');

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -17,6 +17,8 @@ import { InputBoolean } from '../../../decorators';
 import { PoMask } from '../po-input/po-mask';
 
 import { PoDatepickerIsoFormat } from './enums/po-datepicker-iso-format.enum';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 const poDatepickerFormatDefault: string = 'dd/mm/yyyy';
 
@@ -70,7 +72,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   private _minDate: Date;
   private _noAutocomplete?: boolean = false;
   private _placeholder?: string = '';
-
+  private shortLanguage: string;
   protected date: Date;
   protected firstStart = true;
   protected hour: string = 'T00:00:01-00:00';
@@ -289,21 +291,18 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    *
    * Idioma do Datepicker.
    *
-   * Valores válidos:
-   *  - `pt`
-   *  - `en`
-   *  - `es`
+   * > O locale padrão sera recuperado com base no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
    */
   _locale?: string;
   @Input('p-locale') set locale(value: string) {
     if (value) {
-      this._locale = value.length >= 2 ? value : 'pt';
+      this._locale = value.length >= 2 ? value : poLocaleDefault;
     } else {
-      this._locale = getShortBrowserLanguage();
+      this._locale = this.shortLanguage;
     }
   }
   get locale() {
-    return this._locale || getShortBrowserLanguage();
+    return this._locale || this.shortLanguage;
   }
 
   /**
@@ -324,7 +323,9 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    */
   @Output('p-change') onchange: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor() {}
+  constructor(private languageService: PoLanguageService) {
+    this.shortLanguage = this.languageService.getShortLanguage();
+  }
 
   abstract writeValue(value: any): void;
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -16,6 +16,7 @@ import { PoControlPositionService } from './../../../services/po-control-positio
 
 import { PoCalendarComponent } from './po-calendar/po-calendar.component';
 import { PoDatepickerBaseComponent } from './po-datepicker-base.component';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 const poCalendarContentOffset = 8;
 const poCalendarPositionDefault = 'bottom-left';
@@ -102,8 +103,13 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
   /** Texto de apoio do campo. */
   @Input('p-help') help?: string;
 
-  constructor(private controlPosition: PoControlPositionService, private renderer: Renderer2, el: ElementRef) {
-    super();
+  constructor(
+    private controlPosition: PoControlPositionService,
+    languageService: PoLanguageService,
+    private renderer: Renderer2,
+    el: ElementRef
+  ) {
+    super(languageService);
     this.el = el;
   }
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.ts
@@ -43,7 +43,8 @@ export class SamplePoDatepickerLabsComponent implements OnInit {
   public readonly localeOptions: Array<PoRadioGroupOption> = [
     { label: 'pt', value: 'pt' },
     { label: 'en', value: 'en' },
-    { label: 'es', value: 'es' }
+    { label: 'es', value: 'es' },
+    { label: 'ru', value: 'ru' }
   ];
 
   ngOnInit() {


### PR DESCRIPTION
**po-datepicker**

**DTHFUI-4616, DTHFUI-4618**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
o datepicker não tem suporte ao idioma russo e não utiliza o i18n para recuperar o locale padrão

**Qual o novo comportamento?**
o datepicker passa a ter suporte ao idioma russo e  utiliza o i18n para recuperar o locale padrão


**Simulação**
<po-datepicker name="datepicker" p-label="PO Datepicker" p-locale="ru"> </po-datepicker>
