### PR TITLE
fix(menu): corrige "rota" ativa não destacada

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
@@ -1,4 +1,5 @@
 import { Directive } from '@angular/core';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import { expectPropertiesValues } from './../../util-test/util-expect.spec';
@@ -9,6 +10,8 @@ import { PoMenuFilter } from './po-menu-filter/po-menu-filter.interface';
 @Directive()
 export class PoMenuComponent extends PoMenuBaseComponent {
   protected validateCollapseClass() {}
+  protected checkActiveMenuByUrl() {}
+  protected checkingRouterChildrenFragments() {}
 }
 
 describe('PoMenuBaseComponent:', () => {
@@ -480,6 +483,26 @@ describe('PoMenuBaseComponent:', () => {
       const invalidValues = [0, null, undefined, 'undefined', 'null'];
 
       expectPropertiesValues(component, 'collapsed', invalidValues, false);
+    });
+
+    it('menus: should update property with valid values.', fakeAsync(() => {
+      const validValues = [[{ label: 'Level 1.1', link: '/level-1-1', icon: 'clock' }]];
+
+      const spyCheckingRouterChildrenFragments = spyOn(component, <any>'checkingRouterChildrenFragments');
+      const spyCheckActiveMenuByUrl = spyOn(component, <any>'checkActiveMenuByUrl');
+
+      expectPropertiesValues(component, 'menus', validValues, validValues);
+
+      tick();
+
+      expect(spyCheckingRouterChildrenFragments).toHaveBeenCalled();
+      expect(spyCheckActiveMenuByUrl).toHaveBeenCalled();
+    }));
+
+    it('menus: should update property with `[]` if values are invalid.', () => {
+      const invalidValues = [0, null, undefined, 'undefined', 'null', {}, false, true];
+
+      expectPropertiesValues(component, 'menus', invalidValues, []);
     });
   });
 

--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
@@ -85,6 +85,11 @@ export abstract class PoMenuBaseComponent {
   /** Lista dos itens do menu. Se o valor estiver indefinido ou inválido, será inicializado como um array vazio. */
   @Input('p-menus') set menus(menus: Array<PoMenuItem>) {
     this._menus = Array.isArray(menus) ? menus : [];
+
+    setTimeout(() => {
+      const urlRouter = this.checkingRouterChildrenFragments();
+      this.checkActiveMenuByUrl(urlRouter);
+    });
   }
 
   get menus() {
@@ -332,5 +337,7 @@ export abstract class PoMenuBaseComponent {
     }
   }
 
+  protected abstract checkActiveMenuByUrl(urlRouter);
+  protected abstract checkingRouterChildrenFragments();
   protected abstract validateCollapseClass();
 }

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
@@ -509,16 +509,6 @@ describe('PoMenuComponent:', () => {
     expect(component['itemSubscription'].unsubscribe).toHaveBeenCalled();
   });
 
-  it('routeSubscription: should `unsubscribe` `routeSubscription` on destroy.', () => {
-    component['routeSubscription'] = <any>{ unsubscribe: () => {} };
-
-    spyOn(component['routeSubscription'], <any>'unsubscribe');
-
-    component.ngOnDestroy();
-
-    expect(component['routeSubscription'].unsubscribe).toHaveBeenCalled();
-  });
-
   it('should set menu item not found with `literals.itemNotFound`.', () => {
     component.noData = true;
 
@@ -830,22 +820,13 @@ describe('PoMenuComponent:', () => {
   });
 
   describe('Methods:', () => {
-    it(`ngOnInit: should call 'subscribeToMenuItem', 'subscribeToRoute',
-      'checkingRouterChildrenFragments' and 'checkActiveMenuByUrl'`, fakeAsync(() => {
+    it(`ngOnInit: should call 'subscribeToMenuItem'`, () => {
       spyOn(component, 'subscribeToMenuItem');
-      spyOn(component, 'subscribeToRoute');
-      spyOn(component, <any>'checkingRouterChildrenFragments');
-      spyOn(component, 'checkActiveMenuByUrl');
 
       component.ngOnInit();
 
-      tick(50);
-
-      expect(component['checkActiveMenuByUrl']).toHaveBeenCalled();
-      expect(component['checkingRouterChildrenFragments']).toHaveBeenCalled();
       expect(component['subscribeToMenuItem']).toHaveBeenCalled();
-      expect(component['subscribeToRoute']).toHaveBeenCalled();
-    }));
+    });
 
     it(`ngOnDestroy: should call 'resizeListener' if has 'resizeListener`, () => {
       component['createResizeListener']();
@@ -1416,23 +1397,6 @@ describe('PoMenuComponent:', () => {
 
       const rootParent = component['getActiveMenuParent']([groupedMenuItem], activeMenuItem, groupedMenuItem);
       expect(rootParent).toBeUndefined();
-    });
-
-    // TODO Ng V9
-    xit('subscribeToRoute: should call `checkActiveMenuByUrl` if router emits an event', done => {
-      spyOn(component, 'checkActiveMenuByUrl');
-      spyOn(component, <any>'checkingRouterChildrenFragments');
-
-      fixture.ngZone.run(() => {
-        router.navigate(['/search']).then(() => {
-          component.subscribeToRoute();
-
-          expect(component.checkActiveMenuByUrl).toHaveBeenCalled();
-          expect(component['checkingRouterChildrenFragments']).toHaveBeenCalled();
-
-          done();
-        });
-      });
     });
 
     // TODO Ng V9


### PR DESCRIPTION
**po-menu**

**DTHFUI-1426**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Os itens de menu relativos às rotas carregadas via browser não eram marcados como ativos.

**Qual o novo comportamento?**
Agora o o item do menu é ativado no carregamento da página não importando o sub-nível.

**Simulação**
Pode testar no portal acessando qualquer item do menu e dar refresh e também [no app](https://github.com/po-ui/po-angular/files/6090411/app.zip)
