### PR TITLE
page-dynamic-table: corrige uso p-table-custom-actions sem p-actions

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -2304,7 +2304,7 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(customActionServiceSpy).toHaveBeenCalled();
     });
 
-    it('should set "Excluir" button in last item of action', () => {
+    it('should set "Remove" button in last item of action', () => {
       component.actions = {
         remove: true,
         new: '/documentation/po-page-dynamic-edit',
@@ -2319,6 +2319,16 @@ describe('PoPageDynamicTableComponent:', () => {
 
       const tableActions = visibleTableActions();
       expect(tableActions[tableActions.length - 1].label).toBe(component.literals.tableActionDelete);
+    });
+
+    it('shouldn`t add remove action if actions.remove is undefined', () => {
+      component.actions = {};
+      component.tableCustomActions = [{ label: 'Details', action: () => {} }];
+
+      const tableActions = visibleTableActions();
+
+      expect(tableActions.length).toEqual(1);
+      expect(tableActions[0].label).toEqual('Details');
     });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -1035,13 +1035,20 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   }
 
   private updateTableActions() {
-    const tableActionDelete = this._defaultTableActions.find(
-      tableAction => tableAction.label === this.literals.tableActionDelete
-    );
     const defaultTableActionsWithoutActionDelete = this._defaultTableActions.filter(
       tableAction => tableAction.label !== this.literals.tableActionDelete
     );
 
-    this.tableActions = [...defaultTableActionsWithoutActionDelete, ...this._customTableActions, tableActionDelete];
+    const tableActionDelete = this._defaultTableActions.find(
+      tableAction => tableAction.label === this.literals.tableActionDelete
+    );
+
+    const newTableActions = [...defaultTableActionsWithoutActionDelete, ...this._customTableActions];
+
+    if (tableActionDelete) {
+      newTableActions.push(tableActionDelete);
+    }
+
+    this.tableActions = newTableActions;
   }
 }

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1358,6 +1358,12 @@ describe('PoTableComponent:', () => {
       expect(component.visibleActions).toEqual([{ label: 'PO2', visible: true }]);
     });
 
+    it('visibleActions: should return only valid values', () => {
+      component.actions = [{ label: 'PO1' }, undefined, null];
+
+      expect(component.visibleActions).toEqual([{ label: 'PO1' }]);
+    });
+
     it('visibleActions: should be `true` if has action.', () => {
       component.actions = actions;
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -205,7 +205,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   get visibleActions() {
-    return this.actions && this.actions.filter(action => action.visible !== false);
+    return this.actions && this.actions.filter(action => action && action.visible !== false);
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
**PAGE DYNAMIC TABLE**

**#732**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Caso utilizasse p-table-custom-actions sem p-actions ocorria erro no po-table, pois adiciona "undefined" na lista de ações.

**Qual o novo comportamento?**
Não adiciona "undefined" na lista de ações da tabela, fazendo com que o funcione corretamente.


**Simulação**
https://stackblitz.com/edit/po-ui-ued1sn?file=src%2Fapp%2Fapp.component.html