### PR TITLE
calendar/tis 20

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
@@ -3,17 +3,20 @@ import { PoDateService } from './../../services/po-date/po-date.service';
 
 import { PoCalendarBaseComponent } from './po-calendar-base.component';
 import { PoCalendarLangService } from './services/po-calendar.lang.service';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 describe('PoCalendarBaseComponent:', () => {
   let component: PoCalendarBaseComponent;
   let poDate: PoDateService;
   let poCalendarLangService: PoCalendarLangService;
+  let languageService: PoLanguageService;
 
   beforeEach(() => {
     poDate = new PoDateService();
     poCalendarLangService = new PoCalendarLangService();
-
-    component = new PoCalendarBaseComponent(poDate, poCalendarLangService);
+    languageService = new PoLanguageService();
+    component = new PoCalendarBaseComponent(poDate, poCalendarLangService, languageService);
+    component['shortLanguage'] = 'pt';
   });
 
   describe('Properties:', () => {

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
@@ -18,7 +18,7 @@ describe('PoCalendarBaseComponent:', () => {
 
   describe('Properties:', () => {
     it('p-locale: should update with valid values and call `initializeLanguage`', () => {
-      const validValues = ['pt', 'es', 'en'];
+      const validValues = ['pt', 'es', 'en', 'ru'];
 
       spyOn(component, 'initializeLanguage');
 

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
@@ -2,9 +2,10 @@ import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
 import { PoCalendarLangService } from './services/po-calendar.lang.service';
 import { PoDateService } from '../../services/po-date';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
-const poCalendarLocales = ['pt', 'en', 'es'];
 const poCalendarLocaleDefault = 'pt';
+const poCalendarLocales = ['pt', 'en', 'es', 'ru'];
 
 /**
  * @description

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
@@ -3,9 +3,7 @@ import { EventEmitter, Input, Output, Directive } from '@angular/core';
 import { PoCalendarLangService } from './services/po-calendar.lang.service';
 import { PoDateService } from '../../services/po-date';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
-
-const poCalendarLocaleDefault = 'pt';
-const poCalendarLocales = ['pt', 'en', 'es', 'ru'];
+import { poLocales } from '../../services/po-language/po-language.constant';
 
 /**
  * @description
@@ -41,7 +39,8 @@ const poCalendarLocales = ['pt', 'en', 'es', 'ru'];
  */
 @Directive()
 export class PoCalendarBaseComponent {
-  private _locale: string;
+  private shortLanguage: string;
+  private _locale: string = this.languageService.getShortLanguage();
   private _maxDate: Date;
   private _minDate: Date;
 
@@ -75,15 +74,10 @@ export class PoCalendarBaseComponent {
    *
    * Idioma do calendário.
    *
-   * Valores válidos:
-   *  - `pt`
-   *  - `en`
-   *  - `es`
-   *
-   * @default `pt`
+   * > O locale padrão sera recuperado com base no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
    */
   @Input('p-locale') set locale(locale: string) {
-    this._locale = poCalendarLocales.includes(locale) ? locale : poCalendarLocaleDefault;
+    this._locale = poLocales.includes(locale) ? locale : this.shortLanguage;
     this.initializeLanguage();
   }
   get locale() {
@@ -155,7 +149,13 @@ export class PoCalendarBaseComponent {
   /** Evento disparado ao selecionar um dia do calendário. */
   @Output('p-change') change = new EventEmitter<string>();
 
-  constructor(public poDate: PoDateService, public poCalendarLangService: PoCalendarLangService) {}
+  constructor(
+    public poDate: PoDateService,
+    public poCalendarLangService: PoCalendarLangService,
+    private languageService: PoLanguageService
+  ) {
+    this.shortLanguage = languageService.getShortLanguage();
+  }
 
   initializeLanguage() {
     this.poCalendarLangService.setLanguage(this.locale);

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
@@ -5,6 +5,7 @@ import { PoCalendarBaseComponent } from './po-calendar-base.component';
 import { PoCalendarLangService } from './services/po-calendar.lang.service';
 import { PoCalendarService } from './services/po-calendar.service';
 import { PoDateService } from '../../services/po-date/po-date.service';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 /* istanbul ignore next */
 const providers = [
@@ -53,9 +54,10 @@ export class PoCalendarComponent extends PoCalendarBaseComponent implements OnIn
   constructor(
     private poCalendarService: PoCalendarService,
     poCalendarLangService: PoCalendarLangService,
-    poDate: PoDateService
+    poDate: PoDateService,
+    languageService: PoLanguageService
   ) {
-    super(poDate, poCalendarLangService);
+    super(poDate, poCalendarLangService, languageService);
   }
 
   ngOnInit() {

--- a/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-labs/sample-po-calendar-labs.component.html
+++ b/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-labs/sample-po-calendar-labs.component.html
@@ -44,7 +44,7 @@
       class="po-md-6"
       name="locales"
       [(ngModel)]="locale"
-      p-columns="3"
+      p-columns="4"
       p-help="Select a locale for the calendar"
       p-label="Locale"
       [p-options]="localeOptions"

--- a/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-labs/sample-po-calendar-labs.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-labs/sample-po-calendar-labs.component.ts
@@ -16,7 +16,8 @@ export class SamplePoCalendarLabsComponent implements OnInit {
   readonly localeOptions: Array<PoRadioGroupOption> = [
     { label: 'pt', value: 'pt' },
     { label: 'es', value: 'es' },
-    { label: 'en', value: 'en' }
+    { label: 'en', value: 'en' },
+    { label: 'ru', value: 'ru' }
   ];
 
   ngOnInit() {

--- a/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.spec.ts
@@ -21,6 +21,9 @@ describe('PoCalendarLangService:', () => {
     service.setLanguage('es');
     expect(service['language']).toBe('es');
 
+    service.setLanguage('ru');
+    expect(service['language']).toBe('ru');
+
     service.setLanguage('rs');
     expect(service['language']).toBe('pt');
 

--- a/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.ts
+++ b/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.ts
@@ -1,69 +1,83 @@
 import { Injectable } from '@angular/core';
 
+import { poLocales, poLocaleDefault } from '../../../services/po-language/po-language.constant';
+
 @Injectable()
 export class PoCalendarLangService {
-  private language = 'pt';
+  private language = poLocaleDefault;
 
   private months = [
     {
       pt: 'Janeiro',
       en: 'January',
-      es: 'Enero'
+      es: 'Enero',
+      ru: 'Январь'
     },
     {
       pt: 'Fevereiro',
       en: 'February',
-      es: 'Febrero'
+      es: 'Febrero',
+      ru: 'Февраль'
     },
     {
       pt: 'Março',
       en: 'March',
-      es: 'Marzo'
+      es: 'Marzo',
+      ru: 'Март'
     },
     {
       pt: 'Abril',
       en: 'April',
-      es: 'Abril'
+      es: 'Abril',
+      ru: 'Апрель'
     },
     {
       pt: 'Maio',
       en: 'May',
-      es: 'Mayo'
+      es: 'Mayo',
+      ru: 'Май'
     },
     {
       pt: 'Junho',
       en: 'June',
-      es: 'Junio'
+      es: 'Junio',
+      ru: 'Июнь'
     },
     {
       pt: 'Julho',
       en: 'July',
-      es: 'Julio'
+      es: 'Julio',
+      ru: 'Июль'
     },
     {
       pt: 'Agosto',
       en: 'August',
-      es: 'Agosto'
+      es: 'Agosto',
+      ru: 'Август'
     },
     {
       pt: 'Setembro',
       en: 'September',
-      es: 'Setiembre'
+      es: 'Setiembre',
+      ru: 'Сентябрь'
     },
     {
       pt: 'Outubro',
       en: 'October',
-      es: 'Octubre'
+      es: 'Octubre',
+      ru: 'Октябрь'
     },
     {
       pt: 'Novembro',
       en: 'November',
-      es: 'Noviembre'
+      es: 'Noviembre',
+      ru: 'Ноябрь'
     },
     {
       pt: 'Dezembro',
       en: 'December',
-      es: 'Diciembre'
+      es: 'Diciembre',
+      ru: 'Декабрь'
     }
   ];
 
@@ -71,50 +85,59 @@ export class PoCalendarLangService {
     {
       pt: 'Dom',
       en: 'Sun',
-      es: 'Dom'
+      es: 'Dom',
+      ru: 'Вс'
     },
     {
       pt: 'Seg',
       en: 'Mon',
-      es: 'Lun'
+      es: 'Lun',
+      ru: 'Пн'
     },
     {
       pt: 'Ter',
       en: 'Tue',
-      es: 'Mar'
+      es: 'Mar',
+      ru: 'Вт'
     },
     {
       pt: 'Qua',
       en: 'Wed',
-      es: 'Mié'
+      es: 'Mié',
+      ru: 'Ср'
     },
     {
       pt: 'Qui',
       en: 'Thu',
-      es: 'Jue'
+      es: 'Jue',
+      ru: 'Чт'
     },
     {
       pt: 'Sex',
       en: 'Fri',
-      es: 'Vie'
+      es: 'Vie',
+      ru: 'Пт'
     },
     {
       pt: 'Sáb',
       en: 'Sat',
-      es: 'Sáb'
+      es: 'Sáb',
+      ru: 'Сб'
     }
   ];
 
   private monthLabel = {
     pt: 'Mês',
     en: 'Month',
-    es: 'Mes'
+    es: 'Mes',
+    ru: 'Месяц'
   };
 
   private yearLabel = {
     pt: 'Ano',
     en: 'Year',
-    es: 'Año'
+    es: 'Año',
+    ru: 'Год'
   };
 
   getMonth(month: number) {
@@ -152,7 +175,7 @@ export class PoCalendarLangService {
   setLanguage(language: string) {
     if (language && language.length >= 2) {
       language = language.toLowerCase().slice(0, 2);
-      this.language = language === 'pt' || language === 'en' || language === 'es' ? language : 'pt';
+      this.language = poLocales.includes(language) ? language : poLocaleDefault;
     }
   }
 }


### PR DESCRIPTION
**po-calendar**

**DTHFUI-4617, DTHFUI-4619**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
o calendar não tem suporte ao idioma russo e não utiliza o i18n para recuperar o locale padrão

**Qual o novo comportamento?**
o calendar passa a ter suporte ao idioma russo e utiliza o i18n para recuperar o locale padrão



**Simulação**
<po-calendar name="calendar" p-label="PO calendar" p-locale="ru"> </po-calendar>