### PR TITLE
feat(chart): calcula a área de texto no grid

### DIFF
--- a/projects/ui/src/lib/components/po-chart/helpers/po-chart-default-values.constant.ts
+++ b/projects/ui/src/lib/components/po-chart/helpers/po-chart-default-values.constant.ts
@@ -2,7 +2,7 @@
 export const PoChartPadding = 24;
 
 // Área lateral designada para os rótulos do eixo X
-export const PoChartAxisXLabelArea = 72;
+export const PoChartAxisXLabelArea = 56;
 
 // Quantidade de linhas do eixo X
 export const PoChartGridLines = 5;

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-container-size.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-container-size.interface.ts
@@ -9,6 +9,9 @@
  */
 
 export interface PoChartContainerSize {
+  /** Largura referente ao texto mais longo da série ou categoria para designação de área dos textos do eixo X do grid. */
+  axisXLabelWidth?: number;
+
   /** Largura do container. */
   svgWidth?: number;
 
@@ -20,9 +23,6 @@ export interface PoChartContainerSize {
 
   /** Metade da altura do container. */
   centerY?: number;
-
-  /** Medida da largura do container - (padding lateral) - (area do labelX). */
-  svgPlottingAreaWidth?: number;
 
   /** Medida da altura do container - padding superior. */
   svgPlottingAreaHeight?: number;

--- a/projects/ui/src/lib/components/po-chart/po-chart-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-base.component.spec.ts
@@ -9,6 +9,9 @@ import { PoColorService } from '../../services/po-color/po-color.service';
 @Directive()
 class PoCharComponent extends PoChartBaseComponent {
   rebuildComponentRef() {}
+  calculateAxisXLabelArea() {
+    return 0;
+  }
   getSvgContainerSize() {}
 }
 
@@ -156,51 +159,85 @@ describe('PoChartBaseComponent:', () => {
   });
 
   describe('Methods:', () => {
-    it('ngOnChanges: should `validateSerieAndAddType` if type changes', () => {
-      const changes = { type: new SimpleChange(null, component.type, true) };
+    describe('ngOnChanges:', () => {
+      it('should call `validateSerieAndAddType` and `calculateAxisXLabelArea` if type changes', () => {
+        const changes = { type: new SimpleChange(null, component.type, true) };
 
-      const spyValidateSerieAndAddType = spyOn(component, <any>'validateSerieAndAddType');
+        const spyValidateSerieAndAddType = spyOn(component, <any>'validateSerieAndAddType');
+        const spycClculateAxisXLabelArea = spyOn(component, <any>'calculateAxisXLabelArea');
 
-      component.type = PoChartType.Bar;
-      component.series = [{ data: 1, label: 'value' }];
+        component.type = PoChartType.Bar;
+        component.series = [{ data: [1, 2, 3], label: 'value', type: PoChartType.Bar }];
 
-      component.ngOnChanges(changes);
+        component.ngOnChanges(changes);
 
-      expect(spyValidateSerieAndAddType).toHaveBeenCalledWith(component.series);
-    });
+        expect(spyValidateSerieAndAddType).toHaveBeenCalledWith(component.series);
+        expect(spycClculateAxisXLabelArea).toHaveBeenCalled();
+      });
 
-    it('ngOnChanges: should `validateSerieAndAddType` if series is an array', () => {
-      const changes = { series: new SimpleChange(null, component.series, true) };
+      it('should call `validateSerieAndAddType` and `calculateAxisXLabelArea` if `categories` changes', () => {
+        const changes = { categories: new SimpleChange(null, component.categories, true) };
 
-      const spyValidateSerieAndAddType = spyOn(component, <any>'validateSerieAndAddType');
+        const spyValidateSerieAndAddType = spyOn(component, <any>'validateSerieAndAddType');
+        const spycClculateAxisXLabelArea = spyOn(component, <any>'calculateAxisXLabelArea');
 
-      component.series = [{ data: 1, label: 'value' }];
+        component.categories = ['cat1', 'cat2'];
+        component.series = [{ data: [1, 2, 3], label: 'value' }];
+        component.type = PoChartType.Column;
 
-      component.ngOnChanges(changes);
+        component.ngOnChanges(changes);
 
-      expect(spyValidateSerieAndAddType).toHaveBeenCalledWith(component.series);
-    });
+        expect(spyValidateSerieAndAddType).toHaveBeenCalledWith(component.series);
+        expect(spycClculateAxisXLabelArea).toHaveBeenCalled();
+      });
 
-    it('ngOnChanges: shouldn`t call `validateSerieAndAddType` if series is an empty array', () => {
-      const changes = { series: new SimpleChange(null, component.series, true) };
+      it('shouldn`t call `calculateAxisXLabelArea` if `categories` changes but `type` is a circular type', () => {
+        const changes = { categories: new SimpleChange(null, component.categories, true) };
 
-      const spyValidateSerieAndAddType = spyOn(component, <any>'validateSerieAndAddType');
+        const spycClculateAxisXLabelArea = spyOn(component, <any>'calculateAxisXLabelArea');
 
-      component.series = [];
+        component.categories = ['cat1', 'cat2'];
+        component.series = [{ data: 1, label: 'value' }];
+        component.type = PoChartType.Donut;
 
-      component.ngOnChanges(changes);
+        component.ngOnChanges(changes);
 
-      expect(spyValidateSerieAndAddType).not.toHaveBeenCalled();
-    });
+        expect(spycClculateAxisXLabelArea).not.toHaveBeenCalled();
+      });
 
-    it('ngOnChanges: shouldn`t call `validateSerieAndAddType` if series doesn`t change', () => {
-      const changes = { height: new SimpleChange(null, component.height, true) };
+      it('should call `validateSerieAndAddType` if series is an array', () => {
+        const changes = { series: new SimpleChange(null, component.series, true) };
 
-      const spyValidateSerieAndAddType = spyOn(component, <any>'validateSerieAndAddType');
+        const spyValidateSerieAndAddType = spyOn(component, <any>'validateSerieAndAddType');
 
-      component.ngOnChanges(changes);
+        component.series = [{ data: 1, label: 'value' }];
 
-      expect(spyValidateSerieAndAddType).not.toHaveBeenCalled();
+        component.ngOnChanges(changes);
+
+        expect(spyValidateSerieAndAddType).toHaveBeenCalledWith(component.series);
+      });
+
+      it('shouldn`t call `validateSerieAndAddType` if series is an empty array', () => {
+        const changes = { series: new SimpleChange(null, component.series, true) };
+
+        const spyValidateSerieAndAddType = spyOn(component, <any>'validateSerieAndAddType');
+
+        component.series = [];
+
+        component.ngOnChanges(changes);
+
+        expect(spyValidateSerieAndAddType).not.toHaveBeenCalled();
+      });
+
+      it('shouldn`t call `validateSerieAndAddType` if series doesn`t change', () => {
+        const changes = { height: new SimpleChange(null, component.height, true) };
+
+        const spyValidateSerieAndAddType = spyOn(component, <any>'validateSerieAndAddType');
+
+        component.ngOnChanges(changes);
+
+        expect(spyValidateSerieAndAddType).not.toHaveBeenCalled();
+      });
     });
 
     it('onSeriesClick: should call `seriesClick.emit` with `event`', () => {

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.spec.ts
@@ -103,7 +103,7 @@ describe('PoChartAxisComponent', () => {
           centerX: 250,
           svgHeight: 300,
           centerY: 150,
-          svgPlottingAreaWidth: 400,
+          axisXLabelWidth: 72,
           svgPlottingAreaHeight: 280
         };
         const fakeCategories = ['jan', 'fev', 'mar'];
@@ -137,7 +137,7 @@ describe('PoChartAxisComponent', () => {
           centerX: 250,
           svgHeight: 300,
           centerY: 150,
-          svgPlottingAreaWidth: 400,
+          axisXLabelWidth: 72,
           svgPlottingAreaHeight: 280
         };
         const fakeCategories = ['jan', 'fev', 'mar'];
@@ -168,7 +168,7 @@ describe('PoChartAxisComponent', () => {
           centerX: 250,
           svgHeight: 300,
           centerY: 150,
-          svgPlottingAreaWidth: 400,
+          axisXLabelWidth: 72,
           svgPlottingAreaHeight: 280
         };
 
@@ -202,7 +202,7 @@ describe('PoChartAxisComponent', () => {
           centerX: 250,
           svgHeight: 300,
           centerY: 150,
-          svgPlottingAreaWidth: 400,
+          axisXLabelWidth: 72,
           svgPlottingAreaHeight: 280
         };
 
@@ -243,7 +243,7 @@ describe('PoChartAxisComponent', () => {
           centerX: 250,
           svgHeight: 300,
           centerY: 150,
-          svgPlottingAreaWidth: 400,
+          axisXLabelWidth: 72,
           svgPlottingAreaHeight: 280
         };
 
@@ -278,7 +278,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const minMaxAxisValues: PoChartMinMaxValues = {
@@ -309,7 +309,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const minMaxAxisValues: PoChartMinMaxValues = {
@@ -334,7 +334,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const fakeMinMaxAxisValues: PoChartMinMaxValues = {
@@ -365,7 +365,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const fakeMinMaxAxisValues: PoChartMinMaxValues = {
@@ -399,7 +399,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const minMaxAxisValues: PoChartMinMaxValues = {
@@ -425,7 +425,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const minMaxAxisValues: PoChartMinMaxValues = {
@@ -455,7 +455,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const expectedResult: Array<PoChartPathCoordinates> = [{ coordinates: 'Mundefined 8 Lundefined, 288' }];
@@ -476,7 +476,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const expectedResult: Array<PoChartPathCoordinates> = [
@@ -505,7 +505,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const expectedResult = [
@@ -526,8 +526,9 @@ describe('PoChartAxisComponent', () => {
 
     it('calculateAxisXLabelXCoordinate: should return the result of `PoChartAxisXLabelArea` - `labelPoChartPadding`', () => {
       const expectedResult = 64;
+      const axisXLabelWidth = 72;
 
-      const result = component['calculateAxisXLabelXCoordinate']();
+      const result = component['calculateAxisXLabelXCoordinate'](axisXLabelWidth);
 
       expect(result).toEqual(expectedResult);
     });
@@ -540,7 +541,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const fakeIndex = 1;
@@ -558,7 +559,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const fakeIndex = 1;
@@ -575,7 +576,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
 
@@ -593,7 +594,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const fakeIndex = 1;
@@ -612,7 +613,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const fakeIndex = 1;
@@ -629,7 +630,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const fakeIndex = 1;
@@ -648,7 +649,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const fakeIndex = 1;
@@ -666,7 +667,7 @@ describe('PoChartAxisComponent', () => {
         centerX: 250,
         svgHeight: 300,
         centerY: 150,
-        svgPlottingAreaWidth: 400,
+        axisXLabelWidth: 72,
         svgPlottingAreaHeight: 280
       };
       const fakeIndex = 1;
@@ -879,7 +880,7 @@ describe('PoChartAxisComponent', () => {
           centerX: 250,
           svgHeight: 300,
           centerY: 150,
-          svgPlottingAreaWidth: 400,
+          axisXLabelWidth: 72,
           svgPlottingAreaHeight: 280
         };
         const spyCalculateAxisXCoordinateY = spyOn(component, <any>'calculateAxisXCoordinateY').and.callThrough();
@@ -896,7 +897,7 @@ describe('PoChartAxisComponent', () => {
           centerX: 250,
           svgHeight: 300,
           centerY: 150,
-          svgPlottingAreaWidth: 400,
+          axisXLabelWidth: 72,
           svgPlottingAreaHeight: 280
         };
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 
 import {
-  PoChartAxisXLabelArea,
   PoChartGridLines,
   PoChartPadding,
   PoChartPlotAreaPaddingTop
@@ -152,7 +151,7 @@ export class PoChartAxisComponent {
 
   private calculateAxisXCoordinates(amountOfAxisX: number, containerSize: PoChartContainerSize) {
     this.axisXCoordinates = [...Array(amountOfAxisX)].map((_, index: number) => {
-      const startX = PoChartAxisXLabelArea;
+      const startX = containerSize.axisXLabelWidth;
       const endX = containerSize.svgWidth;
       const yCoordinate = this.calculateAxisXCoordinateY(amountOfAxisX, containerSize, index);
 
@@ -172,7 +171,7 @@ export class PoChartAxisComponent {
 
     this.axisXLabelCoordinates = [...Array(amountOfAxisX)].map((_, index: number) => {
       const label = axisXLabels[index];
-      const xCoordinate = this.calculateAxisXLabelXCoordinate();
+      const xCoordinate = this.calculateAxisXLabelXCoordinate(containerSize.axisXLabelWidth);
       const yCoordinate = this.calculateAxisXLabelYCoordinate(amountOfAxisX, containerSize, type, index);
 
       return { label, xCoordinate, yCoordinate };
@@ -219,10 +218,10 @@ export class PoChartAxisComponent {
     });
   }
 
-  private calculateAxisXLabelXCoordinate(): number {
+  private calculateAxisXLabelXCoordinate(axisXLabelWidth: number): number {
     const labelPoChartPadding = PoChartPadding / 3;
 
-    return PoChartAxisXLabelArea - labelPoChartPadding;
+    return axisXLabelWidth - labelPoChartPadding;
   }
 
   private calculateAxisXLabelYCoordinate(
@@ -273,12 +272,16 @@ export class PoChartAxisComponent {
     const xRatio = index / amountOfLines;
 
     if (type === PoChartType.Bar) {
-      return Math.round(PoChartAxisXLabelArea + (containerSize.svgWidth - PoChartAxisXLabelArea) * xRatio);
+      return Math.round(
+        containerSize.axisXLabelWidth + (containerSize.svgWidth - containerSize.axisXLabelWidth) * xRatio
+      );
     }
 
-    const halfCategoryWidth = (containerSize.svgWidth - PoChartAxisXLabelArea) / amountOfAxisY / 2;
+    const halfCategoryWidth = (containerSize.svgWidth - containerSize.axisXLabelWidth) / amountOfAxisY / 2;
     return Math.round(
-      PoChartAxisXLabelArea + halfCategoryWidth + (containerSize.svgWidth - PoChartAxisXLabelArea) * xRatio
+      containerSize.axisXLabelWidth +
+        halfCategoryWidth +
+        (containerSize.svgWidth - containerSize.axisXLabelWidth) * xRatio
     );
   }
 
@@ -292,7 +295,9 @@ export class PoChartAxisComponent {
     const divideIndexByAmountOfLines = index / amountOfLines;
     const xRatio = divideIndexByAmountOfLines === Infinity ? 0 : divideIndexByAmountOfLines;
 
-    return Math.round(PoChartAxisXLabelArea + (containerSize.svgWidth - PoChartAxisXLabelArea) * xRatio);
+    return Math.round(
+      containerSize.axisXLabelWidth + (containerSize.svgWidth - containerSize.axisXLabelWidth) * xRatio
+    );
   }
 
   private checkAxisOptions(options: PoChartAxisOptions = {}): void {

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar-base.component.spec.ts
@@ -21,7 +21,7 @@ describe('PoChartBarBaseComponent', () => {
   const containerSize: PoChartContainerSize = {
     svgWidth: 200,
     svgHeight: 200,
-    svgPlottingAreaWidth: 20,
+    axisXLabelWidth: 72,
     svgPlottingAreaHeight: 20
   };
   const range = { minValue: 0, maxValue: 30 };

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.spec.ts
@@ -13,7 +13,7 @@ describe('PoChartBarComponent', () => {
   const containerSize: PoChartContainerSize = {
     svgWidth: 200,
     svgHeight: 200,
-    svgPlottingAreaWidth: 20,
+    axisXLabelWidth: 72,
     svgPlottingAreaHeight: 20
   };
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { PoChartAxisXLabelArea, PoChartPlotAreaPaddingTop } from './../../helpers/po-chart-default-values.constant';
+import { PoChartPlotAreaPaddingTop } from './../../helpers/po-chart-default-values.constant';
 
 import { PoChartBarBaseComponent } from './po-chart-bar-base.component';
 import { PoChartMathsService } from './../../services/po-chart-maths.service';
@@ -26,17 +26,18 @@ export class PoChartBarComponent extends PoChartBarBaseComponent {
     minMaxSeriesValues: PoChartMinMaxValues,
     serieValue: number
   ) {
-    const { svgWidth, svgPlottingAreaHeight } = containerSize;
-    const { svgPlottingAreaWidth, barHeight, spaceBetweenBars } = this.calculateElementsMeasurements(
-      svgWidth,
-      svgPlottingAreaHeight
-    );
+    const { svgPlottingAreaWidth, barHeight, spaceBetweenBars } = this.calculateElementsMeasurements(containerSize);
 
-    const { x1, x2 } = this.xCoordinates(minMaxSeriesValues, svgPlottingAreaWidth, serieValue);
+    const { x1, x2 } = this.xCoordinates(
+      minMaxSeriesValues,
+      svgPlottingAreaWidth,
+      containerSize.axisXLabelWidth,
+      serieValue
+    );
     const { y1, y2 } = this.yCoordinates(
       seriesIndex,
       serieItemDataIndex,
-      svgPlottingAreaHeight,
+      containerSize.svgPlottingAreaHeight,
       barHeight,
       spaceBetweenBars
     );
@@ -44,12 +45,11 @@ export class PoChartBarComponent extends PoChartBarBaseComponent {
     return ['M', x1, y2, 'L', x2, y2, 'L', x2, y1, 'L', x1, y1, 'z'].join(' ');
   }
 
-  private calculateElementsMeasurements(
-    svgWidth: PoChartContainerSize['svgWidth'],
-    svgPlottingAreaHeight: PoChartContainerSize['svgPlottingAreaHeight']
-  ) {
+  private calculateElementsMeasurements(containerSize: PoChartContainerSize) {
+    const { svgWidth, svgPlottingAreaHeight, axisXLabelWidth } = containerSize;
+
     // Fração das séries em relação à largura da categoria. Incrementa + 2 na extensão das séries pois se trata da área de margem entre as categorias.
-    const svgPlottingAreaWidth = svgWidth - PoChartAxisXLabelArea;
+    const svgPlottingAreaWidth = svgWidth - axisXLabelWidth;
     const categoryHeight = svgPlottingAreaHeight / this.seriesGreaterLength;
     const columnFraction = categoryHeight / (this.series.length + 2);
 
@@ -62,13 +62,18 @@ export class PoChartBarComponent extends PoChartBarBaseComponent {
     return { svgPlottingAreaWidth, barHeight, spaceBetweenBars };
   }
 
-  private xCoordinates(minMaxSeriesValues: PoChartMinMaxValues, svgPlottingAreaWidth: number, serieValue: number) {
+  private xCoordinates(
+    minMaxSeriesValues: PoChartMinMaxValues,
+    svgPlottingAreaWidth: number,
+    axisXLabelWidth: PoChartContainerSize['axisXLabelWidth'],
+    serieValue: number
+  ) {
     // TO DO: tratamento para valores negativos.
     const filterNegativeSerieValue = serieValue <= 0 ? 0 : serieValue;
 
     const xRatio = this.mathsService.getSeriePercentage(minMaxSeriesValues, filterNegativeSerieValue);
-    const x1 = PoChartAxisXLabelArea;
-    const x2 = Math.round(svgPlottingAreaWidth * xRatio + PoChartAxisXLabelArea);
+    const x1 = axisXLabelWidth;
+    const x2 = Math.round(svgPlottingAreaWidth * xRatio + axisXLabelWidth);
 
     return { x1, x2 };
   }

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.spec.ts
@@ -12,7 +12,7 @@ describe('PoChartColumnComponent', () => {
   const containerSize: PoChartContainerSize = {
     svgWidth: 200,
     svgHeight: 200,
-    svgPlottingAreaWidth: 20,
+    axisXLabelWidth: 72,
     svgPlottingAreaHeight: 20
   };
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { PoChartAxisXLabelArea, PoChartPlotAreaPaddingTop } from '../../../helpers/po-chart-default-values.constant';
+import { PoChartPlotAreaPaddingTop } from '../../../helpers/po-chart-default-values.constant';
 
 import { PoChartBarBaseComponent } from '../po-chart-bar-base.component';
 import { PoChartMathsService } from '../../../services/po-chart-maths.service';
@@ -26,18 +26,31 @@ export class PoChartColumnComponent extends PoChartBarBaseComponent {
     minMaxSeriesValues: PoChartMinMaxValues,
     serieValue: number
   ) {
-    const { svgWidth, svgPlottingAreaHeight } = containerSize;
-    const { chartBarPlotArea, barWidth, spaceBetweenBars } = this.calculateElementsMeasurements(svgWidth);
+    const { svgWidth, axisXLabelWidth, svgPlottingAreaHeight } = containerSize;
+    const { chartBarPlotArea, barWidth, spaceBetweenBars } = this.calculateElementsMeasurements(
+      svgWidth,
+      axisXLabelWidth
+    );
 
-    const { x1, x2 } = this.xCoordinates(seriesIndex, serieItemDataIndex, chartBarPlotArea, barWidth, spaceBetweenBars);
+    const { x1, x2 } = this.xCoordinates(
+      seriesIndex,
+      serieItemDataIndex,
+      chartBarPlotArea,
+      barWidth,
+      spaceBetweenBars,
+      axisXLabelWidth
+    );
     const { y1, y2 } = this.yCoordinates(minMaxSeriesValues, svgPlottingAreaHeight, serieValue);
 
     return ['M', x1, y2, 'L', x2, y2, 'L', x2, y1, 'L', x1, y1, 'z'].join(' ');
   }
 
-  private calculateElementsMeasurements(svgWidth: PoChartContainerSize['svgWidth']) {
+  private calculateElementsMeasurements(
+    svgWidth: PoChartContainerSize['svgWidth'],
+    axisXLabelWidth: PoChartContainerSize['axisXLabelWidth']
+  ) {
     // Fração das séries em relação à largura da categoria. Incrementa + 2 na extensão das séries pois se trata da área de margem entre as categorias.
-    const chartBarPlotArea = svgWidth - PoChartAxisXLabelArea;
+    const chartBarPlotArea = svgWidth - axisXLabelWidth;
     const categoryWidth = chartBarPlotArea / this.seriesGreaterLength;
     const columnFraction = categoryWidth / (this.series.length + 2);
 
@@ -55,14 +68,15 @@ export class PoChartColumnComponent extends PoChartBarBaseComponent {
     serieItemDataIndex: number,
     chartBarPlotArea: number,
     barWidth: number,
-    spaceBetweenBars: number
+    spaceBetweenBars: number,
+    axisXLabelWidth: PoChartContainerSize['axisXLabelWidth']
   ) {
     // A área lateral entre a coluna e a linha do eixo Y do grid será sempre equivalente à largura da coluna.
     const spaceBetweenAxisAndBars = barWidth;
     const xRatio = serieItemDataIndex / this.seriesGreaterLength;
 
     const x1 = Math.round(
-      PoChartAxisXLabelArea +
+      axisXLabelWidth +
         chartBarPlotArea * xRatio +
         spaceBetweenAxisAndBars +
         barWidth * seriesIndex +

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.spec.ts
@@ -40,7 +40,7 @@ describe('PoChartCircularComponent', () => {
   const containerSize: PoChartContainerSize = {
     svgWidth: 200,
     svgHeight: 200,
-    svgPlottingAreaWidth: 20,
+    axisXLabelWidth: 72,
     svgPlottingAreaHeight: 20
   };
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.spec.ts
@@ -17,7 +17,7 @@ describe('PoChartContainerComponent', () => {
   const containerSize: PoChartContainerSize = {
     svgWidth: 200,
     svgHeight: 200,
-    svgPlottingAreaWidth: 20,
+    axisXLabelWidth: 72,
     svgPlottingAreaHeight: 20
   };
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
@@ -17,7 +17,7 @@ describe('PoChartLineComponent', () => {
   const containerSize: PoChartContainerSize = {
     svgWidth: 200,
     svgHeight: 200,
-    svgPlottingAreaWidth: 20,
+    axisXLabelWidth: 72,
     svgPlottingAreaHeight: 20
   };
 
@@ -96,7 +96,7 @@ describe('PoChartLineComponent', () => {
 
         component['seriePathPointsDefinition'](component.containerSize, component.series, range);
 
-        const expectedResult = [{ coordinates: ' M104 25 L114 21', color: '#94DAE2' }];
+        const expectedResult = [{ coordinates: ' M104 25 L168 21', color: '#94DAE2' }];
 
         expect(component.seriesPathsCoordinates).toEqual(expectedResult);
         expect(component.seriesPathsCoordinates.length).toBe(1);
@@ -124,7 +124,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 10',
               data: 10,
-              xCoordinate: 114,
+              xCoordinate: 168,
               yCoordinate: 21
             }
           ]
@@ -158,7 +158,7 @@ describe('PoChartLineComponent', () => {
               label: undefined,
               tooltipLabel: '10',
               data: 10,
-              xCoordinate: 114,
+              xCoordinate: 168,
               yCoordinate: 8
             }
           ]
@@ -193,7 +193,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 10',
               data: 10,
-              xCoordinate: 114,
+              xCoordinate: 168,
               yCoordinate: 8
             }
           ]
@@ -226,7 +226,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 12',
               data: 12,
-              xCoordinate: 106.66666666666666,
+              xCoordinate: 178.66666666666666,
               yCoordinate: 0
             }
           ]
@@ -236,7 +236,7 @@ describe('PoChartLineComponent', () => {
 
         expect(component.seriesPointsCoordinates).toEqual(expectedPointsResult);
         expect(component.seriesPathsCoordinates).toEqual([
-          { coordinates: ' M93.33333333333333 8 L106.66666666666666 0', color: '#29B6C5' }
+          { coordinates: ' M93.33333333333333 8 L178.66666666666666 0', color: '#29B6C5' }
         ]);
       });
 
@@ -285,7 +285,7 @@ describe('PoChartLineComponent', () => {
               label: 'Vancouver',
               tooltipLabel: 'Vancouver: 0',
               data: 0,
-              xCoordinate: 100,
+              xCoordinate: 136,
               yCoordinate: 28
             }
           ]

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
 
-import { PoChartAxisXLabelArea, PoChartPlotAreaPaddingTop } from '../../helpers/po-chart-default-values.constant';
+import { PoChartPlotAreaPaddingTop } from '../../helpers/po-chart-default-values.constant';
 
 import { PoChartMathsService } from '../../services/po-chart-maths.service';
 
@@ -150,12 +150,16 @@ export class PoChartLineComponent {
   }
 
   private xCoordinate(index: number, containerSize: PoChartContainerSize) {
-    const halfCategoryWidth = (containerSize.svgWidth - PoChartAxisXLabelArea) / this.seriesLength / 2;
+    const halfCategoryWidth = (containerSize.svgWidth - containerSize.axisXLabelWidth) / this.seriesLength / 2;
 
     const divideIndexBySeriesLength = index / this.seriesLength;
     const xRatio = isNaN(divideIndexBySeriesLength) ? 0 : divideIndexBySeriesLength;
 
-    return PoChartAxisXLabelArea + halfCategoryWidth + containerSize.svgPlottingAreaWidth * xRatio;
+    return (
+      containerSize.axisXLabelWidth +
+      halfCategoryWidth +
+      (containerSize.svgWidth - containerSize.axisXLabelWidth) * xRatio
+    );
   }
 
   private serieCategory(index: number, categories: Array<string> = []) {

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
@@ -392,7 +392,6 @@ describe('PoChartComponent:', () => {
   });
 
   it('getSvgContainerSize: should call `containerService.calculateSVGContainerMeasurements` and `getChartMeasurements`', () => {
-    component.categories = ['cat1', 'cat2'];
     const chartMeasurements = { chartHeaderHeight: 100, chartLegendHeight: 200, chartWrapperWidth: 300 };
 
     const spyCalculateSVGContainerMeasurements = spyOn(
@@ -407,9 +406,72 @@ describe('PoChartComponent:', () => {
       component.height,
       chartMeasurements.chartWrapperWidth,
       chartMeasurements.chartHeaderHeight,
-      chartMeasurements.chartLegendHeight,
-      component.categories.length
+      chartMeasurements.chartLegendHeight
     );
     expect(spyGetChartMeasurements).toHaveBeenCalled();
+  });
+
+  it('getSvgContainerSize: should call `calculateAxisXLabelArea` if `type` isn`t a circular type', () => {
+    component.series = [{ data: [1, 2, 3], type: PoChartType.Column }];
+    component.type = PoChartType.Column;
+
+    const spyCalculateAxisXLabelArea = spyOn(component, <any>'calculateAxisXLabelArea');
+
+    component['getSvgContainerSize']();
+
+    expect(spyCalculateAxisXLabelArea).toHaveBeenCalled();
+  });
+
+  it('getSvgContainerSize: shouldn`t call `calculateAxisXLabelArea` if `type` is a circular type', () => {
+    component.series = [{ data: 12, type: PoChartType.Pie }];
+    component.type = PoChartType.Pie;
+
+    const spyCalculateAxisXLabelArea = spyOn(component, <any>'calculateAxisXLabelArea');
+
+    component['getSvgContainerSize']();
+
+    expect(spyCalculateAxisXLabelArea).not.toHaveBeenCalled();
+  });
+
+  it('calculateAxisXLabelArea: should call `calculateAxisXLabelArea` passing `Vancouver` as param if type is `bar`', () => {
+    component.chartType = PoChartType.Bar;
+    component.categories = ['Vancouver', 'Otawa'];
+    component.series = [
+      { data: [1, 2, 3], type: PoChartType.Bar },
+      { data: [2, 3, 4], type: PoChartType.Bar }
+    ];
+
+    const spyGetAxisXLabelArea = spyOn(component, <any>'getAxisXLabelArea');
+
+    component['calculateAxisXLabelArea']();
+
+    expect(spyGetAxisXLabelArea).toHaveBeenCalledWith(component.categories[0]);
+  });
+
+  it('calculateAxisXLabelArea: should call `calculateAxisXLabelArea` passing `10.75` relative to axis x label average value as param if type isn`t `bar`', () => {
+    component.chartType = PoChartType.Column;
+    component.categories = ['Vancouver', 'Otawa'];
+    component.chartSeries = [
+      { data: [1, 2, 3], type: PoChartType.Column },
+      { data: [2, 3, 40], type: PoChartType.Column }
+    ];
+
+    const spyGetAxisXLabelArea = spyOn(component, <any>'getAxisXLabelArea');
+
+    component['calculateAxisXLabelArea']();
+
+    expect(spyGetAxisXLabelArea).toHaveBeenCalledWith(10.75);
+  });
+
+  it('getAxisXLabelArea: should calculate and return axisXLabel width', () => {
+    const axisXLabel = 'Vancouver';
+
+    expect(component['getAxisXLabelArea'](axisXLabel)).toBe(76);
+  });
+
+  it('getAxisXLabelArea: should calculate and return PoChartAxisXLabelArea default width', () => {
+    const axisXLabel = 12;
+
+    expect(component['getAxisXLabelArea'](axisXLabel)).toBe(56);
   });
 });

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import { PoChartMathsService } from './po-chart-maths.service';
+import { PoChartType } from '../enums/po-chart-type.enum';
 
 describe('PoChartMathsService', () => {
   let service: PoChartMathsService;
@@ -125,6 +126,117 @@ describe('PoChartMathsService', () => {
       validValues.forEach(value => {
         expect(service.verifyIfFloatOrInteger(<any>value)).toBeFalsy();
       });
+    });
+
+    it('getLongestDataValue: should call `sortLongestData` if type is `bar`', () => {
+      const data = ['Vancouver', 'Otawa'];
+      const type = PoChartType.Bar;
+      const options = {};
+
+      const spySortLongestData = spyOn(service, <any>'sortLongestData');
+      const spyGetAxisXLabelLongestValue = spyOn(service, <any>'getAxisXLabelLongestValue');
+
+      service.getLongestDataValue(data, type, options);
+
+      expect(spySortLongestData).toHaveBeenCalledWith(data);
+      expect(spyGetAxisXLabelLongestValue).not.toHaveBeenCalled();
+    });
+
+    it('getLongestDataValue: should call `getAxisXLabelLongestValue` if type is not `bar`', () => {
+      const data = ['Vancouver', 'Otawa'];
+      const type = PoChartType.Line;
+      const options = { axis: { gridLines: 5 } };
+
+      const spySortLongestData = spyOn(service, <any>'sortLongestData');
+      const spyGetAxisXLabelLongestValue = spyOn(service, <any>'getAxisXLabelLongestValue');
+
+      service.getLongestDataValue(data, type, options);
+
+      expect(spyGetAxisXLabelLongestValue).toHaveBeenCalledWith(data, 5);
+      expect(spySortLongestData).not.toHaveBeenCalled();
+    });
+
+    it('getLongestDataValue: should call `getAxisXLabelLongestValue` passing data and 5 as params if options.axis is undefined', () => {
+      const type = PoChartType.Line;
+      const options = undefined;
+
+      const spySortLongestData = spyOn(service, <any>'sortLongestData');
+      const spyGetAxisXLabelLongestValue = spyOn(service, <any>'getAxisXLabelLongestValue');
+
+      service.getLongestDataValue(undefined, type, options);
+
+      expect(spyGetAxisXLabelLongestValue).toHaveBeenCalledWith([], 5);
+      expect(spySortLongestData).not.toHaveBeenCalled();
+    });
+
+    it('getAxisXLabelLongestValue: should call `calculateMinAndMaxValues` passing data and allowNegativeData false as params', () => {
+      const data = [{ data: [-30, 0, 10], type: PoChartType.Column }];
+      const gridLines = 5;
+
+      const spyCalculateMinAndMaxValues = spyOn(service, <any>'calculateMinAndMaxValues');
+      spyOn(service, <any>'range');
+      spyOn(service, <any>'sortLongestData');
+
+      service['getAxisXLabelLongestValue'](data, gridLines);
+
+      expect(spyCalculateMinAndMaxValues).toHaveBeenCalledWith(data, false);
+    });
+
+    it('getAxisXLabelLongestValue: should call `calculateMinAndMaxValues` passing data and allowNegativeData true as params', () => {
+      const data = [{ data: [-30, 0, 10], type: PoChartType.Line }];
+      const gridLines = 5;
+
+      const spyCalculateMinAndMaxValues = spyOn(service, <any>'calculateMinAndMaxValues');
+      spyOn(service, <any>'range');
+      spyOn(service, <any>'sortLongestData');
+
+      service['getAxisXLabelLongestValue'](data, gridLines);
+
+      expect(spyCalculateMinAndMaxValues).toHaveBeenCalledWith(data, true);
+    });
+
+    it('getAxisXLabelLongestValue: should call `range` and `sortLongestData`', () => {
+      const data = [{ data: [-30, 0, 10], type: PoChartType.Line }];
+      const gridLines = 5;
+
+      spyOn(service, <any>'calculateMinAndMaxValues');
+      const spyRange = spyOn(service, <any>'range');
+      const spySortLongestData = spyOn(service, <any>'sortLongestData');
+
+      service['getAxisXLabelLongestValue'](data, gridLines);
+
+      expect(spyRange).toHaveBeenCalled();
+      expect(spySortLongestData).toHaveBeenCalled();
+    });
+
+    it('amountOfGridLines: should return 5 if options is undefined', () => {
+      const options = undefined;
+
+      expect(service['amountOfGridLines'](options)).toBe(5);
+    });
+
+    it('amountOfGridLines: should return 5 if options.gridLines value is lower than 2', () => {
+      const options = { gridLines: 1 };
+
+      expect(service['amountOfGridLines'](options)).toBe(5);
+    });
+
+    it('amountOfGridLines: should return 5 if options.gridLines value is greater than 10', () => {
+      const options = { gridLines: 19 };
+
+      expect(service['amountOfGridLines'](options)).toBe(5);
+    });
+
+    it('amountOfGridLines: should return options.gridLines value', () => {
+      const options = { gridLines: 7 };
+
+      expect(service['amountOfGridLines'](options)).toBe(7);
+    });
+
+    it('sortLongestData: should return 400 as longest data value', () => {
+      const data = [1, 2, 400, 3];
+
+      expect(service['sortLongestData'](data)).toBe(400);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-svg-container.service.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-svg-container.service.spec.ts
@@ -29,25 +29,17 @@ describe('PoChartSvgContainerService', () => {
     });
 
     describe('calculateSVGContainerMeasurements: ', () => {
-      it('should call `svgWidth`, `center`, `svgHeight`, `svgPlottingAreaWidth`, `svgPlottingAreaHeight`', () => {
+      it('should call `svgWidth`, `center`, `svgHeight`, svgPlottingAreaHeight`', () => {
         const spySvgWidth = spyOn(service, <any>'svgWidth');
         const spyCenter = spyOn(service, <any>'center');
         const spySvgHeiht = spyOn(service, <any>'svgHeight');
-        const spySvgPlottingAreaWidth = spyOn(service, <any>'svgPlottingAreaWidth');
         const spySvgPlottingAreaHeight = spyOn(service, <any>'svgPlottingAreaHeight');
 
-        service.calculateSVGContainerMeasurements(
-          chartHeight,
-          chartWrapperWidth,
-          chartHeaderHeight,
-          chartLegendHeight,
-          categoriesLength
-        );
+        service.calculateSVGContainerMeasurements(chartHeight, chartWrapperWidth, chartHeaderHeight, chartLegendHeight);
 
         expect(spySvgWidth).toHaveBeenCalledWith(chartWrapperWidth);
         expect(spyCenter).toHaveBeenCalledTimes(2);
         expect(spySvgHeiht).toHaveBeenCalledWith(chartHeight, chartHeaderHeight, chartLegendHeight);
-        expect(spySvgPlottingAreaWidth).toHaveBeenCalled();
         expect(spySvgPlottingAreaHeight).toHaveBeenCalled();
       });
 
@@ -55,7 +47,6 @@ describe('PoChartSvgContainerService', () => {
         const spySvgWidth = spyOn(service, <any>'svgWidth');
         const spyCenter = spyOn(service, <any>'center');
         const spySvgHeiht = spyOn(service, <any>'svgHeight');
-        const spySvgPlottingAreaWidth = spyOn(service, <any>'svgPlottingAreaWidth');
         const spySvgPlottingAreaHeight = spyOn(service, <any>'svgPlottingAreaHeight');
 
         service.calculateSVGContainerMeasurements();
@@ -63,7 +54,6 @@ describe('PoChartSvgContainerService', () => {
         expect(spySvgWidth).toHaveBeenCalled();
         expect(spyCenter).toHaveBeenCalledTimes(2);
         expect(spySvgHeiht).toHaveBeenCalled();
-        expect(spySvgPlottingAreaWidth).toHaveBeenCalled();
         expect(spySvgPlottingAreaHeight).toHaveBeenCalled();
       });
     });
@@ -89,12 +79,6 @@ describe('PoChartSvgContainerService', () => {
       chartHeight = 50;
 
       expect(service['svgHeight'](chartHeight, chartHeaderHeight, chartLegendHeight)).toBe(0);
-    });
-
-    it('svgPlottingAreaWidth: should return the result of the calculation', () => {
-      const svgWidth = 200;
-
-      expect(service['svgPlottingAreaWidth'](svgWidth)).toBe(128);
     });
 
     it('svgPlottingAreaHeight: should return the result of the calculation', () => {

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-svg-container.service.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-svg-container.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { PoChartAxisXLabelArea, PoChartPadding } from '../helpers/po-chart-default-values.constant';
+import { PoChartPadding } from '../helpers/po-chart-default-values.constant';
 import { PoChartContainerSize } from '../interfaces/po-chart-container-size.interface';
 
 @Injectable({
@@ -15,20 +15,17 @@ export class PoChartSvgContainerService {
    * @param chartWrapperWidth
    * @param chartHeaderHeight
    * @param chartLegendHeight
-   * @param categoriesLength
    */
   calculateSVGContainerMeasurements(
     chartHeight: number = 0,
     chartWrapperWidth: number = 0,
     chartHeaderHeight: number = 0,
-    chartLegendHeight: number = 0,
-    categoriesLength: number = 0
+    chartLegendHeight: number = 0
   ): PoChartContainerSize {
     const svgWidth = this.svgWidth(chartWrapperWidth);
     const centerX = this.center(chartWrapperWidth);
     const svgHeight = this.svgHeight(chartHeight, chartHeaderHeight, chartLegendHeight);
     const centerY = this.center(svgHeight);
-    const svgPlottingAreaWidth = this.svgPlottingAreaWidth(svgWidth);
     const svgPlottingAreaHeight = this.svgPlottingAreaHeight(svgHeight);
 
     return {
@@ -36,7 +33,6 @@ export class PoChartSvgContainerService {
       svgHeight,
       centerX,
       centerY,
-      svgPlottingAreaWidth,
       svgPlottingAreaHeight
     };
   }
@@ -58,20 +54,6 @@ export class PoChartSvgContainerService {
     const subtractedHeights = chartHeight - chartHeaderHeight - chartLegendHeight - PoChartPadding * 2;
 
     return subtractedHeights <= 0 ? 0 : subtractedHeights;
-  }
-
-  /**
-   * Largura de área de plotagem das séries designada para gráficos do tipo linha e área.
-   *
-   * Contempla:
-   *   - a largura do svg: svgWidth.
-   *   - área dos labels eixo X: PoChartAxisXLabelArea
-   *   - espaços laterais dentro do eixo: svgAxisSideSpace
-   *
-   * > A largura máxima para 'svgAxisSideSpace' é de 48px.
-   */
-  private svgPlottingAreaWidth(svgWidth: number) {
-    return svgWidth - PoChartAxisXLabelArea;
   }
 
   /**


### PR DESCRIPTION
**chart**

**DTHFUI-4552**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A área relativa aos textos dos eixos X era fixa. Categorias ou valores de série com uma grandes larguras quebravam o gráfico. 

**Qual o novo comportamento?**
Agora a área dos textos de eixo X é calculada de acordo com a largura do texto maior. Para gráficos do tipo `bar`, as categorias que são lançadas como label do eixo X. Já para os tipos `column` e `line`, são os valores das séries.

**Simulação**
Sample labs aceita toda manipulação necessária para testes.