### PR TITLE
feat(multiselect): adiciona estilo ao posicionar mouse sobre o campo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-search/po-multiselect-search.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-search/po-multiselect-search.component.html
@@ -5,7 +5,7 @@
 
   <input
     #inputElement
-    class="po-input po-input-icon-left"
+    class="po-input po-input-icon-left po-multiselect-search-input"
     type="text"
     [placeholder]="placeholder"
     (keyup)="onChange($event)"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -2,7 +2,7 @@
   <div class="po-field-container-content" [class.po-multiselect-show]="dropdownOpen">
     <input
       #inputElement
-      class="po-input po-input-icon-right po-clickable"
+      class="po-input po-input-icon-right po-multiselect-input po-clickable"
       readonly
       type="text"
       [value]="getPlaceholder()"


### PR DESCRIPTION
**MULTISELECT**

**DTHFUI-4662, #399**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O multiselect não possuía estilo ao posicionar o mouse sobre o mesmo.

**Qual o novo comportamento?**
O multiselect estava com diferenças no hover comparado ao select,
são componentes que devem possuir uma consistência de UI semelhante.


**Simulação**
- Buildar o style com a branch da PR https://github.com/po-ui/po-style/pull/199/
- Atualizar o estilo no projeto po-angular
- npm run build
- npm run build:portal
- ng serve portal

