### PR TITLE
feat(dynamic-form): adiciona a prop `PoDynamicFormField.maskFormatModel`

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -61,6 +61,9 @@ export interface PoDynamicFormField extends PoDynamicField {
   /** Máscara para o campo. */
   mask?: string;
 
+  /** Define que o valor do componente será conforme especificado na mascára. O valor padrão é `false`. */
+  maskFormatModel?: boolean;
+
   /** Define o ícone que será exibido no início do campo.
    * > Esta propriedade o pode ser utilizado nos campos:
    * - Input;

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -255,6 +255,7 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
       const newField = component['createField'](field);
 
       expect(typeof newField === 'object').toBe(true);
+      expect(newField.maskFormatModel).toBe(false);
       expect(Array.isArray(newField.options)).toBe(true);
       expect(newField.label).toBe(field.label);
 
@@ -262,6 +263,25 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
       expect(spyGetGridColumnsClasses).toHaveBeenCalled();
       expect(spyConvertOptions).toHaveBeenCalled();
       expect(spyHasFocus).toHaveBeenCalled();
+    });
+
+    it(`createField: should set maskFormatModel with true if type is 'time'`, () => {
+      const field = { property: 'propertyName', label: 'labelName', type: 'time' };
+
+      const newField = component['createField'](field);
+
+      expect(newField.label).toBe(field.label);
+      expect(newField.maskFormatModel).toBe(true);
+    });
+
+    it(`createField: should set maskFormatModel and mask`, () => {
+      const field = { property: 'propertyName', label: 'labelName', mask: '99/9999', maskFormatModel: true };
+
+      const newField = component['createField'](field);
+
+      expect(newField.label).toBe(field.label);
+      expect(newField.mask).toBe(field.mask);
+      expect(newField.maskFormatModel).toBe(true);
     });
 
     it(`hasFocus: should return true if 'autoFocus' is equal to 'field.property'`, () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -102,6 +102,7 @@ export class PoDynamicFormFieldsBaseComponent {
     const control = this.getComponentControl(field);
     const options = !!field.options ? this.convertOptions(field.options) : undefined;
     const focus = this.hasFocus(field);
+    const type = field && field.type ? field.type.toLocaleLowerCase() : 'string';
 
     const componentClass = getGridColumnsClasses(
       field.gridSmColumns,
@@ -119,6 +120,7 @@ export class PoDynamicFormFieldsBaseComponent {
 
     return {
       label: this.titleCasePipe.transform(field.property),
+      maskFormatModel: this.compareTo(type, PoDynamicFieldType.Time),
       ...field,
       componentClass,
       control,

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -35,6 +35,7 @@
       [p-auto-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
+      [p-mask-format-model]="field.maskFormatModel"
       [p-mask]="field.mask"
       [p-maxlength]="field.maxLength"
       [p-minlength]="field.minLength"


### PR DESCRIPTION
  **<DYNAMIC-FORM>**

**DTHFUI-4688**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
- Ao informar type time, não estava formatando o model corretamente
- Adiciona a propriedade PoDynamicFormField.maskFormatModel
Possibilitando formatar o model conforme a mascara

**Qual o novo comportamento?**
- Adiciona a propriedade PoDynamicFormField.maskFormatModel, possibilitando formatar o model conforme a mascara;
- fix(dynamic-form): corrige valor do model quando informar tipo `time` 

**Simulação**
Portal:
- npm run build:ui
- npm run build:portal
- ng serve portal


APP:

``` 
<po-dynamic-form [p-value]="value" [p-fields]="fields"></po-dynamic-form>

<hr>

{{ value | json }}
```
``` 
  fields = [
    { property: 'sem maskformatmodel', mask: '99/9999' },
    { property: 'com maskformatmodel', mask: '99/9999', maskFormatModel: true },
    { property: 'time', type: 'time' }
  ];

  value = {};
```  
