### PR TITLE
feat(table): adiciona possibilidade de uso de serviço de dados

### DIFF
--- a/projects/ui/src/lib/components/po-table/interfaces/po-table-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-table/interfaces/po-table-filter.interface.ts
@@ -1,0 +1,17 @@
+import { Observable } from 'rxjs';
+import { PoTableFilteredItemsParams } from './po-table-filtered-items-params.interface';
+import { PoTableResponseApi } from './po-table-response-api.interface';
+
+/**
+ * @description
+ *
+ * Define o tipo de busca utilizado no po-table.
+ */
+export interface PoTableFilter {
+  /**
+   * Método que será disparado ao filtrar a lista de itens ou carregar mais resultados no componente, deve-se retornar um *Observable* com a resposta da API no formato da interface `PoTableResponseApi`.
+   *
+   * @param { PoTableFilteredItemsParams } params objeto enviado por parâmetro que implementa a interface `PoTableFilteredItemsParams`
+   */
+  getFilteredItems(params: PoTableFilteredItemsParams): Observable<PoTableResponseApi>;
+}

--- a/projects/ui/src/lib/components/po-table/interfaces/po-table-filtered-items-params.interface.ts
+++ b/projects/ui/src/lib/components/po-table/interfaces/po-table-filtered-items-params.interface.ts
@@ -1,0 +1,30 @@
+/**
+ *
+ * @description
+ *
+ * Interface do objeto enviado como parâmetro da função `getItems`.
+ */
+export interface PoTableFilteredItemsParams {
+  /**
+   * Conteúdo utilizado para filtrar a lista de items.
+   */
+  filter?: string;
+
+  /**
+   * Controla a paginação dos dados e recebe um valor automaticamente a cada clique no botão 'Carregar mais resultados'.
+   */
+  page?: number;
+
+  /**
+   * Quantidade de itens retornados cada vez que o serviço é chamado, por padrão é 10.
+   */
+  pageSize?: number;
+
+  /**
+   * Coluna que está sendo ordenada na tabela.
+   *
+   * - Coluna decrescente será informada da seguinte forma: `-<colunaOrdenada>`, por exemplo `-name`.
+   * - Coluna ascendente será informada da seguinte forma: `<colunaOrdenada>, por exemplo `name`.
+   */
+  order?: string;
+}

--- a/projects/ui/src/lib/components/po-table/interfaces/po-table-response-api.interface.ts
+++ b/projects/ui/src/lib/components/po-table/interfaces/po-table-response-api.interface.ts
@@ -1,0 +1,7 @@
+import { PoResponseApi } from './../../../interfaces';
+
+/**
+ * @docsExtends PoResponseApi
+ *
+ */
+export interface PoTableResponseApi extends PoResponseApi {}

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -36,7 +36,11 @@
   </div>
 </ng-template>
 
-<div class="po-row po-table-footer-show-more" [class.po-invisible]="showMore.observers.length === 0" #tableFooter>
+<div
+  class="po-row po-table-footer-show-more"
+  [class.po-invisible]="showMore.observers.length === 0 && !hasService"
+  #tableFooter
+>
   <po-button
     class="po-offset-xl-4 po-offset-lg-4 po-offset-md-3 po-lg-4 po-md-6"
     [p-disabled]="showMoreDisabled"
@@ -81,7 +85,7 @@
           [style.width]="column.width"
           [style.max-width]="column.width"
           [style.min-width]="column.width"
-          [class.po-clickable]="sort"
+          [class.po-clickable]="sort || hasService"
           [class.po-table-header-subtitle]="column.type === 'subtitle'"
           (click)="sortColumn(column)"
         >

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -4,7 +4,9 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { DecimalPipe } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Routes } from '@angular/router';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
+import { of } from 'rxjs';
 import * as utilsFunctions from '../../utils/util';
 import { configureTestSuite } from './../../util-test/util-expect.spec';
 import { PoColorPaletteService } from './../../services/po-color-palette/po-color-palette.service';
@@ -18,6 +20,7 @@ import { PoTableComponent } from './po-table.component';
 import { PoTableModule } from './po-table.module';
 import { PoTableColumnTemplateDirective } from './po-table-column-template/po-table-column-template.directive';
 import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-arrow-direction.enum';
+import { PoTableService } from './services/po-table.service';
 
 @Component({ template: 'Search' })
 export class SearchComponent {}
@@ -189,9 +192,9 @@ describe('PoTableComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes(routes), PoTableModule],
+      imports: [RouterTestingModule.withRoutes(routes), PoTableModule, HttpClientTestingModule],
       declarations: [TestMenuComponent, SearchComponent],
-      providers: [PoControlPositionService, PoDateService, DecimalPipe, PoColorPaletteService]
+      providers: [PoControlPositionService, PoDateService, DecimalPipe, PoColorPaletteService, PoTableService]
     });
   });
 
@@ -1535,6 +1538,15 @@ describe('PoTableComponent:', () => {
       component.onChangeVisibleColumns(fakeColumns);
 
       expect(component.changeVisibleColumns.emit).toHaveBeenCalledWith(fakeColumns);
+    });
+
+    describe('initializeData', () => {
+      it('should be called when `p-service-api` is used', () => {
+        spyOn(component, 'getFilteredItems').and.returnValue(of({ items: [], hasNext: false }));
+        component.hasService = true;
+        component['initializeData']();
+        expect(component.getFilteredItems).toHaveBeenCalled();
+      });
     });
   });
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -13,12 +13,13 @@ import {
   ViewChildren,
   ViewContainerRef,
   ContentChildren,
-  TemplateRef
+  TemplateRef,
+  OnInit
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { Router } from '@angular/router';
 
-import { convertToBoolean } from '../../utils/util';
+import { convertToBoolean, isTypeof } from '../../utils/util';
 import { PoDateService } from '../../services/po-date/po-date.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { PoPopupComponent } from '../po-popup/po-popup.component';
@@ -32,6 +33,7 @@ import { PoTableSubtitleColumn } from './po-table-subtitle-footer/po-table-subti
 import { PoTableCellTemplateDirective } from './po-table-cell-template/po-table-cell-template.directive';
 import { PoTableColumnTemplateDirective } from './po-table-column-template/po-table-column-template.directive';
 import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-arrow-direction.enum';
+import { PoTableService } from './services/po-table.service';
 
 /**
  * @docsExtends PoTableBaseComponent
@@ -49,6 +51,11 @@ import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-
  *  <file name="sample-po-table-labs/sample-po-table-labs.component.e2e-spec.ts"> </file>
  *  <file name="sample-po-table-labs/sample-po-table-labs.component.po.ts"> </file>
  *  <file name="sample-po-table-labs/sample-po-table-labs.service.ts"> </file>
+ * </example>
+ *
+ * <example name="po-table-with-api" title="PO Table using API">
+ *  <file name="sample-po-table-with-api/sample-po-table-with-api.component.ts"> </file>
+ *  <file name="sample-po-table-with-api/sample-po-table-with-api.component.html"> </file>
  * </example>
  *
  * <example name="po-table-transport" title="PO Table - Transport">
@@ -76,7 +83,7 @@ import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-
   templateUrl: './po-table.component.html',
   providers: [PoDateService]
 })
-export class PoTableComponent extends PoTableBaseComponent implements AfterViewInit, DoCheck, OnDestroy {
+export class PoTableComponent extends PoTableBaseComponent implements OnInit, AfterViewInit, DoCheck, OnDestroy {
   private _columnManagerTarget: ElementRef;
 
   heightTableContainer: number;
@@ -125,9 +132,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     poLanguageService: PoLanguageService,
     private changeDetector: ChangeDetectorRef,
     private decimalPipe: DecimalPipe,
-    private router: Router
+    private router: Router,
+    defaultService: PoTableService
   ) {
-    super(poDate, poLanguageService);
+    super(poDate, poLanguageService, defaultService);
 
     this.differ = differs.find([]).create(null);
 
@@ -210,6 +218,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   ngAfterViewInit() {
     this.initialized = true;
+  }
+
+  ngOnInit() {
+    this.initializeData();
   }
 
   ngDoCheck() {
@@ -466,5 +478,14 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
       return null;
     }
     return template.templateRef;
+  }
+
+  private initializeData(): void {
+    if (this.hasService) {
+      this.loading = true;
+      this.getFilteredItems().subscribe(data => {
+        this.setTableResponseProperties(data);
+      });
+    }
   }
 }

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.html
@@ -1,0 +1,6 @@
+<po-table
+  p-service-api="https://po-sample-api.herokuapp.com/v1/people"
+  p-height="400"
+  [p-columns]="[{ property: 'id' }, { property: 'nickname' }, { property: 'name' }, { property: 'email' }]"
+>
+</po-table>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sample-po-table-with-api',
+  templateUrl: './sample-po-table-with-api.component.html'
+})
+export class SamplePoTableWithApiComponent {}

--- a/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
+++ b/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
@@ -1,0 +1,62 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { TestBed } from '@angular/core/testing';
+
+import { PoTableService } from './po-table.service';
+
+describe('PoTableService', () => {
+  let service: PoTableService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(PoTableService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('setUrl: should be called and set api url', () => {
+    const url = 'https://po-sample-api.herokuapp.com/v1/heroes';
+
+    service.setUrl(url);
+
+    expect(service['url']).toBe(url);
+  });
+
+  it('validateParams: should be called with string and return undefined', () => {
+    const params = 'po-ui';
+
+    const response = service['validateParams'](params);
+
+    expect(response).toBe(undefined);
+  });
+
+  it('validateParams: should be called with object and return the object', () => {
+    const params = {
+      order: '-name',
+      page: 1,
+      pageSize: 10
+    };
+
+    const response = service['validateParams'](params);
+
+    expect(response).toBe(params);
+  });
+
+  it('getFilteredItems: to have been called and call backend', () => {
+    service['url'] = 'https://po-sample-api.herokuapp.com/v1/heroes';
+
+    const filteredParams = {
+      order: '-name',
+      page: 1,
+      pageSize: 10
+    };
+
+    service.getFilteredItems(filteredParams).subscribe(response => {
+      expect(response).toBeDefined();
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-table/services/po-table.service.ts
+++ b/projects/ui/src/lib/components/po-table/services/po-table.service.ts
@@ -1,0 +1,33 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { isTypeof } from '../../../utils/util';
+import { PoTableFilter } from '../interfaces/po-table-filter.interface';
+import { PoTableFilteredItemsParams } from '../interfaces/po-table-filtered-items-params.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PoTableService implements PoTableFilter {
+  private url: string;
+
+  readonly headers: HttpHeaders = new HttpHeaders({
+    'X-PO-No-Message': 'true'
+  });
+
+  constructor(private http: HttpClient) {}
+
+  getFilteredItems(filteredParams?: PoTableFilteredItemsParams): Observable<any> {
+    const params = this.validateParams(filteredParams);
+
+    return this.http.get(this.url, { headers: this.headers, params });
+  }
+
+  setUrl(url: string) {
+    this.url = url;
+  }
+
+  private validateParams(params: any) {
+    return isTypeof(params, 'object') && !Array.isArray(params) ? params : undefined;
+  }
+}


### PR DESCRIPTION
Permite utilização de uma fonte de dados externo através de uma API.

Fixes DTHFUI-1885

**PO-TABLE**

**DTHFUI-1885**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não é possível utilizar um serviço de dados externos.

**Qual o novo comportamento?**
Ao informar a URL na propriedade `p-service-api` será utilizado o serviço para criação dos dados do `po-table`


**Simulação**
Utilizar o sample do Portal [portal.zip](https://github.com/po-ui/po-angular/files/6287730/portal.zip), ou simular no `App` com o código abaixo:
```html
<po-table p-service-api="https://po-sample-api.herokuapp.com/v1/people"></po-table>
```
