### PR TITLE
fix(dynamic-form): corrige disparo do validate ao carregar a pagina

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -26,6 +26,7 @@ describe('PoDynamicFormFieldsComponent: ', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PoDynamicFormFieldsComponent);
     component = fixture.componentInstance;
+    component['form'] = <any>{ touched: true };
 
     fixture.detectChanges();
 
@@ -266,6 +267,20 @@ describe('PoDynamicFormFieldsComponent: ', () => {
         await component.onChangeField(fakeVisibleField, objectValue);
 
         expect(spyObjectValue).not.toHaveBeenCalled();
+      });
+
+      it('shouldn`t call `triggerValidationOnForm` if form.touched is false', async () => {
+        const fakeVisibleField = { property: 'test1' };
+
+        component['previousValue']['test1'] = undefined;
+        component['value']['test1'] = 'value';
+        component['form'] = <any>{ touched: false };
+
+        spyOn(component, <any>'triggerValidationOnForm');
+
+        await component.onChangeField(fakeVisibleField);
+
+        expect(component['triggerValidationOnForm']).not.toHaveBeenCalled();
       });
     });
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -28,7 +28,8 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
   constructor(
     titleCasePipe: TitleCasePipe,
     private validationService: PoDynamicFormValidationService,
-    private changes: ChangeDetectorRef
+    private changes: ChangeDetectorRef,
+    private form: NgForm
   ) {
     super(titleCasePipe);
   }
@@ -58,7 +59,8 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
       this.objectValue.emit(objectValue);
     }
 
-    if (isChangedValueField) {
+    // verifica se o formulario esta touched para não disparar o validate ao carregar a tela.
+    if (this.form.touched && isChangedValueField) {
       const { changedField, changedFieldIndex } = this.getField(property);
 
       if (changedField.validate) {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
@@ -16,7 +16,8 @@ describe('PoDynamicFormComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [PoDynamicModule]
+      imports: [PoDynamicModule],
+      providers: [NgForm]
     });
   });
 


### PR DESCRIPTION
**< DYNAMIC-FORM >**

**< DTHFUI-4626>**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Esta disparando os validates ao carregar a tela.

**Qual o novo comportamento?**
Não deve disparar o validate ao carregar a tela (Tela de edição, por exemplo, pois os dados ja vem validados)

**Simulação**
Utilizar o fonte abaixo e avaliar se ao carregar a tela esta disparando o validate. (verificar console)

```
  <po-dynamic-form
    [p-fields]="fields"
    [p-validate]="onChangeFields.bind(this)"
    [p-value]="person">
  </po-dynamic-form>
```
```
person = {
  name: 'John',
  favoriteHero: 'kakaroto'
}
fields: Array<any> = [
    {
      property: 'name',
      divider: 'PERSONAL DATA',
      required: true,
      minLength: 4,
      maxLength: 50,
      gridColumns: 6,
      gridSmColumns: 12,
    },
    {
      property: 'birthday',
      label: 'Date of birth',
      type: 'date',
      format: 'mm/dd/yyyy',
      gridColumns: 6,
      gridSmColumns: 12,
      maxValue: '2010-01-01',
      errorMessage: 'The date must be before the year 2010.',
      order: -1
    },
    {
      property: 'favoriteHero',
      gridColumns: 6,
      gridSmColumns: 12,
      label: 'Favorite hero',
      optional: true,
      searchService: 'https://po-sample-api.herokuapp.com/v1/heroes',
      columns: [
        { property: 'nickname', label: 'Hero' },
        { property: 'label', label: 'Name' }
      ],
      format: ['id', 'nickname'],
      fieldLabel: 'nickname',
      fieldValue: 'email'
    }
  ];
  
  onChangeFields(changedValue: any) {
      console.log('CHANGE:: ', changedValue)
      return {}
  }
```
