### PR TITLE
fix(chart): correções no tooltip e espaço lateral

### DIFF
--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-container-size.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-container-size.interface.ts
@@ -21,7 +21,7 @@ export interface PoChartContainerSize {
   /** Metade da altura do container. */
   centerY?: number;
 
-  /** Medida da largura do container - (padding lateral) - (area do labelX) - (padding lateral do grid). */
+  /** Medida da largura do container - (padding lateral) - (area do labelX). */
   svgPlottingAreaWidth?: number;
 
   /** Medida da altura do container - padding superior. */

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis-label/po-chart-axis-label.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis-label/po-chart-axis-label.component.spec.ts
@@ -59,7 +59,28 @@ describe('PoChartAxisXLabelComponent', () => {
       expect(chartAxisYLabel.length).toBe(2);
     });
 
-    it('should find `po-chart-centered-label` class if type is different of `Bar`', () => {
+    it('should find `po-chart-centered-label` class once if type is different of `Bar`', () => {
+      component.type = PoChartType.Line;
+
+      component.axisXLabelCoordinates = [
+        { label: 'label', xCoordinate: 20, yCoordinate: 20 },
+        { label: 'label', xCoordinate: 20, yCoordinate: 20 },
+        { label: 'label', xCoordinate: 20, yCoordinate: 20 }
+      ];
+      component.axisYLabelCoordinates = [
+        { label: 'label', xCoordinate: 20, yCoordinate: 20 },
+        { label: 'label', xCoordinate: 20, yCoordinate: 20 },
+        { label: 'label', xCoordinate: 20, yCoordinate: 20 }
+      ];
+
+      fixture.detectChanges();
+
+      const chartCenteredLabel = nativeElement.querySelectorAll('.po-chart-centered-label');
+      expect(chartCenteredLabel).toBeTruthy();
+      expect(chartCenteredLabel.length).toBe(1);
+    });
+
+    it('shouldn`t find `po-chart-centered-label` class if type is different of `Bar` however it contains only two axisY items', () => {
       component.type = PoChartType.Line;
 
       component.axisXLabelCoordinates = [
@@ -76,7 +97,7 @@ describe('PoChartAxisXLabelComponent', () => {
 
       const chartCenteredLabel = nativeElement.querySelectorAll('.po-chart-centered-label');
       expect(chartCenteredLabel).toBeTruthy();
-      expect(chartCenteredLabel.length).toBe(2);
+      expect(chartCenteredLabel.length).toBe(0);
     });
 
     it('shouldn`t find `po-chart-centered-label` class if type is `Bar`', () => {

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis-label/po-chart-axis-label.component.svg
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis-label/po-chart-axis-label.component.svg
@@ -9,9 +9,9 @@
 </svg:g>
 
 <svg:g>
-  <svg:text *ngFor="let item of axisYLabelCoordinates; trackBy: trackBy"
+  <svg:text *ngFor="let item of axisYLabelCoordinates; let first = first; let last = last; trackBy: trackBy"
     class="po-chart-axis-y-label" 
-    [class.po-chart-centered-label]="type !== 'bar'"
+    [class.po-chart-centered-label]="type === 'column' || type == 'line' && !first && !last"
     [attr.x]="item.xCoordinate"
     [attr.y]="item.yCoordinate">
     {{ item.label }}

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.spec.ts
@@ -471,7 +471,7 @@ describe('PoChartAxisComponent', () => {
       );
     });
 
-    it('setAxisYCoordinatesWithSideSpacing: should apply value to `axisYCoordinates`', () => {
+    it('categoriesDefinedByLines: should apply value to `axisYCoordinates`', () => {
       const fakeSeriesLength = 1;
       const fakeContainerSize = {
         svgWidth: 500,
@@ -481,24 +481,16 @@ describe('PoChartAxisComponent', () => {
         svgPlottingAreaWidth: 400,
         svgPlottingAreaHeight: 280
       };
-      const expectedResult: Array<PoChartPathCoordinates> = [
-        { coordinates: '1' },
-        { coordinates: '2' },
-        { coordinates: 'Mundefined 8 Lundefined, 288' }
-      ];
-      const fakeOuterYCoordinates: Array<PoChartPathCoordinates> = [{ coordinates: '1' }, { coordinates: '2' }];
+      const expectedResult: Array<PoChartPathCoordinates> = [{ coordinates: 'M72 8 L72, 288' }];
+      spyOn(component, <any>'beneathCategoryLine').and.callThrough();
 
-      spyOn(component, <any>'setAxisYOuterCoordinates').and.returnValue(fakeOuterYCoordinates);
-      spyOn(component, <any>'calculateAxisYCoordinateXWithSideSpacing');
+      component['categoriesDefinedByLines'](fakeContainerSize, fakeSeriesLength);
 
-      component['setAxisYCoordinatesWithSideSpacing'](fakeContainerSize, fakeSeriesLength);
-
-      expect(component['setAxisYOuterCoordinates']).toHaveBeenCalled();
-      expect(component['calculateAxisYCoordinateXWithSideSpacing']).toHaveBeenCalled();
+      expect(component['beneathCategoryLine']).toHaveBeenCalled();
       expect(component.axisYCoordinates).toEqual(expectedResult);
     });
 
-    it('setAxisYCoordinatesWithoutSideSpacing: should call `calculateAxisYCoordinateX` once if type is `Bar` and apply value to `axisYCoordinates`', () => {
+    it('categoriesDefinedByAreas: should call `calculateAxisYCoordinateX` once if type is `Bar` and apply value to `axisYCoordinates`', () => {
       const amountOfAxisY = 1;
       const fakeContainerSize = {
         svgWidth: 500,
@@ -513,13 +505,13 @@ describe('PoChartAxisComponent', () => {
 
       spyOn(component, <any>'calculateAxisYCoordinateX');
 
-      component['setAxisYCoordinatesWithoutSideSpacing'](fakeContainerSize, amountOfAxisY, type);
+      component['categoriesDefinedByAreas'](fakeContainerSize, amountOfAxisY, type);
 
       expect(component['calculateAxisYCoordinateX']).toHaveBeenCalledTimes(1);
       expect(component.axisYCoordinates).toEqual(expectedResult);
     });
 
-    it('setAxisYCoordinatesWithoutSideSpacing: should call `calculateAxisYCoordinateX` twice if type is different than `Bar` and apply value to `axisYCoordinates`', () => {
+    it('categoriesDefinedByAreas: should call `calculateAxisYCoordinateX` twice if type is different than `Bar` and apply value to `axisYCoordinates`', () => {
       const amountOfAxisY = 1;
       const fakeContainerSize = {
         svgWidth: 500,
@@ -537,28 +529,10 @@ describe('PoChartAxisComponent', () => {
 
       spyOn(component, <any>'calculateAxisYCoordinateX');
 
-      component['setAxisYCoordinatesWithoutSideSpacing'](fakeContainerSize, amountOfAxisY, type);
+      component['categoriesDefinedByAreas'](fakeContainerSize, amountOfAxisY, type);
 
       expect(component['calculateAxisYCoordinateX']).toHaveBeenCalledTimes(2);
       expect(component.axisYCoordinates).toEqual(expectedResult);
-    });
-
-    it('setAxisYOuterCoordinates: should return an array with `firstLineCoordinates` and `lastLineCoordinates`', () => {
-      const fakeContainerSize = {
-        svgWidth: 500,
-        centerX: 250,
-        svgHeight: 300,
-        centerY: 150,
-        svgPlottingAreaWidth: 400,
-        svgPlottingAreaHeight: 280
-      };
-      const expectedResult = [{ coordinates: 'M72 8 L72 288' }, { coordinates: 'M500 8 L500 288' }];
-      const fakeStartY = 8;
-      const fakeEndY = fakeContainerSize.svgPlottingAreaHeight + 8;
-
-      const result = component['setAxisYOuterCoordinates'](fakeStartY, fakeEndY, fakeContainerSize);
-
-      expect(result).toEqual(expectedResult);
     });
 
     it('calculateAxisYLabelCoordinates: should apply value to `axisYLabelCoordinates`', () => {
@@ -582,17 +556,17 @@ describe('PoChartAxisComponent', () => {
       component['hasAxisSideSpacing'] = true;
       const type = PoChartType.Bar;
 
-      spyOn(component, <any>'calculateAxisYCoordinateXWithSideSpacing').and.returnValue(0);
+      spyOn(component, <any>'beneathCategoryLine').and.returnValue(0);
       spyOn(component, <any>'calculateAxisYLabelYCoordinate').and.returnValue(0);
 
       component['calculateAxisYLabelCoordinates'](amountOfAxisY, fakeContainerSize, fakeMinMaxAxisValues, type);
 
-      expect(component['calculateAxisYCoordinateXWithSideSpacing']).toHaveBeenCalled();
+      expect(component['beneathCategoryLine']).toHaveBeenCalled();
       expect(component['calculateAxisYLabelYCoordinate']).toHaveBeenCalled();
       expect(component.axisYLabelCoordinates).toEqual(expectedResult);
     });
 
-    it('calculateAxisYLabelCoordinates: should call `calculateAxisYLabelXCoordinateWithoutSideSpace` if `hasAxisSideSpacing` is false', () => {
+    it('calculateAxisYLabelCoordinates: should call `centeredInCategoryArea` if `hasAxisSideSpacing` is false', () => {
       component.categories = [];
       const amountOfAxisY = 2;
       const fakeMinMaxAxisValues: PoChartMinMaxValues = {
@@ -615,14 +589,14 @@ describe('PoChartAxisComponent', () => {
 
       component['hasAxisSideSpacing'] = false;
 
-      spyOn(component, <any>'calculateAxisYCoordinateXWithSideSpacing');
-      spyOn(component, <any>'calculateAxisYLabelXCoordinateWithoutSideSpace').and.returnValue(0);
+      spyOn(component, <any>'beneathCategoryLine');
+      spyOn(component, <any>'centeredInCategoryArea').and.returnValue(0);
       spyOn(component, <any>'calculateAxisYLabelYCoordinate').and.returnValue(0);
 
       component['calculateAxisYLabelCoordinates'](amountOfAxisY, fakeContainerSize, fakeMinMaxAxisValues, type);
 
-      expect(component['calculateAxisYCoordinateXWithSideSpacing']).not.toHaveBeenCalled();
-      expect(component['calculateAxisYLabelXCoordinateWithoutSideSpace']).toHaveBeenCalled();
+      expect(component['beneathCategoryLine']).not.toHaveBeenCalled();
+      expect(component['centeredInCategoryArea']).toHaveBeenCalled();
       expect(component['calculateAxisYLabelYCoordinate']).toHaveBeenCalled();
       expect(component.axisYLabelCoordinates).toEqual(expectedResult);
     });
@@ -687,7 +661,7 @@ describe('PoChartAxisComponent', () => {
       expect(result).toEqual(expectedResult);
     });
 
-    it(`calculateAxisYLabelXCoordinateWithoutSideSpace: should return the result of the equation considering that type is Bar'`, () => {
+    it(`centeredInCategoryArea: should return the result of the equation considering that type is Bar'`, () => {
       const expectedResult = 158;
       const amountOfAxisY = 6;
       const type = PoChartType.Bar;
@@ -701,17 +675,12 @@ describe('PoChartAxisComponent', () => {
       };
       const fakeIndex = 1;
 
-      const result = component['calculateAxisYLabelXCoordinateWithoutSideSpace'](
-        fakeContainerSize,
-        amountOfAxisY,
-        type,
-        fakeIndex
-      );
+      const result = component['centeredInCategoryArea'](fakeContainerSize, amountOfAxisY, type, fakeIndex);
 
       expect(result).toEqual(expectedResult);
     });
 
-    it(`calculateAxisYLabelXCoordinateWithoutSideSpace: should return the result of the equation considering that type isn't Bar'`, () => {
+    it(`centeredInCategoryArea: should return the result of the equation considering that type isn't Bar'`, () => {
       const expectedResult = 179;
       const amountOfAxisY = 6;
       const type = PoChartType.Line;
@@ -725,19 +694,14 @@ describe('PoChartAxisComponent', () => {
       };
       const fakeIndex = 1;
 
-      const result = component['calculateAxisYLabelXCoordinateWithoutSideSpace'](
-        fakeContainerSize,
-        amountOfAxisY,
-        type,
-        fakeIndex
-      );
+      const result = component['centeredInCategoryArea'](fakeContainerSize, amountOfAxisY, type, fakeIndex);
 
       expect(result).toEqual(expectedResult);
     });
 
-    it(`calculateAxisYCoordinateXWithSideSpacing: should return the result of 'PoChartAxisXLabelArea + svgAxisSideSpacing +
+    it(`beneathCategoryLine: should return the result of 'PoChartAxisXLabelArea  +
     containerSize.svgPlottingAreaWidth * xRatio'`, () => {
-      const expectedResult = 496;
+      const expectedResult = 472;
       const fakeContainerSize = {
         svgWidth: 500,
         centerX: 250,
@@ -749,15 +713,12 @@ describe('PoChartAxisComponent', () => {
       const fakeIndex = 1;
       component['seriesLength'] = 2;
 
-      spyOn(component['mathsService'], 'calculateSideSpacing').and.returnValue(24);
+      const result = component['beneathCategoryLine'](fakeContainerSize, fakeIndex);
 
-      const result = component['calculateAxisYCoordinateXWithSideSpacing'](fakeContainerSize, fakeIndex);
-
-      expect(component['mathsService'].calculateSideSpacing).toHaveBeenCalled();
       expect(result).toEqual(expectedResult);
     });
 
-    it('calculateAxisYCoordinateXWithSideSpacing: should calculate even if `seriesLenght - 1` is zero', () => {
+    it('beneathCategoryLine: should calculate even if `seriesLenght - 1` is zero', () => {
       const fakeContainerSize = {
         svgWidth: 500,
         centerX: 250,
@@ -769,9 +730,9 @@ describe('PoChartAxisComponent', () => {
       component.series = [{ label: 'test 1', data: [1] }];
       component['seriesLength'] = 1;
 
-      const result = component['calculateAxisYCoordinateXWithSideSpacing'](fakeContainerSize, 0);
+      const result = component['beneathCategoryLine'](fakeContainerSize, 0);
 
-      expect(result).toBe(96);
+      expect(result).toBe(72);
     });
 
     it(`calculateAxisYCoordinateX: should return the result of equation considering that type is 'Bar'`, () => {

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.ts
@@ -191,32 +191,26 @@ export class PoChartAxisComponent {
 
   private calculateAxisYCoordinates(amountOfAxisY: number, containerSize: PoChartContainerSize, type: PoChartType) {
     return this.hasAxisSideSpacing
-      ? this.setAxisYCoordinatesWithSideSpacing(containerSize, amountOfAxisY)
-      : this.setAxisYCoordinatesWithoutSideSpacing(containerSize, amountOfAxisY, type);
+      ? this.categoriesDefinedByLines(containerSize, amountOfAxisY)
+      : this.categoriesDefinedByAreas(containerSize, amountOfAxisY, type);
   }
 
-  private setAxisYCoordinatesWithSideSpacing(containerSize: PoChartContainerSize, amountOfAxisY: number) {
+  private categoriesDefinedByLines(containerSize: PoChartContainerSize, amountOfAxisY: number) {
     const startY = PoChartPlotAreaPaddingTop;
     const endY = containerSize.svgPlottingAreaHeight + PoChartPlotAreaPaddingTop;
 
-    const outerYCoordinates = this.setAxisYOuterCoordinates(startY, endY, containerSize);
-
-    const innerYCoordinates = [...Array(amountOfAxisY)].map((_, index: number) => {
-      const xCoordinate = this.calculateAxisYCoordinateXWithSideSpacing(containerSize, index);
+    const axisCoordinates = [...Array(amountOfAxisY)].map((_, index: number) => {
+      const xCoordinate = this.beneathCategoryLine(containerSize, index);
 
       const coordinates = `M${xCoordinate} ${startY} L${xCoordinate}, ${endY}`;
 
       return { coordinates };
     });
 
-    this.axisYCoordinates = [...outerYCoordinates, ...innerYCoordinates];
+    this.axisYCoordinates = [...axisCoordinates];
   }
 
-  private setAxisYCoordinatesWithoutSideSpacing(
-    containerSize: PoChartContainerSize,
-    amountOfAxisY: number,
-    type: PoChartType
-  ) {
+  private categoriesDefinedByAreas(containerSize: PoChartContainerSize, amountOfAxisY: number, type: PoChartType) {
     const startY = PoChartPlotAreaPaddingTop;
     const endY = containerSize.svgPlottingAreaHeight + PoChartPlotAreaPaddingTop;
 
@@ -234,17 +228,6 @@ export class PoChartAxisComponent {
     this.axisYCoordinates = [...innerYCoordinates];
   }
 
-  private setAxisYOuterCoordinates(startY: number, endY: number, containerSize: PoChartContainerSize) {
-    const firstLineCoordinates = {
-      coordinates: `M${PoChartAxisXLabelArea} ${startY} L${PoChartAxisXLabelArea} ${endY}`
-    };
-    const lastLineCoordinates = {
-      coordinates: `M${containerSize.svgWidth} ${startY} L${containerSize.svgWidth} ${endY}`
-    };
-
-    return [firstLineCoordinates, lastLineCoordinates];
-  }
-
   private calculateAxisYLabelCoordinates(
     amountOfAxisY: number,
     containerSize: PoChartContainerSize,
@@ -257,8 +240,8 @@ export class PoChartAxisComponent {
       const label = axisYLabels[index];
 
       const xCoordinate = this.hasAxisSideSpacing
-        ? this.calculateAxisYCoordinateXWithSideSpacing(containerSize, index)
-        : this.calculateAxisYLabelXCoordinateWithoutSideSpace(containerSize, amountOfAxisY, type, index);
+        ? this.beneathCategoryLine(containerSize, index)
+        : this.centeredInCategoryArea(containerSize, amountOfAxisY, type, index);
       const yCoordinate = this.calculateAxisYLabelYCoordinate(containerSize);
 
       return { label, xCoordinate, yCoordinate };
@@ -309,7 +292,7 @@ export class PoChartAxisComponent {
     return containerSize.svgHeight - textPoChartPadding;
   }
 
-  private calculateAxisYLabelXCoordinateWithoutSideSpace(
+  private centeredInCategoryArea(
     containerSize: PoChartContainerSize,
     amountOfAxisY: number,
     type: PoChartType,
@@ -328,12 +311,11 @@ export class PoChartAxisComponent {
     );
   }
 
-  private calculateAxisYCoordinateXWithSideSpacing(containerSize: PoChartContainerSize, index: number): number {
+  private beneathCategoryLine(containerSize: PoChartContainerSize, index: number): number {
     const divideIndexBySeriesLength = index / (this.seriesLength - 1);
     const xRatio = isNaN(divideIndexBySeriesLength) ? 0 : divideIndexBySeriesLength;
-    const svgAxisSideSpacing = this.mathsService.calculateSideSpacing(containerSize.svgWidth, this.seriesLength);
 
-    return Math.round(PoChartAxisXLabelArea + svgAxisSideSpacing + containerSize.svgPlottingAreaWidth * xRatio);
+    return Math.round(PoChartAxisXLabelArea + containerSize.svgPlottingAreaWidth * xRatio);
   }
 
   private calculateAxisYCoordinateX(

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-path/po-chart-bar-path.component.svg
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-path/po-chart-bar-path.component.svg
@@ -1,6 +1,6 @@
 <svg:path *ngFor="let item of coordinates; trackBy: trackBy"
   [p-tooltip]="item.tooltipLabel"
-  p-tooltip-position="right"
+  [p-tooltip-position]="tooltipPosition"
   [p-append-in-body]='true'
   class="po-chart-bar-path"
   [attr.fill]="color"

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-path/po-chart-bar-path.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-path/po-chart-bar-path.component.ts
@@ -11,6 +11,8 @@ export class PoChartBarPathComponent {
 
   @Input('p-coordinates') coordinates: Array<PoChartBarCoordinates>;
 
+  @Input('p-tooltip-position') tooltipPosition: string;
+
   @Output('p-bar-click') barClick = new EventEmitter<any>();
 
   @Output('p-bar-hover') barHover = new EventEmitter<any>();

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.svg
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.svg
@@ -7,6 +7,7 @@
       [attr.key]="'po-chart-bar-path-' + i"
       [p-color]="colors[i]" 
       [p-coordinates]="item"
+      [p-tooltip-position]="tooltipPosition"
       (p-bar-click)="onSerieBarClick($event)"
       (p-bar-hover)="onSerieBarHover($event)"
       >

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.ts
@@ -14,6 +14,8 @@ import { PoChartMinMaxValues } from './../../interfaces/po-chart-min-max-values.
   templateUrl: './po-chart-bar.component.svg'
 })
 export class PoChartBarComponent extends PoChartBarBaseComponent {
+  readonly tooltipPosition = 'right';
+
   constructor(protected colorService: PoChartColorService, protected mathsService: PoChartMathsService) {
     super(colorService, mathsService);
   }

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.ts
@@ -14,6 +14,8 @@ import { PoChartMinMaxValues } from '../../../interfaces/po-chart-min-max-values
   templateUrl: '../po-chart-bar.component.svg'
 })
 export class PoChartColumnComponent extends PoChartBarBaseComponent {
+  readonly tooltipPosition = 'top';
+
   constructor(protected colorService: PoChartColorService, protected mathsService: PoChartMathsService) {
     super(colorService, mathsService);
   }

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
@@ -110,7 +110,7 @@ describe('PoChartLineComponent', () => {
 
         component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
 
-        const expectedResult = [{ coordinates: ' M96 28 L116 8' }];
+        const expectedResult = [{ coordinates: ' M72 28 L92 8' }];
 
         expect(component.seriesPathsCoordinates).toEqual(expectedResult);
         expect(component.seriesPathsCoordinates.length).toBe(1);
@@ -129,7 +129,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 5',
               data: 5,
-              xCoordinate: 96,
+              xCoordinate: 72,
               yCoordinate: 28
             },
             {
@@ -137,7 +137,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 10',
               data: 10,
-              xCoordinate: 116,
+              xCoordinate: 92,
               yCoordinate: 8
             }
           ]
@@ -161,7 +161,7 @@ describe('PoChartLineComponent', () => {
               label: undefined,
               tooltipLabel: '5',
               data: 5,
-              xCoordinate: 96,
+              xCoordinate: 72,
               yCoordinate: 28
             },
             {
@@ -169,7 +169,7 @@ describe('PoChartLineComponent', () => {
               label: undefined,
               tooltipLabel: '10',
               data: 10,
-              xCoordinate: 116,
+              xCoordinate: 92,
               yCoordinate: 8
             }
           ]
@@ -194,7 +194,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 5',
               data: 5,
-              xCoordinate: 96,
+              xCoordinate: 72,
               yCoordinate: 28
             },
             {
@@ -202,7 +202,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 10',
               data: 10,
-              xCoordinate: 116,
+              xCoordinate: 92,
               yCoordinate: 8
             }
           ]
@@ -225,7 +225,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 10',
               data: 10,
-              xCoordinate: 93,
+              xCoordinate: 72,
               yCoordinate: 8
             },
             {
@@ -233,7 +233,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 12',
               data: 12,
-              xCoordinate: 113,
+              xCoordinate: 92,
               yCoordinate: 0
             }
           ]
@@ -242,7 +242,7 @@ describe('PoChartLineComponent', () => {
         component['seriePathPointsDefinition'](component.containerSize, <any>chartSeries, minMaxSeriesValues);
 
         expect(component.seriesPointsCoordinates).toEqual(expectedPointsResult);
-        expect(component.seriesPathsCoordinates).toEqual([{ coordinates: ' M93 8 L113 0' }]);
+        expect(component.seriesPathsCoordinates).toEqual([{ coordinates: ' M72 8 L92 0' }]);
       });
 
       it('shouldn`t apply values to `seriesPointsCoordinates` neither to `seriesPathsCoordinates` if series.data isn`t an array', () => {
@@ -262,7 +262,7 @@ describe('PoChartLineComponent', () => {
 
         component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
 
-        const expectedResult = [{ coordinates: ' M96 28' }];
+        const expectedResult = [{ coordinates: ' M72 28' }];
 
         expect(component.seriesPathsCoordinates).toEqual(expectedResult);
         expect(component.seriesPathsCoordinates.length).toBe(1);

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.ts
@@ -174,9 +174,8 @@ export class PoChartLineComponent {
   private xCoordinate(index: number, containerSize: PoChartContainerSize) {
     const divideIndexBySeriesLength = index / (this.seriesLength - 1);
     const xRatio = isNaN(divideIndexBySeriesLength) ? 0 : divideIndexBySeriesLength;
-    const svgAxisSideSpacing = this.mathsService.calculateSideSpacing(containerSize.svgWidth, this.seriesLength);
 
-    return PoChartAxisXLabelArea + svgAxisSideSpacing + containerSize.svgPlottingAreaWidth * xRatio;
+    return PoChartAxisXLabelArea + containerSize.svgPlottingAreaWidth * xRatio;
   }
 
   private serieCategory(index: number, categories: Array<string> = []) {

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
@@ -40,31 +40,11 @@
 
   <div *ngIf="!isMultipleValues">
     <div class="po-row">
-      <po-input
-        class="po-md-6"
-        name="label"
-        [(ngModel)]="label"
-        p-label="{{ isSingleSerie ? 'Description' : 'Label' }}"
-      >
-      </po-input>
+      <po-input class="po-md-6" name="label" [(ngModel)]="label" p-label="Label"> </po-input>
 
-      <po-number
-        class="po-md-6"
-        name="data"
-        [(ngModel)]="data"
-        p-label="{{ isSingleSerie ? 'Value' : 'Data' }}"
-        p-required
-      >
-      </po-number>
+      <po-number class="po-md-6" name="data" [(ngModel)]="data" p-label="Data" p-required> </po-number>
 
-      <po-input
-        class="po-md-6"
-        name="tooltip"
-        [(ngModel)]="tooltip"
-        p-label="Tooltip Text"
-        [p-disabled]="isSingleSerie"
-      >
-      </po-input>
+      <po-input class="po-md-6" name="tooltip" [(ngModel)]="tooltip" p-label="Tooltip Text"> </po-input>
     </div>
   </div>
 

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
 import {
-  PoChartGaugeSerie,
   PoLineChartSeries,
   PoChartType,
   PoDonutChartSeries,
@@ -21,8 +20,7 @@ export class SamplePoChartLabsComponent implements OnInit {
   height: number;
   multipleSeries: Array<PoPieChartSeries | PoDonutChartSeries>;
   multipleValues: Array<PoLineChartSeries>;
-  series: Array<PoPieChartSeries | PoDonutChartSeries | PoLineChartSeries> | PoChartGaugeSerie;
-  singleSerie: PoChartGaugeSerie;
+  series: Array<PoPieChartSeries | PoDonutChartSeries | PoLineChartSeries>;
   title: string;
   tooltip: string;
   data: number;
@@ -42,7 +40,6 @@ export class SamplePoChartLabsComponent implements OnInit {
 
   readonly typeOptions: Array<PoSelectOption> = [
     { label: 'Donut', value: PoChartType.Donut },
-    { label: 'Gauge', value: PoChartType.Gauge },
     { label: 'Pie', value: PoChartType.Pie },
     { label: 'Line', value: PoChartType.Line },
     { label: 'Column', value: PoChartType.Column },
@@ -52,10 +49,6 @@ export class SamplePoChartLabsComponent implements OnInit {
   ngOnInit() {
     this.restore();
     this.type = PoChartType.Line;
-  }
-
-  get isSingleSerie(): boolean {
-    return this.type === PoChartType.Gauge;
   }
 
   get isMultipleValues(): boolean {
@@ -71,9 +64,7 @@ export class SamplePoChartLabsComponent implements OnInit {
   }
 
   addData() {
-    if (this.isSingleSerie) {
-      this.singleSerie = { value: this.data, description: this.label };
-    } else if (this.isMultipleValues) {
+    if (this.isMultipleValues) {
       const dataSeries = this.convertToArray(this.inputDataSeries);
 
       this.multipleValues = [...this.multipleValues, { label: this.multipleValuesLabel, data: dataSeries }];
@@ -85,11 +76,7 @@ export class SamplePoChartLabsComponent implements OnInit {
   }
 
   applySeriesData() {
-    this.series = this.isSingleSerie
-      ? this.singleSerie
-      : this.isMultipleValues
-      ? this.multipleValues
-      : this.multipleSeries;
+    this.series = this.isMultipleValues ? this.multipleValues : this.multipleSeries;
   }
 
   changeEvent(eventName: string, serieEvent: PoPieChartSeries): void {
@@ -101,7 +88,6 @@ export class SamplePoChartLabsComponent implements OnInit {
     this.categories = undefined;
     this.event = undefined;
     this.height = undefined;
-    this.singleSerie = undefined;
     this.multipleSeries = [];
     this.series = [];
     this.title = undefined;

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
@@ -87,20 +87,6 @@ describe('PoChartMathsService', () => {
       expect(service.range(minMaxValues, gridLines)).toEqual(expectedResult);
     });
 
-    it('calculateSideSpacing: should return value referring to space between label x and serie`s plot', () => {
-      const containerWidth = 200;
-      const seriesLength = 7;
-
-      expect(service.calculateSideSpacing(containerWidth, seriesLength)).toBe(9);
-    });
-
-    it('calculateSideSpacing: should return 24 referring to space between label x and serie`s plot if halfCategoryWidth exceeds the limit of 24', () => {
-      const containerWidth = 200;
-      const seriesLength = 2;
-
-      expect(service.calculateSideSpacing(containerWidth, seriesLength)).toBe(24);
-    });
-
     it('seriesGreaterLength: should return the serie`s greater length value', () => {
       const series = [
         { label: 'A', data: [-20, 20, 45] },

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
@@ -25,20 +25,6 @@ export class PoChartMathsService {
   }
 
   /**
-   * Efetua o cálculo da área lateral entre o os labels X e a plotagem da primeira série. Válido para gráficos do tipo linha e área.
-   *
-   * > A largura máxima permitida é de 24px.
-   *
-   * @param containerWidth Largura do container SVG.
-   * @param seriesLength Quantidade de séries.
-   */
-  calculateSideSpacing(containerWidth: PoChartContainerSize['svgWidth'], seriesLength: number): number {
-    const halfCategoryWidth = Math.trunc((containerWidth - PoChartAxisXLabelArea) / seriesLength / 2);
-
-    return halfCategoryWidth <= PoChartPadding ? halfCategoryWidth : PoChartPadding;
-  }
-
-  /**
    * Retorna o tamanho da série que tiver mais itens.
    *
    * @param series Lista de séries.

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-svg-container.service.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-svg-container.service.spec.ts
@@ -94,19 +94,13 @@ describe('PoChartSvgContainerService', () => {
     it('svgPlottingAreaWidth: should return the result of the calculation', () => {
       const svgWidth = 200;
 
-      expect(service['svgPlottingAreaWidth'](svgWidth, categoriesLength)).toBe(80);
-    });
-
-    it('svgPlottingAreaWidth: should return value considering that svgAxisSideSpace is 48(Padding * 2)', () => {
-      const svgWidth = 50;
-
-      expect(service['svgPlottingAreaWidth'](svgWidth, categoriesLength)).toBe(-11);
+      expect(service['svgPlottingAreaWidth'](svgWidth)).toBe(128);
     });
 
     it('svgPlottingAreaHeight: should return the result of the calculation', () => {
       const svgHeight = 200;
 
-      expect(service['svgPlottingAreaWidth'](svgHeight, categoriesLength)).toBe(80);
+      expect(service['svgPlottingAreaHeight'](svgHeight)).toBe(168);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-svg-container.service.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-svg-container.service.ts
@@ -28,7 +28,7 @@ export class PoChartSvgContainerService {
     const centerX = this.center(chartWrapperWidth);
     const svgHeight = this.svgHeight(chartHeight, chartHeaderHeight, chartLegendHeight);
     const centerY = this.center(svgHeight);
-    const svgPlottingAreaWidth = this.svgPlottingAreaWidth(svgWidth, categoriesLength);
+    const svgPlottingAreaWidth = this.svgPlottingAreaWidth(svgWidth);
     const svgPlottingAreaHeight = this.svgPlottingAreaHeight(svgHeight);
 
     return {
@@ -70,11 +70,8 @@ export class PoChartSvgContainerService {
    *
    * > A largura máxima para 'svgAxisSideSpace' é de 48px.
    */
-  private svgPlottingAreaWidth(svgWidth: number, categoriesLength: number) {
-    const categoryWidth = (svgWidth - PoChartAxisXLabelArea) / categoriesLength;
-    const svgAxisSideSpace = categoryWidth <= PoChartPadding * 2 ? categoryWidth : PoChartPadding * 2;
-
-    return svgWidth - PoChartAxisXLabelArea - svgAxisSideSpace;
+  private svgPlottingAreaWidth(svgWidth: number) {
+    return svgWidth - PoChartAxisXLabelArea;
   }
 
   /**


### PR DESCRIPTION
**po-chart**

**DTHFUI-2805**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
- O tooltip em gráficos do tipo coluna surgem do lado direito das barras;
- O sample labs permite usar a depreciação do Gauge.
- O gráfico do tipo linha possui um espaçamento entre as categorias e os cantos.

**Qual o novo comportamento?**
- O tooltip para gráficos do tipo coluna devem surgir prioritariamente no topo das barras.
- Removido o gauge do sample labs.
- Removida área lateral em gráficos do tipo Linha

**Simulação**
Os samples contemplam todas as alterações acima. Há PR também para o [style](https://github.com/po-ui/po-style/pull/184)