### PR TITLE
feat(tag): adiciona possibilidade de informar outras fontes de ícones

### DIFF
--- a/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Input, Output, Directive } from '@angular/core';
+import { EventEmitter, Input, Output, Directive, TemplateRef } from '@angular/core';
 
 import { convertToBoolean } from '../../utils/util';
 import { PoColorPaletteEnum } from '../../enums/po-color-palette.enum';
@@ -24,7 +24,7 @@ const poTagOrientationDefault = PoTagOrientation.Vertical;
 @Directive()
 export class PoTagBaseComponent {
   private _color?: string;
-  private _icon?: boolean | string;
+  private _icon?: boolean | string | TemplateRef<void>;
   private _inverse?: boolean;
   private _orientation?: PoTagOrientation = poTagOrientationDefault;
   private _type?: PoTagType;
@@ -69,17 +69,33 @@ export class PoTagBaseComponent {
    *
    * Define ou ativa um ícone que será exibido ao lado do valor da *tag*.
    *
-   * > Veja os valores válidos na [biblioteca de ícones](guides/icons).
-   *
    * Quando `p-type` estiver definida, basta informar um valor igual a `true` para que o ícone seja exibido conforme descrições abaixo:
    * - <span class="po-icon po-icon-ok"></span> - `success`
    * - <span class="po-icon po-icon-warning"></span> - `warning`
    * - <span class="po-icon po-icon-close"></span> - `danger`
    * - <span class="po-icon po-icon-info"></span> - `info`
    *
+   * Também É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-tag p-icon="po-icon-user" p-value="PO Tag"></po-tag>
+   * ```
+   * como também utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
+   * ```
+   * <po-tag p-icon="fa fa-podcast" p-value="PO Tag"></po-button>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-tag [p-icon]="template" p-value="Tag template ionic"></po-button>
+   *
+   * <ng-template #template>
+   *  <ion-icon style="font-size: inherit" name="heart"></ion-icon>
+   * </ng-template>
+   * ```
+   * > Para o ícone enquadrar corretamente, deve-se utilizar `font-size: inherit` caso o ícone utilizado não aplique-o.
+   *
    * @default `false`
    */
-  @Input('p-icon') set icon(value: boolean | string) {
+  @Input('p-icon') set icon(value: boolean | string | TemplateRef<void>) {
     if (this.type) {
       this._icon = convertToBoolean(value);
     } else {
@@ -87,7 +103,7 @@ export class PoTagBaseComponent {
     }
   }
 
-  get icon(): boolean | string {
+  get icon() {
     return this._icon;
   }
 

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.html
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.html
@@ -15,7 +15,8 @@
       (keydown.space)="$event.preventDefault()"
       (keyup.space)="onKeyPressed($event)"
     >
-      <span *ngIf="icon" class="po-icon" [ngClass]="!type && iconTypeString ? icon : iconFromType"></span>
+      <po-icon *ngIf="icon" class="po-tag-icon" [p-icon]="!type ? icon : iconFromType"> </po-icon>
+
       <span class="po-tag-value">{{ value }}</span>
     </div>
   </div>

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
@@ -6,6 +6,8 @@ import { Observable } from 'rxjs';
 
 import { configureTestSuite } from './../../util-test/util-expect.spec';
 
+import { PoIconModule } from '../po-icon/po-icon.module';
+
 import { PoTagBaseComponent } from './po-tag-base.component';
 import { PoTagComponent } from './po-tag.component';
 import { PoTagIcon } from './enums/po-tag-icon.enum';
@@ -31,7 +33,8 @@ describe('PoTagComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      declarations: [PoTagComponent, PoTagClickableComponent]
+      declarations: [PoTagComponent, PoTagClickableComponent],
+      imports: [PoIconModule]
     });
   });
 
@@ -78,16 +81,6 @@ describe('PoTagComponent:', () => {
 
       component.type = PoTagType.Warning;
       expect(component.iconFromType).toBe(PoTagIcon.Warning);
-    });
-
-    it('iconTypeString: should return `true` if is string value.', () => {
-      component.icon = 'po-icon-news';
-      expect(component.iconTypeString).toBe(true);
-    });
-
-    it('iconTypeString: should return `false` if isn`t string value.', () => {
-      component.icon = false;
-      expect(component.iconTypeString).toBe(false);
     });
 
     it('tagColor: should return tag type without `inverse`.', () => {
@@ -207,7 +200,7 @@ describe('PoTagComponent:', () => {
       expect(nativeElement.querySelector('.po-tag')).toBeTruthy();
       expect(nativeElement.querySelector('.po-tag-value').innerHTML).toContain(value);
 
-      expect(nativeElement.querySelector('.po-icon')).toBeFalsy();
+      expect(nativeElement.querySelector('.po-tag-icon')).toBeFalsy();
       expect(nativeElement.querySelector('.po-tag-title')).toBeFalsy();
       expect(nativeElement.querySelector('.po-tag-label')).toBeFalsy();
     });

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.ts
@@ -55,10 +55,6 @@ export class PoTagComponent extends PoTagBaseComponent implements OnInit {
     }
   }
 
-  get iconTypeString() {
-    return typeof this.icon === 'string';
-  }
-
   get tagColor() {
     if (this.type) {
       return this.inverse ? `po-tag-${this.type}-inverse` : `po-tag-${this.type}`;

--- a/projects/ui/src/lib/components/po-tag/po-tag.module.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.module.ts
@@ -1,6 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { PoIconModule } from '../po-icon/po-icon.module';
+
 import { PoTagComponent } from './po-tag.component';
 
 /**
@@ -9,7 +11,7 @@ import { PoTagComponent } from './po-tag.component';
  * Módulo do componente `po-tag`.
  */
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, PoIconModule],
   declarations: [PoTagComponent],
   exports: [PoTagComponent],
   providers: [],

--- a/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.ts
+++ b/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.ts
@@ -49,7 +49,9 @@ export class SamplePoTagLabsComponent implements OnInit {
     { label: 'po-icon-light', value: 'po-icon-light' },
     { label: 'po-icon-star', value: 'po-icon-star' },
     { label: 'po-icon-settings', value: 'po-icon-settings' },
-    { label: 'po-icon-world', value: 'po-icon-world' }
+    { label: 'po-icon-world', value: 'po-icon-world' },
+    { label: 'fa fa-address-card', value: 'fa fa-address-card' },
+    { label: 'fa fa-bell', value: 'fa fa-bell' }
   ];
 
   public readonly orientationOptions: Array<PoRadioGroupOption> = [


### PR DESCRIPTION
**< TAG >**

**< DTHFUI-4892 >**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente era possível utilizar ícones da Bibliotecas de ícones apenas do PO UI

**Qual o novo comportamento?**
Permite utilizar outras fontes de ícones, como Font Awesome e Material Icons

PR STYLE
https://github.com/po-ui/po-style/pull/210

**Simulação**
Recuperar o CSS novo, através da PR https://github.com/po-ui/po-style/pull/210;
Rodar o portal e testar no Sample labs.
e
``` 
<po-tag p-icon="po-icon-copy" p-label="TAG" p-value="TAG"></po-tag>

<po-tag p-icon="fa fa-address-card" p-label="TAG" p-value="TAG"></po-tag>

<po-tag p-value="TEMPLATE FA-ICON" [p-icon]="icontemplate">
</po-tag>

<po-tag p-type="success" p-label="TAG " p-value="TAG" [p-icon]="true"></po-tag>

<ng-template #icontemplate>
  <span class="material-icons" >trending_up</span>
</ng-template>
```  
index.html
```
    <link href="https://fonts.googleapis.com/css2?family=Material+Icons" rel="stylesheet">
    <link
      rel="stylesheet"
      href="https://use.fontawesome.com/releases/v5.3.1/css/all.css"
      integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU"
      crossorigin="anonymous"
    />
  </head>
```  

