### PR TITLE
fix(modal): corrige controle de foco em modais

### DIFF
--- a/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
@@ -241,7 +241,7 @@ describe('PoModalComponent:', () => {
       focus: () => {}
     };
     component['id'] = '1';
-    component['poActiveOverlayService'] = { activeOverlay: undefined };
+    component['poActiveOverlayService'] = { activeOverlay: ['1'] };
     component['modalContent'] = {
       nativeElement: {
         contains: () => 0
@@ -343,11 +343,29 @@ describe('PoModalComponent:', () => {
       expect(spyOnHandleFocus).toHaveBeenCalled();
     });
 
+    it(`open: should append id to 'poActiveOverlayService.activeOverlay'.`, () => {
+      const expectedResult = [component['id']];
+
+      component.open();
+
+      expect(component['poActiveOverlayService'].activeOverlay).toEqual(expectedResult);
+    });
+
     it('close: should focus on source element ', () => {
       component.open();
       spyOn(component['sourceElement'], 'focus');
       component.close();
       expect(component['sourceElement'].focus).toHaveBeenCalled();
+    });
+
+    it('close: should remove id from `poActiveOverlayService.activeOverlay` list', () => {
+      component.open();
+
+      fixture.detectChanges();
+
+      component.close();
+
+      expect(component['poActiveOverlayService'].activeOverlay).toEqual([]);
     });
 
     describe('closeModalOnEscapeKey:', () => {

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.ts
@@ -45,7 +45,7 @@ export class PoModalComponent extends PoModalBaseComponent {
   }
 
   close(xClosed = false) {
-    this.poActiveOverlayService.activeOverlay = undefined;
+    this.poActiveOverlayService.activeOverlay.pop();
 
     super.close(xClosed);
 
@@ -80,14 +80,12 @@ export class PoModalComponent extends PoModalBaseComponent {
 
   open() {
     this.sourceElement = document.activeElement;
-
     super.open();
-
     this.handleFocus();
   }
 
   private handleFocus(): any {
-    this.poActiveOverlayService.activeOverlay = this.id;
+    this.poActiveOverlayService.activeOverlay.push(this.id);
 
     setTimeout(() => {
       if (this.modalContent) {
@@ -99,10 +97,12 @@ export class PoModalComponent extends PoModalBaseComponent {
 
   private initFocus() {
     this.focusFunction = (event: any) => {
-      this.poActiveOverlayService.activeOverlay = this.poActiveOverlayService.activeOverlay || this.id;
       const modalElement = this.modalContent.nativeElement;
 
-      if (!modalElement.contains(event.target) && this.poActiveOverlayService.activeOverlay === this.id) {
+      if (
+        !modalElement.contains(event.target) &&
+        this.poActiveOverlayService.activeOverlay[this.poActiveOverlayService.activeOverlay.length - 1] === this.id
+      ) {
         event.stopPropagation();
         this.firstElement.focus();
       }

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
@@ -65,7 +65,7 @@ describe('PoPageSlideComponent', () => {
 
       component['firstElement'] = <any>{ focus: () => {} };
       component['id'] = '1';
-      component['poActiveOverlayService'] = { activeOverlay: undefined };
+      component['poActiveOverlayService'] = { activeOverlay: ['1'] };
       component['pageContent'] = { nativeElement: { contains: () => 0 } };
       component.hideClose = true;
 
@@ -76,6 +76,25 @@ describe('PoPageSlideComponent', () => {
       component['focusEvent'](<any>fakeEvent);
 
       expect(spyEvent).toHaveBeenCalled();
+    });
+
+    it('open: should append id value to `poActiveOverlayService.activeOverlay` list', () => {
+      component.open();
+
+      fixture.detectChanges();
+
+      component['handleFocus']();
+
+      expect(component['poActiveOverlayService'].activeOverlay).toEqual([component['id']]);
+    });
+
+    it('close: should remove id value from `poActiveOverlayService.activeOverlay` list', () => {
+      component.open();
+      fixture.detectChanges();
+
+      component.close();
+
+      expect(component['poActiveOverlayService'].activeOverlay).toEqual([]);
     });
   });
 

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
@@ -81,7 +81,7 @@ export class PoPageSlideComponent extends PoPageSlideBaseComponent {
   }
 
   public close(): void {
-    this.poActiveOverlayService.activeOverlay = undefined;
+    this.poActiveOverlayService.activeOverlay.pop();
     super.close();
 
     this.removeEventListeners();
@@ -95,7 +95,7 @@ export class PoPageSlideComponent extends PoPageSlideBaseComponent {
   }
 
   private handleFocus(): void {
-    this.poActiveOverlayService.activeOverlay = this.id;
+    this.poActiveOverlayService.activeOverlay.push(this.id);
     this.loadFirstElement();
     this.initFocus();
 
@@ -105,11 +105,9 @@ export class PoPageSlideComponent extends PoPageSlideBaseComponent {
   private initFocus() {
     // O foco não pode sair da página.
     this.focusEvent = (event: Event) => {
-      this.poActiveOverlayService.activeOverlay = this.poActiveOverlayService.activeOverlay || this.id;
-
       if (
         !this.pageContent.nativeElement.contains(event.target) &&
-        this.poActiveOverlayService.activeOverlay === this.id
+        this.poActiveOverlayService.activeOverlay[this.poActiveOverlayService.activeOverlay.length - 1] === this.id
       ) {
         event.stopPropagation();
         this.firstElement.focus();

--- a/projects/ui/src/lib/services/po-active-overlay/po-active-overlay.service.ts
+++ b/projects/ui/src/lib/services/po-active-overlay/po-active-overlay.service.ts
@@ -4,5 +4,5 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class PoActiveOverlayService {
-  activeOverlay: string;
+  activeOverlay: Array<string> = [];
 }


### PR DESCRIPTION
**po-modal**

**DTHFUI-4749**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O controle de modal ativa para implementação do foco se perdia quando se tratava de múltiplas camadas de modal. 


**Qual o novo comportamento?**
Foi alterado o tipo em `PoActiveOverlayService.activeOverlay` para `Array<string>` e, desta forma, manter armazenada a lista de ids para a validação da modal ativa.

**Simulação**
Favor testar com o código abaixo que exemplifica múltiplas camadas de modal. Pode também modificar a primeira referência de `po-modal` para `po-page-slide` para uma simulação com modal inserida dentro de page-slide.

````
<po-page-default p-title="PO UI">

    <po-modal #inclusaoPrevisaoEntrega p-title="Erro com Po-Page Slide" p-click-out="true">
        <po-lookup name="lookup" p-field-label="label" p-field-value="value"
        p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
        p-label="Abrir PO Lookup - Ao clicar em algum registro ocorre erro.">
        </po-lookup>
    
        <po-button p-label="ABRIR modal 3" (p-click)="modal1.open()"></po-button>
    </po-modal>
    
    <po-button p-label="Page Slide" p-type="primary" (p-click)="inclusaoPrevisaoEntrega.open()">
    </po-button>
</po-page-default>
    
<po-modal #modal1>
    <po-lookup name="lookup" p-field-label="label" p-field-value="value"
    p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
    p-label="Abrir PO Lookup - Ao clicar em algum registro ocorre erro.">
    </po-lookup>

    <po-button p-label="ABRIR modal 4" (p-click)="modal2.open()"></po-button>
</po-modal>

<po-modal #modal2>
    <po-lookup name="lookup" p-field-label="label" p-field-value="value"
    p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
    p-label="Abrir PO Lookup - Ao clicar em algum registro ocorre erro.">
    </po-lookup>

    <po-button p-label="ABRIR modal 5" (p-click)="modal3.open()"></po-button>
</po-modal>

<po-modal #modal3>
    <po-lookup name="lookup" p-field-label="label" p-field-value="value"
    p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
    p-label="Abrir PO Lookup - Ao clicar em algum registro ocorre erro.">
    </po-lookup>
</po-modal>
````
