### PR TITLE
fix(email): corrige expressão regular para permitir letras maiusculas

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-email/po-email.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-email/po-email.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { FormControl } from '@angular/forms';
 
 import { configureTestSuite } from './../../../util-test/util-expect.spec';
 
@@ -152,6 +153,21 @@ describe('PoEmailComponent:', () => {
       fixture.detectChanges();
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-field-optional')).toBeNull();
+    });
+  });
+
+  describe('Integration:', () => {
+    it(`should return null on validate if email is valid`, () => {
+      expect(component.validate(new FormControl('JOHN@EMAIL.COM'))).toBe(null);
+      expect(component.validate(new FormControl('JOHN@email.com'))).toBe(null);
+    });
+
+    it(`should return '{ pattern: { valid: false } }' on validate if email is invalid`, () => {
+      const patternError = { pattern: { valid: false } };
+
+      expect(component.validate(new FormControl('JOHN@'))).toEqual(patternError);
+      expect(component.validate(new FormControl('JOHN@EMAIL.'))).toEqual(patternError);
+      expect(component.validate(new FormControl('JOHN'))).toEqual(patternError);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-email/po-email.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-email/po-email.component.ts
@@ -55,7 +55,7 @@ export class PoEmailComponent extends PoInputGeneric implements AfterViewInit, O
 
   type = 'email';
 
-  pattern = '^([\\w-]+(?:\\.[\\w-]+)*)@((?:[\\w-]+\\.)*\\w[\\w-]{0,66})\\.([a-z]{2,6}(?:\\.[a-z]{2})?)$';
+  pattern = '^([\\w-]+(?:\\.[\\w-]+)*)@((?:[\\w-]+\\.)*\\w[\\w-]{0,66})\\.([A-Za-z]{2,6}(?:\\.[A-Za-z]{2})?)$';
 
   mask = '';
 


### PR DESCRIPTION
**EMAIL**

**DTHFUI-4814**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Informava error no componente quando utilizava o final do email com letra maiuscula, ex: john@gmail.COM

**Qual o novo comportamento?**
Permite informar letra maiuscula

**Simulação**
npm run build
npm run build:portal
ng serve portal

Inserir os seguintes conteúdos no EMAIL:
"JOHN@GMAIL.COM"
"JOHN@GMAIL.com"
"JOHN@gmail.com