### PR TITLE
feat(interceptor): permite informar type no retorno do erro

### DIFF
--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -40,7 +40,7 @@ Para todas as mensagens que representam um erro (códigos HTTP 4xx e 5xx) deve-s
 Opcionalmente pode-se retornar os campos:
 
 - `helpUrl`: link para a documentação do erro;
-- `type`: pode ser informado os seguintes valores: `success`, `information`, `warning` e `error`;
+- `type`: pode ser informado os seguintes valores: `error`, `warning` e `information`;
 - `details`: lista de objetos de erro (recursiva) com mais detalhes sobre o erro principal.
 
 ```

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.spec.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.spec.ts
@@ -30,6 +30,8 @@ describe('PoHttpInterceptorBaseService', () => {
   let errResponse: HttpErrorResponse;
 
   let mockErrorResponse;
+  let mockWarningResponse;
+  let mockInfoResponse;
   let mockErrorServerNotResponding;
   let mockSuccessResponse;
   let poErrorMessage;
@@ -53,6 +55,8 @@ describe('PoHttpInterceptorBaseService', () => {
 
   beforeEach(() => {
     mockErrorResponse = { status: 404, statusText: 'Bad Request' };
+    mockWarningResponse = { status: 102, statusText: 'Processing', type: 'warning' };
+    mockInfoResponse = { status: 102, statusText: 'Processing', type: 'info' };
     mockErrorServerNotResponding = { status: 0, statusText: 'Server not responding' };
     mockSuccessResponse = { status: 200, statusText: 'Success' };
     poErrorMessage = { message: 'erro po', code: '1', detailedMessage: '', details: [{}], helpUrl: '' };
@@ -135,6 +139,78 @@ describe('PoHttpInterceptorBaseService', () => {
 
       poErrorMessage.details = undefined;
       poErrorMessage.detailedMessage = undefined;
+
+      http.get('/data').subscribe(
+        res => (response = res),
+        err => (errResponse = err)
+      );
+
+      httpMock.expectOne('/data').flush(poErrorMessage, mockErrorResponse);
+
+      expect(service.notification.error).toHaveBeenCalledWith({
+        message: poErrorMessage.message,
+        actionLabel: undefined,
+        action: undefined
+      });
+    }
+  ));
+
+  it('should show warning notification', inject(
+    [HttpClient, HttpTestingController],
+    (http: HttpClient, httpMock: HttpTestingController) => {
+      spyOn(service.notification, 'warning');
+
+      poErrorMessage.details = undefined;
+      poErrorMessage.detailedMessage = undefined;
+      poErrorMessage.type = 'warning';
+
+      http.get('/data').subscribe(
+        res => (response = res),
+        err => (errResponse = err)
+      );
+
+      httpMock.expectOne('/data').flush(poErrorMessage, mockWarningResponse);
+
+      expect(service.notification.warning).toHaveBeenCalledWith({
+        message: poErrorMessage.message,
+        actionLabel: undefined,
+        action: undefined
+      });
+    }
+  ));
+
+  it('should show information notification', inject(
+    [HttpClient, HttpTestingController],
+    (http: HttpClient, httpMock: HttpTestingController) => {
+      spyOn(service.notification, 'information');
+
+      poErrorMessage.details = undefined;
+      poErrorMessage.detailedMessage = undefined;
+      poErrorMessage.type = 'information';
+
+      http.get('/data').subscribe(
+        res => (response = res),
+        err => (errResponse = err)
+      );
+
+      httpMock.expectOne('/data').flush(poErrorMessage, mockInfoResponse);
+
+      expect(service.notification.information).toHaveBeenCalledWith({
+        message: poErrorMessage.message,
+        actionLabel: undefined,
+        action: undefined
+      });
+    }
+  ));
+
+  it('should show error notification when return invalid type', inject(
+    [HttpClient, HttpTestingController],
+    (http: HttpClient, httpMock: HttpTestingController) => {
+      spyOn(service.notification, 'error');
+
+      poErrorMessage.details = undefined;
+      poErrorMessage.detailedMessage = undefined;
+      poErrorMessage.type = 'angular';
 
       http.get('/data').subscribe(
         res => (response = res),

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
@@ -120,6 +120,7 @@ const NO_MESSAGE_HEADER_PARAM = 'X-PO-No-Message';
  *
  * - `helpUrl`: link para a documentação do erro;
  *    - Caso for informado, será exibido uma ação de "Ajuda" na notificação, para isso não deverá ter a propriedade `detailedMessage`.
+ * - `type`: É possível informar `error`, `warning` e `information`, sendo `error` o valor padrão.
  * - `details`: Uma lista de objetos de mensagem (recursiva) com mais detalhes sobre a mensagem principal.
  *
  * > Veja o [Guia de implementação de APIs](guides/api) para mais detalhes sobre a estrutura das mensagens.
@@ -201,9 +202,13 @@ export abstract class PoHttpInterceptorBaseService implements HttpInterceptor {
 
     const hasNoErrorParam = this.hasNoErrorParam(request);
     const hasNoMessageParam = this.hasNoMessageParam(request);
+    const errorResponseValidTypes = this.notificationTypes.slice(1);
 
     if (errorResponse && errorResponse.message && !hasNoErrorParam && !hasNoMessageParam) {
-      this.showNotification({ ...errorResponse, type: 'error' });
+      this.showNotification({
+        ...errorResponse,
+        type: errorResponseValidTypes.includes(errorResponse.type) ? errorResponse.type : 'error'
+      });
     }
   }
 

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail-literals.interface.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail-literals.interface.ts
@@ -5,7 +5,7 @@ export const poHttpInterceptorDetailLiteralsDefault = {
     detail: 'Detail',
     error: 'Error',
     warning: 'Warning',
-    info: 'Information',
+    information: 'Information',
     success: 'Success'
   },
   es: <any>{
@@ -14,7 +14,7 @@ export const poHttpInterceptorDetailLiteralsDefault = {
     detail: 'Detalle',
     error: 'Error',
     warning: 'Advertencia',
-    info: 'Informacion',
+    information: 'Informacion',
     success: 'Éxito'
   },
   pt: <any>{
@@ -23,7 +23,7 @@ export const poHttpInterceptorDetailLiteralsDefault = {
     detail: 'Detalhe',
     error: 'Erro',
     warning: 'Aviso',
-    info: 'Informação',
+    information: 'Informação',
     success: 'Sucesso'
   },
   ru: <any>{
@@ -32,7 +32,7 @@ export const poHttpInterceptorDetailLiteralsDefault = {
     detail: 'Деталь',
     error: 'Ошибка',
     warning: 'Предупреждение',
-    info: 'Информация',
+    information: 'Информация',
     success: 'Yспех'
   }
 };


### PR DESCRIPTION
Permite informar o tipo da notificação que será exibida quando ocorrer algum erro de negócio.

Fixes DTHFUI-4750

**PO-HTTP-INTERCEPTOR**

**DTHFUI-4750**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Sempre que o interceptor recebe um erro, é sempre exibido como erro. Ignorando o tipo enviado.


**Qual o novo comportamento?**
O componente valida o tipo do erro, e exibe entre os tipos possíveis ('error', 'warning' ou 'information'), caso não esteja dentro dos tipos possíveis ou não seja enviado, o componente exibe como 'error'.


**Simulação**
Para testar é preciso usar o  `SamplePoHttpInterceptorLabsComponent` passandos os seguintes itens abaixo de acordo com o tipo informado.

`Warning`
```
{
    "code": "401",
    "message": "Not Authorized",
    "detailedMessage": "The request has not been applied because it lacks valid authentication credentials for the target resource.",
    "type": "warning",
    "helpUrl": "",
    "details": [{
        "code": "406",
        "message": "Not Acceptable",
        "detailedMessage": "The target resource does not have a current representation that would be acceptable to the user agent",
        "type": "warning"
    }]
}
```

`Information`
```
{
    "code": "401",
    "message": "Not Authorized",
    "detailedMessage": "The request has not been applied because it lacks valid authentication credentials for the target resource.",
    "type": "information",
    "helpUrl": "",
    "details": [{
        "code": "406",
        "message": "Not Acceptable",
        "detailedMessage": "The target resource does not have a current representation that would be acceptable to the user agent",
        "type": "information"
    }]
}
```

`Outro tipo`
```
{
    "code": "401",
    "message": "Not Authorized",
    "detailedMessage": "The request has not been applied because it lacks valid authentication credentials for the target resource.",
    "type": "other",
    "helpUrl": "",
    "details": [{
        "code": "406",
        "message": "Not Acceptable",
        "detailedMessage": "The target resource does not have a current representation that would be acceptable to the user agent",
        "type": "other"
    }]
}
```