### PR TITLE
slide: permite esconder setas de navegação e controle de passos externo

### DIFF
--- a/projects/ui/src/lib/components/po-slide/po-slide-base.component.ts
+++ b/projects/ui/src/lib/components/po-slide/po-slide-base.component.ts
@@ -1,5 +1,6 @@
 import { Input, Directive } from '@angular/core';
 
+import { InputBoolean } from '../../decorators';
 import { convertToInt } from './../../utils/util';
 
 import { PoSlideItem } from './interfaces/po-slide-item.interface';
@@ -89,6 +90,18 @@ export abstract class PoSlideBaseComponent {
   get slides(): Array<PoSlideItem | string | any> {
     return this._slides;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a exibição das setas de navegação.
+   *
+   * @default `false`
+   */
+
+  @Input('p-hide-arrows') @InputBoolean() hideArrows: boolean = false;
 
   abstract setSlideHeight(height: number): void;
 

--- a/projects/ui/src/lib/components/po-slide/po-slide-base.component.ts
+++ b/projects/ui/src/lib/components/po-slide/po-slide-base.component.ts
@@ -100,7 +100,6 @@ export abstract class PoSlideBaseComponent {
    *
    * @default `false`
    */
-
   @Input('p-hide-arrows') @InputBoolean() hideArrows: boolean = false;
 
   abstract setSlideHeight(height: number): void;

--- a/projects/ui/src/lib/components/po-slide/po-slide.component.html
+++ b/projects/ui/src/lib/components/po-slide/po-slide.component.html
@@ -15,10 +15,14 @@
       </ng-container>
     </div>
 
-    <po-slide-control *ngIf="hasSlides && slides.length > 1" p-control="previous" (p-click)="previousControl()">
+    <po-slide-control
+      *ngIf="!hideArrows && hasSlides && slides.length > 1"
+      p-control="previous"
+      (p-click)="previousControl()"
+    >
     </po-slide-control>
 
-    <po-slide-control *ngIf="hasSlides && slides.length > 1" p-control="next" (p-click)="nextControl()">
+    <po-slide-control *ngIf="!hideArrows && hasSlides && slides.length > 1" p-control="next" (p-click)="nextControl()">
     </po-slide-control>
   </div>
 

--- a/projects/ui/src/lib/components/po-slide/po-slide.component.spec.ts
+++ b/projects/ui/src/lib/components/po-slide/po-slide.component.spec.ts
@@ -163,6 +163,14 @@ describe('PoSlideComponent:', () => {
       expect(component['setSlideHeight']).not.toHaveBeenCalled();
     });
 
+    it('getCurrentSlideIndex: should call and return current slide index', () => {
+      component.currentSlideIndex = 1;
+
+      const index = component.getCurrentSlideIndex();
+
+      expect(index).toBe(1);
+    });
+
     it('goToItem: should set `currentSlideIndex` and call `animate` with `offset`', () => {
       const index = 3;
 

--- a/projects/ui/src/lib/components/po-slide/po-slide.component.ts
+++ b/projects/ui/src/lib/components/po-slide/po-slide.component.ts
@@ -46,6 +46,11 @@ const poSlideTiming = '250ms ease';
  *   <file name="sample-po-slide-landscapes/sample-po-slide-landscapes.component.html"> </file>
  *   <file name="sample-po-slide-landscapes/sample-po-slide-landscapes.component.ts"> </file>
  * </example>
+ *
+ * <example name="po-slide-external-controls" title="PO Slide - External Controls">
+ *  <file name="sample-po-slide-external-controls/sample-po-slide-external-controls.component.html"> </file>
+ *  <file name="sample-po-slide-external-controls/sample-po-slide-external-controls.component.ts"> </file>
+ * </example>
  */
 @Component({
   selector: 'po-slide',
@@ -112,6 +117,21 @@ export class PoSlideComponent extends PoSlideBaseComponent implements DoCheck, O
     }
   }
 
+  /**
+   * Método que retorna o index do slide atual
+   *
+   * ```
+   * @ViewChild('slideComponent', { static: true }) slideComponent: PoSlideComponent;
+   *  myFunction() {
+   *    let currentIndex = this.slideComponent.getCurrentSlideIndex();
+   * }
+   *
+   * ```
+   */
+  getCurrentSlideIndex(): number {
+    return this.currentSlideIndex;
+  }
+
   goToItem(index: number) {
     if (this.interval > poSlideIntervalMin) {
       this.startInterval();
@@ -129,6 +149,17 @@ export class PoSlideComponent extends PoSlideBaseComponent implements DoCheck, O
     this.next();
   }
 
+  /**
+   * Método para chamar o próximo slide.
+   *
+   * ```
+   * @ViewChild('slideComponent', { static: true }) slideComponent: PoSlideComponent;
+   *
+   * myFunction() {
+   *  this.slideComponent.next();
+   * }
+   * ```
+   */
   next() {
     if (this.currentSlideIndex + 1 === this.slideItems.length) {
       this.currentSlideIndex = 0;
@@ -138,7 +169,17 @@ export class PoSlideComponent extends PoSlideBaseComponent implements DoCheck, O
     this.currentSlideIndex = (this.currentSlideIndex + 1) % this.slideItems.length;
     this.animate(this.offset);
   }
-
+  /**
+   * Método para chamar o slide anterior.
+   *
+   * ```
+   * @ViewChild('slideComponent', { static: true }) slideComponent: PoSlideComponent;
+   *
+   * myFunction() {
+   *  this.slideComponent.previous();
+   * }
+   * ```
+   */
   previous() {
     if (this.currentSlideIndex === 0) {
       this.currentSlideIndex = this.slideItems.length - 1;

--- a/projects/ui/src/lib/components/po-slide/samples/sample-po-slide-external-controls/sample-po-slide-external-controls.component.html
+++ b/projects/ui/src/lib/components/po-slide/samples/sample-po-slide-external-controls/sample-po-slide-external-controls.component.html
@@ -1,0 +1,40 @@
+<po-slide #slideComponent p-height="450" [p-slides]="sampleItems" p-interval="0" p-hide-arrows>
+  <ng-template p-slide-content-template let-item>
+    <div
+      class="sample-background-image"
+      [style.background-image]="'url(' + item.imagem + ')'"
+      [style.backgroundSize]="'cover'"
+      [style.height.%]="100"
+    >
+      <div class="po-row">
+        <div
+          class="po-offset-sm-1 po-offset-md-1 po-offset-lg-1 po-offset-xl-1 po-lg-5 po-sm-10 po-mt-4 po-mb-4 po-p-5"
+          [style.background]="'white'"
+        >
+          <div class="po-font-text">{{ item.date }} by {{ item.author }}</div>
+          <div class="po-font-display">{{ item.title }}</div>
+          <po-divider></po-divider>
+          <div class="po-font-text-large-bold po-mb-3">{{ item.description }}</div>
+          <po-button p-label="Read More" (p-click)="redirectLink(item.link)"></po-button>
+        </div>
+      </div>
+    </div>
+  </ng-template>
+</po-slide>
+
+<div class="po-row">
+  <po-button
+    class="po-xl-4 po-lg-4 po-md-6 po-sm-6"
+    p-label="Previous"
+    (p-click)="previousBtn()"
+    [p-disabled]="slideComponent.getCurrentSlideIndex() === 0"
+  >
+  </po-button>
+  <po-button
+    class="po-offset-lg-4 po-offset-xl-4 po-xl-4 po-lg-4 po-md-6 po-sm-6"
+    p-label="Next"
+    (p-click)="nextBtn()"
+    [p-disabled]="slideComponent.getCurrentSlideIndex() === sampleItems.length - 1"
+  >
+  </po-button>
+</div>

--- a/projects/ui/src/lib/components/po-slide/samples/sample-po-slide-external-controls/sample-po-slide-external-controls.component.ts
+++ b/projects/ui/src/lib/components/po-slide/samples/sample-po-slide-external-controls/sample-po-slide-external-controls.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnChanges, ViewChild } from '@angular/core';
+
+import { PoSlideComponent } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-slide-external-controls',
+  templateUrl: './sample-po-slide-external-controls.component.html'
+})
+export class SamplePoSlideExternalControlsComponent {
+  @ViewChild('slideComponent', { static: true }) slideComponent: PoSlideComponent;
+
+  nextLabel: string = 'Next';
+  sampleItems: Array<any> = [
+    {
+      title: 'The Iceberg Method',
+      description: 'How could you ever take 20 minutes to just breathe?',
+      date: 'December 11, 2016',
+      author: 'Patrick Buggy',
+      link: 'https://bit.ly/2OVCypl',
+      imagem: '/assets/graphics/landscape-01.jpeg'
+    },
+    {
+      title: 'What Meditation Isn’t',
+      description: 'Meditating won’t solve your problems — but it will help you face them honestly',
+      date: 'August 17, 2018',
+      author: 'Seizan Egyo',
+      link: 'https://bit.ly/2UercLM',
+      imagem: '/assets/graphics/landscape-02.jpeg'
+    },
+    {
+      title: 'Get out of your mental cocoon',
+      description: 'You Can’t Change without Transforming Your World',
+      date: 'January 22, 2019',
+      author: 'Gustavo Razzetti',
+      link: 'https://bit.ly/2Tbc16b',
+      imagem: '/assets/graphics/landscape-03.jpeg'
+    }
+  ];
+
+  redirectLink(link: string) {
+    window.open(link, '_blank');
+  }
+
+  nextBtn() {
+    this.slideComponent.next();
+  }
+
+  previousBtn() {
+    this.slideComponent.previous();
+  }
+}


### PR DESCRIPTION
**PO-SLIDE**

**DTHFUI-4753**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Não existe a possibilidade de controlar os passos do slide externamente, bem como de esconder as setas de navegação.

**Qual o novo comportamento?**
- Criada a propriedade `p-hide-arrows`: esconde as setas de navegação do po-slide.
- Publicados os métodos getCurrentSlideIndex, next e previous para controle externo dos passos do slide.


**Simulação**
Pode ser utilizado o sample `SamplePoSlideExternalControlsComponent` no app, ou utilizando o código abaixo:

```html
<!-- app.component.html -->

<po-slide #slide p-height="450" [p-slides]="items" p-interval="0" p-hide-arrows></po-slide>

<po-button
    p-label="Previous"
    (p-click)="previousAction()"
    [p-disabled]="disablePrevious()"
  >
  </po-button>
  <po-button
    p-label="Next"
    (p-click)="nextAction()"
    [p-disabled]="disableNext()"
  >
  </po-button>
```

```javascript
// app.component.ts

@ViewChild('slide', { static: true }) slide: PoSlideComponent;

items: Array<PoSlideItem> = [
  {image: 'https://po-ui.io/assets/graphics/landscape-01.jpeg'},
  {image: 'https://po-ui.io/assets/graphics/landscape-02.jpeg'},
  {image: 'https://po-ui.io/assets/graphics/landscape-03.jpeg'}
];

disableNext() {
  return (slideComponent.getCurrentSlideIndex() === items.length - 1);
}

disablePrevious() {
  return (slideComponent.getCurrentSlideIndex() === 0);
}

nextAction() {
  this.slideComponent.next();
}

previousAction() {
  this.slideComponent.previous();
}
```