### PR TITLE
feat(chart): permite valores negativos em gráficos do tipo `column`

### DIFF
--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-axis-options.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-axis-options.interface.ts
@@ -34,6 +34,8 @@ export interface PoChartAxisOptions {
    * Se por acaso o valor mínimo das séries for inferior ao definido aqui, esta propriedade será ignorada.
    *
    * > Esta definição não deve refletir na plotagem das séries. Os valores máximos e mínimos encontrados nas séries serão as bases para seus alcance.
+   *
+   * > Gráficos do tipo `Bar` não possuem implementação de tratamento para valores negativos. Por conta disso, neste caso não é possível declarar valor negativo para `minRange`.
    */
   minRange?: number;
 }

--- a/projects/ui/src/lib/components/po-chart/po-chart-base.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-base.component.ts
@@ -166,7 +166,7 @@ export abstract class PoChartBaseComponent implements OnChanges {
    *    },
    *  };
    * ```
-   * > Para gráficos dos tipos `Column` e `Bar`, não será aceito valor negativo para a cofiguração `axis.minRange`.
+   * > Gráficos do tipo `Bar` não possuem implementação de tratamento para valores negativos. Por conta disso, neste caso não é possível declarar valor negativo para a configuração `axis.minRange`.
    */
   @Input('p-options') set options(value: PoChartOptions) {
     if (value instanceof Object && !(value instanceof Array)) {

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-axis/po-chart-axis.component.spec.ts
@@ -11,6 +11,7 @@ import { PoChartType } from '../../enums/po-chart-type.enum';
 describe('PoChartAxisComponent', () => {
   let component: PoChartAxisComponent;
   let fixture: ComponentFixture<PoChartAxisComponent>;
+  let nativeElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -23,6 +24,8 @@ describe('PoChartAxisComponent', () => {
     fixture = TestBed.createComponent(PoChartAxisComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    nativeElement = fixture.debugElement.nativeElement;
   });
 
   it('should create', () => {
@@ -292,7 +295,7 @@ describe('PoChartAxisComponent', () => {
 
       component['setAxisXCoordinates'](gridLines, seriesLength, containerSize, minMaxAxisValues, type);
 
-      expect(spyCalculateAxisXCoordinates).toHaveBeenCalledWith(seriesLength + 1, containerSize);
+      expect(spyCalculateAxisXCoordinates).toHaveBeenCalledWith(seriesLength + 1, containerSize, minMaxAxisValues);
       expect(spyCalculateAxisXLabelCoordinates).toHaveBeenCalledWith(
         seriesLength,
         containerSize,
@@ -323,7 +326,7 @@ describe('PoChartAxisComponent', () => {
 
       component['setAxisXCoordinates'](gridLines, seriesLength, containerSize, minMaxAxisValues, type);
 
-      expect(spyCalculateAxisXCoordinates).toHaveBeenCalledWith(gridLines, containerSize);
+      expect(spyCalculateAxisXCoordinates).toHaveBeenCalledWith(gridLines, containerSize, minMaxAxisValues);
       expect(spyCalculateAxisXLabelCoordinates).toHaveBeenCalledWith(gridLines, containerSize, minMaxAxisValues, type);
     });
 
@@ -883,9 +886,16 @@ describe('PoChartAxisComponent', () => {
           axisXLabelWidth: 72,
           svgPlottingAreaHeight: 280
         };
+        const fakeMinMaxAxisValues: PoChartMinMaxValues = {
+          minValue: 1,
+          maxValue: 3
+        };
+
+        component['axisXLabels'] = ['-20', '11', '40'];
+
         const spyCalculateAxisXCoordinateY = spyOn(component, <any>'calculateAxisXCoordinateY').and.callThrough();
 
-        component['calculateAxisXCoordinates'](amountOfAxisX, containerSize);
+        component['calculateAxisXCoordinates'](amountOfAxisX, containerSize, fakeMinMaxAxisValues);
 
         expect(spyCalculateAxisXCoordinateY).toHaveBeenCalledTimes(2);
       });
@@ -900,10 +910,16 @@ describe('PoChartAxisComponent', () => {
           axisXLabelWidth: 72,
           svgPlottingAreaHeight: 280
         };
+        const fakeMinMaxAxisValues: PoChartMinMaxValues = {
+          minValue: 1,
+          maxValue: 3
+        };
+
+        component['axisXLabels'] = ['-20', '11', '40'];
 
         const spyCalculateAxisXCoordinateY = spyOn(component, <any>'calculateAxisXCoordinateY').and.callThrough();
 
-        component['calculateAxisXCoordinates'](amountOfAxisX, containerSize);
+        component['calculateAxisXCoordinates'](amountOfAxisX, containerSize, fakeMinMaxAxisValues);
 
         expect(spyCalculateAxisXCoordinateY).toHaveBeenCalledTimes(2);
       });
@@ -958,6 +974,32 @@ describe('PoChartAxisComponent', () => {
       component['getAxisYLabels'](component.type, component['minMaxAxisValues'], 5);
 
       expect(spyGenerateAverageOfLabels).toHaveBeenCalled();
+    });
+  });
+
+  describe('Template', () => {
+    it(`should contain an extra axis X line related to value 'zero'`, () => {
+      component.allowNegativeData = true;
+      component.type = PoChartType.Column;
+      component.series = [{ data: [-25, 58, 83, 66], label: 'Vancouver', type: PoChartType.Column }];
+
+      fixture.detectChanges();
+
+      const chartBarElement = nativeElement.querySelectorAll('.po-chart-axis-path');
+      expect(chartBarElement).toBeTruthy();
+      expect(chartBarElement.length).toBe(11);
+    });
+
+    it(`shouldn't contain an extra axis X line if one of axisXLabel's value is zero`, () => {
+      component.allowNegativeData = true;
+      component.type = PoChartType.Column;
+      component.series = [{ data: [0, 58, 83, 66], label: 'Vancouver', type: PoChartType.Column }];
+
+      fixture.detectChanges();
+
+      const chartBarElement = nativeElement.querySelectorAll('.po-chart-axis-path');
+      expect(chartBarElement).toBeTruthy();
+      expect(chartBarElement.length).toBe(10);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.spec.ts
@@ -86,28 +86,8 @@ describe('PoChartColumnComponent', () => {
           minMaxSeriesValues,
           serieValue
         );
-        expect(expectedResult).toBe('M 82 28 L 92 28 L 92 28 L 82 28 z');
+        expect(expectedResult).toBe('M 82 28 L 92 28 L 92 29 L 82 29 z');
       });
-    });
-
-    it('should consider serieValue as 0 for calculations if it is a negative value', () => {
-      component.series = [
-        { label: 'category', data: [-10, 2, 3] },
-        { label: 'category B', data: [10, 20, 30] }
-      ];
-      const seriesIndex = 0;
-      const serieItemDataIndex = 0;
-      const minMaxSeriesValues = { minValue: 0, maxValue: 30 };
-      const serieValue = -10;
-
-      const expectedResult = component['barCoordinates'](
-        seriesIndex,
-        serieItemDataIndex,
-        component.containerSize,
-        minMaxSeriesValues,
-        serieValue
-      );
-      expect(expectedResult).toBe('M 82 28 L 92 28 L 92 28 L 82 28 z');
     });
 
     it('shouldn`t subctract the spaceBetweenBars calculation by the X coordinate if series.length is lower than 2', () => {
@@ -125,7 +105,7 @@ describe('PoChartColumnComponent', () => {
         minMaxSeriesValues,
         serieValue
       );
-      expect(expectedResult).toBe('M 86 28 L 100 28 L 100 28 L 86 28 z');
+      expect(expectedResult).toBe('M 86 28 L 100 28 L 100 38 L 86 38 z');
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-column/po-chart-column.component.ts
@@ -89,11 +89,12 @@ export class PoChartColumnComponent extends PoChartBarBaseComponent {
   }
 
   private yCoordinates(minMaxSeriesValues: PoChartMinMaxValues, svgPlottingAreaHeight: number, serieValue: number) {
-    // TO DO: tratamento para valores negativos.
-    const filterNegativeSerieValue = serieValue <= 0 ? 0 : serieValue;
+    const valueZeroPercentage = this.mathsService.getSeriePercentage(minMaxSeriesValues, 0);
+    const y1 = Math.round(
+      svgPlottingAreaHeight - svgPlottingAreaHeight * valueZeroPercentage + PoChartPlotAreaPaddingTop
+    );
 
-    const yRatio = this.mathsService.getSeriePercentage(minMaxSeriesValues, filterNegativeSerieValue);
-    const y1 = Math.round(svgPlottingAreaHeight + PoChartPlotAreaPaddingTop);
+    const yRatio = this.mathsService.getSeriePercentage(minMaxSeriesValues, serieValue);
     const y2 = Math.round(svgPlottingAreaHeight - svgPlottingAreaHeight * yRatio + PoChartPlotAreaPaddingTop);
 
     return { y1, y2 };

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.spec.ts
@@ -205,22 +205,22 @@ describe('PoChartContainerComponent', () => {
       expect(spyGetRange).not.toHaveBeenCalled();
     });
 
-    it('seriesTypeLine: should return true if all series type are `PoChartType.Line`', () => {
+    it('allowSeriesWithNegativeValues: should return true if all series type are `PoChartType.Line` or `PoChartType.Column`', () => {
       const chartSeries = [
         { data: [10, 2, 300], label: 'Vancouver', type: PoChartType.Line },
-        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Line }
+        { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Column }
       ];
 
-      expect(component['seriesTypeLine'](chartSeries)).toBeTruthy();
+      expect(component['allowSeriesWithNegativeValues'](chartSeries)).toBeTruthy();
     });
 
-    it('seriesTypeLine: should return false if series have a serie with `type` property value different of `line`', () => {
+    it('allowSeriesWithNegativeValues: should return false if series have a serie with `type` property value different of `line` or `column`', () => {
       const chartSeries = [
         { data: [10, 2, 300], label: 'Vancouver', type: PoChartType.Line },
         { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Bar }
       ];
 
-      expect(component['seriesTypeLine'](chartSeries)).toBeFalsy();
+      expect(component['allowSeriesWithNegativeValues'](chartSeries)).toBeFalsy();
     });
 
     it('verifyAxisOptions: shouldn`t call `getRange` if `isTypeCircular` is false', () => {
@@ -271,8 +271,8 @@ describe('PoChartContainerComponent', () => {
   });
 
   describe('Properties: ', () => {
-    it('p-series: should `seriesTypeLine` `setSeriesByType` and `setRange`', () => {
-      const spySeriesTypeLine = spyOn(component, <any>['seriesTypeLine']);
+    it('p-series: should `allowSeriesWithNegativeValues` `setSeriesByType` and `setRange`', () => {
+      const spyAllowSeriesWithNegativeValues = spyOn(component, <any>['allowSeriesWithNegativeValues']);
       const spysetSeriesByType = spyOn(component, <any>['setSeriesByType']).and.callThrough();
       const spySetRange = spyOn(component, <any>['setRange']);
 
@@ -286,7 +286,7 @@ describe('PoChartContainerComponent', () => {
         { data: [4, 2, 2], label: 'Toronto', type: PoChartType.Column, color: '#29B6C5' }
       ];
 
-      expect(spySeriesTypeLine).toHaveBeenCalledWith(seriesWithColor);
+      expect(spyAllowSeriesWithNegativeValues).toHaveBeenCalledWith(seriesWithColor);
       expect(spysetSeriesByType).toHaveBeenCalledWith(seriesWithColor);
       expect(spySetRange).toHaveBeenCalledWith(seriesWithColor, component.options);
     });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.ts
@@ -46,7 +46,7 @@ export class PoChartContainerComponent implements OnChanges {
 
   @Input('p-series') set series(data: Array<PoChartSerie>) {
     this._series = data;
-    this.allowNegativeData = this.seriesTypeLine(this._series);
+    this.allowNegativeData = this.allowSeriesWithNegativeValues(this._series);
     this.setSeriesByType(this._series);
     this.setRange(this._series, this.options);
   }
@@ -78,7 +78,7 @@ export class PoChartContainerComponent implements OnChanges {
   private getRange(series: Array<PoChartSerie>, options: PoChartOptions = {}): PoChartMinMaxValues {
     const domain = this.mathsService.calculateMinAndMaxValues(series, this.allowNegativeData);
     const minValue =
-      !this.allowNegativeData && !options.axis?.minRange
+      (!this.allowNegativeData && !options.axis?.minRange) || (this.allowNegativeData && domain.minValue > 0)
         ? 0
         : options.axis?.minRange < domain.minValue
         ? options.axis.minRange
@@ -95,8 +95,8 @@ export class PoChartContainerComponent implements OnChanges {
     }
   }
 
-  private seriesTypeLine(series: Array<PoChartSerie>): boolean {
-    return series.every(serie => serie.type === PoChartType.Line);
+  private allowSeriesWithNegativeValues(series: Array<PoChartSerie>): boolean {
+    return series.every(serie => serie.type === PoChartType.Line || serie.type === PoChartType.Column);
   }
 
   private setSeriesByType(series: Array<PoChartSerie>) {

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts
@@ -55,8 +55,8 @@ export class SamplePoChartCoffeeRankingComponent {
 
   evolutionOfCoffeeAndSomeCompetitors: Array<PoChartSerie> = [
     { label: '2014', data: [91, 40, 42], type: PoChartType.Column },
-    { label: '2017', data: [93, 52, 39], type: PoChartType.Column },
-    { label: '2020', data: [95, 46, 31], type: PoChartType.Column },
+    { label: '2017', data: [93, 52, 18], type: PoChartType.Column },
+    { label: '2020', data: [95, 21, -17], type: PoChartType.Column },
     { label: 'Coffee consumption in Brazil', data: [34, 27, 79], type: PoChartType.Line, color: 'color-10' }
   ];
 
@@ -98,9 +98,9 @@ export class SamplePoChartCoffeeRankingComponent {
 
   optionsColumn: PoChartOptions = {
     axis: {
-      minRange: 0,
+      minRange: -20,
       maxRange: 100,
-      gridLines: 5
+      gridLines: 7
     }
   };
 

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
@@ -48,6 +48,17 @@ describe('PoChartMathsService', () => {
       expect(service.calculateMinAndMaxValues(series, acceptNegativeValues)).toEqual(expectedResult);
     });
 
+    it('calculateMinAndMaxValues: should return 0 for maxValue if `acceptNegativeValues` is true and maxValue is negative', () => {
+      const series = [
+        { label: 'A', data: [-20, -20, -45] },
+        { label: 'B', data: [-200, -170, -210] }
+      ];
+      const expectedResult = { minValue: -210, maxValue: 0 };
+      const acceptNegativeValues = true;
+
+      expect(service.calculateMinAndMaxValues(series, acceptNegativeValues)).toEqual(expectedResult);
+    });
+
     it('range: should call `getGridLineArea` and return a list of values according with gridLabels default value', () => {
       const minMaxValues = { minValue: 0, maxValue: 200 };
       const expectedResult = [0, 50, 100, 150, 200];

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
@@ -21,7 +21,11 @@ export class PoChartMathsService {
   calculateMinAndMaxValues(series: Array<any>, acceptNegativeValues: boolean = true): PoChartMinMaxValues {
     const minValue = this.getDomain(series, 'min');
     const maxValue = this.getDomain(series, 'max');
-    return { minValue: !acceptNegativeValues && minValue < 0 ? 0 : minValue, maxValue };
+
+    return {
+      minValue: !acceptNegativeValues && minValue < 0 ? 0 : minValue,
+      maxValue: acceptNegativeValues && maxValue < 0 ? 0 : maxValue
+    };
   }
 
   /**


### PR DESCRIPTION
**po-chart**

**DTHFUI-4737**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não era possível declarar séries com valores negativos em gráficos do tipo `column`.

**Qual o novo comportamento?**
- É possível utilizar séries contendo tanto valores positivos quanto negativos em gráficos dos tipos `column` e também em combinações entre `line` e `column`.

- Efetuado tratamento específico para o caso de somente houverem valores negativos nas séries. Nesse caso, o valor máximo será o zero.
- Se na média de labels referentes ao eixo X não houver um valor 0(zero), então é gerada uma linha adicional referente a ela. No entanto, o label zero não é exibido. Há uma imagem de referência na issue da tarefa.

**Simulação**
Efetuar testes no sample labs e também verificar o sample de caso de uso.