### PR TITLE
feat(upload): adiciona a propriedade p-headers

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -464,6 +464,9 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
     return this._required;
   }
 
+  /** Objeto que contém os cabeçalhos que será enviado na requisição dos arquvios. */
+  @Input('p-headers') headers: { [name: string]: string | Array<string> };
+
   /**
    * @optional
    *

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.service.spec.ts
@@ -75,21 +75,22 @@ describe('PoUploadBaseService:', () => {
     fakeFile['name'] = 'Teste';
     fakeFile['webkitRelativePath'] = '';
     const files = [new PoUploadFile(<File>fakeFile)];
+    const headers = { Authorization: '145236' };
     const tOnUpload = new EventEmitter<any>();
     const callback = (file: PoUploadFile, event: any) => '';
 
     spyOn(service, 'sendFile');
-    service.upload('', files, tOnUpload, callback, callback, callback);
+    service.upload('', files, headers, tOnUpload, callback, callback, callback);
     expect(service.sendFile).toHaveBeenCalled();
 
-    service.upload('', files, undefined, callback, callback, callback);
+    service.upload('', files, headers, undefined, callback, callback, callback);
     expect(service.sendFile).toHaveBeenCalled();
   }));
 
   it('should execute uploadCallback function', inject([PoUploadBaseService], (service: PoUploadBaseService) => {
     const methods = returnMethodsCallback();
     const fakeThis = {
-      getRequest: (url: any, formData: any) => {
+      getRequest: (url: any, headers: any, formData: any) => {
         return new Observable(observer => {
           observer.next({ type: 1 });
           observer.complete();
@@ -103,6 +104,7 @@ describe('PoUploadBaseService:', () => {
     service.sendFile.call(
       fakeThis,
       '',
+      {},
       null,
       new FormData(),
       methods.uploadCallback,
@@ -116,7 +118,7 @@ describe('PoUploadBaseService:', () => {
   it('should execute successCallback function', inject([PoUploadBaseService], (service: PoUploadBaseService) => {
     const methods = returnMethodsCallback();
     const fakeThis = {
-      getRequest: (url: any, formData: any) => {
+      getRequest: (url: any, headers: any, formData: any) => {
         return new Observable(observer => {
           observer.next(new HttpResponse());
           observer.complete();
@@ -130,6 +132,7 @@ describe('PoUploadBaseService:', () => {
     service.sendFile.call(
       fakeThis,
       '',
+      {},
       null,
       new FormData(),
       methods.uploadCallback,
@@ -157,6 +160,7 @@ describe('PoUploadBaseService:', () => {
     service.sendFile.call(
       fakeThis,
       '',
+      {},
       null,
       new FormData(),
       methods.uploadCallback,
@@ -170,7 +174,7 @@ describe('PoUploadBaseService:', () => {
   it('should execute errorCallback function', inject([PoUploadBaseService], (service: PoUploadBaseService) => {
     const methods = returnMethodsCallback();
     const fakeThis = {
-      getRequest: (url: any, formData: any) => {
+      getRequest: (url: any, headers: any, formData: any) => {
         return new Observable(observer => {
           observer.error();
         });
@@ -183,6 +187,7 @@ describe('PoUploadBaseService:', () => {
     service.sendFile.call(
       fakeThis,
       '',
+      {},
       null,
       new FormData(),
       methods.uploadCallback,
@@ -193,7 +198,7 @@ describe('PoUploadBaseService:', () => {
   }));
 
   it('should return a promisse', inject([PoUploadBaseService], (service: PoUploadBaseService) => {
-    const req = service.getRequest('', new FormData());
+    const req = service.getRequest('', {}, new FormData());
     expect(typeof req.subscribe()).toBe('object');
   }));
 });

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.service.ts
@@ -1,5 +1,12 @@
 import { Injectable, EventEmitter } from '@angular/core';
-import { HttpClient, HttpEventType, HttpErrorResponse, HttpRequest, HttpResponse } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpEventType,
+  HttpErrorResponse,
+  HttpRequest,
+  HttpResponse,
+  HttpHeaders
+} from '@angular/common/http';
 
 import { PoUploadFile } from './po-upload-file';
 
@@ -25,6 +32,7 @@ export class PoUploadBaseService {
   public upload(
     url: string,
     files: Array<PoUploadFile>,
+    headers: { [name: string]: string | Array<string> },
     tOnUpload: EventEmitter<any>,
     uploadCallback: (file: PoUploadFile, percent: number) => void,
     successCallback: (file: PoUploadFile, event: any) => void,
@@ -51,19 +59,20 @@ export class PoUploadBaseService {
         formData.append('data', JSON.stringify(uploadEvent.data));
       }
 
-      this.sendFile(url, file, formData, uploadCallback, successCallback, errorCallback);
+      this.sendFile(url, file, headers, formData, uploadCallback, successCallback, errorCallback);
     }
   }
 
   public sendFile(
     url: string,
     file: PoUploadFile,
+    headers: { [name: string]: string | Array<string> },
     formData: FormData,
     uploadCallback: (file: PoUploadFile, percent: number) => void,
     successCallback: (file: PoUploadFile, event: any) => void,
     errorCallback: (file: PoUploadFile, event: any) => void
   ) {
-    const request = this.getRequest(url, formData).subscribe(
+    const request = this.getRequest(url, headers, formData).subscribe(
       event => {
         if (event.type === HttpEventType.UploadProgress) {
           this.addRequest(file, request);
@@ -81,11 +90,17 @@ export class PoUploadBaseService {
     );
   }
 
-  public getRequest(url: string, formData: FormData): Observable<any> {
-    const req = new HttpRequest('POST', url, formData, {
-      reportProgress: true
-    });
+  public getRequest(
+    url: string,
+    headers: { [name: string]: string | Array<string> },
+    formData: FormData
+  ): Observable<any> {
+    const httpHeaders = new HttpHeaders(headers);
 
+    const req = new HttpRequest('POST', url, formData, {
+      reportProgress: true,
+      headers: httpHeaders
+    });
     return this.http.request(req);
   }
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
@@ -581,7 +581,7 @@ describe('PoUploadComponent:', () => {
       it('should call uploadingHandler function when upload files', () => {
         const fakeThis = {
           uploadService: {
-            upload: function (url, filez, tUpload, uploadCallback, successCallback, errorCallback) {
+            upload: function (url, filez, headers, tUpload, uploadCallback, successCallback, errorCallback) {
               return uploadCallback(file, 100);
             }
           },
@@ -597,7 +597,7 @@ describe('PoUploadComponent:', () => {
       it('should call responseHandler function when upload files', () => {
         const fakeThis = {
           uploadService: {
-            upload: function (url, filez, tUpload, uploadCallback, successCallback, errorCallback) {
+            upload: function (url, filez, headers, tUpload, uploadCallback, successCallback, errorCallback) {
               return successCallback(file, 100);
             }
           },
@@ -615,7 +615,7 @@ describe('PoUploadComponent:', () => {
       it('should call responseHandler function when upload files', () => {
         const fakeThis = {
           uploadService: {
-            upload: function (url, filez, tUpload, uploadCallback, successCallback, errorCallback) {
+            upload: function (url, filez, headers, tUpload, uploadCallback, successCallback, errorCallback) {
               return errorCallback(file, 100);
             }
           },

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
@@ -295,10 +295,10 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
   // Envia os arquivos passados por parâmetro, exceto os que já foram enviados ao serviço.
   uploadFiles(files: Array<PoUploadFile>) {
     const filesFiltered = files.filter(file => file.status !== PoUploadStatus.Uploaded);
-
     this.uploadService.upload(
       this.url,
       filesFiltered,
+      this.headers,
       this.onUpload,
       (file, percent): any => {
         // UPLOADING

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
@@ -18,6 +18,7 @@
   [p-required]="properties.includes('required')"
   [p-restrictions]="restrictions"
   [p-url]="url"
+  [p-headers]="headers"
   (p-error)="changeEvent('p-error')"
   (p-success)="changeEvent('p-success')"
   (p-upload)="changeEvent('p-upload')"
@@ -112,7 +113,17 @@
 
   <div class="po-row">
     <po-input
-      class="po-md-12"
+      class="po-md-6"
+      name="headers"
+      [(ngModel)]="headersLabs"
+      p-help='Ex.: {"Authorization": "12312414"}'
+      p-label="Headers"
+      (p-change)="onChangeHeaders($event)"
+    >
+    </po-input>
+
+    <po-input
+      class="po-md-6"
       name="literals"
       [(ngModel)]="literals"
       p-help='Ex.: {"selectFile": "Select file", "deleteFile": "Delete file", "cancel": "Cancel sending"}'

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
@@ -22,7 +22,8 @@ export class SamplePoUploadLabsComponent implements OnInit {
   restrictions: PoUploadFileRestrictions;
   upload: Array<any>;
   url: string;
-
+  headers: { [name: string]: string | Array<string> };
+  headersLabs: string;
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'autoupload', label: 'Automatic upload' },
     { value: 'directory', label: 'Directory' },
@@ -52,6 +53,13 @@ export class SamplePoUploadLabsComponent implements OnInit {
     }
   }
 
+  onChangeHeaders(headers) {
+    try {
+      this.headers = JSON.parse(headers);
+    } catch {
+      this.headers = undefined;
+    }
+  }
   onChangeExtension() {
     this.restrictions = Object.assign({}, this.restrictions, { allowedExtensions: this.allowedExtensions.split(',') });
   }
@@ -84,6 +92,8 @@ export class SamplePoUploadLabsComponent implements OnInit {
     this.restrictions = {};
     this.upload = undefined;
     this.url = 'https://thf.totvs.com.br/sample/api/uploads/addFile';
+    this.headers = undefined;
+    this.headersLabs = undefined;
   }
 
   private getValueInBytes(value: number) {


### PR DESCRIPTION
Adiciona a propriedade headers no componente, para permitir envia-los para a requisição do envio do arquivo.

Fixes #593

**upload**

**#593**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não existe propriedade headers no componente não podendo enviar um header para a requisição

**Qual o novo comportamento?**
Adiciona a propriedade headers permitindo envia-los para a requisição do envio do arquivo.

**Simulação**

< po-upload
    name="upload"
    p-label="PO Upload"
    p-url="https://thf.totvs.com.br/sample/api/uploads/addFile"
    [p-headers]="{ 'XPTO': ['API-123131-31321', '33']}">
  < /po-upload>

  < po-upload
     name="upload"
     p-label="PO Upload"
     p-url="https://thf.totvs.com.br/sample/api/uploads/addFile"
     [p-headers]="{ 'Authorization': 'API-123131-31321'}">
  < /po-upload>