### PR TITLE
fix(ui): correções para permitir usar com strictTemplates habilitado

### DIFF
--- a/projects/ui/src/lib/components/po-avatar/po-avatar-base.component.ts
+++ b/projects/ui/src/lib/components/po-avatar/po-avatar-base.component.ts
@@ -46,7 +46,7 @@ export class PoAvatarBaseComponent {
   }
 
   /** Evento disparado ao clicar na imagem do *avatar*. */
-  @Output('p-click') click? = new EventEmitter<any>();
+  @Output('p-click') click = new EventEmitter<any>();
 
   get hasClickEvent() {
     return !!this.click.observers.length;

--- a/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail-base.component.ts
@@ -118,7 +118,7 @@ export class PoPageDetailBaseComponent {
    *
    * > Caso não utilizar esta propriedade, o botão de "Voltar" não será exibido.
    */
-  @Output('p-back') back? = new EventEmitter();
+  @Output('p-back') back = new EventEmitter();
 
   /**
    * Evento que será disparado ao clicar no botão de "Editar".
@@ -130,7 +130,7 @@ export class PoPageDetailBaseComponent {
    *
    * > Caso não utilizar esta propriedade, o botão de "Editar" não será exibido.
    */
-  @Output('p-edit') edit? = new EventEmitter();
+  @Output('p-edit') edit = new EventEmitter();
 
   /**
    * Evento que será disparado ao clicar no botão de "Remover".
@@ -142,7 +142,7 @@ export class PoPageDetailBaseComponent {
    *
    * > Caso não utilizar esta propriedade, o botão de "Remover" não será exibido.
    */
-  @Output('p-remove') remove? = new EventEmitter();
+  @Output('p-remove') remove = new EventEmitter();
 
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit-base.component.ts
@@ -125,7 +125,7 @@ export class PoPageEditBaseComponent {
    *
    * > Caso não utilizar esta propriedade, o botão de "Cancelar" não será exibido.
    */
-  @Output('p-cancel') cancel? = new EventEmitter();
+  @Output('p-cancel') cancel = new EventEmitter();
 
   /**
    * Evento que será disparado ao clicar no botão de "Salvar".
@@ -137,7 +137,7 @@ export class PoPageEditBaseComponent {
    *
    * > Caso não utilizar esta propriedade, o botão de "Salvar" não será exibido.
    */
-  @Output('p-save') save? = new EventEmitter();
+  @Output('p-save') save = new EventEmitter();
 
   /**
    * Evento que será disparado ao clicar no botão de "Salvar e Novo".
@@ -149,7 +149,7 @@ export class PoPageEditBaseComponent {
    *
    * > Caso não utilizar esta propriedade, o botão de "Salvar e Novo" não será exibido.
    */
-  @Output('p-save-new') saveNew? = new EventEmitter();
+  @Output('p-save-new') saveNew = new EventEmitter();
 
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -391,8 +391,8 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * @default `false`
    */
   sort?: boolean;
-  @Input('p-sort') set setSort(sort: string) {
-    this.sort = sort === '' ? false : convertToBoolean(sort);
+  @Input('p-sort') set setSort(sort: boolean) {
+    this.sort = <any>sort === '' ? false : convertToBoolean(sort);
   }
 
   /**
@@ -403,8 +403,8 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * @default `false`
    */
   showMoreDisabled?: boolean;
-  @Input('p-show-more-disabled') set setShowMoreDisabled(showMoreDisabled: string) {
-    this.showMoreDisabled = showMoreDisabled === '' ? false : convertToBoolean(showMoreDisabled);
+  @Input('p-show-more-disabled') set setShowMoreDisabled(showMoreDisabled: boolean) {
+    this.showMoreDisabled = <any>showMoreDisabled === '' ? false : convertToBoolean(showMoreDisabled);
   }
 
   /**
@@ -416,8 +416,8 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * @default `false`
    */
   striped?: boolean;
-  @Input('p-striped') set setStriped(striped: string) {
-    this.striped = striped === '' ? false : convertToBoolean(striped);
+  @Input('p-striped') set setStriped(striped: boolean) {
+    this.striped = <any>striped === '' ? false : convertToBoolean(striped);
   }
 
   /**
@@ -430,8 +430,8 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * @default `false`
    */
   hideSelectAll?: boolean;
-  @Input('p-hide-select-all') set setHideSelectAll(hideSelectAll: string) {
-    this.hideSelectAll = hideSelectAll === '' ? false : convertToBoolean(hideSelectAll);
+  @Input('p-hide-select-all') set setHideSelectAll(hideSelectAll: boolean) {
+    this.hideSelectAll = <any>hideSelectAll === '' ? false : convertToBoolean(hideSelectAll);
   }
 
   /**
@@ -442,8 +442,8 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * > Esta definição não se aplica aos itens filhos, os mesmos possuem comportamento independente do item pai.
    */
   singleSelect?: boolean;
-  @Input('p-single-select') set setSingleSelect(value: string) {
-    this.singleSelect = value === '' ? true : convertToBoolean(value);
+  @Input('p-single-select') set setSingleSelect(value: boolean) {
+    this.singleSelect = <any>value === '' ? true : convertToBoolean(value);
   }
 
   /**


### PR DESCRIPTION
**PoPageEdit/Detail PoAvatar PoTable**

**#810**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
#810 

**Qual o novo comportamento?**
Correções para permitir usar com strictTemplates habilitado

Alterado os componentes:
PoPageEdit
PoPageDetail
PoAvatar
PoTable


**Simulação**
- ng new aplicacaoteste --strict
- instalar o pacote po-ui/ng-componentes
- usar os componentes PoPageEdit e PoTable com os atributos afetados;

```
<po-page-edit (p-save)="save()">
   <po-table
       [p-items]="[{name: 'JOHN', age: 25}]"
      [p-show-more-disabled]="false">
    </po-table>
</po-page-edit>
```
- ng serve

É para ocorrer o erro.

Agora instalar o ng-components gerado localmente com a correção

subir novamente o ng serve, não é para acontecer o erro.
