### PR TITLE
fix(page-slide): corrige focus ao usar modal dentro do page-slide

### DIFF
--- a/projects/ui/src/lib/components/po-modal/index.ts
+++ b/projects/ui/src/lib/components/po-modal/index.ts
@@ -1,5 +1,4 @@
 export * from './po-modal-action.interface';
 export * from './po-modal.component';
-export * from './po-modal-service';
 
 export * from './po-modal.module';

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 
 import { PoButtonModule } from '../po-button';
 
+import { PoActiveOverlayService } from '../../services/po-active-overlay/po-active-overlay.service';
 import { PoCleanComponent } from './../po-field/po-clean/po-clean.component';
 import { PoFieldContainerBottomComponent } from './../po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from './../po-field/po-field-container/po-field-container.component';
@@ -13,7 +14,6 @@ import { PoInputComponent } from './../po-field/po-input/po-input.component';
 import { PoModalAction } from './po-modal-action.interface';
 import { PoModalBaseComponent } from './po-modal-base.component';
 import { PoModalComponent } from './po-modal.component';
-import { PoModalService } from './po-modal-service';
 
 @Component({
   template: `
@@ -51,7 +51,7 @@ describe('PoModalComponent:', () => {
         ContentProjectionComponent,
         PoFieldContainerBottomComponent
       ],
-      providers: [PoModalService]
+      providers: [PoActiveOverlayService]
     });
     fixture = TestBed.createComponent(PoModalComponent);
     component = fixture.componentInstance;
@@ -231,7 +231,7 @@ describe('PoModalComponent:', () => {
     expect(element.nativeElement.querySelectorAll('.po-button').length).toBe(1);
   });
 
-  it(`focusFunction: should call 'stopPropagation' if 'modalActive' is equal to id`, () => {
+  it(`focusFunction: should call 'stopPropagation' if 'activeOverlay' is equal to id`, () => {
     const fakeEvent = {
       target: 'click',
       stopPropagation: () => {}
@@ -241,7 +241,7 @@ describe('PoModalComponent:', () => {
       focus: () => {}
     };
     component['id'] = '1';
-    component['poModalService'] = { modalActive: undefined };
+    component['poActiveOverlayService'] = { activeOverlay: undefined };
     component['modalContent'] = {
       nativeElement: {
         contains: () => 0

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.ts
@@ -1,8 +1,9 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 
 import { PoModalBaseComponent } from './po-modal-base.component';
-import { PoModalService } from './po-modal-service';
 import { uuid } from '../../utils/util';
+
+import { PoActiveOverlayService } from '../../services/po-active-overlay/po-active-overlay.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 /**
@@ -39,12 +40,12 @@ export class PoModalComponent extends PoModalBaseComponent {
   private id: string = uuid();
   private sourceElement;
 
-  constructor(private poModalService: PoModalService, poLanguageService: PoLanguageService) {
+  constructor(private poActiveOverlayService: PoActiveOverlayService, poLanguageService: PoLanguageService) {
     super(poLanguageService);
   }
 
   close(xClosed = false) {
-    this.poModalService.modalActive = undefined;
+    this.poActiveOverlayService.activeOverlay = undefined;
 
     super.close(xClosed);
 
@@ -86,7 +87,7 @@ export class PoModalComponent extends PoModalBaseComponent {
   }
 
   private handleFocus(): any {
-    this.poModalService.modalActive = this.id;
+    this.poActiveOverlayService.activeOverlay = this.id;
 
     setTimeout(() => {
       if (this.modalContent) {
@@ -98,10 +99,10 @@ export class PoModalComponent extends PoModalBaseComponent {
 
   private initFocus() {
     this.focusFunction = (event: any) => {
-      this.poModalService.modalActive = this.poModalService.modalActive || this.id;
+      this.poActiveOverlayService.activeOverlay = this.poActiveOverlayService.activeOverlay || this.id;
       const modalElement = this.modalContent.nativeElement;
 
-      if (!modalElement.contains(event.target) && this.poModalService.modalActive === this.id) {
+      if (!modalElement.contains(event.target) && this.poActiveOverlayService.activeOverlay === this.id) {
         event.stopPropagation();
         this.firstElement.focus();
       }

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
+import { PoActiveOverlayService } from '../../../services/po-active-overlay';
 import { PoFieldModule } from '../../po-field';
 import { PoPageSlideComponent } from './po-page-slide.component';
 
@@ -34,7 +35,8 @@ describe('PoPageSlideComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [FormsModule, NoopAnimationsModule, PoFieldModule],
-        declarations: [PoPageSlideComponent, TestComponent]
+        declarations: [PoPageSlideComponent, TestComponent],
+        providers: [PoActiveOverlayService]
       }).compileComponents();
     })
   );
@@ -55,6 +57,26 @@ describe('PoPageSlideComponent', () => {
 
   it('should create component', () => {
     expect(component instanceof PoPageSlideComponent).toBeTruthy();
+  });
+
+  describe('Methods:', () => {
+    it('focusEvent: should call `stopPropagation` if `activeOverlay` is equal to id', () => {
+      const fakeEvent = { target: 'click', stopPropagation: () => {} };
+
+      component['firstElement'] = <any>{ focus: () => {} };
+      component['id'] = '1';
+      component['poActiveOverlayService'] = { activeOverlay: undefined };
+      component['pageContent'] = { nativeElement: { contains: () => 0 } };
+      component.hideClose = true;
+
+      const spyEvent = spyOn(fakeEvent, 'stopPropagation');
+
+      component['initFocus']();
+      fixture.detectChanges();
+      component['focusEvent'](<any>fakeEvent);
+
+      expect(spyEvent).toHaveBeenCalled();
+    });
   });
 
   it('should open() and close() methods includes and removes component on DOM', () => {

--- a/projects/ui/src/lib/services/index.ts
+++ b/projects/ui/src/lib/services/index.ts
@@ -1,5 +1,6 @@
 export * from './services.module';
 
+export * from './po-active-overlay/index';
 export * from './po-color-palette/index';
 export * from './po-component-injector/index';
 export * from './po-control-position/index';

--- a/projects/ui/src/lib/services/po-active-overlay/index.ts
+++ b/projects/ui/src/lib/services/po-active-overlay/index.ts
@@ -1,0 +1,3 @@
+export * from './po-active-overlay.service';
+
+export * from './po-active-overlay.module';

--- a/projects/ui/src/lib/services/po-active-overlay/po-active-overlay.module.ts
+++ b/projects/ui/src/lib/services/po-active-overlay/po-active-overlay.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+
+import { PoActiveOverlayService } from './po-active-overlay.service';
+
+/**
+ * @description
+ *
+ * Módulo do serviço `po-active-overlay`.
+ */
+@NgModule({
+  providers: [PoActiveOverlayService],
+  bootstrap: []
+})
+export class PoActiveOverlayModule {}

--- a/projects/ui/src/lib/services/po-active-overlay/po-active-overlay.service.ts
+++ b/projects/ui/src/lib/services/po-active-overlay/po-active-overlay.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@angular/core';
 @Injectable({
   providedIn: 'root'
 })
-export class PoModalService {
-  modalActive: string;
+export class PoActiveOverlayService {
+  activeOverlay: string;
 }

--- a/projects/ui/src/lib/services/services.module.ts
+++ b/projects/ui/src/lib/services/services.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 
+import { PoActiveOverlayModule } from './po-active-overlay/po-active-overlay.module';
 import { PoColorPaletteModule } from './po-color-palette/po-color-palette.module';
 import { PoComponentInjectorModule } from './po-component-injector/po-component-injector.module';
 import { PoControlPositionModule } from './po-control-position/po-control-position.module';
@@ -12,6 +13,7 @@ import { PoNotificationModule } from './po-notification/po-notification.module';
 @NgModule({
   declarations: [PoI18nPipe],
   imports: [
+    PoActiveOverlayModule,
     PoColorPaletteModule,
     PoComponentInjectorModule,
     PoControlPositionModule,
@@ -21,6 +23,7 @@ import { PoNotificationModule } from './po-notification/po-notification.module';
     PoNotificationModule
   ],
   exports: [
+    PoActiveOverlayModule,
     PoColorPaletteModule,
     PoComponentInjectorModule,
     PoControlPositionModule,


### PR DESCRIPTION
**po-page-slide**

**DTHFUI-4666**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao usar modal ou um componente que chame a modal dentro do page-slide dá erro 'Maximum call stack size exceeded'.

**Qual o novo comportamento?**
Modificado serviço `PoModalService` para `PoActiveOverlayService` para controle de camada ativa (activeOverlay) através de repasse de id. Desta forma, o evento de focus do page-slide não será disparado caso o id seja diferente do declarado no serviço.

**Simulação**
Testar no exemplo anexado na issue (`po-lookup` inserido dentro do `po-page-slide`).
Testar também situação semelhante na modal (`po-lookup` dentro do `po-modal`).



