### PR TITLE
fix(datepicker-range): corrige posicionamento ao digitar o valor

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
@@ -11,9 +11,10 @@
         [name]="startDateInputName"
         [readonly]="readonly"
         (blur)="onBlur($event)"
-        (focus)="onFocus()"
+        (focus)="onFocus($event)"
         (keydown)="onKeydown($event)"
         (keyup)="onKeyup($event)"
+        (click)="eventOnClick($event)"
       />
     </div>
 
@@ -30,9 +31,10 @@
         [name]="endDateInputName"
         [readonly]="readonly"
         (blur)="onBlur($event)"
-        (focus)="onFocus()"
+        (focus)="onFocus($event)"
         (keydown)="onKeydown($event)"
         (keyup)="onKeyup($event)"
+        (click)="eventOnClick($event)"
       />
     </div>
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
@@ -229,6 +229,15 @@ describe('PoDatepickerRangeComponent:', () => {
       expect(component.endDateInputValue).toBe('');
     });
 
+    it('eventOnClick: should click when select text and edit model', () => {
+      spyOn(component['poMaskObject'], 'click');
+      const eventMock = { target: { name: '' } };
+
+      component.eventOnClick(eventMock);
+
+      expect(component['poMaskObject'].click).toHaveBeenCalledWith(eventMock);
+    });
+
     it('focus: should call `focus` of datepicker-range', () => {
       component.startDateInput = {
         nativeElement: {
@@ -282,9 +291,12 @@ describe('PoDatepickerRangeComponent:', () => {
 
     it('onFocus: should call `applyFocusOnDatePickerRangeField`', () => {
       spyOn(component, <any>'applyFocusOnDatePickerRangeField');
+      spyOn(component['poMaskObject'], 'resetPositions');
+      const eventMock = { target: { name: '' } };
 
-      component.onFocus();
+      component.onFocus(eventMock);
       expect(component['applyFocusOnDatePickerRangeField']).toHaveBeenCalled();
+      expect(component['poMaskObject'].resetPositions).toHaveBeenCalledWith(eventMock);
     });
 
     it('onKeydown: should call `poMaskObject.keydown` if `readonly` is false', () => {
@@ -1653,7 +1665,6 @@ describe('PoDatepickerRangeComponent:', () => {
       const keydownBoardEventBackspace = new KeyboardEvent('keydown', <any>{ keyCode: 8 });
       // keyCode 37 is arrow left
       const keyupBoardEventArrowLeft = new KeyboardEvent('keyup', <any>{ keyCode: 37 });
-
       spyOn(component.startDateInput.nativeElement, 'focus');
 
       component.startDateInput.nativeElement.value = '24/1';
@@ -1768,7 +1779,8 @@ describe('PoDatepickerRangeComponent:', () => {
       const startDateInputName = `input[name="${component.startDateInputName}"]`;
 
       const startDateInput = fixture.debugElement.query(By.css(startDateInputName));
-      startDateInput.triggerEventHandler('focus', null);
+      const eventMock = { target: { name: '' } };
+      startDateInput.triggerEventHandler('focus', eventMock);
 
       fixture.detectChanges();
 
@@ -1782,7 +1794,8 @@ describe('PoDatepickerRangeComponent:', () => {
       const endDateInputName = `input[name="${component.endDateInputName}"]`;
 
       const endDateInput = fixture.debugElement.query(By.css(endDateInputName));
-      endDateInput.triggerEventHandler('focus', null);
+      const eventMock = { target: { name: '' } };
+      endDateInput.triggerEventHandler('focus', eventMock);
 
       fixture.detectChanges();
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -150,6 +150,10 @@ export class PoDatepickerRangeComponent extends PoDatepickerRangeBaseComponent i
     this.updateModel(this.dateRange);
   }
 
+  eventOnClick($event: any) {
+    this.poMaskObject.click($event);
+  }
+
   /**
    * Função que atribui foco ao componente.
    *
@@ -181,8 +185,9 @@ export class PoDatepickerRangeComponent extends PoDatepickerRangeBaseComponent i
     this.removeFocusFromDatePickerRangeField();
   }
 
-  onFocus() {
+  onFocus(event: any) {
     this.applyFocusOnDatePickerRangeField();
+    this.poMaskObject.resetPositions(event);
   }
 
   onKeydown(event?: any) {

--- a/projects/ui/src/lib/components/po-field/po-input/po-mask.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-mask.ts
@@ -177,6 +177,7 @@ export class PoMask {
 
           default:
             // qualquer outra tecla válida
+            this.getPosition($event);
             value = value.slice(0, this.initialPosition) + $event.key + value.slice(this.finalPosition);
             value = this.controlFormatting(value);
             $event.target.value = value;


### PR DESCRIPTION
**DATEPICKER-RANGE**

**DTHFUI-2412**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao selecionar um trecho ou todo o conteúdo do campo e digitar um novo valor, o cursor se perdia alterava fora da seleção.

**Qual o novo comportamento?**
Corrige o posicionamento do cursor quando selecionado um trecho ou todo o conteúdo do campo e digitado um novo valor.

**Simulação**
npm run build
npm run build:portal
ng serve portal

Seleção com o Mouse
- Inserir uma data válida
- Selecionar um trecho do código
- Alterar o trecho

Seleção com comandos do teclado (`ctrl + a`, `shift + tab`, `tab`)
- Inserir uma data válida
- Selecionar o campo com qualquer um dos comandos acima
- Alterar o trecho