### PR TITLE
feat(chart): nova propriedade `PoChartOptions.legend`

### DIFF
--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-options.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-options.interface.ts
@@ -10,4 +10,7 @@ import { PoChartAxisOptions } from './po-chart-axis-options.interface';
 export interface PoChartOptions {
   /** Define um objeto do tipo `PoChartAxisOptions` para configuração dos eixos. */
   axis?: PoChartAxisOptions;
+
+  /** Define a exibição da legenda do gráfico. Valor padrão é `true` */
+  legend?: boolean;
 }

--- a/projects/ui/src/lib/components/po-chart/po-chart-base.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-base.component.ts
@@ -154,10 +154,11 @@ export abstract class PoChartBaseComponent implements OnChanges {
    *
    * Objeto com as configurações usadas no `po-chart`.
    *
-   * É possível definir as configurações dos eixos(*axis*) para os gráfico do tipo `Line`, `Column` e `Bar` da seguinte forma:
+   * É possível, por exemplo, definir as configurações de exibição das legendas, configurar os eixos(*axis*) para os gráfico do tipo `Line`, `Column` e `Bar` da seguinte forma:
    *
    * ```
    *  chartOptions: PoChartOptions = {
+   *    legend: true,
    *    axis: {
    *      minRange: 0,
    *      maxRange: 100,
@@ -170,6 +171,10 @@ export abstract class PoChartBaseComponent implements OnChanges {
   @Input('p-options') set options(value: PoChartOptions) {
     if (value instanceof Object && !(value instanceof Array)) {
       this._options = value;
+
+      if (this._options.hasOwnProperty('legend') && typeof this._options.legend === 'boolean') {
+        this.getSvgContainerSize();
+      }
     }
   }
 

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.html
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.html
@@ -17,7 +17,7 @@
   <!-- Diretiva para injeção de gráficos do tipo circular. Serão repassados para dentro do po-chart-container futuramente.  -->
   <ng-template #chartContainer></ng-template>
 
-  <div *ngIf="!isChartGaugeType">
+  <div *ngIf="!isChartGaugeType && options?.legend !== false">
     <ng-container *ngTemplateOutlet="chartLegendGroup"></ng-container>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
@@ -389,89 +389,113 @@ describe('PoChartComponent:', () => {
 
       expect(expectedResult).toBe(0);
     });
+
+    it('getSvgContainerSize: should call `containerService.calculateSVGContainerMeasurements` and `getChartMeasurements`', () => {
+      const chartMeasurements = { chartHeaderHeight: 100, chartLegendHeight: 200, chartWrapperWidth: 300 };
+
+      const spyCalculateSVGContainerMeasurements = spyOn(
+        component['containerService'],
+        'calculateSVGContainerMeasurements'
+      );
+      const spyGetChartMeasurements = spyOn(component, <any>'getChartMeasurements').and.returnValue(chartMeasurements);
+
+      component['getSvgContainerSize']();
+
+      expect(spyCalculateSVGContainerMeasurements).toHaveBeenCalledWith(
+        component.height,
+        chartMeasurements.chartWrapperWidth,
+        chartMeasurements.chartHeaderHeight,
+        chartMeasurements.chartLegendHeight
+      );
+      expect(spyGetChartMeasurements).toHaveBeenCalled();
+    });
+
+    it('getSvgContainerSize: should call `calculateAxisXLabelArea` if `type` isn`t a circular type', () => {
+      component.series = [{ data: [1, 2, 3], type: PoChartType.Column }];
+      component.type = PoChartType.Column;
+
+      const spyCalculateAxisXLabelArea = spyOn(component, <any>'calculateAxisXLabelArea');
+
+      component['getSvgContainerSize']();
+
+      expect(spyCalculateAxisXLabelArea).toHaveBeenCalled();
+    });
+
+    it('getSvgContainerSize: shouldn`t call `calculateAxisXLabelArea` if `type` is a circular type', () => {
+      component.series = [{ data: 12, type: PoChartType.Pie }];
+      component.type = PoChartType.Pie;
+
+      const spyCalculateAxisXLabelArea = spyOn(component, <any>'calculateAxisXLabelArea');
+
+      component['getSvgContainerSize']();
+
+      expect(spyCalculateAxisXLabelArea).not.toHaveBeenCalled();
+    });
+
+    it('calculateAxisXLabelArea: should call `calculateAxisXLabelArea` passing `Vancouver` as param if type is `bar`', () => {
+      component.chartType = PoChartType.Bar;
+      component.categories = ['Vancouver', 'Otawa'];
+      component.series = [
+        { data: [1, 2, 3], type: PoChartType.Bar },
+        { data: [2, 3, 4], type: PoChartType.Bar }
+      ];
+
+      const spyGetAxisXLabelArea = spyOn(component, <any>'getAxisXLabelArea');
+
+      component['calculateAxisXLabelArea']();
+
+      expect(spyGetAxisXLabelArea).toHaveBeenCalledWith(component.categories[0]);
+    });
+
+    it('calculateAxisXLabelArea: should call `calculateAxisXLabelArea` passing `10.75` relative to axis x label average value as param if type isn`t `bar`', () => {
+      component.chartType = PoChartType.Column;
+      component.categories = ['Vancouver', 'Otawa'];
+      component.chartSeries = [
+        { data: [1, 2, 3], type: PoChartType.Column },
+        { data: [2, 3, 40], type: PoChartType.Column }
+      ];
+
+      const spyGetAxisXLabelArea = spyOn(component, <any>'getAxisXLabelArea');
+
+      component['calculateAxisXLabelArea']();
+
+      expect(spyGetAxisXLabelArea).toHaveBeenCalledWith(10.75);
+    });
+
+    it('getAxisXLabelArea: should calculate and return axisXLabel width', () => {
+      const axisXLabel = 'Vancouver';
+
+      expect(component['getAxisXLabelArea'](axisXLabel)).toBe(76);
+    });
+
+    it('getAxisXLabelArea: should calculate and return PoChartAxisXLabelArea default width', () => {
+      const axisXLabel = 12;
+
+      expect(component['getAxisXLabelArea'](axisXLabel)).toBe(56);
+    });
   });
 
-  it('getSvgContainerSize: should call `containerService.calculateSVGContainerMeasurements` and `getChartMeasurements`', () => {
-    const chartMeasurements = { chartHeaderHeight: 100, chartLegendHeight: 200, chartWrapperWidth: 300 };
+  describe('Template', () => {
+    it('should have `po-chart-legend` class if `PoChartOptions.legend` is true', () => {
+      component.options = { legend: true };
+      component.series = [{ data: [1, 2, 3], label: 'Vancouver', type: PoChartType.Column }];
 
-    const spyCalculateSVGContainerMeasurements = spyOn(
-      component['containerService'],
-      'calculateSVGContainerMeasurements'
-    );
-    const spyGetChartMeasurements = spyOn(component, <any>'getChartMeasurements').and.returnValue(chartMeasurements);
+      fixture.detectChanges();
 
-    component['getSvgContainerSize']();
+      const chartLegendElement = nativeElement.querySelector('.po-chart-legend');
 
-    expect(spyCalculateSVGContainerMeasurements).toHaveBeenCalledWith(
-      component.height,
-      chartMeasurements.chartWrapperWidth,
-      chartMeasurements.chartHeaderHeight,
-      chartMeasurements.chartLegendHeight
-    );
-    expect(spyGetChartMeasurements).toHaveBeenCalled();
-  });
+      expect(chartLegendElement).toBeTruthy();
+    });
 
-  it('getSvgContainerSize: should call `calculateAxisXLabelArea` if `type` isn`t a circular type', () => {
-    component.series = [{ data: [1, 2, 3], type: PoChartType.Column }];
-    component.type = PoChartType.Column;
+    it('should have `po-chart-legend` class if `PoChartOptions.legend` is false', () => {
+      component.options = { legend: false };
+      component.series = [{ data: [1, 2, 3], label: 'Vancouver', type: PoChartType.Column }];
 
-    const spyCalculateAxisXLabelArea = spyOn(component, <any>'calculateAxisXLabelArea');
+      fixture.detectChanges();
 
-    component['getSvgContainerSize']();
+      const chartLegendElement = nativeElement.querySelector('.po-chart-legend');
 
-    expect(spyCalculateAxisXLabelArea).toHaveBeenCalled();
-  });
-
-  it('getSvgContainerSize: shouldn`t call `calculateAxisXLabelArea` if `type` is a circular type', () => {
-    component.series = [{ data: 12, type: PoChartType.Pie }];
-    component.type = PoChartType.Pie;
-
-    const spyCalculateAxisXLabelArea = spyOn(component, <any>'calculateAxisXLabelArea');
-
-    component['getSvgContainerSize']();
-
-    expect(spyCalculateAxisXLabelArea).not.toHaveBeenCalled();
-  });
-
-  it('calculateAxisXLabelArea: should call `calculateAxisXLabelArea` passing `Vancouver` as param if type is `bar`', () => {
-    component.chartType = PoChartType.Bar;
-    component.categories = ['Vancouver', 'Otawa'];
-    component.series = [
-      { data: [1, 2, 3], type: PoChartType.Bar },
-      { data: [2, 3, 4], type: PoChartType.Bar }
-    ];
-
-    const spyGetAxisXLabelArea = spyOn(component, <any>'getAxisXLabelArea');
-
-    component['calculateAxisXLabelArea']();
-
-    expect(spyGetAxisXLabelArea).toHaveBeenCalledWith(component.categories[0]);
-  });
-
-  it('calculateAxisXLabelArea: should call `calculateAxisXLabelArea` passing `10.75` relative to axis x label average value as param if type isn`t `bar`', () => {
-    component.chartType = PoChartType.Column;
-    component.categories = ['Vancouver', 'Otawa'];
-    component.chartSeries = [
-      { data: [1, 2, 3], type: PoChartType.Column },
-      { data: [2, 3, 40], type: PoChartType.Column }
-    ];
-
-    const spyGetAxisXLabelArea = spyOn(component, <any>'getAxisXLabelArea');
-
-    component['calculateAxisXLabelArea']();
-
-    expect(spyGetAxisXLabelArea).toHaveBeenCalledWith(10.75);
-  });
-
-  it('getAxisXLabelArea: should calculate and return axisXLabel width', () => {
-    const axisXLabel = 'Vancouver';
-
-    expect(component['getAxisXLabelArea'](axisXLabel)).toBe(76);
-  });
-
-  it('getAxisXLabelArea: should calculate and return PoChartAxisXLabelArea default width', () => {
-    const axisXLabel = 12;
-
-    expect(component['getAxisXLabelArea'](axisXLabel)).toBe(56);
+      expect(chartLegendElement).toBeNull();
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
@@ -86,7 +86,7 @@
     <po-divider class="po-md-12" p-label="Chart options"></po-divider>
 
     <po-number
-      class="po-md-4"
+      class="po-md-3"
       name="minRange"
       [(ngModel)]="options.axis.minRange"
       p-help="Example: 0"
@@ -96,7 +96,7 @@
     </po-number>
 
     <po-number
-      class="po-md-4"
+      class="po-md-3"
       name="maxRange"
       [(ngModel)]="options.axis.maxRange"
       p-help="Example: 100"
@@ -106,7 +106,7 @@
     </po-number>
 
     <po-number
-      class="po-md-4"
+      class="po-md-3"
       name="gridLines"
       [(ngModel)]="options.axis.gridLines"
       p-help="Example: 6"
@@ -114,6 +114,18 @@
       (p-blur)="addOptions()"
     >
     </po-number>
+
+    <po-checkbox-group
+      class="po-md-3"
+      name="propertiesOptions"
+      p-help="Boolean properties"
+      p-indeterminate
+      p-label="Properties"
+      [(ngModel)]="optionsActions"
+      [p-options]="propertiesOptions"
+      (p-change)="changeActionOptions()"
+    >
+    </po-checkbox-group>
   </div>
 
   <po-divider class="po-md-12"></po-divider>

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoChartSerie, PoChartType, PoSelectOption, PoChartOptions } from '@po-ui/ng-components';
+import { PoChartSerie, PoChartType, PoSelectOption, PoChartOptions, PoCheckboxGroupOption } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-chart-labs',
@@ -14,6 +14,7 @@ export class SamplePoChartLabsComponent implements OnInit {
   event: string;
   height: number;
   label: string;
+  optionsActions: PoChartOptions;
   series: Array<PoChartSerie>;
   serieType: PoChartType;
   title: string;
@@ -27,6 +28,8 @@ export class SamplePoChartLabsComponent implements OnInit {
     }
   };
 
+  readonly propertiesOptions: Array<PoCheckboxGroupOption> = [{ value: 'legend', label: 'Legend' }];
+
   readonly typeOptions: Array<PoSelectOption> = [
     { label: 'Donut', value: PoChartType.Donut },
     { label: 'Pie', value: PoChartType.Pie },
@@ -39,8 +42,8 @@ export class SamplePoChartLabsComponent implements OnInit {
     this.restore();
   }
 
-  addOptions() {
-    this.options = { ...this.options };
+  addOptions(actionOptions?: PoChartOptions) {
+    this.options = { ...this.options, ...(actionOptions ? { ...actionOptions } : {}) };
   }
 
   addCategories() {
@@ -50,8 +53,18 @@ export class SamplePoChartLabsComponent implements OnInit {
   addData() {
     const data = isNaN(this.data) ? this.convertToArray(this.data) : Math.floor(this.data);
     const type = this.serieType ?? this.type;
+    const color = this.color;
 
-    this.series = [...this.series, { label: this.label, data, tooltip: this.tooltip, color: this.color, type }];
+    this.series = [
+      ...this.series,
+      { label: this.label, data, tooltip: this.tooltip, ...(color ? { color } : {}), type }
+    ];
+  }
+
+  changeActionOptions() {
+    const legend = this.optionsActions.legend;
+
+    this.addOptions({ legend });
   }
 
   changeEvent(eventName: string, serieEvent: PoChartSerie): void {
@@ -59,6 +72,7 @@ export class SamplePoChartLabsComponent implements OnInit {
   }
 
   restore() {
+    this.color = undefined;
     this.type = undefined;
     this.serieType = undefined;
     this.label = undefined;
@@ -70,7 +84,11 @@ export class SamplePoChartLabsComponent implements OnInit {
     this.tooltip = undefined;
     this.data = undefined;
     this.allCategories = [];
+    this.optionsActions = {
+      legend: null
+    };
     this.options = {
+      ...this.optionsActions,
       axis: {
         minRange: undefined,
         maxRange: undefined,

--- a/projects/ui/src/lib/services/po-color/po-color.service.spec.ts
+++ b/projects/ui/src/lib/services/po-color/po-color.service.spec.ts
@@ -25,6 +25,14 @@ describe('PoColorService', () => {
         expect(service.defaultColors).toEqual(PoDefaultColors[0]);
       });
 
+      it('should apply value to `defaultColors` if data has property color but its value is undefined', () => {
+        const data = [{ from: 0, to: 50, color: undefined }];
+
+        service.getColors<any>(data);
+
+        expect(service.defaultColors).toEqual(PoDefaultColors[0]);
+      });
+
       it('should apply value to `defaultColors` if one of data list doesn`t contain property `color`', () => {
         const data = [
           { from: 0, to: 50, color: 'red' },

--- a/projects/ui/src/lib/services/po-color/po-color.service.ts
+++ b/projects/ui/src/lib/services/po-color/po-color.service.ts
@@ -35,8 +35,7 @@ export class PoColorService {
   }
 
   private verifyIfHasColorProperty<T extends PoColorArgs>(data: Array<T>): void {
-    const hasColorProperty = data.every(serie => serie.hasOwnProperty('color'));
-
+    const hasColorProperty = data.every(dataItem => dataItem.hasOwnProperty('color') && dataItem.color?.length > 0);
     if (!hasColorProperty) {
       this.defaultColors = this.getDefaultColors(data.length);
     }


### PR DESCRIPTION
**po-chart**

**DTHFUI-4732**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não há opção para desabilitar a exibição de legendas

**Qual o novo comportamento?**
Adicionada `PoChartOptions.legend` para que seja possível ocultar as legendas do chart e seu valor default é `true`;

ps.: reparada e sanada situação em que, se passado `PoChartOptions.color` com undefined, estourava erro no console.

**Simulação**
Sample Labs
