### PR TITLE
feat(chart): combinação de tipos no mesmo gráfico

### DIFF
--- a/projects/ui/src/lib/components/po-chart/index.ts
+++ b/projects/ui/src/lib/components/po-chart/index.ts
@@ -3,6 +3,7 @@ export * from './interfaces/po-chart-column-series.interface';
 export * from './interfaces/po-chart-bar-series.interface';
 export * from './interfaces/po-chart-donut-series.interface';
 export * from './interfaces/po-chart-pie-series.interface';
+export * from './interfaces/po-chart-serie.interface';
 export * from './po-chart-types/po-chart-gauge/po-chart-gauge-series.interface';
 
 export * from './enums/po-chart-type.enum';

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-bar-coordinates.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-bar-coordinates.interface.ts
@@ -11,6 +11,9 @@ export interface PoChartBarCoordinates {
   /** Categoria do eixo Y na qual o item da série está presente. */
   category: string;
 
+  /** A cor da série. */
+  color?: string;
+
   /** A série para a qual correspondem as coordenadas. */
   label: string;
 

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-donut-series.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-donut-series.interface.ts
@@ -17,7 +17,7 @@ export interface PoDonutChartSeries extends PoCircularChartSeries {
    *
    * Define o texto que será exibido ao passar o mouse por cima das séries do *chart*.
    *
-   * > Caso não seja informado um valor para o *tooltip*, será exibido: `categoria: valor proporcional ao total em porcentagem`.
+   * > Caso não seja informado um valor para o *tooltip*, será exibido: `label`: valor proporcional ao total em porcentagem.
    */
   tooltip?: string;
 }

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-path-coordinates.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-path-coordinates.interface.ts
@@ -12,7 +12,7 @@ export interface PoChartPathCoordinates {
   color?: string;
 
   /** As coordenadas da série. */
-  coordinates: string;
+  coordinates?: string;
 
   /** Valor da série. */
   data?: number;

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-pie-series.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-pie-series.interface.ts
@@ -17,7 +17,7 @@ export interface PoPieChartSeries extends PoCircularChartSeries {
    *
    * Define o texto que será exibido ao passar o mouse por cima das séries do *chart*.
    *
-   * > Caso não seja informado um valor para o *tooltip*, será exibido: `categoria: valor`.
+   * > Caso não seja informado um valor para o *tooltip*, será exibido: `label`: `data`.
    */
   tooltip?: string;
 }

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie.interface.ts
@@ -1,0 +1,64 @@
+import { PoChartType } from '../enums/po-chart-type.enum';
+
+/**
+ * @usedBy PoChartComponent
+ *
+ * @description
+ *
+ * Interface das series dinâmicas do `po-chart` que possibilita desenhar gráficos dos tipos `bar`, `column`, `line`, `donut` e `pie`
+ */
+export interface PoChartSerie {
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a lista de valores para a série. Os tipos esperados são de acordo com o tipo de gráfico:
+   * - Para gráficos dos tipos `donut` e `pie`, espera-se *number*;
+   * - Para gráficos dos tipos `bar`, `column` e `line`, espera-se um *array* de `data`.
+   *
+   * > Se passado valor `null` em determinado item da lista, a iteração irá ignorá-lo.
+   */
+  data?: number | Array<number>;
+
+  /** Rótulo referência da série;. */
+  label?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o texto que será exibido ao passar o mouse por cima das séries do *chart*.
+   *
+   * > Caso não seja informado um valor para o *tooltip*, será exibido da seguinte forma:
+   * - `donut`: `label`: valor proporcional ao total em porcentagem.
+   * - `bar`, `column`, `line` e `pie`: `label`: `data`.
+   */
+  tooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define em qual tipo de gráfico que será exibida a série. É possível combinar séries dos tipos `column` e `line` no mesmo gráfico. Para isso, basta criar as séries com as configurações:
+   * - Serie A: `{ type: ChartType.Column, data: ... }`;
+   * - Série B: `{ type: ChartType.Line, data: ... }`.
+   *
+   * Se tanto `p-type` quanto `{ type }` forem ignorados, o padrão gerado pelo componente será:
+   * - `column`: se `data` receber `Array<number>`;
+   * - `pie`: se `data` for *number*.
+   *
+   * > Se utilizada a propriedade `p-type`, dispensa-se a definição desta propriedade. Porém, se houver declaração para ambas, o valor `{type}` da primeira série sobrescreverá o valor definido em `p-type`.
+   *
+   * > O componente só exibirá as séries que tiverem o mesmo `type` definido, exceto para mesclagem para tipos `column` e `line`.
+   */
+  type?: PoChartType;
+
+  // **Deprecated 6.x.x**. Define o valor do objeto.
+  value?: number;
+
+  // **Deprecated 6.x.x**. Define o valor da categoria do objeto.
+  category?: string;
+}

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-base.component.spec.ts
@@ -1,11 +1,9 @@
-import { expectPropertiesValues } from 'projects/ui/src/lib/util-test/util-expect.spec';
-
 import { PoChartBarBaseComponent } from './po-chart-bar-base.component';
 
-import { PoChartColorService } from '../../services/po-chart-color.service';
 import { PoChartMathsService } from '../../services/po-chart-maths.service';
 import { PoChartContainerSize } from '../../interfaces/po-chart-container-size.interface';
 import { PoChartType } from '../../enums/po-chart-type.enum';
+import { expectPropertiesValues } from 'projects/ui/src/lib/util-test/util-expect.spec';
 
 class PoChartColumnComponent extends PoChartBarBaseComponent {
   barCoordinates(): string {
@@ -26,12 +24,12 @@ describe('PoChartBarBaseComponent', () => {
     svgPlottingAreaWidth: 20,
     svgPlottingAreaHeight: 20
   };
+  const range = { minValue: 0, maxValue: 30 };
 
-  const colorService: PoChartColorService = new PoChartColorService();
   const mathsService: PoChartMathsService = new PoChartMathsService();
 
   beforeEach(() => {
-    component = new PoChartColumnComponent(colorService, mathsService);
+    component = new PoChartColumnComponent(mathsService);
     component.containerSize = containerSize;
     component.series = series;
   });
@@ -68,75 +66,32 @@ describe('PoChartBarBaseComponent', () => {
       expect(component.trackBy(index)).toBe(expectedValue);
     });
 
-    it('getDomainValues: should always apply zero to minValue and get maxValue from `minMaxSeriesValues`', () => {
-      component.options = undefined;
-      component['acceptNegativeValues'] = true;
-
-      component['getDomainValues'](component.options);
-
-      expect(component['minMaxSeriesValues']).toEqual({ minValue: 0, maxValue: 30 });
-    });
-
-    it('getDomainValues: should apply maxValue with the min and max values of `options` but apply zero to minValue', () => {
-      component.options = { minRange: -10, maxRange: 50 };
-      component['acceptNegativeValues'] = true;
-
-      component['getDomainValues'](component.options);
-
-      expect(component['minMaxSeriesValues']).toEqual({ minValue: 0, maxValue: 50 });
-    });
-
-    it('getDomainValues: should apply minValue with zero if `acceptNegativeValues` is false and `options` is undefined', () => {
-      component.options = undefined;
-      component['acceptNegativeValues'] = false;
-
-      component['getDomainValues'](component.options);
-
-      expect(component['minMaxSeriesValues']).toEqual({ minValue: 0, maxValue: 30 });
-    });
-
-    it('getDomainValues: should apply minValue with zero if `minValue` is negative and `acceptNegativeValues` is false', () => {
-      component.options = { minRange: -10, maxRange: 50 };
-      component['acceptNegativeValues'] = false;
-
-      component['getDomainValues'](component.options);
-
-      expect(component['minMaxSeriesValues']).toEqual({ minValue: 0, maxValue: 50 });
-    });
-
-    it('getDomainValues: should apply minValue with the min values of `series` if `minValue` isn`t negative and `acceptNegativeValues` is false', () => {
-      component.options = { minRange: 10, maxRange: 50 };
-      component['acceptNegativeValues'] = false;
-
-      component['getDomainValues'](component.options);
-
-      expect(component['minMaxSeriesValues']).toEqual({ minValue: 1, maxValue: 50 });
-    });
-
     describe('calculateSeriesPathsCoordinates', () => {
-      it('should call `verifyIfFloatOrInteger`, `barCoordinates`, `serieCategory` and `serieLabel`', () => {
+      it('should call `verifyIfFloatOrInteger`, `barCoordinates`, `serieCategory` and `getTooltipLabel`', () => {
         const minMaxSeriesValues = { minValue: 1, maxValue: 30 };
 
         const spyVerifyIfFloatOrInteger = spyOn(component['mathsService'], 'verifyIfFloatOrInteger').and.callThrough();
         const spyBarCoordinates = spyOn(component, <any>'barCoordinates');
         const spySerieCategory = spyOn(component, <any>'serieCategory');
-        const spySerieLabel = spyOn(component, <any>'serieLabel');
+        const spyGetTooltipLabel = spyOn(component, <any>'getTooltipLabel');
 
         component['calculateSeriesPathsCoordinates'](component.containerSize, component.series, minMaxSeriesValues);
 
         expect(spyVerifyIfFloatOrInteger).toHaveBeenCalled();
         expect(spyBarCoordinates).toHaveBeenCalled();
         expect(spySerieCategory).toHaveBeenCalled();
-        expect(spySerieLabel).toHaveBeenCalled();
+        expect(spyGetTooltipLabel).toHaveBeenCalled();
       });
 
       it('should apply apply value to `seriesPathsCoordinates`', () => {
-        component.series = [{ label: 'Vancouver', data: [5, 10] }];
-        const minMaxSeriesValues = { minValue: 5, maxValue: 10 };
+        component.series = [{ label: 'Vancouver', data: [5, 10], type: PoChartType.Column, color: '#94DAE2' }];
+
+        const minMaxSeriesValues = { minValue: 0, maxValue: 10 };
         const expectedResult = [
           [
             {
               category: undefined,
+              color: '#94DAE2',
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 5',
               data: 5,
@@ -144,6 +99,7 @@ describe('PoChartBarBaseComponent', () => {
             },
             {
               category: undefined,
+              color: '#94DAE2',
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 10',
               data: 10,
@@ -162,13 +118,14 @@ describe('PoChartBarBaseComponent', () => {
     });
 
     it('should apply apply only data to tooltipLabel if label is undefined', () => {
-      component.series = [{ label: undefined, data: [5, 10] }];
+      component.series = [{ label: undefined, data: [5, 10], color: '#94DAE2' }];
       const minMaxSeriesValues = { minValue: 5, maxValue: 10 };
 
       const expectedResult = [
         [
           {
             category: undefined,
+            color: '#94DAE2',
             label: undefined,
             tooltipLabel: '5',
             data: 5,
@@ -176,6 +133,7 @@ describe('PoChartBarBaseComponent', () => {
           },
           {
             category: undefined,
+            color: '#94DAE2',
             label: undefined,
             tooltipLabel: '10',
             data: 10,
@@ -194,13 +152,14 @@ describe('PoChartBarBaseComponent', () => {
     });
 
     it('should apply `categories` values at seriesPathsCoordinates', () => {
-      component.series = [{ label: 'Vancouver', data: [5, 10] }];
+      component.series = [{ label: 'Vancouver', data: [5, 10], color: '#94DAE2' }];
       component.categories = ['janeiro', 'fevereiro'];
       const minMaxSeriesValues = { minValue: 5, maxValue: 10 };
       const expectedResult = [
         [
           {
             category: 'janeiro',
+            color: '#94DAE2',
             label: 'Vancouver',
             tooltipLabel: 'Vancouver: 5',
             data: 5,
@@ -208,6 +167,7 @@ describe('PoChartBarBaseComponent', () => {
           },
           {
             category: 'fevereiro',
+            color: '#94DAE2',
             label: 'Vancouver',
             tooltipLabel: 'Vancouver: 10',
             data: 10,
@@ -228,11 +188,12 @@ describe('PoChartBarBaseComponent', () => {
     it('should ignore to coordinates the serie.data which it`s value is null', () => {
       component.categories = ['janeiro', 'fevereiro', 'março'];
       const minMaxSeriesValues = { minValue: 5, maxValue: 10 };
-      const chartSeries = [{ label: 'Vancouver', data: [10, null, 12] }];
+      const chartSeries = [{ label: 'Vancouver', data: [10, null, 12], color: '#94DAE2' }];
       const expectedResult = [
         [
           {
             category: 'janeiro',
+            color: '#94DAE2',
             label: 'Vancouver',
             tooltipLabel: 'Vancouver: 10',
             data: 10,
@@ -240,6 +201,7 @@ describe('PoChartBarBaseComponent', () => {
           },
           {
             category: 'março',
+            color: '#94DAE2',
             label: 'Vancouver',
             tooltipLabel: 'Vancouver: 12',
             data: 12,
@@ -266,63 +228,52 @@ describe('PoChartBarBaseComponent', () => {
   });
 
   describe('Properties:', () => {
-    it('p-container-size: should call `getDomainValues` and `calculateSeriesPathsCoordinates`', () => {
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
+    it('p-container-size: should call `calculateSeriesPathsCoordinates`', () => {
       const spyCalculateSeriesPathsCoordinates = spyOn(component, <any>'calculateSeriesPathsCoordinates');
 
       component.containerSize = containerSize;
+      component.range = range;
 
-      expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
       expect(spyCalculateSeriesPathsCoordinates).toHaveBeenCalledWith(
         component.containerSize,
         component.series,
-        component['minMaxSeriesValues']
+        component.range
       );
     });
 
-    it('p-series: should call `getDomainValues`, `calculateSeriesPathsCoordinates`, `seriesGreaterLength` and `getSeriesColor`', () => {
-      const type = PoChartType.Column;
+    it('p-series: should call`calculateSeriesPathsCoordinates`, and `seriesGreaterLength`', () => {
       const spySeriesGreaterLength = spyOn(component['mathsService'], <any>'seriesGreaterLength');
-      const spyGetSeriesColor = spyOn(component['colorService'], 'getSeriesColor');
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
       const spyCalculateSeriesPathsCoordinatesn = spyOn(component, <any>'calculateSeriesPathsCoordinates');
 
       component.series = series;
+      component.range = range;
 
       expect(spySeriesGreaterLength).toHaveBeenCalledWith(component.series);
-      expect(spyGetSeriesColor).toHaveBeenCalledWith(component.series, type);
-      expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
       expect(spyCalculateSeriesPathsCoordinatesn).toHaveBeenCalledWith(
         component.containerSize,
         component.series,
-        component['minMaxSeriesValues']
+        component.range
       );
     });
 
-    it(`p-series: should call 'getDomainValues', 'calculateSeriesPathsCoordinates', 'seriesGreaterLength' and 'getSeriesColor' if 'serie.data'
+    it(`p-series: should call 'calculateSeriesPathsCoordinates' and 'seriesGreaterLength' if 'serie.data'
     is an empty array`, () => {
-      const type = PoChartType.Column;
       const spySeriesGreaterLength = spyOn(component['mathsService'], <any>'seriesGreaterLength');
-      const spyGetSeriesColor = spyOn(component['colorService'], 'getSeriesColor');
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
       const spyCalculateSeriesPathsCoordinatesn = spyOn(component, <any>'calculateSeriesPathsCoordinates');
 
       component.series = <any>[{ label: 'category', data: [] }];
+      component.range = range;
 
       expect(spySeriesGreaterLength).toHaveBeenCalledWith(component.series);
-      expect(spyGetSeriesColor).toHaveBeenCalledWith(component.series, type);
-      expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
       expect(spyCalculateSeriesPathsCoordinatesn).toHaveBeenCalledWith(
         component.containerSize,
         component.series,
-        component['minMaxSeriesValues']
+        component.range
       );
     });
 
     it('p-series: shouldn`t bind any function if `serie.data` isn`t an array', () => {
       const spySeriesGreaterLength = spyOn(component['mathsService'], <any>'seriesGreaterLength');
-      const spyGetSeriesColor = spyOn(component['colorService'], 'getSeriesColor');
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
       const spyCalculateSeriesPathsCoordinatesn = spyOn(component, <any>'calculateSeriesPathsCoordinates');
 
       component.series = <any>[
@@ -331,35 +282,35 @@ describe('PoChartBarBaseComponent', () => {
       ];
 
       expect(spySeriesGreaterLength).not.toHaveBeenCalled();
-      expect(spyGetSeriesColor).not.toHaveBeenCalled();
-      expect(spyGetDomainValues).not.toHaveBeenCalled();
       expect(spyCalculateSeriesPathsCoordinatesn).not.toHaveBeenCalled();
     });
 
-    it('p-options: should update property if valid values', () => {
-      const validValues = [{}, { gridLines: 5 }];
+    it('p-range: should update property with valid values', () => {
+      const validValues = [{ minValue: 1, maxValue: 30 }, {}];
 
-      expectPropertiesValues(component, 'options', validValues, validValues);
+      expectPropertiesValues(component, 'range', validValues, validValues);
     });
 
-    it('p-options: shouldn`t update property if invalid values', () => {
-      const invalidValues = [undefined, null, '', false, 0, ['1'], [{ key: 'value' }]];
+    it('p-range: should update property if invalid values', () => {
+      const invalidValues = [undefined, null, '', false, 0, [], 'value'];
 
-      expectPropertiesValues(component, 'options', invalidValues, undefined);
+      expectPropertiesValues(component, 'range', invalidValues, {});
     });
 
-    it('p-options: should call `getDomainValues` and `calculateSeriesPathsCoordinates`', () => {
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
-      const spyCalculateSeriesPathsCoordinatesn = spyOn(component, <any>'calculateSeriesPathsCoordinates');
+    it('p-range: should call `calculateSeriesPathsCoordinates` if range is an object', () => {
+      const spyCalculateSeriesPathsCoordinates = spyOn(component, <any>'calculateSeriesPathsCoordinates');
 
-      component.options = { gridLines: 5, maxRange: 100, minRange: 0 };
+      component.range = { minValue: 1, maxValue: 30 };
 
-      expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
-      expect(spyCalculateSeriesPathsCoordinatesn).toHaveBeenCalledWith(
-        component.containerSize,
-        component.series,
-        component['minMaxSeriesValues']
-      );
+      expect(spyCalculateSeriesPathsCoordinates).toHaveBeenCalled();
+    });
+
+    it('p-range: shouldn`t call `calculateSeriesPathsCoordinates` if range isn`t an object', () => {
+      const spyCalculateSeriesPathsCoordinates = spyOn(component, <any>'calculateSeriesPathsCoordinates');
+
+      component.range = <any>false;
+
+      expect(spyCalculateSeriesPathsCoordinates).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.svg
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.svg
@@ -5,7 +5,7 @@
     <!-- SERIES PATHS -->
     <svg:g po-chart-bar-path
       [attr.key]="'po-chart-bar-path-' + i"
-      [p-color]="colors[i]" 
+      [p-color]="item[0].color" 
       [p-coordinates]="item"
       [p-tooltip-position]="tooltipPosition"
       (p-bar-click)="onSerieBarClick($event)"

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import { PoChartAxisXLabelArea, PoChartPlotAreaPaddingTop } from './../../helpers/po-chart-default-values.constant';
 
 import { PoChartBarBaseComponent } from './po-chart-bar-base.component';
-import { PoChartColorService } from './../../services/po-chart-color.service';
 import { PoChartMathsService } from './../../services/po-chart-maths.service';
 
 import { PoChartContainerSize } from './../../interfaces/po-chart-container-size.interface';
@@ -16,8 +15,8 @@ import { PoChartMinMaxValues } from './../../interfaces/po-chart-min-max-values.
 export class PoChartBarComponent extends PoChartBarBaseComponent {
   readonly tooltipPosition = 'right';
 
-  constructor(protected colorService: PoChartColorService, protected mathsService: PoChartMathsService) {
-    super(colorService, mathsService);
+  constructor(protected mathsService: PoChartMathsService) {
+    super(mathsService);
   }
 
   protected barCoordinates(

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import { PoChartAxisXLabelArea, PoChartPlotAreaPaddingTop } from '../../../helpers/po-chart-default-values.constant';
 
 import { PoChartBarBaseComponent } from '../po-chart-bar-base.component';
-import { PoChartColorService } from '../../../services/po-chart-color.service';
 import { PoChartMathsService } from '../../../services/po-chart-maths.service';
 
 import { PoChartContainerSize } from '../../../interfaces/po-chart-container-size.interface';
@@ -16,8 +15,8 @@ import { PoChartMinMaxValues } from '../../../interfaces/po-chart-min-max-values
 export class PoChartColumnComponent extends PoChartBarBaseComponent {
   readonly tooltipPosition = 'top';
 
-  constructor(protected colorService: PoChartColorService, protected mathsService: PoChartMathsService) {
-    super(colorService, mathsService);
+  constructor(protected mathsService: PoChartMathsService) {
+    super(mathsService);
   }
 
   protected barCoordinates(

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.spec.ts
@@ -7,18 +7,16 @@ import { PoChartCompleteCircle } from '../../helpers/po-chart-default-values.con
 import { PoChartCircularComponent } from './po-chart-circular.component';
 import { PoChartCircularLabelComponent } from './po-chart-circular-label/po-chart-circular-label.component';
 import { PoChartCircularPathComponent } from './po-chart-circular-path/po-chart-circular-path.component';
-import { PoChartColorService } from '../../services/po-chart-color.service';
 import { PoChartContainerSize } from '../../interfaces/po-chart-container-size.interface';
 import { PoChartModule } from '../../po-chart.module';
-import { PoChartType } from '../../enums/po-chart-type.enum';
 
 @Component({
   selector: 'po-chart-circular-test',
   template: ` <svg:path #svgPaths></svg:path> `
 })
 class PoChartPieComponent extends PoChartCircularComponent {
-  constructor(colorService: PoChartColorService, ngZone: NgZone, changeDetector: ChangeDetectorRef) {
-    super(colorService, ngZone, changeDetector);
+  constructor(ngZone: NgZone, changeDetector: ChangeDetectorRef) {
+    super(ngZone, changeDetector);
   }
 
   getTooltipLabel() {}
@@ -34,11 +32,9 @@ describe('PoChartCircularComponent', () => {
   let fixturePath: ComponentFixture<PoChartCircularPathComponent>;
   let fixtureLabel: ComponentFixture<PoChartCircularLabelComponent>;
 
-  const colorList = ['#0C6C94', '#29B6C5'];
-
   const series = [
-    { label: 'category A', data: 10 },
-    { label: 'category B', data: 20 }
+    { label: 'category A', data: 10, color: '#0C6C94' },
+    { label: 'category B', data: 20, color: '#29B6C5' }
   ];
 
   const containerSize: PoChartContainerSize = {
@@ -67,7 +63,6 @@ describe('PoChartCircularComponent', () => {
     componentLabel = fixtureLabel.componentInstance;
 
     component.containerSize = containerSize;
-    component['colorList'] = colorList;
     spyOn(component, <any>'getTooltipLabel').and.returnValue('label');
 
     fixture.detectChanges();
@@ -158,6 +153,16 @@ describe('PoChartCircularComponent', () => {
       const spyInitDrawPaths = spyOn(component, <any>'initDrawPaths');
 
       component['drawSeries'](mockSeries, containerSize.svgHeight);
+
+      expect(spyInitDrawPaths).not.toHaveBeenCalled();
+    });
+
+    it('drawSeries: shouldn`t call `initDrawPaths` if seriesList doesn`t have length', () => {
+      spyOn(component, <any>'validateSeries').and.returnValue([]);
+      spyOn(component['changeDetector'], <any>'detectChanges');
+      const spyInitDrawPaths = spyOn(component, <any>'initDrawPaths');
+
+      component['drawSeries'](undefined, containerSize.svgHeight);
 
       expect(spyInitDrawPaths).not.toHaveBeenCalled();
     });
@@ -387,15 +392,9 @@ describe('PoChartCircularComponent', () => {
   });
 
   describe('Properties:', () => {
-    it('p-series: should apply value to `animate` and `colorList`', () => {
-      const type = PoChartType.Pie;
-      const seriesColors = ['#0C6C94', '#29B6C5'];
-      const spyGetSeriesColor = spyOn(component['colorService'], 'getSeriesColor').and.callThrough();
-
+    it('p-series: should apply value to `animate`', () => {
       component.series = series;
 
-      expect(spyGetSeriesColor).toHaveBeenCalledWith(component.series, type);
-      expect(component['colorList']).toEqual(seriesColors);
       expect(component['animate']).toBe(true);
     });
   });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.ts
@@ -17,17 +17,14 @@ import {
 
 import { PoChartCircularLabelComponent } from './po-chart-circular-label/po-chart-circular-label.component';
 import { PoChartCircularPathComponent } from './po-chart-circular-path/po-chart-circular-path.component';
-import { PoChartColorService } from '../../services/po-chart-color.service';
 import { PoChartContainerSize } from '../../interfaces/po-chart-container-size.interface';
 import { PoChartLabelCoordinates } from '../../interfaces/po-chart-label-coordinates.interface';
 import { PoChartPathCoordinates } from '../../interfaces/po-chart-path-coordinates.interface';
-import { PoChartType } from '../../enums/po-chart-type.enum';
-import { PoDonutChartSeries } from '../../interfaces/po-chart-donut-series.interface';
-import { PoPieChartSeries } from '../../interfaces/po-chart-pie-series.interface';
+import { ChartSerieColor } from '../po-chart-container.component';
 
 @Directive()
 export abstract class PoChartCircularComponent {
-  private _series: Array<PoPieChartSeries | PoDonutChartSeries>;
+  private _series: Array<ChartSerieColor>;
 
   seriesLabels: Array<PoChartLabelCoordinates> = [];
   seriesList: Array<PoChartPathCoordinates>;
@@ -35,16 +32,14 @@ export abstract class PoChartCircularComponent {
 
   protected totalValue: number;
 
-  private colorList: Array<string> = [];
   private animate: boolean;
 
   @Input('p-container-size') containerSize: PoChartContainerSize;
 
-  @Input('p-series') set series(value: Array<PoPieChartSeries | PoDonutChartSeries>) {
+  @Input('p-series') set series(value: Array<ChartSerieColor>) {
     this._series = value;
 
     this.animate = true;
-    this.colorList = this.colorService.getSeriesColor(this.series, PoChartType.Pie);
   }
 
   get series() {
@@ -59,11 +54,7 @@ export abstract class PoChartCircularComponent {
 
   @ViewChildren('svgLabels') private svgLabels: QueryList<PoChartCircularLabelComponent>;
 
-  constructor(
-    private colorService: PoChartColorService,
-    private ngZone: NgZone,
-    private changeDetector: ChangeDetectorRef
-  ) {}
+  constructor(private ngZone: NgZone, private changeDetector: ChangeDetectorRef) {}
 
   onSerieClick(selectedItem: any) {
     this.circularClick.emit(selectedItem);
@@ -77,7 +68,7 @@ export abstract class PoChartCircularComponent {
     return (data / totalValue) * (Math.PI * 2);
   }
 
-  protected drawSeries(series: Array<PoPieChartSeries | PoDonutChartSeries> = [], height: number) {
+  protected drawSeries(series: Array<ChartSerieColor> = [], height: number) {
     this.seriesList = [];
     this.showLabels = false;
     this.totalValue = this.calculateTotalValue(series);
@@ -91,23 +82,19 @@ export abstract class PoChartCircularComponent {
     }
   }
 
-  private calculateTotalValue(series: Array<PoPieChartSeries | PoDonutChartSeries>) {
-    return series.reduce((previousValue, serie) => {
+  private calculateTotalValue(series: Array<ChartSerieColor>) {
+    return series.reduce((previousValue, serie: any) => {
       const data = serie.data ? serie.data : serie.value;
 
       return previousValue + (data > 0 ? data : 0);
     }, 0);
   }
 
-  private calculateSerieCoordinates(
-    series: Array<PoPieChartSeries | PoDonutChartSeries>,
-    totalValue: number,
-    height: number
-  ) {
+  private calculateSerieCoordinates(series: Array<PoChartPathCoordinates>, totalValue: number, height: number) {
     let startRadianAngle;
     let endRadianAngle = PoChartStartAngle;
 
-    series.forEach((serie, index) => {
+    series.forEach((serie: any, index) => {
       startRadianAngle = endRadianAngle;
       endRadianAngle = startRadianAngle + this.calculateAngle(serie.data, totalValue);
 
@@ -119,7 +106,7 @@ export abstract class PoChartCircularComponent {
   }
 
   private calculateCoordinatesWithAnimation(
-    series: Array<PoPieChartSeries | PoDonutChartSeries>,
+    series: Array<PoChartPathCoordinates>,
     totalValue: number,
     height: number,
     startRadianAngle: number,
@@ -173,7 +160,7 @@ export abstract class PoChartCircularComponent {
       : startRadianAngle + currentRadianAngle;
   }
 
-  private initDrawPaths(seriesList: Array<PoPieChartSeries | PoDonutChartSeries>, totalValue: number, height: number) {
+  private initDrawPaths(seriesList: Array<PoChartPathCoordinates>, totalValue: number, height: number) {
     if (!this.animate) {
       this.calculateSerieCoordinates(seriesList, totalValue, height);
     } else {
@@ -192,11 +179,11 @@ export abstract class PoChartCircularComponent {
     }
   }
 
-  private validateSeries(series: Array<PoPieChartSeries | PoDonutChartSeries>) {
-    return series.reduce((seriesList, serie, index) => {
+  private validateSeries(series: Array<ChartSerieColor>) {
+    return series.reduce((seriesList, serie: any) => {
       const data = serie.data ?? serie.value;
       if (data && data > 0) {
-        const color = this.colorList[index];
+        const color = serie.color;
         const label = serie.label;
         const tooltip = serie.tooltip;
         const tooltipLabel = this.getTooltipLabel(data, label, tooltip);

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-donut/po-chart-donut.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-donut/po-chart-donut.component.spec.ts
@@ -1,8 +1,8 @@
 import { SimpleChanges } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { PoChartContainerSize } from '../../../interfaces/po-chart-container-size.interface';
-import { PoPieChartSeries } from '../../../interfaces/po-chart-pie-series.interface';
 
+import { PoChartContainerSize } from '../../../interfaces/po-chart-container-size.interface';
+import { ChartSerieColor } from '../../po-chart-container.component';
 import { PoChartDonutComponent } from './po-chart-donut.component';
 
 describe('PoChartDonutComponent', () => {
@@ -27,7 +27,7 @@ describe('PoChartDonutComponent', () => {
 
   describe('Methods:', () => {
     it('ngOnChanges: should call `drawSeries` and `applySeriesLabels` if `changes.series`', () => {
-      const series: Array<PoPieChartSeries> = [{ label: 'teste', data: 30 }];
+      const series: Array<ChartSerieColor> = [{ label: 'teste', data: 30 }];
       const containerSize: PoChartContainerSize = { svgHeight: 300 };
       const seriesList = [];
       const changes: SimpleChanges = {
@@ -53,7 +53,7 @@ describe('PoChartDonutComponent', () => {
     });
 
     it('ngOnChanges: should call `drawSeries` and `applySeriesLabels` if `changes.containerSize`', () => {
-      const series: Array<PoPieChartSeries> = [{ label: 'teste', data: 30 }];
+      const series: Array<ChartSerieColor> = [{ label: 'teste', data: 30 }];
       const containerSize: PoChartContainerSize = { svgHeight: 300 };
       const seriesList = [];
       const changes: SimpleChanges = {
@@ -79,7 +79,7 @@ describe('PoChartDonutComponent', () => {
     });
 
     it('ngOnChanges: should`t call `drawSeries` and `applySeriesLabels`', () => {
-      const series: Array<PoPieChartSeries> = [{ label: 'teste', data: 30 }];
+      const series: Array<ChartSerieColor> = [{ label: 'teste', data: 30 }];
       const containerSize: PoChartContainerSize = { svgHeight: 300 };
       const seriesList = [];
       const changes: SimpleChanges = {};

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-donut/po-chart-donut.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-donut/po-chart-donut.component.ts
@@ -4,7 +4,6 @@ import { convertNumberToDecimal } from '../../../../../utils/util';
 
 import { PoChartCircularComponent } from '../po-chart-circular.component';
 import { PoChartDonutThickness, PoChartStartAngle } from '../../../helpers/po-chart-default-values.constant';
-import { PoChartColorService } from '../../../services/po-chart-color.service';
 import { PoSeriesTextBlack } from '../../../helpers/po-chart-colors.constant';
 
 @Component({
@@ -16,8 +15,8 @@ export class PoChartDonutComponent extends PoChartCircularComponent implements O
   private readonly poChartWhiteColor = '#ffffff';
 
   /* istanbul ignore next */
-  constructor(colorService: PoChartColorService, ngZone: NgZone, changeDetector: ChangeDetectorRef) {
-    super(colorService, ngZone, changeDetector);
+  constructor(ngZone: NgZone, changeDetector: ChangeDetectorRef) {
+    super(ngZone, changeDetector);
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-pie/po-chart-pie.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-pie/po-chart-pie.component.spec.ts
@@ -96,6 +96,20 @@ describe('PoChartPieComponent', () => {
       expect(result).toBe(expectedResult);
     });
 
+    it('calculateCoordinates: should return coordinates considering largeArc as false', () => {
+      const height = 50;
+      const startRadianAngle = 0.5;
+      const endRadianAngle = 1;
+      const expectedResult =
+        'M 46.93956404725932 36.985638465105076 A 25 25 0 0,1 38.507557646703496 46.03677462019741 L 25 25 Z';
+
+      spyOn(component, <any>'drawSeries');
+
+      const result = component['calculateCoordinates'](height, startRadianAngle, endRadianAngle);
+
+      expect(result).toBe(expectedResult);
+    });
+
     it('getTooltipLabel: should return tooltipLabel', () => {
       const data = 30;
       const label = 'teste';
@@ -105,6 +119,14 @@ describe('PoChartPieComponent', () => {
       const result = component['getTooltipLabel'](data, label, tooltipLabel);
 
       expect(result).toEqual(expectedResult);
+    });
+
+    it('getTooltipLabel: should return only `data` if `label` is undefined', () => {
+      const data = 30;
+      const label = undefined;
+      const result = component['getTooltipLabel'](data, label);
+
+      expect(result).toBe(data.toString());
     });
 
     it('getTooltipLabel: should return dataLabel:dataValue if tooltipLabel is undefied', () => {

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-pie/po-chart-pie.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-pie/po-chart-pie.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectorRef, Component, NgZone, OnChanges, SimpleChanges } from '@angular/core';
 
 import { PoChartCircularComponent } from '../po-chart-circular.component';
-import { PoChartColorService } from '../../../services/po-chart-color.service';
 
 @Component({
   selector: '[po-chart-pie]',
@@ -9,8 +8,8 @@ import { PoChartColorService } from '../../../services/po-chart-color.service';
 })
 export class PoChartPieComponent extends PoChartCircularComponent implements OnChanges {
   /* istanbul ignore next */
-  constructor(colorService: PoChartColorService, ngZone: NgZone, changeDetector: ChangeDetectorRef) {
-    super(colorService, ngZone, changeDetector);
+  constructor(ngZone: NgZone, changeDetector: ChangeDetectorRef) {
+    super(ngZone, changeDetector);
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.html
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.html
@@ -9,6 +9,7 @@
   <svg:g
     *ngIf="!isTypeCircular"
     po-chart-axis
+    [p-allow-negative-data]="allowNegativeData"
     [p-type]="type"
     [p-series]="series"
     [p-container-size]="containerSize"
@@ -16,28 +17,29 @@
     [p-categories]="categories"
   ></svg:g>
 
-  <!-- chart line -->
-  <svg:g
-    *ngIf="type === 'line'"
-    po-chart-line
-    [p-categories]="categories"
-    [p-series]="series"
-    [p-options]="axisOptions"
-    [p-container-size]="containerSize"
-    (p-point-hover)="onSerieHover($event)"
-    (p-point-click)="onSerieClick($event)"
-  ></svg:g>
-
   <!-- chart column -->
   <svg:g
-    *ngIf="type === 'column'"
+    *ngIf="(type === 'column' || type === 'line') && seriesByType['column'].length"
     po-chart-column
     [p-categories]="categories"
-    [p-series]="series"
-    [p-options]="axisOptions"
+    [p-range]="range"
+    [p-series]="seriesByType['column']"
     [p-container-size]="containerSize"
     (p-bar-hover)="onSerieHover($event)"
     (p-bar-click)="onSerieClick($event)"
+  ></svg:g>
+
+  <!-- chart line -->
+  <svg:g
+    *ngIf="(type === 'column' || type === 'line') && seriesByType['line'].length"
+    po-chart-line
+    [p-allow-negative-data]="allowNegativeData"
+    [p-categories]="categories"
+    [p-range]="range"
+    [p-series]="seriesByType['line']"
+    [p-container-size]="containerSize"
+    (p-point-hover)="onSerieHover($event)"
+    (p-point-click)="onSerieClick($event)"
   ></svg:g>
 
   <!-- chart bar -->
@@ -45,8 +47,8 @@
     *ngIf="type === 'bar'"
     po-chart-bar
     [p-categories]="categories"
-    [p-series]="series"
-    [p-options]="axisOptions"
+    [p-range]="range"
+    [p-series]="seriesByType['bar']"
     [p-container-size]="containerSize"
     (p-bar-hover)="onSerieHover($event)"
     (p-bar-click)="onSerieClick($event)"
@@ -55,7 +57,7 @@
   <svg:g
     *ngIf="type === 'pie'"
     po-chart-pie
-    [p-series]="series"
+    [p-series]="seriesByType['pie']"
     [p-container-size]="containerSize"
     (p-circular-hover)="onSerieHover($event)"
     (p-circular-click)="onSerieClick($event)"
@@ -64,7 +66,7 @@
   <svg:g
     *ngIf="type === 'donut'"
     po-chart-donut
-    [p-series]="series"
+    [p-series]="seriesByType['donut']"
     [p-container-size]="containerSize"
     (p-circular-hover)="onSerieHover($event)"
     (p-circular-click)="onSerieClick($event)"

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.spec.ts
@@ -7,7 +7,6 @@ import { PoChartModule } from '../po-chart.module';
 import { PoChartContainerComponent } from './po-chart-container.component';
 import { PoChartContainerSize } from '../interfaces/po-chart-container-size.interface';
 import { PoChartType } from '../enums/po-chart-type.enum';
-import { SimpleChange } from '@angular/core';
 
 describe('PoChartContainerComponent', () => {
   let component: PoChartContainerComponent;
@@ -98,9 +97,202 @@ describe('PoChartContainerComponent', () => {
 
       expect(spySerieHover).toHaveBeenCalledWith('event');
     });
+
+    describe('getRange:', () => {
+      it('should return zero to `minValue` if `allowNegativeData` is false and has a serie with negative value', () => {
+        const chartSeries = [
+          { data: [-70, 2, 3], label: 'Vancouver', type: PoChartType.Line },
+          { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Column }
+        ];
+        const expectedResult = { minValue: 0, maxValue: 4 };
+        component.allowNegativeData = false;
+
+        expect(component['getRange'](chartSeries)).toEqual(expectedResult);
+      });
+
+      it('should return the lowest value to `minValue` if `allowNegativeData` is true and has a serie with negative value', () => {
+        const chartSeries = [
+          { data: [-70, 2, 3], label: 'Vancouver', type: PoChartType.Line },
+          { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Column }
+        ];
+        const expectedResult = { minValue: -70, maxValue: 4 };
+        component.allowNegativeData = true;
+
+        expect(component['getRange'](chartSeries)).toEqual(expectedResult);
+      });
+
+      it('should return `minValue` and `maxValue` according with `options` values', () => {
+        const chartSeries = [
+          { data: [10, 2, 3], label: 'Vancouver', type: PoChartType.Line },
+          { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Column }
+        ];
+        const options = { axis: { minRange: 0, maxRange: 100 } };
+        const expectedResult = { minValue: 0, maxValue: 100 };
+        component.allowNegativeData = false;
+
+        expect(component['getRange'](chartSeries, options)).toEqual(expectedResult);
+      });
+
+      it('should return `minValue` of series instead of `options` if it is lower and `allowNegativeData` is true', () => {
+        const chartSeries = [
+          { data: [-10, 2, 3], label: 'Vancouver', type: PoChartType.Line },
+          { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Line }
+        ];
+        const options = { axis: { minRange: 0, maxRange: 100 } };
+        const expectedResult = { minValue: -10, maxValue: 100 };
+        component.allowNegativeData = true;
+
+        expect(component['getRange'](chartSeries, options)).toEqual(expectedResult);
+      });
+
+      it('should return `maxValue` of series instead of `options` if it is greater', () => {
+        const chartSeries = [
+          { data: [10, 2, 300], label: 'Vancouver', type: PoChartType.Line },
+          { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Line }
+        ];
+        const options = { axis: { minRange: 0, maxRange: 100 } };
+        const expectedResult = { minValue: 0, maxValue: 300 };
+        component.allowNegativeData = true;
+
+        expect(component['getRange'](chartSeries, options)).toEqual(expectedResult);
+      });
+
+      it('should apply zero to minValue if `options.axis.minRange` has negative value but `allowNegativeData` is false', () => {
+        const chartSeries = [
+          { data: [10, 2, 300], label: 'Vancouver', type: PoChartType.Bar },
+          { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Bar }
+        ];
+        const options = { axis: { minRange: -100, maxRange: 100 } };
+        const expectedResult = { minValue: 0, maxValue: 300 };
+
+        component.allowNegativeData = false;
+
+        expect(component['getRange'](chartSeries, options)).toEqual(expectedResult);
+      });
+    });
+
+    it('setRange: should call `getRange` if `isTypeCircular` is true', () => {
+      const serie = [{ data: [1, 2, 3], label: 'Vancouver' }];
+      const options = {};
+      component.type = PoChartType.Bar;
+
+      const spyGetRange = spyOn(component, <any>'getRange');
+
+      component['setRange'](serie, options);
+
+      expect(spyGetRange).toHaveBeenCalled();
+    });
+
+    it('setRange: shouldn`t call `getRange` if `isTypeCircular` is true', () => {
+      const serie = [{ data: 1, label: 'Vancouver' }];
+      component.type = PoChartType.Donut;
+
+      const spyGetRange = spyOn(component, <any>'getRange');
+
+      component['setRange'](serie);
+
+      expect(spyGetRange).not.toHaveBeenCalled();
+    });
+
+    it('setRange: shouldn`t call `getRange` if `isTypeCircular` is false', () => {
+      const serie = [{ data: 1, label: 'Vancouver' }];
+      component.type = PoChartType.Pie;
+
+      const spyGetRange = spyOn(component, <any>'getRange');
+
+      component['setRange'](serie);
+
+      expect(spyGetRange).not.toHaveBeenCalled();
+    });
+
+    it('seriesTypeLine: should return true if all series type are `PoChartType.Line`', () => {
+      const chartSeries = [
+        { data: [10, 2, 300], label: 'Vancouver', type: PoChartType.Line },
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Line }
+      ];
+
+      expect(component['seriesTypeLine'](chartSeries)).toBeTruthy();
+    });
+
+    it('seriesTypeLine: should return false if series have a serie with `type` property value different of `line`', () => {
+      const chartSeries = [
+        { data: [10, 2, 300], label: 'Vancouver', type: PoChartType.Line },
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Bar }
+      ];
+
+      expect(component['seriesTypeLine'](chartSeries)).toBeFalsy();
+    });
+
+    it('verifyAxisOptions: shouldn`t call `getRange` if `isTypeCircular` is false', () => {
+      component.series = [
+        { data: [10, 2, 300], label: 'Vancouver', type: PoChartType.Line },
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Bar }
+      ];
+      const spyGetRange = spyOn(component, <any>'getRange');
+
+      component['verifyAxisOptions']({});
+
+      expect(spyGetRange).not.toHaveBeenCalled();
+    });
+
+    it('verifyAxisOptions: shouldn`t call `getRange` if `isTypeCircular` is true but options does not have `axis` property', () => {
+      component.series = [
+        { data: 10, label: 'Vancouver', type: PoChartType.Donut },
+        { data: 20, label: 'Toronto', type: PoChartType.Donut }
+      ];
+      const spyGetRange = spyOn(component, <any>'getRange');
+
+      component['verifyAxisOptions']({});
+
+      expect(spyGetRange).not.toHaveBeenCalled();
+    });
+
+    it('setSeriesByType: should set value to `seriesByType`', () => {
+      const chartSeries = [
+        { data: 1, type: PoChartType.Pie },
+        { data: 1, type: PoChartType.Donut },
+        { data: [1, 2], type: PoChartType.Line },
+        { data: [1, 2], type: PoChartType.Column },
+        { data: [1, 2], type: PoChartType.Bar }
+      ];
+
+      const expectedResult = {
+        [PoChartType.Column]: chartSeries.filter(serie => serie.type === PoChartType.Column),
+        [PoChartType.Bar]: chartSeries.filter(serie => serie.type === PoChartType.Bar),
+        [PoChartType.Line]: chartSeries.filter(serie => serie.type === PoChartType.Line),
+        [PoChartType.Donut]: chartSeries.filter(serie => serie.type === PoChartType.Donut),
+        [PoChartType.Pie]: chartSeries.filter(serie => serie.type === PoChartType.Pie)
+      };
+
+      component['setSeriesByType'](chartSeries);
+
+      expect(component.seriesByType).toEqual(expectedResult);
+    });
   });
 
   describe('Properties: ', () => {
+    it('p-series: should call `getSeriesColor`, `seriesTypeLine` `setSeriesByType` and `setRange`', () => {
+      const spyGetSeriesColor = spyOn(component['colorService'], <any>'getSeriesColor').and.callThrough();
+      const spySeriesTypeLine = spyOn(component, <any>['seriesTypeLine']);
+      const spysetSeriesByType = spyOn(component, <any>['setSeriesByType']).and.callThrough();
+      const spySetRange = spyOn(component, <any>['setRange']);
+
+      component.series = [
+        { data: [1, 2, 3], label: 'Vancouver', type: PoChartType.Line },
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Column }
+      ];
+
+      const seriesWithColor = [
+        { data: [1, 2, 3], label: 'Vancouver', type: PoChartType.Line, color: '#0C6C94' },
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Column, color: '#29B6C5' }
+      ];
+
+      expect(spyGetSeriesColor).toHaveBeenCalled();
+      expect(spySeriesTypeLine).toHaveBeenCalledWith(seriesWithColor);
+      expect(spysetSeriesByType).toHaveBeenCalledWith(seriesWithColor);
+      expect(spySetRange).toHaveBeenCalledWith(seriesWithColor, component.options);
+    });
+
     it('p-options: should update property with valid values', () => {
       const validValue = [{}, { axis: { minRange: 0 } }];
 
@@ -127,24 +319,87 @@ describe('PoChartContainerComponent', () => {
   });
 
   describe('Template:', () => {
-    it('should have po-chart-bar-path tag if type is `Line`', () => {
+    it('should have `po-chart-bar-path` if type is `Column`', () => {
       component.type = PoChartType.Column;
+      component.series = [{ data: [1, 2, 3], label: 'Vancouver', type: PoChartType.Column }];
 
       fixture.detectChanges();
 
-      const chartContainerContent = nativeElement.querySelector('.po-chart-bar-path');
+      const chartBarElement = nativeElement.querySelector('.po-chart-bar-path');
 
-      expect(chartContainerContent).toBeTruthy();
+      expect(chartBarElement).toBeTruthy();
     });
 
-    it('should have po-chart-line-path tag if type is `Line`', () => {
+    it('should have `po-chart-line-path` if type is `Line`', () => {
       component.type = PoChartType.Line;
+
+      component.series = [{ data: [1, 2, 3], label: 'Vancouver', type: PoChartType.Line }];
 
       fixture.detectChanges();
 
-      const chartContainerContent = nativeElement.querySelector('.po-chart-line-path');
+      const chartLineElement = nativeElement.querySelector('.po-chart-line-path');
 
-      expect(chartContainerContent).toBeTruthy();
+      expect(chartLineElement).toBeTruthy();
+    });
+
+    it('shouldn`t contain any `chartType.Bar` element if type is `Line`', () => {
+      component.type = PoChartType.Line;
+
+      component.series = [
+        { data: [1, 2, 3], label: 'Vancouver', type: PoChartType.Line },
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Line },
+        { data: [1, 2, 3], label: 'Montreal', type: PoChartType.Bar }
+      ];
+
+      fixture.detectChanges();
+
+      const chartLineElementList = nativeElement.querySelectorAll('.po-chart-line-path');
+      const chartBarElementList = nativeElement.querySelectorAll('.po-chart-bar-path');
+
+      expect(chartLineElementList[0]).toBeTruthy();
+      expect(chartLineElementList.length).toBe(2);
+      expect(chartBarElementList[0]).toBeUndefined();
+      expect(chartBarElementList.length).toBe(0);
+    });
+
+    it('shouldn`t contain any `chartType.Line` element if type is `Bar`', () => {
+      component.type = PoChartType.Bar;
+
+      component.series = [
+        { data: [1, 2, 3], label: 'Montreal', type: PoChartType.Bar },
+        { data: [1, 2, 3], label: 'Vancouver', type: PoChartType.Line },
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Line }
+      ];
+
+      fixture.detectChanges();
+
+      const chartLineElementList = nativeElement.querySelectorAll('.po-chart-line-path');
+      const chartBarElementList = nativeElement.querySelectorAll('.po-chart-bar-path');
+
+      expect(chartLineElementList[0]).toBeFalsy();
+      expect(chartBarElementList[0]).toBeTruthy();
+      expect(chartBarElementList.length).toBe(3);
+    });
+
+    it('should contain six `chartType.Bar` elements referring to `ChartType.column` if type is `Line` and ignore the last one item', () => {
+      component.type = PoChartType.Line;
+
+      component.series = [
+        { data: [1, 2, 3], label: 'Vancouver', type: PoChartType.Line },
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Column },
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Column },
+        { data: [1, 2, 3], label: 'Montreal', type: PoChartType.Bar }
+      ];
+
+      fixture.detectChanges();
+
+      const chartLineElementList = nativeElement.querySelectorAll('.po-chart-line-path');
+      const chartBarElementList = nativeElement.querySelectorAll('.po-chart-bar-path');
+
+      expect(chartLineElementList[0]).toBeTruthy();
+      expect(chartLineElementList.length).toBe(1);
+      expect(chartBarElementList[0]).toBeTruthy();
+      expect(chartBarElementList.length).toBe(6);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.ts
@@ -1,20 +1,32 @@
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 
 import { PoChartType } from '../enums/po-chart-type.enum';
-import { PoLineChartSeries } from '../interfaces/po-chart-line-series.interface';
 import { PoChartContainerSize } from '../interfaces/po-chart-container-size.interface';
 import { PoChartOptions } from '../interfaces/po-chart-options.interface';
 import { PoChartAxisOptions } from '../interfaces/po-chart-axis-options.interface';
+import { PoChartColorService } from '../services/po-chart-color.service';
+import { PoChartMathsService } from '../services/po-chart-maths.service';
+import { PoChartMinMaxValues } from '../interfaces/po-chart-min-max-values.interface';
+import { PoChartSerie } from '../interfaces/po-chart-serie.interface';
+
+// TODO: remover quando PoChartSerie tiver color.
+export interface ChartSerieColor extends PoChartSerie {
+  color?: string;
+}
 
 @Component({
   selector: 'po-chart-container',
   templateUrl: './po-chart-container.component.html'
 })
 export class PoChartContainerComponent implements OnChanges {
-  axisOptions: PoChartAxisOptions;
-  viewBox: string;
-
   private _options: PoChartOptions;
+  private _series: Array<ChartSerieColor> = [];
+
+  allowNegativeData: boolean;
+  axisOptions: PoChartAxisOptions;
+  range: PoChartMinMaxValues;
+  seriesByType;
+  viewBox: string;
 
   @Input('p-categories') categories: Array<string>;
 
@@ -38,11 +50,25 @@ export class PoChartContainerComponent implements OnChanges {
     return this._options;
   }
 
-  @Input('p-series') series: Array<PoLineChartSeries>;
+  @Input('p-series') set series(data: Array<PoChartSerie>) {
+    const seriesColors = this.colorService.getSeriesColor(data, PoChartType.Line);
+    this._series = data.map((serie, index) => {
+      return { ...serie, color: seriesColors[index] };
+    });
+    this.allowNegativeData = this.seriesTypeLine(this._series);
+    this.setSeriesByType(this._series);
+    this.setRange(this._series, this.options);
+  }
+
+  get series() {
+    return this._series;
+  }
 
   get isTypeCircular() {
     return this.type === PoChartType.Pie || this.type === PoChartType.Donut;
   }
+
+  constructor(private colorService: PoChartColorService, private mathsService: PoChartMathsService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.type || changes.containerSize) {
@@ -58,6 +84,40 @@ export class PoChartContainerComponent implements OnChanges {
     this.serieHover.emit(event);
   }
 
+  private getRange(series: Array<PoChartSerie>, options: PoChartOptions = {}): PoChartMinMaxValues {
+    const domain = this.mathsService.calculateMinAndMaxValues(series, this.allowNegativeData);
+    const minValue =
+      !this.allowNegativeData && !options.axis?.minRange
+        ? 0
+        : options.axis?.minRange < domain.minValue
+        ? options.axis.minRange
+        : domain.minValue;
+    const maxValue = options.axis?.maxRange > domain.maxValue ? options.axis.maxRange : domain.maxValue;
+    const updatedDomainValues = { minValue: !this.allowNegativeData && minValue < 0 ? 0 : minValue, maxValue };
+
+    return { ...domain, ...updatedDomainValues };
+  }
+
+  private setRange(series: Array<PoChartSerie>, options: PoChartOptions = {}) {
+    if (!this.isTypeCircular) {
+      this.range = this.getRange(series, options);
+    }
+  }
+
+  private seriesTypeLine(series: Array<PoChartSerie>): boolean {
+    return series.every(serie => serie.type === PoChartType.Line);
+  }
+
+  private setSeriesByType(series: Array<PoChartSerie>) {
+    this.seriesByType = {
+      [PoChartType.Column]: series.filter(serie => serie.type === PoChartType.Column),
+      [PoChartType.Bar]: series.filter(serie => serie.type === PoChartType.Bar),
+      [PoChartType.Line]: series.filter(serie => serie.type === PoChartType.Line),
+      [PoChartType.Donut]: series.filter(serie => serie.type === PoChartType.Donut),
+      [PoChartType.Pie]: series.filter(serie => serie.type === PoChartType.Pie)
+    };
+  }
+
   private setViewBox() {
     const { svgWidth, svgHeight } = this.containerSize;
     const viewBoxWidth = this.isTypeCircular ? svgHeight : svgWidth;
@@ -68,7 +128,8 @@ export class PoChartContainerComponent implements OnChanges {
   }
 
   private verifyAxisOptions(options: PoChartOptions): void {
-    if (options.hasOwnProperty('axis')) {
+    if (!this.isTypeCircular && options.hasOwnProperty('axis')) {
+      this.range = this.getRange(this.series, this.options);
       this.axisOptions = {
         ...this.axisOptions,
         ...options.axis

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
@@ -1,9 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { expectPropertiesValues } from '../../../../util-test/util-expect.spec';
+import { expectPropertiesValues } from 'projects/ui/src/lib/util-test/util-expect.spec';
 
 import { PoChartLineComponent } from './po-chart-line.component';
-import { PoChartType } from '../../enums/po-chart-type.enum';
 import { PoChartContainerSize } from '../../interfaces/po-chart-container-size.interface';
 import { PoChartModule } from '../../po-chart.module';
 
@@ -12,8 +11,8 @@ describe('PoChartLineComponent', () => {
   let fixture: ComponentFixture<PoChartLineComponent>;
 
   const series = [
-    { label: 'category', data: [1, 2, 3] },
-    { label: 'category B', data: [10, 20, 30] }
+    { label: 'category', data: [1, 2, 3], color: '#94DAE2' },
+    { label: 'category B', data: [10, 20, 30], color: '#29B6C5' }
   ];
   const containerSize: PoChartContainerSize = {
     svgWidth: 200,
@@ -21,6 +20,8 @@ describe('PoChartLineComponent', () => {
     svgPlottingAreaWidth: 20,
     svgPlottingAreaHeight: 20
   };
+
+  const range = { minValue: 1, maxValue: 30 };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -71,29 +72,15 @@ describe('PoChartLineComponent', () => {
       expect(component.trackBy(index)).toBe(expectedValue);
     });
 
-    it('getDomainValues: should apply value to `minMaxSeriesValues` with the min and max series values', () => {
-      component.options = undefined;
-      component['getDomainValues'](component.options);
-
-      expect(component['minMaxSeriesValues']).toEqual({ minValue: 1, maxValue: 30 });
-    });
-
-    it('getDomainValues: should apply value to `minMaxSeriesValues` with the min and max values of `options`', () => {
-      component.options = { minRange: -10, maxRange: 50 };
-      component['getDomainValues'](component.options);
-
-      expect(component['minMaxSeriesValues']).toEqual({ minValue: -10, maxValue: 50 });
-    });
-
     describe('seriePathPointsDefinition: ', () => {
-      it('should call `svgPathCommand`, `xCoordinate`, `yCoordinate`, `serieCategory` and `serieLabel`', () => {
+      it('should call `svgPathCommand`, `xCoordinate`, `yCoordinate`, `serieCategory` and `getTooltipLabel`', () => {
         const minMaxSeriesValues = { minValue: 0, maxValue: 30 };
 
         const spySvgPathCommand = spyOn(component, <any>'svgPathCommand');
         const spyXCoordinate = spyOn(component, <any>'xCoordinate');
         const spyYCoordinate = spyOn(component, <any>'yCoordinate');
         const spySerieCategory = spyOn(component, <any>'serieCategory');
-        const spySerieLabel = spyOn(component, <any>'serieLabel');
+        const spyGetTooltipLabel = spyOn(component, <any>'getTooltipLabel');
 
         component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
 
@@ -101,26 +88,24 @@ describe('PoChartLineComponent', () => {
         expect(spyXCoordinate).toHaveBeenCalled();
         expect(spyYCoordinate).toHaveBeenCalled();
         expect(spySerieCategory).toHaveBeenCalled();
-        expect(spySerieLabel).toHaveBeenCalled();
+        expect(spyGetTooltipLabel).toHaveBeenCalled();
       });
 
       it('should apply apply value to `seriesPathsCoordinates`', () => {
-        const minMaxSeriesValues = { minValue: 5, maxValue: 10 };
-        component.series = [{ label: 'Vancouver', data: [5, 10] }];
+        component.series = [{ label: 'Vancouver', data: [5, 10], color: '#94DAE2' }];
 
-        component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
+        component['seriePathPointsDefinition'](component.containerSize, component.series, range);
 
-        const expectedResult = [{ coordinates: ' M72 28 L92 8' }];
+        const expectedResult = [{ coordinates: ' M104 25 L114 21', color: '#94DAE2' }];
 
         expect(component.seriesPathsCoordinates).toEqual(expectedResult);
         expect(component.seriesPathsCoordinates.length).toBe(1);
       });
 
       it('should apply apply value to `seriesPointsCoordinates`', () => {
-        const minMaxSeriesValues = { minValue: 5, maxValue: 10 };
         component.series = [{ label: 'Vancouver', data: [5, 10] }];
 
-        component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
+        component['seriePathPointsDefinition'](component.containerSize, component.series, range);
 
         const expectedResult = [
           [
@@ -129,16 +114,16 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 5',
               data: 5,
-              xCoordinate: 72,
-              yCoordinate: 28
+              xCoordinate: 104,
+              yCoordinate: 25
             },
             {
               category: undefined,
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 10',
               data: 10,
-              xCoordinate: 92,
-              yCoordinate: 8
+              xCoordinate: 114,
+              yCoordinate: 21
             }
           ]
         ];
@@ -161,7 +146,7 @@ describe('PoChartLineComponent', () => {
               label: undefined,
               tooltipLabel: '5',
               data: 5,
-              xCoordinate: 72,
+              xCoordinate: 104,
               yCoordinate: 28
             },
             {
@@ -169,7 +154,7 @@ describe('PoChartLineComponent', () => {
               label: undefined,
               tooltipLabel: '10',
               data: 10,
-              xCoordinate: 92,
+              xCoordinate: 114,
               yCoordinate: 8
             }
           ]
@@ -194,7 +179,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 5',
               data: 5,
-              xCoordinate: 72,
+              xCoordinate: 104,
               yCoordinate: 28
             },
             {
@@ -202,7 +187,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 10',
               data: 10,
-              xCoordinate: 92,
+              xCoordinate: 114,
               yCoordinate: 8
             }
           ]
@@ -215,7 +200,7 @@ describe('PoChartLineComponent', () => {
 
       it('should ignore to coordinates the serie.data which it`s value is null', () => {
         const minMaxSeriesValues = { minValue: 5, maxValue: 10 };
-        const chartSeries = [{ label: 'Vancouver', data: [10, null, 12] }];
+        const chartSeries = [{ label: 'Vancouver', data: [10, null, 12], color: '#29B6C5' }];
         component.categories = ['janeiro', 'fevereiro', 'março'];
 
         const expectedPointsResult = [
@@ -225,7 +210,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 10',
               data: 10,
-              xCoordinate: 72,
+              xCoordinate: 93.33333333333333,
               yCoordinate: 8
             },
             {
@@ -233,7 +218,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 12',
               data: 12,
-              xCoordinate: 92,
+              xCoordinate: 106.66666666666666,
               yCoordinate: 0
             }
           ]
@@ -242,7 +227,9 @@ describe('PoChartLineComponent', () => {
         component['seriePathPointsDefinition'](component.containerSize, <any>chartSeries, minMaxSeriesValues);
 
         expect(component.seriesPointsCoordinates).toEqual(expectedPointsResult);
-        expect(component.seriesPathsCoordinates).toEqual([{ coordinates: ' M72 8 L92 0' }]);
+        expect(component.seriesPathsCoordinates).toEqual([
+          { coordinates: ' M93.33333333333333 8 L106.66666666666666 0', color: '#29B6C5' }
+        ]);
       });
 
       it('shouldn`t apply values to `seriesPointsCoordinates` neither to `seriesPathsCoordinates` if series.data isn`t an array', () => {
@@ -258,14 +245,45 @@ describe('PoChartLineComponent', () => {
 
       it('shouldn`t apply only `M` coordenate at `seriesPathsCoordinates.coordinates` `seriesPathsCoordinates` if series.data has only one item', () => {
         const minMaxSeriesValues = { minValue: 10, maxValue: 10 };
-        component.series = [{ label: 'Vancouver', data: [10] }];
+        component.series = [{ label: 'Vancouver', data: [10], color: '#29B6C5' }];
 
         component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
 
-        const expectedResult = [{ coordinates: ' M72 28' }];
+        const expectedResult = [{ coordinates: ' M136 28', color: '#29B6C5' }];
 
         expect(component.seriesPathsCoordinates).toEqual(expectedResult);
         expect(component.seriesPathsCoordinates.length).toBe(1);
+      });
+
+      it('should convert series values to zero if allowNegativeData is false and serie.data has negative value', () => {
+        component.allowNegativeData = false;
+        component.categories = ['janeiro', 'fevereiro', 'março'];
+
+        const chartSeries = [{ label: 'Vancouver', data: [-10, -15], color: '#29B6C5' }];
+        const expectedPointsResult = [
+          [
+            {
+              category: 'janeiro',
+              label: 'Vancouver',
+              tooltipLabel: 'Vancouver: 0',
+              data: 0,
+              xCoordinate: 93.33333333333333,
+              yCoordinate: 28
+            },
+            {
+              category: 'fevereiro',
+              label: 'Vancouver',
+              tooltipLabel: 'Vancouver: 0',
+              data: 0,
+              xCoordinate: 100,
+              yCoordinate: 28
+            }
+          ]
+        ];
+
+        component['seriePathPointsDefinition'](component.containerSize, <any>chartSeries, range);
+
+        expect(component.seriesPointsCoordinates).toEqual(expectedPointsResult);
       });
     });
 
@@ -279,66 +297,61 @@ describe('PoChartLineComponent', () => {
       expect(component.animate).toBeFalsy();
       expect(spyAppendChild).toHaveBeenCalled();
     });
+
+    it('xCoordinate: should return `Infinity` if xRatio returns` isNan', () => {
+      component['seriesLength'] = 0;
+
+      expect(component['xCoordinate'](0, containerSize)).toBe(Infinity);
+    });
   });
 
   describe('Properties:', () => {
-    it('p-container-size: should call `getDomainValues` and `seriePathPointsDefinition`', () => {
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
+    it('p-container-size: should call `seriePathPointsDefinition`', () => {
       const spySeriePathPointsDefinition = spyOn(component, <any>'seriePathPointsDefinition');
 
       component.containerSize = containerSize;
+      component.range = range;
 
-      expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
       expect(spySeriePathPointsDefinition).toHaveBeenCalledWith(
         component.containerSize,
         component.series,
-        component['minMaxSeriesValues']
+        component.range
       );
     });
 
-    it('p-series: should call `calculateMinAndMaxValues`, `getDomainValues`, `seriePathPointsDefinition`, `seriesGreaterLength` and `getSeriesColor`', () => {
-      const type = PoChartType.Line;
+    it('p-series: should call `calculateMinAndMaxValues`, `seriePathPointsDefinition` and `seriesGreaterLength`', () => {
       const spySeriesGreaterLength = spyOn(component['mathsService'], <any>'seriesGreaterLength');
-      const spyGetSeriesColor = spyOn(component['colorService'], 'getSeriesColor');
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
       const spySeriePathPointsDefinition = spyOn(component, <any>'seriePathPointsDefinition');
 
       component.series = series;
+      component.range = range;
 
       expect(spySeriesGreaterLength).toHaveBeenCalledWith(component.series);
-      expect(spyGetSeriesColor).toHaveBeenCalledWith(component.series, type);
-      expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
       expect(spySeriePathPointsDefinition).toHaveBeenCalledWith(
         component.containerSize,
         component.series,
-        component['minMaxSeriesValues']
+        component.range
       );
     });
 
-    it(`p-series: should call 'calculateMinAndMaxValues', 'getDomainValues', 'seriePathPointsDefinition', 'seriesGreaterLength' and 'getSeriesColor' if 'serie.data'
+    it(`p-series: should call 'calculateMinAndMaxValues', 'seriePathPointsDefinition' and 'seriesGreaterLength' if 'serie.data'
     is an empty array`, () => {
-      const type = PoChartType.Line;
       const spySeriesGreaterLength = spyOn(component['mathsService'], <any>'seriesGreaterLength');
-      const spyGetSeriesColor = spyOn(component['colorService'], 'getSeriesColor');
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
       const spySeriePathPointsDefinition = spyOn(component, <any>'seriePathPointsDefinition');
 
       component.series = <any>[{ label: 'category', data: [] }];
+      component.range = range;
 
       expect(spySeriesGreaterLength).toHaveBeenCalledWith(component.series);
-      expect(spyGetSeriesColor).toHaveBeenCalledWith(component.series, type);
-      expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
       expect(spySeriePathPointsDefinition).toHaveBeenCalledWith(
         component.containerSize,
         component.series,
-        component['minMaxSeriesValues']
+        component.range
       );
     });
 
     it('p-series: shouldn`t bind any function if `serie.data` isn`t an array', () => {
       const spySeriesGreaterLength = spyOn(component['mathsService'], <any>'seriesGreaterLength');
-      const spyGetSeriesColor = spyOn(component['colorService'], 'getSeriesColor');
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
       const spySeriePathPointsDefinition = spyOn(component, <any>'seriePathPointsDefinition');
 
       component.series = <any>[
@@ -347,35 +360,35 @@ describe('PoChartLineComponent', () => {
       ];
 
       expect(spySeriesGreaterLength).not.toHaveBeenCalled();
-      expect(spyGetSeriesColor).not.toHaveBeenCalled();
-      expect(spyGetDomainValues).not.toHaveBeenCalled();
       expect(spySeriePathPointsDefinition).not.toHaveBeenCalled();
     });
 
-    it('p-options: should update property if valid values', () => {
-      const validValues = [{}, { gridLines: 5 }];
+    it('p-range: should update property with valid values', () => {
+      const validValues = [{ minValue: 1, maxValue: 30 }, {}];
 
-      expectPropertiesValues(component, 'options', validValues, validValues);
+      expectPropertiesValues(component, 'range', validValues, validValues);
     });
 
-    it('p-options: shouldn`t update property if invalid values', () => {
-      const invalidValues = [undefined, null, '', false, 0, ['1'], [{ key: 'value' }]];
+    it('p-range: should update property if invalid values', () => {
+      const invalidValues = [undefined, null, '', false, 0, [], 'value'];
 
-      expectPropertiesValues(component, 'options', invalidValues, undefined);
+      expectPropertiesValues(component, 'range', invalidValues, {});
     });
 
-    it('p-options: should call `getDomainValues` and `seriePathPointsDefinition`', () => {
-      const spyGetDomainValues = spyOn(component, <any>'getDomainValues');
-      const spySeriePathPointsDefinition = spyOn(component, <any>'seriePathPointsDefinition');
+    it('p-range: should call `seriePathPointsDefinition` if range is an object', () => {
+      const spyseriePathPointsDefinition = spyOn(component, <any>'seriePathPointsDefinition');
 
-      component.options = { gridLines: 5, maxRange: 100, minRange: 0 };
+      component.range = { minValue: 1, maxValue: 30 };
 
-      expect(spyGetDomainValues).toHaveBeenCalledWith(component.options);
-      expect(spySeriePathPointsDefinition).toHaveBeenCalledWith(
-        component.containerSize,
-        component.series,
-        component['minMaxSeriesValues']
-      );
+      expect(spyseriePathPointsDefinition).toHaveBeenCalled();
+    });
+
+    it('p-range: shouldn`t call `calculateSeriesPathsCoordinates` if range isn`t an object', () => {
+      const spyseriePathPointsDefinition = spyOn(component, <any>'seriePathPointsDefinition');
+
+      component.range = <any>false;
+
+      expect(spyseriePathPointsDefinition).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.svg
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.svg
@@ -7,7 +7,7 @@
     <svg:g po-chart-path
       [attr.key]="'po-chart-line-path-' + i"
       [p-animate]="animate"
-      [p-color]="colors[i]" 
+      [p-color]="item.color" 
       [p-coordinates]="item?.coordinates"
       >
       </svg:g>
@@ -15,7 +15,7 @@
     <!-- SERIES POINTS -->
     <svg:g po-chart-series-point
       [p-animate]="animate"
-      [p-color]="colors[i]"
+      [p-color]="item.color"
       [p-relative-to]="'po-chart-line-path-group-' + i" 
       [p-coordinates]="seriesPointsCoordinates[i]"
       [attr.key]="'po-chart-line-path-points-group-' + i"

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.html
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.html
@@ -6,7 +6,7 @@
   <po-chart-container
     *ngIf="!isChartGaugeType"
     [p-options]="options"
-    [p-type]="type"
+    [p-type]="chartType"
     [p-series]="chartSeries"
     [p-categories]="categories"
     [p-container-size]="svgContainerSize"
@@ -23,5 +23,5 @@
 </div>
 
 <ng-template #chartLegendGroup>
-  <po-chart-legend #chartLegend [p-series]="series" [p-type]="type"> </po-chart-legend>
+  <po-chart-legend #chartLegend [p-series]="chartSeries" [p-type]="type"> </po-chart-legend>
 </ng-template>

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
@@ -241,18 +241,16 @@ describe('PoChartComponent:', () => {
         chartWrapper: { nativeElement: { offsetWidth: 200 } }
       };
 
+      component.type = PoChartType.Gauge;
       component.height = 400;
-      component['series'] = <any>[
-        { category: 'A', value: 10 },
-        { category: 'B', value: 10 }
-      ];
+      component.series = { description: 'A', value: 10 };
       component['colors'] = ['orange', 'red'];
 
       component['setComponentRefProperties'](instance);
 
       expect(instance.height).toBe(component.height);
       expect(instance.type).toBe(component.type);
-      expect(instance.series).toEqual(component['series']);
+      expect(instance.series).toEqual([component.series]);
       expect(instance.colors).toEqual(component['colors']);
       expect(instance.chartHeader).toBe(component.chartHeader.nativeElement.offsetHeight);
       expect(instance.chartLegend).toBe(component.chartLegend.nativeElement.offsetHeight);
@@ -417,29 +415,5 @@ describe('PoChartComponent:', () => {
       component.categories.length
     );
     expect(spyGetChartMeasurements).toHaveBeenCalled();
-  });
-
-  describe('Templates:', () => {
-    it('should have po-chart-line-path tag if type is `Line`', () => {
-      component.series = [{ label: 'catA', data: [1, 2, 3] }];
-      component.type = PoChartType.Line;
-
-      fixture.detectChanges();
-
-      const chartContainerContent = nativeElement.querySelector('.po-chart-line-path');
-
-      expect(chartContainerContent).toBeTruthy();
-    });
-
-    it('shouldn`t have po-chart-line-path if type is different from `Line`', () => {
-      component.type = PoChartType.Pie;
-      component.series = [{ category: 'catA', value: 20 }];
-
-      fixture.detectChanges();
-
-      const chartContainerContent = nativeElement.querySelector('.po-chart-line-path');
-
-      expect(chartContainerContent).toBeNull();
-    });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.html
@@ -17,7 +17,6 @@
         [p-options]="optionsColumn"
         [p-categories]="categoriesColumn"
         [p-series]="evolutionOfCoffeeAndSomeCompetitors"
-        [p-type]="evolutionOfCoffeeAndSomeCompetitorsType"
       >
       </po-chart>
     </div>

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts
@@ -1,14 +1,6 @@
 import { Component } from '@angular/core';
 
-import {
-  PoChartType,
-  PoDialogService,
-  PoDonutChartSeries,
-  PoLineChartSeries,
-  PoPieChartSeries,
-  PoBarChartSeries,
-  PoChartOptions
-} from '@po-ui/ng-components';
+import { PoChartType, PoChartOptions, PoChartSerie, PoDialogService } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-chart-coffee-ranking',
@@ -40,7 +32,7 @@ export class SamplePoChartCoffeeRankingComponent {
     'Icetea'
   ];
 
-  coffeeConsumption: Array<PoDonutChartSeries> = [
+  coffeeConsumption: Array<PoChartSerie> = [
     { label: 'Finland', data: 9.6, tooltip: 'Finland (Europe)' },
     { label: 'Norway', data: 7.2, tooltip: 'Norway (Europe)' },
     { label: 'Netherlands', data: 6.7, tooltip: 'Netherlands (Europe)' },
@@ -48,12 +40,12 @@ export class SamplePoChartCoffeeRankingComponent {
     { label: 'Austria', data: 5.5, tooltip: 'Austria (Europe)' }
   ];
 
-  consumptionPerCapita: Array<PoBarChartSeries> = [
+  consumptionPerCapita: Array<PoChartSerie> = [
     { label: '2018', data: [86.5, 51.3, 44.6, 39.5, 27.6, 27.3, 25.4, 21.5, 20.8, 15.9, 15.4, 14.4] },
     { label: '2020', data: [86.1, 52.1, 47.3, 37.8, 29.8, 28.5, 24.9, 22.5, 21.1, 14.5, 15.5, 15.5] }
   ];
 
-  participationByCountryInWorldExports: Array<PoLineChartSeries> = [
+  participationByCountryInWorldExports: Array<PoChartSerie> = [
     { label: 'Brazil', data: [35, 32, 25, 29, 33, 33] },
     { label: 'Vietnam', data: [15, 17, 23, 19, 22, 18] },
     { label: 'Colombia', data: [8, 7, 6, 9, 10, 11] },
@@ -61,13 +53,14 @@ export class SamplePoChartCoffeeRankingComponent {
     { label: 'Indonesia', data: [7, 6, 10, 10, 4, 6] }
   ];
 
-  evolutionOfCoffeeAndSomeCompetitors: Array<PoLineChartSeries> = [
-    { label: '2014', data: [91, 40, 42] },
-    { label: '2017', data: [93, 52, 39] },
-    { label: '2020', data: [95, 46, 31] }
+  evolutionOfCoffeeAndSomeCompetitors: Array<PoChartSerie> = [
+    { label: '2014', data: [91, 40, 42], type: PoChartType.Column },
+    { label: '2017', data: [93, 52, 39], type: PoChartType.Column },
+    { label: '2020', data: [95, 46, 31], type: PoChartType.Column },
+    { label: 'Coffee consumption in Brazil', data: [34, 27, 79], type: PoChartType.Line }
   ];
 
-  coffeeProduction: Array<PoPieChartSeries> = [
+  coffeeProduction: Array<PoChartSerie> = [
     { label: 'Brazil', data: 2796, tooltip: 'Brazil (South America)' },
     { label: 'Vietnam', data: 1076, tooltip: 'Vietnam (Asia)' },
     { label: 'Colombia', data: 688, tooltip: 'Colombia (South America)' },

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
@@ -19,15 +19,7 @@
 <po-divider class="po-md-12" p-label="Properties"></po-divider>
 
 <form>
-  <po-select
-    class="po-md-4"
-    name="type"
-    [(ngModel)]="type"
-    p-columns="3"
-    p-label="Type"
-    [p-options]="typeOptions"
-    (p-change)="restore()"
-  >
+  <po-select class="po-md-4" name="type" [(ngModel)]="type" p-columns="3" p-label="Type" [p-options]="typeOptions">
   </po-select>
 
   <po-number class="po-md-4" name="height" [(ngModel)]="height" p-label="Height"> </po-number>
@@ -38,35 +30,37 @@
 <form #chartSeries="ngForm">
   <po-divider class="po-md-12" p-label="Chart series"></po-divider>
 
-  <div *ngIf="!isMultipleValues">
-    <div class="po-row">
-      <po-input class="po-md-6" name="label" [(ngModel)]="label" p-label="Label"> </po-input>
-
-      <po-number class="po-md-6" name="data" [(ngModel)]="data" p-label="Data" p-required> </po-number>
-
-      <po-input class="po-md-6" name="tooltip" [(ngModel)]="tooltip" p-label="Tooltip Text"> </po-input>
-    </div>
-  </div>
-
-  <div class="po-row" *ngIf="isMultipleValues">
+  <div class="po-row">
     <po-input
-      class="po-md-4"
-      name="multipleValuesLabel"
-      [(ngModel)]="multipleValuesLabel"
+      class="po-md-3"
+      name="label"
+      [(ngModel)]="label"
       p-label="Label"
-      p-help="Series label"
+      p-help="Serie label"
+      p-required
+    ></po-input>
+
+    <po-input
+      class="po-md-3"
+      name="data"
+      [(ngModel)]="data"
+      p-label="Data"
+      p-help="Example: [25, 58, 83, 66] or 25"
       p-required
     >
     </po-input>
 
-    <po-input
-      class="po-md-4"
-      name="inputDataSeries"
-      [(ngModel)]="inputDataSeries"
-      p-label="Data"
-      p-help="Example: [24, 58, 83, 66, 75, 19]"
-      p-required
+    <po-select
+      class="po-md-3"
+      name="serieType"
+      [(ngModel)]="serieType"
+      p-help="Serie Type"
+      p-label="Type"
+      [p-options]="typeOptions"
     >
+    </po-select>
+
+    <po-input class="po-md-3" name="tooltip" [(ngModel)]="tooltip" p-label="Tooltip" p-help="Custom Tooltip">
     </po-input>
   </div>
 
@@ -76,7 +70,7 @@
 </form>
 
 <form>
-  <div class="po-row" *ngIf="isMultipleValues">
+  <div class="po-row">
     <po-divider class="po-md-12"></po-divider>
 
     <po-input

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
@@ -1,35 +1,23 @@
 import { Component, OnInit } from '@angular/core';
 
-import {
-  PoLineChartSeries,
-  PoChartType,
-  PoDonutChartSeries,
-  PoPieChartSeries,
-  PoSelectOption,
-  PoChartOptions
-} from '@po-ui/ng-components';
+import { PoChartSerie, PoChartType, PoSelectOption, PoChartOptions } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-chart-labs',
   templateUrl: './sample-po-chart-labs.component.html'
 })
 export class SamplePoChartLabsComponent implements OnInit {
-  label: string;
-  totalValues: Array<number> = [];
+  allCategories: Array<string> = [];
+  categories: string;
+  data;
   event: string;
   height: number;
-  multipleSeries: Array<PoPieChartSeries | PoDonutChartSeries>;
-  multipleValues: Array<PoLineChartSeries>;
-  series: Array<PoPieChartSeries | PoDonutChartSeries | PoLineChartSeries>;
+  label: string;
+  series: Array<PoChartSerie>;
+  serieType: PoChartType;
   title: string;
   tooltip: string;
-  data: number;
   type: PoChartType;
-  lineValues: number;
-  multipleValuesLabel: string = '';
-  categories: string;
-  allCategories: Array<string> = [];
-  inputDataSeries: string;
   options: PoChartOptions = {
     axis: {
       minRange: undefined,
@@ -48,11 +36,6 @@ export class SamplePoChartLabsComponent implements OnInit {
 
   ngOnInit() {
     this.restore();
-    this.type = PoChartType.Line;
-  }
-
-  get isMultipleValues(): boolean {
-    return this.type === PoChartType.Line || this.type === PoChartType.Column || this.type === PoChartType.Bar;
   }
 
   addOptions() {
@@ -64,40 +47,28 @@ export class SamplePoChartLabsComponent implements OnInit {
   }
 
   addData() {
-    if (this.isMultipleValues) {
-      const dataSeries = this.convertToArray(this.inputDataSeries);
+    const data = isNaN(this.data) ? this.convertToArray(this.data) : Math.floor(this.data);
+    const type = this.serieType ?? this.type;
 
-      this.multipleValues = [...this.multipleValues, { label: this.multipleValuesLabel, data: dataSeries }];
-    } else {
-      this.multipleSeries = [...this.multipleSeries, { label: this.label, data: this.data, tooltip: this.tooltip }];
-    }
-
-    this.applySeriesData();
+    this.series = [...this.series, { label: this.label, data, tooltip: this.tooltip, type }];
   }
 
-  applySeriesData() {
-    this.series = this.isMultipleValues ? this.multipleValues : this.multipleSeries;
-  }
-
-  changeEvent(eventName: string, serieEvent: PoPieChartSeries): void {
+  changeEvent(eventName: string, serieEvent: PoChartSerie): void {
     this.event = `${eventName}: ${JSON.stringify(serieEvent)}`;
   }
 
   restore() {
+    this.type = undefined;
+    this.serieType = undefined;
     this.label = undefined;
     this.categories = undefined;
     this.event = undefined;
     this.height = undefined;
-    this.multipleSeries = [];
     this.series = [];
     this.title = undefined;
     this.tooltip = undefined;
     this.data = undefined;
     this.allCategories = [];
-    this.inputDataSeries = undefined;
-    this.multipleValuesLabel = undefined;
-    this.lineValues = undefined;
-    this.multipleValues = [];
     this.options = {
       axis: {
         minRange: undefined,

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-color.service.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-color.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 
 import { PoChartType } from '../enums/po-chart-type.enum';
-import { PoChartSeries } from '../po-chart-base.component';
 import { PoChartColors } from '../helpers/po-chart-colors.constant';
+import { PoChartSerie } from '../interfaces/po-chart-serie.interface';
+import { PoChartGaugeSerie } from '../po-chart-types/po-chart-gauge/po-chart-gauge-series.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -15,7 +16,7 @@ export class PoChartColorService {
    * @param series
    * @param type
    */
-  getSeriesColor(series: PoChartSeries, type: PoChartType) {
+  getSeriesColor(series: Array<PoChartSerie | PoChartGaugeSerie>, type: PoChartType) {
     const colorsLength = PoChartColors.length - 1;
 
     if (!series) {

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
@@ -1,17 +1,12 @@
 import { Injectable } from '@angular/core';
 
-import { PoChartAxisXLabelArea, PoChartPadding } from '../helpers/po-chart-default-values.constant';
-
-import { PoChartContainerSize } from '../interfaces/po-chart-container-size.interface';
-import { PoLineChartSeries } from '../interfaces/po-chart-line-series.interface';
 import { PoChartMinMaxValues } from '../interfaces/po-chart-min-max-values.interface';
+import { PoChartSerie } from '../interfaces/po-chart-serie.interface';
 
 @Injectable({
   providedIn: 'root'
 })
 export class PoChartMathsService {
-  constructor() {}
-
   /**
    * Calcula e retorna os válores mínimo e máximo das séries.
    *
@@ -29,8 +24,8 @@ export class PoChartMathsService {
    *
    * @param series Lista de séries.
    */
-  seriesGreaterLength(series: Array<PoLineChartSeries>): number {
-    return series.reduce((result, serie) => (result > serie.data.length ? result : serie.data.length), 0);
+  seriesGreaterLength(series: Array<PoChartSerie>): number {
+    return series.reduce((result, serie: any) => (result > serie.data.length ? result : serie.data.length), 0);
   }
 
   /**


### PR DESCRIPTION
**po-chart**

**DTHFUI-2805**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente só é possível utilizar gráficos do mesmo tipo definido.

**Qual o novo comportamento?**
- Agora o usuário pode utilizar combinações de gráficos. No momento, a possibilidade se restringe a gráficos dos tipos `line` e `column`.
- Criada a interface `PoChartSerie` para que seja possível mesclar gráficos de coluna e linha no mesmo gráfico.
- Além disso, foi incorporada a possibilidade de customizar o tooltip em gráficos dos tipos `line`, `bar` e `column`;
- O valor default `p-type` agora é definido de acordo com o tipo de serie.data passado. Se for um `Array<number>`, então o padrão será `column`. Para o caso de `number`, então será `pie` como já praticado atualmente.
- Alterado padrão de posicionamento das séries do tipo linha para que fique alinhada corretamente em relação aos gráficos de coluna. 

**Simulação**
Os samples labs + caso de uso contem os testes necessários.

Favor conferir em conjunto com a [PR criada em po-styles](https://github.com/po-ui/po-style/pull/192) que trata do posicionamento dos textos dos eixos Y para gráficos do tipo linha. 