### PR TITLE
feat(code-editor): adiciona o atributo ignoreCase à interface options

### DIFF
--- a/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable-options.interface.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable-options.interface.ts
@@ -22,4 +22,7 @@ export interface PoCodeEditorRegisterableOptions {
 
   /** Interface para recebimento de token específicos da sintaxe. */
   tokenizer: PoCodeEditorRegisterableTokens;
+
+  /** Define se a sintaxe será case sensitive ou não. */
+  ignoreCase?: boolean;
 }

--- a/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.constant.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.constant.ts
@@ -28,6 +28,7 @@ export function provideCompletionItems() {
 export const customRegister: PoCodeEditorRegisterable = {
   language: 'terraform',
   options: {
+    ignoreCase: false,
     keywords: ['resource', 'provider', 'variable', 'output', 'module', 'true', 'false'],
     operators: ['{', '}', '(', ')', '[', ']', '?', ':'],
     symbols: new RegExp('[=><!~?:&|+\\-*\\/\\^%]+'),


### PR DESCRIPTION
Durante o registro de uma nova sintaxe não era possível defini-la como case-insensitive.
Adiciona o atributo ignoreCase à interface PoCodeEditorRegisterableOptions, permitindo o registro de uma sintaxe case-insensitive.

**po-code-editor**

**778**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não era possivel registrar uma sintaxe case-insensitive

**Qual o novo comportamento?**
É possível definir uma sintaxe case-insensitive, através do atributo ignoreCase

**Simulação**
1-Registrar uma nova sintaxe com ignoreCase=true
2-Definir uma keyword como return
3-Incluir no po-code-editor RETURN, por exemplo