### PR TITLE
chart: permite definir expessura do donut

### DIFF
--- a/projects/ui/src/lib/components/po-chart/helpers/po-chart-default-values.constant.ts
+++ b/projects/ui/src/lib/components/po-chart/helpers/po-chart-default-values.constant.ts
@@ -13,8 +13,8 @@ export const PoChartPlotAreaPaddingTop = 8;
 // Angulação inicial de raio para gráficos do tipo circular
 export const PoChartStartAngle = -Math.PI / 2;
 
-// Chamado de coroa circular, refere-se à área entre os círculos externos e internos e que define a espessura do gráfico do tipo Donut.
-export const PoChartDonutThickness = 40;
+// Valor referente à espessura padrão do gráfico do tipo Donut.
+export const PoChartDonutDefaultThickness = 40;
 
 // Valor para subtração do valor de angulo radiano final de série em tipos Donut e Pie. Necessário para o caso de uma série única: se uma circunferência tiver valores de ângulo de raio inicial e final iguais não plota.
 export const PoChartCompleteCircle = 0.0001;

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-options.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-options.interface.ts
@@ -11,6 +11,9 @@ export interface PoChartOptions {
   /** Define um objeto do tipo `PoChartAxisOptions` para configuração dos eixos. */
   axis?: PoChartAxisOptions;
 
+  /** Define o diâmetro, em valor percentual entre `0` e `100`, da área central para gráficos do tipo `donut`. Se passado um percentual que torne a espessura do gráfico menor do que `40px`, os textos internos do gráficos serão ocultados para que não haja quebra de layout. */
+  innerRadius?: number;
+
   /** Define a exibição da legenda do gráfico. Valor padrão é `true` */
   legend?: boolean;
 }

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.svg
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-bar/po-chart-bar.component.svg
@@ -5,7 +5,7 @@
     <!-- SERIES PATHS -->
     <svg:g po-chart-bar-path
       [attr.key]="'po-chart-bar-path-' + i"
-      [p-color]="item[0].color" 
+      [p-color]="item[0]?.color" 
       [p-coordinates]="item"
       [p-tooltip-position]="tooltipPosition"
       (p-bar-click)="onSerieBarClick($event)"

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.spec.ts
@@ -9,6 +9,7 @@ import { PoChartCircularLabelComponent } from './po-chart-circular-label/po-char
 import { PoChartCircularPathComponent } from './po-chart-circular-path/po-chart-circular-path.component';
 import { PoChartContainerSize } from '../../interfaces/po-chart-container-size.interface';
 import { PoChartModule } from '../../po-chart.module';
+import { expectPropertiesValues } from 'projects/templates/src/lib/util-test/util-expect.spec';
 
 @Component({
   selector: 'po-chart-circular-test',
@@ -173,6 +174,7 @@ describe('PoChartCircularComponent', () => {
       const expectedEndAngle = 4.71228898038469;
       const height = 200;
 
+      component.canDisplayLabels = true;
       component['totalValue'] = 30;
 
       const spyApplyCoordinates = spyOn(componentPath, 'applyCoordinates');
@@ -400,6 +402,20 @@ describe('PoChartCircularComponent', () => {
       component.series = series;
 
       expect(component['animate']).toBe(true);
+    });
+
+    it('p-options: should update property with valid values', () => {
+      const validValue = [{ innerRadius: 30 }];
+
+      expectPropertiesValues(component, 'options', validValue, validValue);
+      expect(component['innerRadius']).toBe(30);
+    });
+
+    it('p-options: shouldn`t update property if receives invalid values', () => {
+      const invalidValues = [undefined, null, '', false, 0, ['1'], [{ key: 'value' }]];
+
+      expectPropertiesValues(component, 'options', invalidValues, undefined);
+      expect(component['innerRadius']).toBeUndefined();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.svg
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.svg
@@ -10,11 +10,13 @@
   </svg:g>
 
   <!-- SERIES LABELS -->
-  <svg:g *ngFor="let item of seriesLabels; let i = index">
-    <svg:g #svgLabels po-chart-circular-label
-      [attr.key]="'po-chart-circular-label-' + i"
-      [p-serie]="item"
-      [p-show-label]="showLabels">
+  <svg:g *ngIf="canDisplayLabels">
+    <svg:g *ngFor="let item of seriesLabels; let i = index">
+      <svg:g #svgLabels po-chart-circular-label
+        [attr.key]="'po-chart-circular-label-' + i"
+        [p-serie]="item"
+        [p-show-label]="showLabels">
+      </svg:g>
     </svg:g>
   </svg:g>
 </svg:g>

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular.component.ts
@@ -19,22 +19,37 @@ import { PoChartCircularLabelComponent } from './po-chart-circular-label/po-char
 import { PoChartCircularPathComponent } from './po-chart-circular-path/po-chart-circular-path.component';
 import { PoChartContainerSize } from '../../interfaces/po-chart-container-size.interface';
 import { PoChartLabelCoordinates } from '../../interfaces/po-chart-label-coordinates.interface';
+import { PoChartOptions } from '../../interfaces/po-chart-options.interface';
 import { PoChartPathCoordinates } from '../../interfaces/po-chart-path-coordinates.interface';
 import { PoChartSerie } from '../../interfaces/po-chart-serie.interface';
 
 @Directive()
 export abstract class PoChartCircularComponent {
+  private _options: PoChartOptions;
   private _series: Array<PoChartSerie>;
 
+  canDisplayLabels: boolean = false;
   seriesLabels: Array<PoChartLabelCoordinates> = [];
   seriesList: Array<PoChartPathCoordinates>;
   showLabels: boolean = false;
 
+  protected innerRadius: number;
   protected totalValue: number;
 
   private animate: boolean;
 
   @Input('p-container-size') containerSize: PoChartContainerSize;
+
+  @Input('p-options') set options(value: PoChartOptions) {
+    if (!isNaN(value?.innerRadius)) {
+      this._options = value;
+      this.innerRadius = Math.min(Math.max(this._options.innerRadius, 0), 100);
+    }
+  }
+
+  get options() {
+    return this._options;
+  }
 
   @Input('p-series') set series(value: Array<PoChartSerie>) {
     this._series = value;
@@ -101,7 +116,7 @@ export abstract class PoChartCircularComponent {
       const coordinates = this.calculateCoordinates(height, startRadianAngle, endRadianAngle);
 
       this.svgPaths.toArray()[index].applyCoordinates(coordinates);
-      this.showLabels = true;
+      this.showLabels = this.canDisplayLabels;
     });
   }
 
@@ -195,6 +210,6 @@ export abstract class PoChartCircularComponent {
     }, []);
   }
 
-  protected abstract getTooltipLabel(data, label, tooltip);
   protected abstract calculateCoordinates(height, startRadianAngle, currentEndRadianAngle);
+  protected abstract getTooltipLabel(data, label, tooltip);
 }

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-donut/po-chart-donut.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-donut/po-chart-donut.component.spec.ts
@@ -78,6 +78,32 @@ describe('PoChartDonutComponent', () => {
       expect(component['applySeriesLabels']).toHaveBeenCalledWith(seriesList, containerSize.svgHeight);
     });
 
+    it('ngOnChanges: should call `drawSeries` and `applySeriesLabels` if `changes.options`', () => {
+      const series: Array<PoChartSerie> = [{ label: 'teste', data: 30 }];
+      const containerSize: PoChartContainerSize = { svgHeight: 300 };
+      const seriesList = [];
+      const changes: SimpleChanges = {
+        options: {
+          previousValue: 20,
+          currentValue: 30,
+          firstChange: false,
+          isFirstChange: () => false
+        }
+      };
+
+      component.series = series;
+      component.containerSize = containerSize;
+      component.seriesList = seriesList;
+
+      spyOn(component, <any>'drawSeries');
+      spyOn(component, <any>'applySeriesLabels');
+
+      component.ngOnChanges(changes);
+
+      expect(component['drawSeries']).toHaveBeenCalledWith(series, containerSize.svgHeight);
+      expect(component['applySeriesLabels']).toHaveBeenCalledWith(seriesList, containerSize.svgHeight);
+    });
+
     it('ngOnChanges: should`t call `drawSeries` and `applySeriesLabels`', () => {
       const series: Array<PoChartSerie> = [{ label: 'teste', data: 30 }];
       const containerSize: PoChartContainerSize = { svgHeight: 300 };
@@ -244,6 +270,31 @@ describe('PoChartDonutComponent', () => {
       const result = component['getTextColor'](color);
 
       expect(result).toEqual(expectedResult);
+    });
+
+    it('getInnerRadius: should return innerRadius value based on `innerRadius` value', () => {
+      const radius = 200;
+      component.options = { innerRadius: 50 };
+
+      expect(component['getInnerRadius'](radius)).toBe(100);
+    });
+
+    it('getInnerRadius: should return the innerRadius default value ia `innerRadius` is undefined', () => {
+      const radius = 200;
+
+      expect(component['getInnerRadius'](radius)).toBe(160);
+    });
+
+    it('verifyDisplayLabels: should apply false to `canDisplayLabels` if `innerRadius` value exceeds the maximum allowed chart thickness', () => {
+      component['verifyDisplayLabels'](200, 180);
+
+      expect(component.canDisplayLabels).toBe(false);
+    });
+
+    it('verifyDisplayLabels: should apply trie to `canDisplayLabels` if `innerRadius` value respects the chart thickness maximun width', () => {
+      component['verifyDisplayLabels'](200, 120);
+
+      expect(component.canDisplayLabels).toBe(true);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-donut/po-chart-donut.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-donut/po-chart-donut.component.ts
@@ -2,9 +2,9 @@ import { ChangeDetectorRef, Component, NgZone, OnChanges, SimpleChanges } from '
 
 import { convertNumberToDecimal } from '../../../../../utils/util';
 import { PoDefaultColorsTextBlack } from '../../../../../services/po-color/po-colors.constant';
+import { PoChartDonutDefaultThickness, PoChartStartAngle } from '../../../helpers/po-chart-default-values.constant';
 
 import { PoChartCircularComponent } from '../po-chart-circular.component';
-import { PoChartDonutThickness, PoChartStartAngle } from '../../../helpers/po-chart-default-values.constant';
 
 @Component({
   selector: '[po-chart-donut]',
@@ -20,7 +20,7 @@ export class PoChartDonutComponent extends PoChartCircularComponent implements O
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.series || changes.containerSize) {
+    if (changes.series || changes.containerSize || changes.options) {
       this.drawSeries(this.series, this.containerSize.svgHeight);
       this.applySeriesLabels(this.seriesList, this.containerSize.svgHeight);
     }
@@ -28,7 +28,8 @@ export class PoChartDonutComponent extends PoChartCircularComponent implements O
 
   protected calculateCoordinates(height: number, startRadianAngle: number, endRadianAngle: number) {
     const radius = height / 2;
-    const innerRadius = radius - PoChartDonutThickness;
+
+    const innerRadius = this.getInnerRadius(radius);
 
     const sinAlpha = Math.sin(startRadianAngle);
     const cosAlpha = Math.cos(startRadianAngle);
@@ -49,6 +50,8 @@ export class PoChartDonutComponent extends PoChartCircularComponent implements O
     const endInnerY = radius + sinBeta * innerRadius;
 
     const largeArc = endRadianAngle - startRadianAngle > Math.PI;
+
+    this.verifyDisplayLabels(radius, innerRadius);
 
     return [
       'M',
@@ -100,15 +103,21 @@ export class PoChartDonutComponent extends PoChartCircularComponent implements O
 
   private calculateLabelCoordinates(height: number, startRadianAngle: number, endRadianAngle: number) {
     const radius = height / 2;
-    const innerRadius = radius - PoChartDonutThickness;
+    const innerRadius = this.getInnerRadius(radius);
 
     const sliceCenterAngle = (startRadianAngle + endRadianAngle) / 2;
-    const labelRadius = innerRadius + +(PoChartDonutThickness / 2);
+    const labelRadius = innerRadius + (radius - innerRadius) / 2;
 
     const xCoordinate = labelRadius * Math.cos(sliceCenterAngle) + radius;
     const yCoordinate = labelRadius * Math.sin(sliceCenterAngle) + radius;
 
     return { xCoordinate, yCoordinate };
+  }
+
+  private getInnerRadius(radius: number): number {
+    const defaultInnerRadius = radius - PoChartDonutDefaultThickness;
+
+    return this.innerRadius >= 0 ? (this.innerRadius / 100) * radius : defaultInnerRadius;
   }
 
   private getPercentValue(value: number, totalValue: number) {
@@ -124,5 +133,9 @@ export class PoChartDonutComponent extends PoChartCircularComponent implements O
     }
 
     return this.poChartWhiteColor;
+  }
+
+  private verifyDisplayLabels(radius: number, innerRadius: number): void {
+    this.canDisplayLabels = radius - innerRadius >= radius - (radius - PoChartDonutDefaultThickness);
   }
 }

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.html
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.html
@@ -65,6 +65,7 @@
   <svg:g
     *ngIf="type === 'donut'"
     po-chart-donut
+    [p-options]="options"
     [p-series]="seriesByType['donut']"
     [p-container-size]="containerSize"
     (p-circular-hover)="onSerieHover($event)"

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
@@ -86,7 +86,7 @@
     <po-divider class="po-md-12" p-label="Chart options"></po-divider>
 
     <po-number
-      class="po-md-3"
+      class="po-md-4"
       name="minRange"
       [(ngModel)]="options.axis.minRange"
       p-help="Example: 0"
@@ -96,7 +96,7 @@
     </po-number>
 
     <po-number
-      class="po-md-3"
+      class="po-md-4"
       name="maxRange"
       [(ngModel)]="options.axis.maxRange"
       p-help="Example: 100"
@@ -106,7 +106,7 @@
     </po-number>
 
     <po-number
-      class="po-md-3"
+      class="po-md-4"
       name="gridLines"
       [(ngModel)]="options.axis.gridLines"
       p-help="Example: 6"
@@ -115,8 +115,18 @@
     >
     </po-number>
 
+    <po-number
+      class="po-md-4"
+      name="innerRadius"
+      [(ngModel)]="options.innerRadius"
+      p-help="Example: value between 0 and 100"
+      p-label="innerRadius"
+      (p-blur)="addOptions()"
+    >
+    </po-number>
+
     <po-checkbox-group
-      class="po-md-3"
+      class="po-md-4"
       name="propertiesOptions"
       p-help="Boolean properties"
       p-indeterminate


### PR DESCRIPTION
**po-chart**

**DTHFUI-2109**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
O gráfico do tipo donut possui uma espessura padrão.

**Qual o novo comportamento?**
- Criada propriedade `PoChartOptions.innerRadius`: Define o tamanho do diâmetro do gráfico tipo donut em porcentagem.
Se passado um percentual que torne a espessura do gráfico menor do que `40px`, os textos internos do gráficos serão ocultados para que não haja quebra de layout.

- Corrigido erro quando passado `[null]` em gráficos do tipo `bar` e `column`.

**Simulação**
Sample labs do portal.