### PR TITLE
feat(decimal): utiliza keyboard numérico ao usar no mobile

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
@@ -17,6 +17,7 @@
       [placeholder]="placeholder"
       [readonly]="readonly"
       [required]="required"
+      inputmode="decimal"
       type="text"
       (blur)="onBlur($event)"
       (focus)="onFocus($event)"


### PR DESCRIPTION
Adiciona inputmode=decimal para utilizar o keyboard numérico no mobile

closes #751

**po-decimal**

**#751**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
No mobile o keyboard apresentado é de texto, deixando ruim o seu manuseio.

**Qual o novo comportamento?**
No mobile utiliza o keyboard numérico.

**Simulação**
< po-decimal name="decimal" p-label="PO Decimal" > < /po-decimal >

Para testar pode usar a aplicação da seguinte forma:

ng serve app --host 0.0.0.0

E no celular, estando na mesma rede, acessar via IP da maquina.
