### PR TITLE
feat(page-list): adiciona `clearInputSearch`

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
@@ -500,6 +500,16 @@ describe('PoPageListComponent - Desktop:', () => {
       expect(changeDetectorSpy).toHaveBeenCalled();
     });
 
+    it('clearInputSearch: should call and clear input', () => {
+      component.filterInput = <any>{
+        nativeElement: { value: 'test filter' }
+      };
+
+      component.clearInputSearch();
+
+      expect(component.filterInput.nativeElement.value).toBe(null);
+    });
+
     it('callAction: should open an external URL in a new tab in the browser by calling Utils`s openExternalLink method', () => {
       const url = 'http://po-ui.io';
 

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -161,6 +161,12 @@ export class PoPageListComponent
     this.filter[field](this.filterInput.nativeElement.value);
     this.changeDetector.detectChanges();
   }
+  /**
+   * Limpa o campo de pesquisa.
+   */
+  clearInputSearch() {
+    this.filterInput.nativeElement.value = null;
+  }
 
   onkeypress(key) {
     if (key === 13) {

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.html
@@ -1,4 +1,5 @@
 <po-page-list
+  #poPageList
   p-title="Hiring processes"
   [p-actions]="actions"
   [p-breadcrumb]="breadcrumb"

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.ts
@@ -9,6 +9,7 @@ import { PoModalAction, PoModalComponent } from '@po-ui/ng-components';
 import { PoNotificationService } from '@po-ui/ng-components';
 import { PoPageAction, PoPageFilter } from '@po-ui/ng-components';
 import { PoTableColumn } from '@po-ui/ng-components';
+import { PoPageListComponent } from '@po-ui/ng-components';
 
 import { SamplePoPageListHiringProcessesService } from './sample-po-page-list-hiring-processes.service';
 
@@ -39,6 +40,7 @@ export class SamplePoPageListHiringProcessesComponent implements OnInit {
 
   public readonly advancedFilterPrimaryAction: PoModalAction = {
     action: () => {
+      this.poPageList.clearInputSearch();
       this.advancedFilterModal.close();
       const filters = [...this.jobDescription, ...this.status];
       this.filterAction(filters);
@@ -55,6 +57,7 @@ export class SamplePoPageListHiringProcessesComponent implements OnInit {
   private disclaimers = [];
 
   @ViewChild('advancedFilterModal', { static: true }) advancedFilterModal: PoModalComponent;
+  @ViewChild('poPageList', { static: true }) poPageList: PoPageListComponent;
 
   constructor(
     private sampleHiringProcessesService: SamplePoPageListHiringProcessesService,
@@ -67,7 +70,8 @@ export class SamplePoPageListHiringProcessesComponent implements OnInit {
     this.disclaimerGroup = {
       title: 'Filters',
       disclaimers: [],
-      change: this.onChangeDisclaimer.bind(this)
+      change: this.onChangeDisclaimer.bind(this),
+      remove: this.onClearDisclaimer.bind(this)
     };
 
     this.hiringProcesses = this.sampleHiringProcessesService.getItems();
@@ -130,8 +134,17 @@ export class SamplePoPageListHiringProcessesComponent implements OnInit {
     this.filter();
   }
 
+  onClearDisclaimer(disclaimers) {
+    if (disclaimers.removedDisclaimer.property === 'search') {
+      this.poPageList.clearInputSearch();
+    }
+    this.disclaimers = [];
+    this.filter();
+  }
+
   populateDisclaimers(filters: Array<any>) {
-    this.disclaimers = filters.map(value => ({ value }));
+    const property = filters.length > 1 ? 'advanced' : 'search';
+    this.disclaimers = filters.map(value => ({ value, property }));
 
     if (this.disclaimers && this.disclaimers.length > 0) {
       this.disclaimerGroup.disclaimers = [...this.disclaimers];

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1697,6 +1697,40 @@ describe('PoTableComponent:', () => {
 
       expect(component.selectAll).toBe(false);
     });
+
+    it('unselectRows: should set item.$select and selectAll with false when `columnMasterDetail` is null', () => {
+      component.selectAll = null;
+      const rows = [
+        { id: 1, $selected: true },
+        { id: 2, $selected: false },
+        { id: 3, $selected: false },
+        { id: 4, $selected: true },
+        { id: 5, detail: [{ package: 'base', $selected: true }], $selected: false }
+      ];
+
+      const newColumns = [
+        { property: 'id', label: 'Identificador' },
+        {
+          property: 'detail',
+          label: 'Identificador',
+          type: 'detail',
+          detail: { columns: [{ property: 'package' }], typeHeader: 'top' }
+        }
+      ];
+
+      component.selectAll = null;
+      component.items = rows;
+      component.columns = newColumns;
+
+      component.columnMasterDetail = null;
+
+      component.unselectRows();
+
+      expect(component.items.every(item => item.$selected === false)).toBeTruthy();
+      expect(component.items[4].detail.every(item => item.$selected === false)).toBeFalsy();
+
+      expect(component.selectAll).toBeFalsy();
+    });
   });
 
   describe('Templates:', () => {


### PR DESCRIPTION
**PAGE LIST**

**DTHFUI-4916**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [ ] Documentação
- [X] Samples

**Qual o comportamento atual?**
Ao realizar uma busca na pagina de listagem não é possível apagar o conteúdo do campo de busca. O mesmo esta sendo mantido mesmo após remover o disclaimer atribuído a ele.


**Qual o novo comportamento?**
Quando é removido um disclaimer que foi digitado pelo campo de busca, o campo é limpo.


**Simulação**
Rodar o Portal (ou utilizar [portal.zip](https://github.com/po-ui/po-angular/files/6418075/portal.zip)) e testar utilizando o `Sample Hiring Process`.
