### PR TITLE
fix(po-lookup): não remove espaços quando realizada busca pelo código

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -371,6 +371,21 @@ describe('PoLookupBaseComponent:', () => {
       }
     ));
 
+    it('searchById: should call getObjectByValue with value starting with white spaces', inject(
+      [LookupFilterService],
+      (lookupFilterService: LookupFilterService) => {
+        const expectedValue = ' Item X';
+        component.service = lookupFilterService;
+
+        spyOn(component.service, 'getObjectByValue').and.returnValue(throwError({ id: 1 }));
+
+        component.filterParams = undefined;
+        component.searchById(expectedValue);
+
+        expect(component.service['getObjectByValue']).toHaveBeenCalledWith(expectedValue, component.filterParams);
+      }
+    ));
+
     it('writeValue: should call `cleanViewValue` when execute the method `writeValue` with undefined param.', () => {
       spyOn(component, <any>'cleanViewValue');
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -424,11 +424,13 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
   }
 
   searchById(value: string) {
-    if (typeof value === 'string') {
-      value = value.trim();
+    let checkedValue = value;
+
+    if (typeof checkedValue === 'string') {
+      checkedValue = checkedValue.trim();
     }
 
-    if (value !== '') {
+    if (checkedValue !== '') {
       this.getSubscription = this.service.getObjectByValue(value, this.filterParams).subscribe(
         element => {
           if (element) {


### PR DESCRIPTION
**po-lookup**

**DTHFUI-4638**
_____________________________________________________________________________

**PR Checklist**

- [ x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente caso o valor informado no campo lookup fosse iniciado com um espaço, o mesmo era removido, fazendo com que o valor informado pelo usuário não fosse o mesmo a ser enviado para o servidor.

**Qual o novo comportamento?**
Foi realizada uma validação para que caso o valor informado seja apenas espaços em branco, a pesquisa não seja disparada, e caso o valor informado possua espaços os mesmos sejam preservados para serem enviados ao servidor.

**Simulação**
Executar a simulação relatada na ISSUE DTHFUI-4638