### PR TITLE
feat(dynamic-form): adiciona possibilidade de usar instancia de serviço

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -1,3 +1,4 @@
+import { PoComboFilter, PoLookupFilter } from '../../po-field';
 import { PoLookupColumn } from '../../po-field/po-lookup/interfaces/po-lookup-column.interface';
 import { PoMultiselectOption } from '../../po-field/po-multiselect/po-multiselect-option.interface';
 import { PoSelectOption } from '../../po-field/po-select/po-select-option.interface';
@@ -45,18 +46,24 @@ export interface PoDynamicFormField extends PoDynamicField {
    */
   optionsMulti?: boolean;
 
-  /** Serviço que será utilizado para buscar os itens e preencher a lista de opções dinamicamente. */
-  optionsService?: string;
+  /**
+   *  Serviço que será utilizado para buscar os itens e preencher a lista de opções dinamicamente.
+   *  Pode ser informada uma URL ou uma instancia do serviço baseado em PoComboFilter.
+   *  **Importante**
+   *  > Para que funcione corretamente, é importante que o serviço siga o
+   *  [guia de API do PO UI](https://po-ui.io/guides/api).
+   */
+  optionsService?: string | PoComboFilter;
 
   /**
    * Serviço que será utilizado para realizar a busca avançada. Pode ser utilizado em conjunto com a propriedade `columns`.
-   *
+   * Pode ser ser informada uma URL ou uma instancia do serviço baseado em PoLookupFilter.
    * **Importante:**
    * > Caso utilizar a propriedade `optionsService` esta propriedade será ignorada.
    * > Para que funcione corretamente, é importante que o serviço siga o
    * [guia de API do PO UI](https://po-ui.io/guides/api).
    */
-  searchService?: string;
+  searchService?: string | PoLookupFilter;
 
   /** Máscara para o campo. */
   mask?: string;

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -499,7 +499,7 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         expect(field.mask).toBe('99:99');
       });
 
-      it('should call `isCombo` and return `combo` if contains `optionsService`', () => {
+      it('should call `isCombo` and return `combo` if contains `optionsService` as url string', () => {
         const expectedValue = 'combo';
         const field = { optionService: 'http://api.example/1', property: 'code' };
 
@@ -509,9 +509,37 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         expect(component['isCombo']).toHaveBeenCalledWith(field);
       });
 
-      it('should call `isLookup` and return `lookup` if contains `searchService`.', () => {
+      it('should call `isCombo` and return `combo` if contains `optionsService` as `PoComboFilter` instance', () => {
+        const expectedValue = 'combo';
+        const mockService = {
+          getFilteredData: null,
+          getObjectByValue: null
+        };
+        const field = { optionService: mockService, property: 'code' };
+
+        spyOn(component, <any>'isCombo').and.returnValue(true);
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isCombo']).toHaveBeenCalledWith(field);
+      });
+
+      it('should call `isLookup` and return `lookup` if contains `searchService` as url string.', () => {
         const expectedValue = 'lookup';
         const field = { searchService: 'http://api.example/1', property: 'code' };
+
+        spyOn(component, <any>'isLookup').and.returnValue(true);
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isLookup']).toHaveBeenCalledWith(field);
+      });
+
+      it('should call `isLookup` and return `lookup` if contains `searchService` as `PoLookupFilter` instance.', () => {
+        const expectedValue = 'lookup';
+        const mockService = {
+          getObjectByValue: null,
+          getFilteredItems: null
+        };
+        const field = { searchService: mockService, property: 'code' };
 
         spyOn(component, <any>'isLookup').and.returnValue(true);
 
@@ -567,6 +595,16 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
       expect(component['isCombo']({ optionsService, property: 'states' })).toBe(true);
     });
 
+    it('isCombo: should return `true` if `optionsService` is defined service', () => {
+      const optionsService = {
+        getFilteredData: null,
+        getObjectByValue: null
+      };
+      const field = { optionsService, property: 'states' };
+
+      expect(component['isCombo'](field)).toBeTruthy();
+    });
+
     it('isCombo: should return `false` if `optionsService` is invalid string', () => {
       const optionsService = '';
 
@@ -593,6 +631,15 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
 
     it('isLookup: should return `true` if `searchService` is defined string.', () => {
       const field = { searchService: 'http://service.api:3100', property: 'states' };
+
+      expect(component['isLookup'](field)).toBeTruthy();
+    });
+
+    it('isLookup: should return `true` if `searchService` is defined service.', () => {
+      const searchService = {
+        getObjectByValue: null
+      };
+      const field = { searchService: searchService, property: 'states' };
 
       expect(component['isLookup'](field)).toBeTruthy();
     });

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -7,6 +7,8 @@ import { getGridColumnsClasses, isVisibleField } from '../../po-dynamic.util';
 import { PoDynamicFieldType } from '../../po-dynamic-field-type.enum';
 import { PoDynamicFormField } from '../po-dynamic-form-field.interface';
 import { PoDynamicFormFieldInternal } from './po-dynamic-form-field-internal.interface';
+import { PoComboFilter } from '../../../po-field/po-combo/interfaces/po-combo-filter.interface';
+import { PoLookupFilter } from '../../../po-field/po-lookup/interfaces/po-lookup-filter.interface';
 
 @Directive()
 export class PoDynamicFormFieldsBaseComponent {
@@ -185,7 +187,7 @@ export class PoDynamicFormFieldsBaseComponent {
   private isCombo(field: PoDynamicFormField) {
     const { optionsService } = field;
 
-    return !!optionsService && isTypeof(optionsService, 'string');
+    return !!optionsService && (isTypeof(optionsService, 'string') || this.isComboFilter(optionsService));
   }
 
   private isCurrencyType(field: PoDynamicFormField, type: string) {
@@ -194,10 +196,18 @@ export class PoDynamicFormFieldsBaseComponent {
     return this.compareTo(type, PoDynamicFieldType.Currency) && !mask && !pattern;
   }
 
+  private isLookupFilter(object: any): object is PoLookupFilter {
+    return object && (<PoLookupFilter>object).getObjectByValue !== undefined;
+  }
+
+  private isComboFilter(object: any): object is PoComboFilter {
+    return object && (<PoComboFilter>object).getFilteredData !== undefined;
+  }
+
   private isLookup(field: PoDynamicFormField) {
     const { searchService } = field;
 
-    return !!searchService && isTypeof(searchService, 'string');
+    return !!searchService && (isTypeof(searchService, 'string') || this.isLookupFilter(searchService));
   }
 
   private isMultiselect(field: PoDynamicFormField) {


### PR DESCRIPTION
**DYNAMIC-FORM**

**DTHFUI-4127**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
As propriedades `optionsService` e `searchService` aceitam uma URL como método de entrada de dados.


**Qual o novo comportamento?**
As propriedades `optionsService` e `searchService` continuam aceitando uma URL como serviço, mas poderá também receber instancias de serviços baseados em `PoComboFilter` e `PoLookupFilter` como métodos de entrada de dados.


**Simulação**
Baixar os arquivos [app.zip](https://github.com/po-ui/po-angular/files/6207716/app.zip) e realizar os testes.
