### PR TITLE
feat(fields): implementa a atualização do `ng-touched` no blur do campo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -20,6 +20,7 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
   checkboxValue: boolean | null;
   id = uuid();
   propagateChange: any;
+  onTouched;
 
   private _disabled?: boolean = false;
 
@@ -93,7 +94,9 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
     this.propagateChange = fn;
   }
 
-  registerOnTouched(fn: any): void {}
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
 
   writeValue(value: any) {
     if (value !== this.checkboxValue) {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
@@ -16,6 +16,7 @@
     [class.po-clickable]="!disabled"
     [for]="id"
     [tabindex]="disabled ? -1 : 0"
+    (blur)="onBlur()"
     (click)="checkOption(checkboxValue)"
     (keydown)="onKeyDown($event, checkboxValue)"
   >

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
@@ -138,6 +138,15 @@ describe('PoCheckboxComponent:', () => {
 
       expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
     });
+
+    it('onBlur: should call `onTouched` on blur', () => {
+      component.onTouched = value => {};
+
+      spyOn(component, 'onTouched');
+      component.onBlur();
+
+      expect(component.onTouched).toHaveBeenCalledWith();
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.ts
@@ -77,6 +77,10 @@ export class PoCheckboxComponent extends PoCheckboxBaseComponent implements Afte
     }
   }
 
+  onBlur() {
+    this.onTouched();
+  }
+
   ngAfterViewInit() {
     if (this.autoFocus) {
       this.focus();

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -82,7 +82,6 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   isFiltering: boolean = false;
   keyupSubscribe: any;
   onModelChange: any;
-  onModelTouched: any;
   previousSearchValue: string = '';
   selectedOption: PoComboOption | PoComboGroup;
   selectedValue: any;
@@ -91,6 +90,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   visibleOptions: Array<PoComboOption | PoComboGroup> = [];
 
   private validatorChange: any;
+  protected onModelTouched: any = null;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -17,6 +17,7 @@
       [required]="required"
       (click)="toggleComboVisibility()"
       (keyup)="onKeyUp($event)"
+      (blur)="onBlur()"
       (keyup.enter)="searchOnEnter($event.target.value)"
       (keydown)="onKeyDown($event)"
     />

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -412,6 +412,15 @@ describe('PoComboComponent:', () => {
       expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
     });
 
+    it('onBlur: should be called when blur event', () => {
+      component['onModelTouched'] = () => {};
+      spyOn(component, <any>'onModelTouched');
+
+      component.onBlur();
+
+      expect(component['onModelTouched']).toHaveBeenCalled();
+    });
+
     describe('onKeyUp:', () => {
       function fakeKeypressEvent(code: number, target: any = 1) {
         return {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -204,6 +204,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }
   }
 
+  onBlur() {
+    this.onModelTouched();
+  }
+
   onKeyDown(event?: any) {
     const key = event.keyCode;
     const inputValue = event.target.value;

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
@@ -268,23 +268,31 @@ describe('PoDatepickerRangeComponent:', () => {
     });
 
     it('onBlur: should call `removeFocusFromDatePickerRangeField` and `updateModelByScreen` with `true`', () => {
+      component['onTouchedModel'] = () => {};
       spyOn(component, <any>'removeFocusFromDatePickerRangeField');
       spyOn(component, <any>'updateModelByScreen');
+      spyOn(component, <any>'onTouchedModel');
+
       const eventMock = { target: { name: 'start-date' } };
 
       component.onBlur(eventMock);
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModelByScreen']).toHaveBeenCalledWith(true);
       expect(component['removeFocusFromDatePickerRangeField']).toHaveBeenCalled();
     });
 
     it('onBlur: should call `removeFocusFromDatePickerRangeField` and `updateModelByScreen` with `false`', () => {
+      component['onTouchedModel'] = () => {};
       spyOn(component, <any>'removeFocusFromDatePickerRangeField');
       spyOn(component, <any>'updateModelByScreen');
+      spyOn(component, <any>'onTouchedModel');
+
       const eventMock = { target: { name: 'end-date' } };
 
       component.onBlur(eventMock);
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModelByScreen']).toHaveBeenCalledWith(false);
       expect(component['removeFocusFromDatePickerRangeField']).toHaveBeenCalled();
     });
@@ -1386,14 +1394,17 @@ describe('PoDatepickerRangeComponent:', () => {
     it('should update model with empty string if the length of the end date input value is different from 10', () => {
       component.startDate = '';
       component.endDate = '';
+      component['onTouchedModel'] = () => {};
 
       spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'onTouchedModel');
 
       fixture.detectChanges();
 
       component.endDateInput.nativeElement.value = '2';
       component.endDateInput.nativeElement.dispatchEvent(blurFocusEvent);
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModel']).toHaveBeenCalledWith({ start: '', end: '' });
       expect(component.endDateInput.nativeElement.value).toBe('2');
     });
@@ -1401,14 +1412,17 @@ describe('PoDatepickerRangeComponent:', () => {
     it('should update model with empty end date if the length of the end date input value is different from 10', () => {
       component.startDate = '2018-11-05T02:00:00-03:00';
       component.endDate = '2018-12-24';
+      component['onTouchedModel'] = () => {};
 
       spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'onTouchedModel');
 
       fixture.detectChanges();
 
       component.endDateInput.nativeElement.value = '24/12/201';
       component.endDateInput.nativeElement.dispatchEvent(blurFocusEvent);
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModel']).toHaveBeenCalledWith({ start: '2018-11-05', end: '' });
       expect(component['dateRange']).toEqual({ start: '2018-11-05', end: '' });
       expect(component.startDateInput.nativeElement.value).toBe('05/11/2018');
@@ -1418,14 +1432,17 @@ describe('PoDatepickerRangeComponent:', () => {
     it('should update model with empty start date if the length of the start date input value is different from 10', () => {
       component.startDate = '2018-12-24T02:00:00-03:00';
       component.endDate = '2018-12-24';
+      component['onTouchedModel'] = () => {};
 
       spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'onTouchedModel');
 
       fixture.detectChanges();
 
       component.startDateInput.nativeElement.value = '24/12/201';
       component.startDateInput.nativeElement.dispatchEvent(blurFocusEvent);
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModel']).toHaveBeenCalledWith({ start: '', end: '2018-12-24' });
       expect(component['dateRange']).toEqual({ start: '', end: '2018-12-24' });
       expect(component.startDateInput.nativeElement.value).toBe('24/12/201');
@@ -1435,13 +1452,16 @@ describe('PoDatepickerRangeComponent:', () => {
     it(`should update model with empty string if the length of the start date and end date input value are
       different from 10`, () => {
       component['dateRange'] = { start: '', end: '' };
+      component['onTouchedModel'] = () => {};
 
       spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'onTouchedModel');
 
       component.startDateInput.nativeElement.value = '24/1';
       component.endDateInput.nativeElement.value = '24/12/201';
       component.startDateInput.nativeElement.dispatchEvent(blurFocusEvent);
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModel']).toHaveBeenCalledWith({ start: '', end: '' });
       expect(component.startDateInput.nativeElement.value).toBe('24/1');
       expect(component.endDateInput.nativeElement.value).toBe('24/12/201');
@@ -1450,8 +1470,10 @@ describe('PoDatepickerRangeComponent:', () => {
     it('should update model with empty string if end date is invalid', () => {
       component.startDate = '2018-12-24T02:00:00-03:00';
       component.endDate = '2018-12-24';
+      component['onTouchedModel'] = () => {};
 
       spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'onTouchedModel');
 
       fixture.detectChanges();
 
@@ -1460,6 +1482,7 @@ describe('PoDatepickerRangeComponent:', () => {
 
       fixture.detectChanges();
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModel']).toHaveBeenCalledWith({ start: '2018-12-24', end: '' });
       expect(component['dateRange']).toEqual({ start: '2018-12-24', end: '' });
       expect(component.endDateInput.nativeElement.value).toBe('24/88/2018');
@@ -1468,14 +1491,17 @@ describe('PoDatepickerRangeComponent:', () => {
     it('should update model with empty string if start date is invalid', () => {
       component.startDate = '2018-12-24T02:00:00-03:00';
       component.endDate = '2018-12-24';
+      component['onTouchedModel'] = () => {};
 
       spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'onTouchedModel');
 
       fixture.detectChanges();
 
       component.startDateInput.nativeElement.value = '24/88/2018';
       component.startDateInput.nativeElement.dispatchEvent(blurFocusEvent);
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModel']).toHaveBeenCalledWith({ start: '', end: '2018-12-24' });
       expect(component['dateRange']).toEqual({ start: '', end: '2018-12-24' });
       expect(component.startDateInput.nativeElement.value).toBe('24/88/2018');
@@ -1484,14 +1510,17 @@ describe('PoDatepickerRangeComponent:', () => {
     it('should update model with start date empty if start date is greater than end date', () => {
       component.startDate = '2018-12-24T02:00:00-03:00';
       component.endDate = '2018-12-24';
+      component['onTouchedModel'] = () => {};
 
       spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'onTouchedModel');
 
       fixture.detectChanges();
 
       component.startDateInput.nativeElement.value = '24/12/2019';
       component.startDateInput.nativeElement.dispatchEvent(blurFocusEvent);
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModel']).toHaveBeenCalledWith({ start: '', end: '2018-12-24' });
       expect(component['dateRange']).toEqual({ start: '', end: '2018-12-24' });
       expect(component.startDateInput.nativeElement.value).toBe('24/12/2019');
@@ -1500,14 +1529,17 @@ describe('PoDatepickerRangeComponent:', () => {
     it('should update model with end date empty if start date is greater than end date', () => {
       component.startDate = '2018-12-24T02:00:00-03:00';
       component.endDate = '2018-12-24';
+      component['onTouchedModel'] = () => {};
 
       spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'onTouchedModel');
 
       fixture.detectChanges();
 
       component.endDateInput.nativeElement.value = '24/12/2016';
       component.endDateInput.nativeElement.dispatchEvent(blurFocusEvent);
 
+      expect(component['onTouchedModel']).toHaveBeenCalled();
       expect(component['updateModel']).toHaveBeenCalledWith({ start: '2018-12-24', end: '' });
       expect(component['dateRange']).toEqual({ start: '2018-12-24', end: '' });
       expect(component.endDateInput.nativeElement.value).toBe('24/12/2016');

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -178,6 +178,7 @@ export class PoDatepickerRangeComponent extends PoDatepickerRangeBaseComponent i
   }
 
   onBlur(event: any) {
+    this.onTouchedModel();
     const isStartDateTargetEvent = event.target.name === this.startDateInputName;
 
     this.updateModelByScreen(isStartDateTargetEvent);

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -80,8 +80,8 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   protected isExtendedISO: boolean = false;
   protected objMask: any;
   protected onChangeModel: any = null;
-  protected onTouchedModel: any = null;
   protected validatorChange: any;
+  protected onTouchedModel: any = null;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -130,7 +130,10 @@ describe('PoDatepickerComponent:', () => {
   });
 
   it('should call onblur', () => {
+    component['onTouchedModel'] = () => {};
+
     spyOn(component.onblur, 'emit');
+    spyOn(component, <any>'onTouchedModel');
 
     const input = fixture.debugElement.nativeElement.querySelector('input');
     const event = document.createEvent('Event');
@@ -138,11 +141,16 @@ describe('PoDatepickerComponent:', () => {
     input.dispatchEvent(event);
 
     component.eventOnBlur(event);
+
+    expect(component['onTouchedModel']).toHaveBeenCalled();
     expect(component.onblur.emit).toHaveBeenCalled();
   });
 
   it('should call onblur and callOnChange to have been called', () => {
+    component['onTouchedModel'] = () => {};
+
     spyOn(component, 'callOnChange');
+    spyOn(component, <any>'onTouchedModel');
 
     const input = fixture.debugElement.nativeElement.querySelector('input');
     input.value = '11/11/2011';
@@ -156,6 +164,7 @@ describe('PoDatepickerComponent:', () => {
 
     component.eventOnBlur(fakeEvent);
 
+    expect(component['onTouchedModel']).toHaveBeenCalled();
     expect(component.callOnChange).toHaveBeenCalled();
   });
 
@@ -447,7 +456,10 @@ describe('PoDatepickerComponent:', () => {
   });
 
   it('should call onBlur emit', () => {
+    component['onTouchedModel'] = () => {};
+
     spyOn(component.onblur, 'emit');
+    spyOn(component, <any>'onTouchedModel');
 
     const fakeEvent = {
       keyCode: 10,
@@ -458,6 +470,7 @@ describe('PoDatepickerComponent:', () => {
 
     component.eventOnBlur(fakeEvent);
 
+    expect(component['onTouchedModel']).toHaveBeenCalled();
     expect(component.onblur.emit).toHaveBeenCalled();
   });
 
@@ -654,15 +667,18 @@ describe('PoDatepickerComponent:', () => {
           onblur: { emit: () => {} },
           controlChangeEmitter: () => {},
           callOnChange: () => {},
-          inputEl: { nativeElement: { value: undefined } }
+          inputEl: { nativeElement: { value: undefined } },
+          onTouchedModel: () => {}
         };
 
         spyOn(fakeThis, <any>'controlChangeEmitter');
         spyOn(fakeThis['objMask'], 'blur');
         spyOn(fakeThis.onblur, 'emit');
+        spyOn(fakeThis, 'onTouchedModel');
 
         component.eventOnBlur.call(fakeThis, undefined);
 
+        expect(fakeThis['onTouchedModel']).toHaveBeenCalled();
         expect(fakeThis.controlChangeEmitter).toHaveBeenCalled();
         expect(fakeThis.objMask.blur).toHaveBeenCalled();
         expect(fakeThis.onblur.emit).toHaveBeenCalled();
@@ -672,13 +688,16 @@ describe('PoDatepickerComponent:', () => {
         fakeEvent.target.value = '06/11/2019';
         component.date = new Date(2017, 5, 2);
         component.inputEl.nativeElement.value = '06/11/2019';
+        component['onTouchedModel'] = () => {};
 
         spyOn(component, <any>'verifyMobile').and.returnValue(false);
         spyOn(component, 'controlModel');
         spyOn(component, <any>'controlChangeEmitter');
+        spyOn(component, <any>'onTouchedModel');
 
         component.eventOnBlur(fakeEvent);
 
+        expect(component['onTouchedModel']).toHaveBeenCalled();
         expect(component.controlModel).toHaveBeenCalled();
         expect(component['controlChangeEmitter']).toHaveBeenCalled();
       });
@@ -687,12 +706,15 @@ describe('PoDatepickerComponent:', () => {
         fakeEvent.target.value = undefined;
         component.date = new Date(2017, 5, 2);
         component.inputEl.nativeElement.value = '06/11/2019';
+        component['onTouchedModel'] = () => {};
 
         spyOn(component, <any>'verifyMobile').and.returnValue(false);
         spyOn(component, 'controlModel');
+        spyOn(component, <any>'onTouchedModel');
 
         component.eventOnBlur(fakeEvent);
 
+        expect(component['onTouchedModel']).toHaveBeenCalled();
         expect(component.controlModel).not.toHaveBeenCalled();
       });
 
@@ -700,12 +722,15 @@ describe('PoDatepickerComponent:', () => {
         fakeEvent.target.value = '05/02/20';
         component.date = new Date(2017, 5, 2);
         component.inputEl.nativeElement.value = '06/11/2019';
+        component['onTouchedModel'] = () => {};
 
         spyOn(component, <any>'verifyMobile').and.returnValue(false);
         spyOn(component, 'controlModel');
+        spyOn(component, <any>'onTouchedModel');
 
         component.eventOnBlur(fakeEvent);
 
+        expect(component['onTouchedModel']).toHaveBeenCalled();
         expect(component.controlModel).toHaveBeenCalledWith(null);
       });
     });

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -239,6 +239,7 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
   }
 
   eventOnBlur($event: any) {
+    this.onTouchedModel();
     const date = this.inputEl.nativeElement.value;
     const newDate = date ? this.getDateFromString(date) : undefined;
     this.objMask.blur($event);

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -196,11 +196,15 @@ describe('PoDecimalComponent:', () => {
         value: '123.456'
       }
     };
+    component['onTouched'] = () => {};
 
     spyOn(component.blur, 'emit');
     spyOn(component, <any>'controlChangeEmitter');
+    spyOn(component, <any>'onTouched');
 
     component.onBlur(fakeEvent);
+
+    expect(component['onTouched']).toHaveBeenCalled();
     expect(component.blur.emit).toHaveBeenCalled();
     expect(component['controlChangeEmitter']).toHaveBeenCalled();
   });
@@ -209,11 +213,15 @@ describe('PoDecimalComponent:', () => {
     const fakeEvent = {
       target: {}
     };
+    component['onTouched'] = () => {};
 
     spyOn(component.blur, 'emit');
     spyOn(component, <any>'controlChangeEmitter');
+    spyOn(component, <any>'onTouched');
 
     component.onBlur(fakeEvent);
+
+    expect(component['onTouched']).toHaveBeenCalled();
     expect(component.blur.emit).toHaveBeenCalled();
     expect(component['controlChangeEmitter']).toHaveBeenCalled();
   });
@@ -224,11 +232,15 @@ describe('PoDecimalComponent:', () => {
         value: 'ABC'
       }
     };
+    component['onTouched'] = () => {};
 
     spyOn(component, <any>'setViewValue');
     spyOn(component, <any>'callOnChange');
+    spyOn(component, <any>'onTouched');
 
     component.onBlur(fakeEvent);
+
+    expect(component['onTouched']).toHaveBeenCalled();
     expect(component['setViewValue']).toHaveBeenCalled();
     expect(component['callOnChange']).toHaveBeenCalled();
   });
@@ -1169,12 +1181,15 @@ describe('PoDecimalComponent:', () => {
           value: '1,200,50'
         }
       };
+      component['onTouched'] = () => {};
 
       spyOn(component, <any>'setViewValue');
       spyOn(component, <any>'callOnChange');
+      spyOn(component, <any>'onTouched');
 
       component.onBlur(fakeEvent);
 
+      expect(component['onTouched']).toHaveBeenCalled();
       expect(component['setViewValue']).toHaveBeenCalledWith('');
       expect(component['callOnChange']).toHaveBeenCalledWith(undefined);
     });

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -309,6 +309,7 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
 
   // função responsável por adicionar os zeroes com as casa decimais ao sair do campo.
   onBlur(event: any) {
+    this.onTouched();
     const value = event.target.value;
 
     if (value) {

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
@@ -418,7 +418,8 @@ describe('PoInputGeneric:', () => {
         mask: hasMask,
         objMask: { blur: (value: any) => {} },
         blur: component.blur,
-        controlChangeEmitter: () => {}
+        controlChangeEmitter: () => {},
+        onTouched: () => {}
       };
     }
 
@@ -538,9 +539,11 @@ describe('PoInputGeneric:', () => {
       const fakeThis = createFakeThis(true);
 
       spyOn(fakeThis.objMask, 'blur');
+      spyOn(fakeThis, <any>'onTouched');
 
       component.eventOnBlur.call(fakeThis, fakeEvent);
 
+      expect(fakeThis['onTouched']).toHaveBeenCalled();
       expect(fakeThis.objMask.blur).toHaveBeenCalled();
     });
 
@@ -548,9 +551,11 @@ describe('PoInputGeneric:', () => {
       const fakeThis = createFakeThis(false);
 
       spyOn(fakeThis.objMask, 'blur');
+      spyOn(fakeThis, <any>'onTouched');
 
       component.eventOnBlur.call(fakeThis, fakeEvent);
 
+      expect(fakeThis['onTouched']).toHaveBeenCalled();
       expect(fakeThis.objMask.blur).not.toHaveBeenCalled();
     });
 
@@ -559,9 +564,11 @@ describe('PoInputGeneric:', () => {
 
       spyOn(fakeThis.blur, 'emit');
       spyOn(fakeThis, 'controlChangeEmitter');
+      spyOn(fakeThis, <any>'onTouched');
 
       component.eventOnBlur.call(fakeThis, { type: 'blur' });
 
+      expect(fakeThis['onTouched']).toHaveBeenCalled();
       expect(fakeThis.blur.emit).toHaveBeenCalled();
       expect(fakeThis.controlChangeEmitter).toHaveBeenCalled();
     });
@@ -571,9 +578,11 @@ describe('PoInputGeneric:', () => {
 
       spyOn(fakeThis.blur, 'emit');
       spyOn(fakeThis, 'controlChangeEmitter');
+      spyOn(fakeThis, <any>'onTouched');
 
       component.eventOnBlur.call(fakeThis, fakeEvent);
 
+      expect(fakeThis['onTouched']).toHaveBeenCalled();
       expect(fakeThis.blur.emit).not.toHaveBeenCalled();
       expect(fakeThis.controlChangeEmitter).not.toHaveBeenCalled();
     });

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -106,6 +106,7 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
   }
 
   eventOnBlur(e: any) {
+    this.onTouched();
     if (this.mask) {
       this.objMask.blur(e);
     }

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
@@ -160,11 +160,11 @@ describe('PoInputBase:', () => {
   });
 
   it('should register function registerOnTouched', () => {
-    component.onTouched = undefined;
+    component['onTouched'] = undefined;
     const func = () => true;
 
     component.registerOnTouched(func);
-    expect(component.onTouched).toBe(func);
+    expect(component['onTouched']).toBe(func);
   });
 
   it('should call writeValueModel', () => {

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -300,9 +300,9 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
   type: string;
 
   onChangePropagate: any = null;
-  onTouched: any = null;
   objMask: any;
   modelLastUpdate: any;
+  protected onTouched: any = null;
 
   callOnChange(value: any) {
     this.updateModel(value);

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -58,7 +58,7 @@ export abstract class PoLookupBaseComponent
 
   private onChangePropagate: any = null;
   // tslint:disable-next-line
-  private onTouched: any = null;
+  protected onTouched: any = null;
   private validatorChange: any;
 
   private control!: AbstractControl;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -90,10 +90,14 @@ describe('PoLookupComponent:', () => {
     (lookupFilterService: LookupFilterService) => {
       component['oldValue'] = 'po';
       component.inputEl.nativeElement.value = 'po';
+      component['onTouched'] = () => {};
 
       spyOn(component, <any>'selectModel');
+      spyOn(component, <any>'onTouched');
 
       component.searchEvent();
+
+      expect(component['onTouched']).toHaveBeenCalled();
       expect(component['selectModel']).not.toHaveBeenCalled();
     }
   ));
@@ -141,11 +145,14 @@ describe('PoLookupComponent:', () => {
         component.service = lookupFilterService;
         component.inputEl.nativeElement.value = 'po JOI';
         component['oldValue'] = 'po SP';
+        component['onTouched'] = () => {};
 
         spyOn(component, <any>'searchById');
+        spyOn(component, <any>'onTouched');
 
         component.searchEvent();
 
+        expect(component['onTouched']).toHaveBeenCalled();
         expect(component['searchById']).toHaveBeenCalled();
       }
     ));
@@ -156,11 +163,14 @@ describe('PoLookupComponent:', () => {
         component.service = lookupFilterService;
         component.inputEl.nativeElement.value = 'po';
         component['oldValue'] = 'po';
+        component['onTouched'] = () => {};
 
         spyOn(component, <any>'searchById');
+        spyOn(component, <any>'onTouched');
 
         component.searchEvent();
 
+        expect(component['onTouched']).toHaveBeenCalled();
         expect(component['searchById']).not.toHaveBeenCalled();
       }
     ));

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -181,6 +181,7 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
   }
 
   searchEvent() {
+    this.onTouched();
     const value = this.getViewValue();
 
     if (this.oldValue.toString() !== value) {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -60,9 +60,9 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
 
   private lastLengthModel;
   private onModelChange: any;
-  // tslint:disable-next-line
-  private onModelTouched: any;
   private validatorChange: any;
+  // tslint:disable-next-line
+  protected onModelTouched: any = null;
 
   selectedOptions: Array<PoMultiselectOption> = [];
   visibleOptionsDropdown: Array<PoMultiselectOption> = [];

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -9,6 +9,7 @@
       [disabled]="disabled"
       (keydown)="onKeyDown($event)"
       (click)="toggleDropdownVisibility()"
+      (blur)="onBlur()"
     />
 
     <div class="po-field-icon-container-right">

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -472,6 +472,15 @@ describe('PoMultiselectComponent:', () => {
       expect(closeSpy).toHaveBeenCalled();
     });
 
+    it('onBlur: should be called when blur event', () => {
+      component['onModelTouched '] = () => {};
+      spyOn(component, <any>'onModelTouched');
+
+      component.onBlur();
+
+      expect(component['onModelTouched']).toHaveBeenCalled();
+    });
+
     it('debounceResize: should call `calculateVisibleItems` after 200 milliseconds', done => {
       spyOn(component, 'calculateVisibleItems');
       component.debounceResize();

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -208,6 +208,10 @@ export class PoMultiselectComponent extends PoMultiselectBaseComponent implement
     }, 200);
   }
 
+  onBlur() {
+    this.onModelTouched();
+  }
+
   onKeyDown(event?: any) {
     if (event.keyCode === PoKeyCodeEnum.arrowUp || event.keyCode === PoKeyCodeEnum.arrowDown) {
       event.preventDefault();

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
@@ -26,9 +26,9 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
   onChangeModel: any = null;
   value: string;
 
-  // tslint:disable-next-line
-  private onTouched: any = null;
   private validatorChange: any;
+  // tslint:disable-next-line
+  protected onTouched: any = null;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
@@ -161,6 +161,7 @@ describe('PoRichTextBodyComponent:', () => {
         modelValue: 'value',
         valueBeforeChange: '1',
         change: component.change,
+        blur: component.blur,
         bodyElement: {
           nativeElement: {
             innerHTML: 'value'
@@ -169,9 +170,11 @@ describe('PoRichTextBodyComponent:', () => {
       };
 
       spyOn(fakeThis.change, 'emit');
+      spyOn(fakeThis.blur, 'emit');
       component.onBlur.call(fakeThis);
       tick(250);
 
+      expect(fakeThis.blur.emit).toHaveBeenCalled();
       expect(fakeThis.change.emit).toHaveBeenCalledWith(fakeThis.modelValue);
     }));
 
@@ -182,6 +185,9 @@ describe('PoRichTextBodyComponent:', () => {
         change: {
           emit: () => {}
         },
+        blur: {
+          emit: () => {}
+        },
         bodyElement: {
           nativeElement: {
             innerHTML: 'value'
@@ -189,10 +195,13 @@ describe('PoRichTextBodyComponent:', () => {
         }
       };
 
+      spyOn(fakeThis.blur, 'emit');
       spyOn(fakeThis.change, 'emit');
+
       component.onBlur.call(fakeThis);
       tick(250);
 
+      expect(fakeThis.blur.emit).toHaveBeenCalled();
       expect(fakeThis.change.emit).not.toHaveBeenCalled();
     }));
 

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
@@ -49,6 +49,8 @@ export class PoRichTextBodyComponent implements OnInit, OnDestroy {
 
   @Output('p-value') value = new EventEmitter<any>();
 
+  @Output('p-blur') blur = new EventEmitter<any>();
+
   constructor(private richTextService: PoRichTextService) {}
 
   ngOnInit() {
@@ -94,6 +96,7 @@ export class PoRichTextBodyComponent implements OnInit, OnDestroy {
   }
 
   onBlur() {
+    this.blur.emit();
     if (this.modelValue !== this.valueBeforeChange) {
       clearTimeout(this.timeoutChange);
       this.timeoutChange = setTimeout(() => {

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
@@ -11,6 +11,7 @@
       (p-selected-link)="richTextToolbar.selectedLink($event)"
       (p-shortcut-command)="richTextToolbar.shortcutTrigger()"
       (p-value)="updateValue($event)"
+      (p-blur)="onBlur()"
     >
     </po-rich-text-body>
 

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.spec.ts
@@ -153,6 +153,15 @@ describe('PoRichTextComponent:', () => {
       expect(component.bodyElement.focus).toHaveBeenCalled();
     });
 
+    it('onBlur: should be called when `po-rich-text-body` emit blur event', () => {
+      component['onTouched'] = () => {};
+      spyOn(component, <any>'onTouched');
+
+      component.onBlur();
+
+      expect(component['onTouched']).toHaveBeenCalled();
+    });
+
     it('updateValue: should apply values to value, invalid and call updateModel', () => {
       spyOn(component, <any>'updateModel');
       spyOn(component, <any>'controlChangeModelEmitter');

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
@@ -101,6 +101,10 @@ export class PoRichTextComponent extends PoRichTextBaseComponent implements Afte
     this.bodyElement.focus();
   }
 
+  onBlur() {
+    this.onTouched();
+  }
+
   onChangeValue(value: any) {
     this.change.emit(value);
   }

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
@@ -7,6 +7,7 @@
     [ngClass]="{ 'po-select-mobile': isMobile, 'po-invisible': isInvisibleSelectNative }"
     [required]="required"
     (change)="onSelectChange($event.target.value)"
+    (blur)="onBlur()"
   >
     <option *ngIf="isMobile" disabled hidden selected></option>
     <option *ngFor="let option of options" [disabled]="readonly" [value]="option.value" (click)="onOptionClick(option)">

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -215,6 +215,15 @@ describe('PoSelectComponent:', () => {
       expect(component.selectElement.nativeElement.focus).not.toHaveBeenCalled();
     });
 
+    it('onBlur: should be called when blur event', () => {
+      component['onModelTouched'] = () => {};
+      spyOn(component, <any>'onModelTouched');
+
+      component.onBlur();
+
+      expect(component['onModelTouched']).toHaveBeenCalled();
+    });
+
     it('getSelectItemHeight: should return height of po-select-item class', () => {
       const selectItem: any = { clientHeight: 5 };
 

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -194,6 +194,10 @@ export class PoSelectComponent extends PoSelectBaseComponent implements AfterVie
     return value === inputValue;
   }
 
+  onBlur() {
+    this.onModelTouched();
+  }
+
   onOptionClick(option: PoSelectOption) {
     this.updateModel(option);
     this.toggleButton();

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
@@ -24,6 +24,7 @@ export class PoSwitchBaseComponent implements ControlValueAccessor {
   private _disabled?: boolean = false;
 
   propagateChange: any;
+  onTouched;
   switchValue: boolean = false;
 
   /** Nome do componente. */
@@ -148,7 +149,9 @@ export class PoSwitchBaseComponent implements ControlValueAccessor {
     this.propagateChange = fn;
   }
 
-  registerOnTouched(fn: any): void {}
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
 
   writeValue(value: any): void {
     if (value !== this.switchValue) {

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
@@ -10,6 +10,7 @@
       [tabindex]="disabled ? -1 : 0"
       (click)="eventClick()"
       (keydown)="onKeyDown($event)"
+      (blur)="onBlur()"
     >
       <div
         class="po-switch-button"

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
@@ -207,6 +207,15 @@ describe('PoSwitchComponent', () => {
         expect(fakeEvent.preventDefault).not.toHaveBeenCalled();
       });
     });
+
+    it('onBlur: should call `onTouched` on blur', () => {
+      component.onTouched = value => {};
+
+      spyOn(component, 'onTouched');
+      component.onBlur();
+
+      expect(component.onTouched).toHaveBeenCalledWith();
+    });
   });
 
   describe('Template:', () => {

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
@@ -88,6 +88,10 @@ export class PoSwitchComponent extends PoSwitchBaseComponent implements AfterVie
     }
   }
 
+  onBlur() {
+    this.onTouched();
+  }
+
   getLabelPosition() {
     switch (this.labelPosition) {
       case PoSwitchLabelPosition.Left:

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -34,9 +34,9 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
 
   private modelLastUpdate: any;
   private onChangePropagate: any = null;
-  // tslint:disable-next-line
-  private onTouched: any = null;
   private validatorChange: any;
+  // tslint:disable-next-line
+  protected onTouched: any = null;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
@@ -81,10 +81,15 @@ describe('PoTextareaComponent:', () => {
   });
 
   it('blur event must be called', () => {
+    component['onTouched'] = () => {};
+
     spyOn(component.blur, 'emit');
     spyOn(component, 'controlChangeEmitter');
+    spyOn(component, <any>'onTouched');
 
     component.eventOnBlur();
+
+    expect(component['onTouched']).toHaveBeenCalled();
     expect(component.blur.emit).toHaveBeenCalled();
     expect(component.controlChangeEmitter).toHaveBeenCalled();
   });

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
@@ -120,6 +120,7 @@ export class PoTextareaComponent extends PoTextareaBaseComponent implements Afte
   }
 
   eventOnBlur() {
+    this.onTouched();
     this.blur.emit();
     this.controlChangeEmitter();
   }

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
@@ -106,7 +106,7 @@ describe('PoUploadBaseComponent:', () => {
       const registerOnTouchedFn = () => {};
 
       component.registerOnTouched(registerOnTouchedFn);
-      expect(component.onModelTouched).toBe(registerOnTouchedFn);
+      expect(component['onModelTouched']).toBe(registerOnTouchedFn);
     });
 
     it('registerOnValidatorChange: should register validatorChange function', () => {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -159,13 +159,13 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
 
   canHandleDirectory: boolean;
   onModelChange: any;
-  onModelTouched: any;
 
   private validatorChange: any;
 
   protected extensionNotAllowed = 0;
   protected quantityNotAllowed = 0;
   protected sizeNotAllowed = 0;
+  protected onModelTouched: any = null;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
@@ -457,10 +457,13 @@ describe('PoUploadComponent:', () => {
 
     it('selectFiles: should click on input and set `calledByCleanInputValue` to false', () => {
       const calledByCleanInputValue = 'calledByCleanInputValue';
+      component['onModelTouched'] = () => {};
+      spyOn(component, <any>'onModelTouched');
 
       component[calledByCleanInputValue] = true;
       component.selectFiles();
 
+      expect(component['onModelTouched']).toHaveBeenCalled();
       expect(component.selectFiles).toBeTruthy();
       expect(component[calledByCleanInputValue]).toBeFalsy();
     });

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
@@ -235,6 +235,7 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
 
   /** Método responsável por **abrir** a janela para seleção de arquivo(s). */
   selectFiles() {
+    this.onModelTouched();
     this.calledByCleanInputValue = false;
     this.inputFile.nativeElement.click();
   }


### PR DESCRIPTION
**FIELDS**

**DTHFUI-1343**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Nossos componentes de entrada não atualizam o `ng-touched`, o campo sempre permanece `ng-untouched`.

**Qual o novo comportamento?**
Ao sair de algum campo e ser acionado o blur event o estado `ng-untouched` deve ser alterado para `ng-touched`

- Campos alterados
  - input
  - decimal
  - url
  - email
  - lookup
  - login
  - number
  - datepicker
  - datepicker-range
  - combo
  - select
  - upload
  - rich-text
  - password
  - textarea
  - multiselect


**Simulação**
Baixar o arquivo [app.zip](https://github.com/po-ui/po-angular/files/6198344/app.zip) e verificar a troca no **_Inspecionar Elementos_** do navegador

