### PR TITLE
fix(chart): corrige resize em gráficos circulares

### DIFF
--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.spec.ts
@@ -163,20 +163,24 @@ describe('PoChartCircularComponent', () => {
     });
 
     it('calculateSerieCoordinates: should call `calculateAngle`, `calculateCoordinates`, `svgPaths.toArray`, `applyCoordinates`, and set value to `showLabels`:', () => {
-      const serie = [{ label: 'category A', data: 10 }];
+      const serie = [{ label: 'category A', data: 30 }];
+      const expectedStartAngle = -1.5707963267948966;
+      const expectedEndAngle = 4.71228898038469;
+      const height = 200;
+
       component['totalValue'] = 30;
 
       const spyApplyCoordinates = spyOn(componentPath, 'applyCoordinates');
       const spySvgPathsToArray = spyOn(component['svgPaths'], 'toArray').and.returnValue([componentPath]);
-      const spyCalculateAngle = spyOn(component, <any>'calculateAngle');
+      const spyCalculateAngle = spyOn(component, <any>'calculateAngle').and.callThrough();
       const spyCalculateCoordinates = spyOn(component, <any>'calculateCoordinates');
 
-      component['calculateSerieCoordinates'](serie, component['totalValue'], 200);
+      component['calculateSerieCoordinates'](serie, component['totalValue'], height);
 
       expect(spyApplyCoordinates).toHaveBeenCalled();
       expect(spySvgPathsToArray).toHaveBeenCalled();
-      expect(spyCalculateAngle).toHaveBeenCalled();
-      expect(spyCalculateCoordinates).toHaveBeenCalled();
+      expect(spyCalculateAngle).toHaveBeenCalledWith(serie[0].data, serie[0].data);
+      expect(spyCalculateCoordinates).toHaveBeenCalledWith(height, expectedStartAngle, expectedEndAngle);
       expect(component.showLabels).toBeTruthy();
     });
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.ts
@@ -109,7 +109,7 @@ export abstract class PoChartCircularComponent {
 
     series.forEach((serie, index) => {
       startRadianAngle = endRadianAngle;
-      endRadianAngle = startRadianAngle + this.calculateAngle(serie.data, totalValue);
+      endRadianAngle = startRadianAngle + this.calculateAngle(serie.data, totalValue) - PoChartCompleteCircle;
 
       const coordinates = this.calculateCoordinates(height, startRadianAngle, endRadianAngle);
 


### PR DESCRIPTION


**po-chart**

**DTHFUI-4719**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Os gráficos dos tipos 'pie' e 'donut' com apenas uma única série desaparecem no resize.

**Qual o novo comportamento?**
Permanecem na tela no resize

**Simulação**
Sample labs do portal