### PR TITLE
feat(button): adiciona compatibilidade com outras fontes de ícones 

### DIFF
--- a/projects/portal/src/index.html
+++ b/projects/portal/src/index.html
@@ -7,6 +7,12 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.3.1/css/all.css"
+      integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU"
+      crossorigin="anonymous"
+    />
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-163592264-1"></script>

--- a/projects/ui/src/lib/components/components.module.ts
+++ b/projects/ui/src/lib/components/components.module.ts
@@ -35,6 +35,7 @@ import { PoTagModule } from './po-tag/po-tag.module';
 import { PoToolbarModule } from './po-toolbar/po-toolbar.module';
 import { PoTreeViewModule } from './po-tree-view/po-tree-view.module';
 import { PoWidgetModule } from './po-widget/po-widget.module';
+import { PoIconModule } from './po-icon/po-icon.module';
 
 @NgModule({
   imports: [
@@ -54,6 +55,7 @@ import { PoWidgetModule } from './po-widget/po-widget.module';
     PoFieldModule,
     PoGaugeModule,
     PoGridModule,
+    PoIconModule,
     PoInfoModule,
     PoListViewModule,
     PoLoadingModule,
@@ -91,6 +93,7 @@ import { PoWidgetModule } from './po-widget/po-widget.module';
     PoFieldModule,
     PoGaugeModule,
     PoGridModule,
+    PoIconModule,
     PoInfoModule,
     PoListViewModule,
     PoLoadingModule,

--- a/projects/ui/src/lib/components/index.ts
+++ b/projects/ui/src/lib/components/index.ts
@@ -16,6 +16,7 @@ export * from './po-dynamic/index';
 export * from './po-field/index';
 export * from './po-gauge/index';
 export * from './po-grid/index';
+export * from './po-icon/index';
 export * from './po-info/index';
 export * from './po-list-view/index';
 export * from './po-loading/index';

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Input, Output, Directive } from '@angular/core';
+import { EventEmitter, Input, Output, Directive, TemplateRef } from '@angular/core';
 
 import { convertToBoolean } from '../../utils/util';
 import { InputBoolean } from '../../decorators';
@@ -69,11 +69,30 @@ export class PoButtonBaseComponent {
   }
 
   /**
+   * @optional
+   *
+   * @description
    * Ícone exibido ao lado esquerdo do label do botão.
    *
-   * É possível usar qualquer uma dos ícones da [Biblioteca de ícones](/guides/icons).
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-button p-icon="po-icon-user" p-label="PO button"></po-button>
+   * ```
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
+   * ```
+   * <po-button p-icon="fa fa-podcast" p-label="PO button"></po-button>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-button [p-icon]="template" p-label="button template ionic"></po-button>
+   *
+   * <ng-template #template>
+   *  <ion-icon style="font-size: inherit" name="heart"></ion-icon>
+   * </ng-template>
+   * ```
+   * > Para o ícone enquadrar corretamente, deve-se utilizar `font-size: inherit` caso o ícone utilizado não aplique-o.
    */
-  @Input('p-icon') icon?: string;
+  @Input('p-icon') icon?: string | TemplateRef<void>;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-button/po-button.component.html
+++ b/projects/ui/src/lib/components/po-button/po-button.component.html
@@ -13,6 +13,7 @@
   <div *ngIf="loading" class="po-button-loading-icon">
     <po-loading-icon p-neutral-color></po-loading-icon>
   </div>
-  <span *ngIf="icon" class="po-icon {{ icon }}" aria-hidden="true"></span>
+
+  <po-icon *ngIf="icon" class="po-button-icon" [p-icon]="icon"></po-icon>
   <span *ngIf="label" class="po-button-label">{{ label }}</span>
 </button>

--- a/projects/ui/src/lib/components/po-button/po-button.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button/po-button.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { configureTestSuite } from './../../util-test/util-expect.spec';
 
 import { PoLoadingModule } from '../po-loading';
+import { PoIconModule } from './../po-icon';
 
 import { PoButtonComponent } from './po-button.component';
 import { PoButtonBaseComponent } from './po-button-base.component';
@@ -17,7 +18,7 @@ describe('PoButtonComponent: ', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [PoLoadingModule],
+      imports: [PoLoadingModule, PoIconModule],
       declarations: [PoButtonComponent]
     });
   });
@@ -85,11 +86,11 @@ describe('PoButtonComponent: ', () => {
     expect(nativeElement.querySelector('.po-button-danger')).toBeFalsy();
   });
 
-  it('should add span with an icon when `p-icon` is defined', () => {
+  it('should add i with an icon when `p-icon` is defined', () => {
     component.icon = 'po-icon-news';
     fixture.detectChanges();
 
-    expect(nativeElement.querySelector('span.po-icon.po-icon-news')).toBeTruthy();
+    expect(nativeElement.querySelector('i.po-icon.po-icon-news')).toBeTruthy();
   });
 
   it('should simulate button click.', () => {
@@ -118,11 +119,11 @@ describe('PoButtonComponent: ', () => {
       expect(nativeElement.querySelector('span.po-button-label')).toBeTruthy();
     });
 
-    it('p-label: should not add span tag if `p-label` has not been declared', () => {
+    it('p-label: should not add i tag if `p-label` has not been declared', () => {
       component.label = undefined;
       fixture.detectChanges();
 
-      expect(nativeElement.querySelector('span.po-button-label')).toBeFalsy();
+      expect(nativeElement.querySelector('i.po-button-label')).toBeFalsy();
     });
   });
 

--- a/projects/ui/src/lib/components/po-button/po-button.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button.component.ts
@@ -20,6 +20,11 @@ import { PoButtonBaseComponent } from './po-button-base.component';
  *  <file name="sample-po-button-labs/sample-po-button-labs.component.e2e-spec.ts"> </file>
  *  <file name="sample-po-button-labs/sample-po-button-labs.component.po.ts"> </file>
  * </example>
+ *
+ * <example name="po-button-social-network" title="PO Button Social Network">
+ *  <file name="sample-po-button-social-network/sample-po-button-social-network.component.html"> </file>
+ *  <file name="sample-po-button-social-network/sample-po-button-social-network.component.ts"> </file>
+ * </example>
  */
 @Component({
   selector: 'po-button',

--- a/projects/ui/src/lib/components/po-button/po-button.module.ts
+++ b/projects/ui/src/lib/components/po-button/po-button.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { PoIconModule } from './../po-icon/index';
 import { PoLoadingModule } from './../po-loading/index';
 
 import { PoButtonComponent } from './po-button.component';
@@ -11,7 +12,7 @@ import { PoButtonComponent } from './po-button.component';
  * Módulo do componente po-button.
  */
 @NgModule({
-  imports: [CommonModule, PoLoadingModule],
+  imports: [CommonModule, PoLoadingModule, PoIconModule],
   declarations: [PoButtonComponent],
   exports: [PoButtonComponent]
 })

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
@@ -22,7 +22,7 @@ export class SamplePoButtonLabsComponent implements OnInit {
     { label: 'po-icon-news', value: 'po-icon-news' },
     { label: 'po-icon-calendar', value: 'po-icon-calendar' },
     { label: 'po-icon-user', value: 'po-icon-user' },
-    { label: 'po-icon-telephone', value: 'po-icon-telephone' }
+    { label: 'fa fa-podcast', value: 'fa fa-podcast' }
   ];
 
   typesOptions: Array<PoRadioGroupOption> = [

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-social-network/sample-po-button-social-network.component.html
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-social-network/sample-po-button-social-network.component.html
@@ -1,0 +1,46 @@
+<div class="po-row">
+  <po-widget class="po-lg-6" p-title="Friend Request">
+    <ng-container *ngIf="currentFriend; else noMoreRequest">
+      <div class="po-row">
+        <po-avatar class="po-md-4" p-size="lg" [p-src]="userAvatar"> </po-avatar>
+
+        <div class="po-md-8">
+          <span class="po-sm-12 po-font-subtitle">
+            {{ currentFriend.name }}
+          </span>
+
+          <span class="po-sm-12 po-font-text"> {{ currentFriend.mutualFriends }} mutual friends </span>
+
+          <span class="po-sm-12 po-font-text"> Resides in {{ currentFriend.reside }} </span>
+        </div>
+      </div>
+
+      <div class="po-row">
+        <po-button
+          class="po-md-4"
+          p-icon="fa fa-check-circle"
+          p-label="Confirm"
+          (p-click)="notification('added', 'success')"
+        ></po-button>
+        <po-button
+          class="po-md-4"
+          p-icon="fa fa-eye-slash"
+          p-label="Ignore"
+          (p-click)="notification('ignored', 'warning')"
+        ></po-button>
+        <po-button
+          class="po-md-4"
+          p-icon="fa fa-ban"
+          p-label="Block"
+          (p-click)="notification('blocked', 'information')"
+        ></po-button>
+      </div>
+    </ng-container>
+
+    <ng-template #noMoreRequest>
+      <div class="po-row">
+        <span class="po-lg-8 po-font-subtitle">Congratulations Totver, no more requests!</span>
+      </div>
+    </ng-template>
+  </po-widget>
+</div>

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-social-network/sample-po-button-social-network.component.ts
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-social-network/sample-po-button-social-network.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+
+import { PoNotificationService } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-button-social-network',
+  templateUrl: './sample-po-button-social-network.component.html'
+})
+export class SamplePoButtonSocialNetworkComponent implements OnInit {
+  currentFriend: object;
+  userAvatar: string = 'https://lorempixel.com/144/144/';
+
+  public readonly newFriends: Array<object> = [
+    { name: 'Mr. Dev PO', mutualFriends: '7', reside: 'Mountain View, CA' },
+    { name: 'Mr. AI PO', mutualFriends: '99+', reside: 'New York City, NY' },
+    { name: 'Mr. UX PO', mutualFriends: '14', reside: 'Los Angeles, CA' }
+  ];
+
+  private indexFriend: number = 0;
+
+  constructor(private poNotification: PoNotificationService) {}
+
+  ngOnInit() {
+    this.setCurrentFriend(0);
+  }
+
+  notification(action: string, notificationType: string) {
+    this.poNotification[notificationType](`User ${action} successfully!`);
+
+    this.indexFriend++;
+    this.setCurrentFriend(this.indexFriend);
+  }
+
+  private setCurrentFriend(index: number) {
+    this.currentFriend = this.newFriends[index];
+  }
+}

--- a/projects/ui/src/lib/components/po-icon/index.ts
+++ b/projects/ui/src/lib/components/po-icon/index.ts
@@ -1,0 +1,3 @@
+export * from './po-icon.component';
+
+export * from './po-icon.module';

--- a/projects/ui/src/lib/components/po-icon/po-icon.component.html
+++ b/projects/ui/src/lib/components/po-icon/po-icon.component.html
@@ -1,0 +1,5 @@
+<ng-container *ngIf="class; then fontTemplate; else icon"></ng-container>
+
+<ng-template #fontTemplate>
+  <i [class]="class" aria-hidden="true"></i>
+</ng-template>

--- a/projects/ui/src/lib/components/po-icon/po-icon.component.spec.ts
+++ b/projects/ui/src/lib/components/po-icon/po-icon.component.spec.ts
@@ -1,0 +1,113 @@
+import { TemplateRef } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { PoIconComponent } from './po-icon.component';
+
+class TemplateA extends TemplateRef<void> {
+  elementRef;
+  createEmbeddedView(context) {
+    return <any>null;
+  }
+}
+
+describe('PoIconComponent: ', () => {
+  let component: PoIconComponent;
+  let fixture: ComponentFixture<PoIconComponent>;
+
+  let nativeElement: any;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [PoIconComponent]
+      }).compileComponents();
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoIconComponent);
+    component = fixture.componentInstance;
+
+    nativeElement = fixture.debugElement.nativeElement;
+  });
+
+  it('should be created', fakeAsync(() => {
+    expect(component instanceof PoIconComponent).toBeTruthy();
+  }));
+
+  describe('Properties: ', () => {
+    describe('p-icon: ', () => {
+      it('should call `addClasses` if value is a string.', () => {
+        spyOn(component, <any>'addClasses');
+
+        const iconString = 'po-icon-user';
+        component.icon = iconString;
+
+        expect(component['addClasses']).toHaveBeenCalledWith(iconString);
+      });
+
+      it('should update `icon` value if value is a TemplateRef.', () => {
+        spyOn(component, <any>'addClasses');
+
+        const expectedResult = new TemplateA();
+        component.icon = expectedResult;
+
+        expect(component['addClasses']).not.toHaveBeenCalled();
+        expect(component.icon).toEqual(expectedResult);
+      });
+
+      it('shouldn`t update `icon` value if value isn`t a TemplateRef or string.', () => {
+        spyOn(component, <any>'addClasses');
+
+        component.icon = <any>2;
+
+        expect(component['addClasses']).not.toHaveBeenCalled();
+        expect(component.icon).toEqual(undefined);
+      });
+    });
+  });
+
+  describe('Methods:', () => {
+    describe('addClasses: ', () => {
+      it('should update `class` if icon class starts with `po-icon`.', () => {
+        const iconString = 'po-icon-user';
+        const expectedValue = 'po-icon po-icon-user';
+        component['addClasses'](iconString);
+
+        expect(component.class).toBe(expectedValue);
+      });
+
+      it('should update `class` if icon class don`t starts with `po-icon`.', () => {
+        const iconString = 'fa fa-podcast';
+        const expectedResult = 'po-fonts-icon fa fa-podcast';
+        component['addClasses'](iconString);
+
+        expect(component.class).toBe(expectedResult);
+      });
+    });
+  });
+
+  describe('Template:', () => {
+    it('should contain the `po-icon` selector.', () => {
+      const iconString = 'po-icon-user';
+      component.icon = iconString;
+      fixture.detectChanges();
+      const icon = nativeElement.querySelector('i.po-icon');
+
+      expect(icon).toBeTruthy();
+    });
+
+    it('shouldn`t contain the `po-icon` selector.', () => {
+      const iconString = 'fa fa-podcast';
+      component.icon = iconString;
+
+      fixture.detectChanges();
+
+      const poClass = nativeElement.querySelector('i.po-icon');
+      const fontClass = nativeElement.querySelector('i.fa');
+
+      expect(poClass).toBeFalsy();
+      expect(fontClass).toBeTruthy();
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-icon/po-icon.component.ts
+++ b/projects/ui/src/lib/components/po-icon/po-icon.component.ts
@@ -1,0 +1,61 @@
+import { Input, TemplateRef, Component, ChangeDetectionStrategy } from '@angular/core';
+
+/**
+ * @docsPrivate
+ *
+ * @usedBy PoButton
+ *
+ * @description
+ *
+ * Permite a exibição de ícones.
+ */
+@Component({
+  selector: 'po-icon',
+  templateUrl: './po-icon.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PoIconComponent {
+  class: string;
+  private _icon: string | TemplateRef<void>;
+
+  constructor() {}
+
+  /**
+   * Define o ícone a ser exibido.
+   *
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-button p-icon="po-icon-user" p-label="PO button"></po-button>
+   * ```
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
+   * ```
+   * <po-button p-icon="fa fa-podcast" p-label="PO button"></po-button>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-button [p-icon]="template" p-label="button template ionic"></po-button>
+   *
+   * <ng-template #template>
+   *  <ion-icon style="font-size: inherit" name="heart"></ion-icon>
+   * </ng-template>
+   * ```
+   * > Para o ícone enquadrar corretamente, deve-se utilizar `font-size: inherit` caso o ícone utilizado não aplique-o.
+   */
+  @Input('p-icon') set icon(value: string | TemplateRef<void>) {
+    if (typeof value === 'string') {
+      this.addClasses(value);
+    } else if (value instanceof TemplateRef) {
+      this._icon = value;
+    }
+  }
+
+  get icon() {
+    return this._icon;
+  }
+
+  private addClasses(value: string) {
+    this.class = value.startsWith('po-icon-')
+      ? (this.class = `po-icon ${value}`)
+      : (this.class = `po-fonts-icon ${value}`);
+  }
+}

--- a/projects/ui/src/lib/components/po-icon/po-icon.module.ts
+++ b/projects/ui/src/lib/components/po-icon/po-icon.module.ts
@@ -1,0 +1,16 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { PoIconComponent } from './po-icon.component';
+
+/**
+ * @description
+ *
+ * Módulo do componente Po-Icon.
+ */
+@NgModule({
+  imports: [CommonModule],
+  declarations: [PoIconComponent],
+  exports: [PoIconComponent]
+})
+export class PoIconModule {}

--- a/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail.component.spec.ts
@@ -223,12 +223,10 @@ describe('PoPageDetailComponent:', () => {
 
       fixture.detectChanges();
 
-      const primaryButtons = debugElement.querySelectorAll('po-button > button.po-button-primary');
-      const editButton = debugElement.querySelectorAll('po-button > button.po-button-primary > span + span')[0];
+      const primaryButtonLabel = debugElement.querySelector('po-button > button.po-button-primary > span');
 
-      expect(editButton).toBeTruthy();
-      expect(editButton.innerHTML).toBe(editLabel);
-      expect(primaryButtons.length).toBe(1);
+      expect(primaryButtonLabel).toBeTruthy();
+      expect(primaryButtonLabel.innerHTML).toBe(editLabel);
     });
 
     it('should have only one primary action and `Remove` button with `primary` applyed.', () => {
@@ -241,12 +239,10 @@ describe('PoPageDetailComponent:', () => {
 
       fixture.detectChanges();
 
-      const primaryButtons = debugElement.querySelectorAll('po-button > button.po-button-primary');
-      const removeButton = debugElement.querySelectorAll('po-button > button.po-button-primary > span + span')[0];
+      const primaryButtonLabel = debugElement.querySelector('po-button > button.po-button-primary > span');
 
-      expect(removeButton).toBeTruthy();
-      expect(removeButton.innerHTML).toBe(removeLabel);
-      expect(primaryButtons.length).toBe(1);
+      expect(primaryButtonLabel).toBeTruthy();
+      expect(primaryButtonLabel.innerHTML).toBe(removeLabel);
     });
 
     it('should have only one primary action and `Back` button with `p-primary` applyed.', () => {
@@ -258,12 +254,10 @@ describe('PoPageDetailComponent:', () => {
 
       fixture.detectChanges();
 
-      const primaryButtons = debugElement.querySelectorAll('po-button > button.po-button-primary');
-      const backButton = debugElement.querySelectorAll('po-button > button.po-button-primary > span + span')[0];
+      const primaryButtonLabel = debugElement.querySelector('po-button > button.po-button-primary > span');
 
-      expect(backButton).toBeTruthy();
-      expect(backButton.innerHTML).toBe(backLabel);
-      expect(primaryButtons.length).toBe(1);
+      expect(primaryButtonLabel).toBeTruthy();
+      expect(primaryButtonLabel.innerHTML).toBe(backLabel);
     });
 
     it('should show page header if `hasPageHeader` return true', () => {

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.spec.ts
@@ -221,12 +221,10 @@ describe('PoPageEditComponent', () => {
 
       fixture.detectChanges();
 
-      const primaryButtons = debugElement.querySelectorAll('po-button > button.po-button-primary > span');
-      const saveButton = primaryButtons[1];
+      const primaryButtonLabel = debugElement.querySelector('po-button > button.po-button-primary > span');
 
-      expect(saveButton).toBeTruthy();
-      expect(saveButton.innerHTML).toBe(saveLabel);
-      expect(primaryButtons.length).toBe(2);
+      expect(primaryButtonLabel).toBeTruthy();
+      expect(primaryButtonLabel.innerHTML).toBe(saveLabel);
     });
 
     it('should apply `p-primary` only in SaveNew button if save function is undefined', () => {
@@ -239,12 +237,10 @@ describe('PoPageEditComponent', () => {
 
       fixture.detectChanges();
 
-      const primaryButtons = debugElement.querySelectorAll('po-button > button.po-button-primary > span');
-      const saveNewButton = primaryButtons[1];
+      const primaryButtonLabel = debugElement.querySelector('po-button > button.po-button-primary > span');
 
-      expect(saveNewButton).toBeTruthy();
-      expect(saveNewButton.innerHTML).toBe(saveNewLabel);
-      expect(primaryButtons.length).toBe(2);
+      expect(primaryButtonLabel).toBeTruthy();
+      expect(primaryButtonLabel.innerHTML).toBe(saveNewLabel);
     });
 
     it('should apply `p-primary` only in Cancel button if save and saveNew functions are undefined', () => {
@@ -256,12 +252,10 @@ describe('PoPageEditComponent', () => {
 
       fixture.detectChanges();
 
-      const primaryButtons = debugElement.querySelectorAll('po-button > button.po-button-primary > span');
-      const cancelButton = primaryButtons[1];
+      const primaryButtonLabel = debugElement.querySelector('po-button > button.po-button-primary > span');
 
-      expect(cancelButton).toBeTruthy();
-      expect(cancelButton.innerHTML).toBe(cancelLabel);
-      expect(primaryButtons.length).toBe(2);
+      expect(primaryButtonLabel).toBeTruthy();
+      expect(primaryButtonLabel.innerHTML).toBe(cancelLabel);
     });
 
     it('should show page header if `hasPageHeader` return true', () => {
@@ -283,8 +277,8 @@ describe('PoPageEditComponent', () => {
 
       fixture.detectChanges();
 
-      const saveIcon = debugElement.querySelectorAll('po-button button span[class="po-icon po-icon-ok"]');
-      const cancelIcon = debugElement.querySelectorAll('po-button button span[class="po-icon po-icon-close"]');
+      const saveIcon = debugElement.querySelectorAll('po-button button po-icon i[class="po-icon po-icon-ok"]');
+      const cancelIcon = debugElement.querySelectorAll('po-button button po-icon i[class="po-icon po-icon-close"]');
 
       expect(saveIcon.length).toBe(1);
       expect(cancelIcon.length).toBe(0);
@@ -296,8 +290,8 @@ describe('PoPageEditComponent', () => {
 
       fixture.detectChanges();
 
-      const saveIcon = debugElement.querySelectorAll('po-button button span[class="po-icon po-icon-ok"]');
-      const cancelIcon = debugElement.querySelectorAll('po-button button span[class="po-icon po-icon-close"]');
+      const saveIcon = debugElement.querySelectorAll('po-button button po-icon i[class="po-icon po-icon-ok"]');
+      const cancelIcon = debugElement.querySelectorAll('po-button button po-icon i[class="po-icon po-icon-close"]');
 
       expect(saveIcon.length).toBe(1);
       expect(cancelIcon.length).toBe(0);
@@ -308,8 +302,8 @@ describe('PoPageEditComponent', () => {
 
       fixture.detectChanges();
 
-      const saveIcon = debugElement.querySelectorAll('po-button button span[class="po-icon po-icon-ok"]');
-      const cancelIcon = debugElement.querySelectorAll('po-button button span[class="po-icon po-icon-close"]');
+      const saveIcon = debugElement.querySelectorAll('po-button button po-icon i[class="po-icon po-icon-ok"]');
+      const cancelIcon = debugElement.querySelectorAll('po-button button po-icon i[class="po-icon po-icon-close"]');
 
       expect(saveIcon.length).toBe(0);
       expect(cancelIcon.length).toBe(1);


### PR DESCRIPTION
**PO-BUTTON, PO-ICON, PO-PAGE-DETAIL, PO-PAGE-EDIT**

**DTHFUI-1795**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Não é possível utilizar outras fontes de ícones no componente `po-button`.

**Qual o novo comportamento?**
Criado e inserido no `po-button` o novo componente interno `po-icon` que permite a utilização e compatibilidade de outras fontes de ícones e customização via TemplateRef. 

**Simulação**
É possivel simular no sample labs e no sample de caso de uso do `po-button` no portal. Testar também com TemplateRef em app.
[my-po-project.zip](https://github.com/po-ui/po-angular/files/6229166/my-po-project.zip).

Obs: Ver [PR no po-style](https://github.com/po-ui/po-style/pull/203).
