### PR TITLE
fix(table): corrige tradução pelo google translate

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -184,7 +184,7 @@
             (click)="selectable ? selectRow(row) : 'javascript:;'"
           >
             <div
-              class="po-table-column-cell"
+              class="po-table-column-cell notranslate"
               [class.po-table-body-ellipsis]="hideTextOverflow"
               [ngSwitch]="column.type"
               [p-tooltip]="tooltipText"


### PR DESCRIPTION
**TABLE**

**DTHFUI-4145**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao manipular uma tabela com dados e ordenação, com o google translate para portugues habilitado, 
a tabela não é atualizada corretamente e a ordenação não funciona.

Encontrado problema semelhante 
https://github.com/angular/angular.js/issues/11265

**Qual o novo comportamento?**
Desabilitado a tradução dos dados da tabela (notranslate), dessa forma a tabela funciona corretamente.

**Simulação**
Problema atual:

PO Page List - Hiring Processes
https://po-ui.io/documentation/po-page-list?view=web

Com a solução:
Entrar na branch, subir o portal e testar o mesmo sample


https://user-images.githubusercontent.com/6907801/107089155-e78a5200-67dc-11eb-84e4-91c985ff521a.mp4




