### PR TITLE
fix(upload): corrige validação para arquivos especificos

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.directive.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.directive.spec.ts
@@ -391,22 +391,39 @@ describe('PoUploadDragDropDirective:', () => {
       expect(directive.notification.information).toHaveBeenCalledWith('fileType 2');
     });
 
-    it(`getOnlyFiles: should return an array of files that only contain type and increment 'invalidFileType'`, () => {
+    it(`getOnlyFiles: should return an array of files and increment 'invalidFileType'`, () => {
       directive['invalidFileType'] = 0;
-      const fileList = [
-        { name: 'file1', type: '', size: 300 },
-        { name: 'file2', type: '.pdf', size: 500 },
-        { name: 'file3', type: '.txt', size: 100 },
-        { name: 'file4', type: '', size: 700 }
+
+      function webkitGetAsEntry() {
+        return {
+          name: this.name,
+          isFile: this.name !== 'folder'
+        };
+      }
+
+      const dataTransfer = {
+        files: [
+          { name: 'file1.zpl', type: '', size: 300 },
+          { name: 'file2.pdf', type: '.pdf', size: 500 },
+          { name: 'file3.txt', type: '.txt', size: 100 },
+          { name: 'folder', type: '', size: 100 }
+        ],
+        items: [
+          { name: 'file1.zpl', webkitGetAsEntry },
+          { name: 'file2.pdf', webkitGetAsEntry },
+          { name: 'file3.txt', webkitGetAsEntry },
+          { name: 'folder', webkitGetAsEntry }
+        ]
+      };
+
+      const expectedValue = [
+        { name: 'file1.zpl', type: '', size: 300 },
+        { name: 'file2.pdf', type: '.pdf', size: 500 },
+        { name: 'file3.txt', type: '.txt', size: 100 }
       ];
 
-      const result = [
-        { name: 'file2', type: '.pdf', size: 500 },
-        { name: 'file3', type: '.txt', size: 100 }
-      ];
-
-      expect(directive.getOnlyFiles(fileList)).toEqual(result);
-      expect(directive['invalidFileType']).toBe(2);
+      expect(directive.getOnlyFiles(dataTransfer)).toEqual(expectedValue);
+      expect(directive['invalidFileType']).toBe(1);
     });
 
     it(`sendFiles: should call 'fileChange.emit' with 'files' if 'areaElement' contains 'event.target' and 'files.length'

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.directive.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.directive.ts
@@ -64,7 +64,7 @@ export class PoUploadDragDropDirective {
           this.sendFiles(event, this.files);
         });
       } else {
-        const files = this.getOnlyFiles(event.dataTransfer.files);
+        const files = this.getOnlyFiles(event.dataTransfer);
         this.sendFiles(event, files);
       }
     }
@@ -100,9 +100,14 @@ export class PoUploadDragDropDirective {
   }
 
   // return only files. If it is a directory, invalidFileType counts.
-  private getOnlyFiles(fileList: FileList): Array<File> {
-    return Array.from(fileList).reduce((newFiles, file) => {
-      if (file.type) {
+  private getOnlyFiles(dataTransfer: DataTransfer): Array<File> {
+    const fileList: Array<File> = Array.from(dataTransfer.files);
+    const entriesFiles: Array<any> = Array.from(dataTransfer.items).map(item => item.webkitGetAsEntry());
+
+    return fileList.reduce((newFiles, file) => {
+      const entryFile = entriesFiles.find(entry => entry.name === file.name);
+
+      if (entryFile.isFile) {
         return newFiles.concat(file);
       } else {
         this.invalidFileType++;

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
@@ -61,7 +61,8 @@ export class SamplePoUploadLabsComponent implements OnInit {
     }
   }
   onChangeExtension() {
-    this.restrictions = Object.assign({}, this.restrictions, { allowedExtensions: this.allowedExtensions.split(',') });
+    const allowedExtensions = this.allowedExtensions.split(',').map(allowedExtension => allowedExtension.trim());
+    this.restrictions = Object.assign({}, this.restrictions, { allowedExtensions });
   }
 
   onChangeMaxFiles(maxFiles: number) {


### PR DESCRIPTION
**UPLOAD**

**DTHFUI-4792**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao utilizar o po-upload em drag drop, arquivos especificos, que não possuiam type (.prn, .zpl), estavam sendo ignorados.


**Qual o novo comportamento?**
Permite informar arquivos em formatos específicos, a validação da permissão foi alterada, para verificar se de fato é um arquivo e não olhar o type que poderia vir em "" (branco) e ser invalidado.

**Simulação**
- Buildar o projeto com a branch upload/DTHFUI-4792
- Rodar o portal e utilizar o Sample Po Upload Labs
- Atualizando o allowedExtensions nos formatos ".zpl, .prn, .xml"