### PR TITLE
feat(navbar): deprecia a propriedade `p-menu`

### DIFF
--- a/projects/ui/src/lib/components/po-menu/index.ts
+++ b/projects/ui/src/lib/components/po-menu/index.ts
@@ -5,6 +5,8 @@ export * from './po-menu-filter/po-menu-filter.interface';
 
 export * from './po-menu-header-template/po-menu-header-template.directive';
 
+export * from './services/po-menu-global.service';
+
 export * from './po-menu.component';
 
 export * from './po-menu.module';

--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
@@ -17,6 +17,9 @@ export class PoMenuComponent extends PoMenuBaseComponent {
 describe('PoMenuBaseComponent:', () => {
   let component: PoMenuBaseComponent;
 
+  const menuGlobalService: any = {
+    sendMenus: menus => {}
+  };
   const languageService: any = {
     getShortLanguage: () => {
       return 'pt';
@@ -30,7 +33,7 @@ describe('PoMenuBaseComponent:', () => {
     getFilteredData: () => {}
   };
   beforeEach(() => {
-    component = new PoMenuComponent(menuService, languageService);
+    component = new PoMenuComponent(menuGlobalService, menuService, languageService);
     component.menus = [
       {
         label: 'Level 1.1',
@@ -491,12 +494,15 @@ describe('PoMenuBaseComponent:', () => {
       const spyCheckingRouterChildrenFragments = spyOn(component, <any>'checkingRouterChildrenFragments');
       const spyCheckActiveMenuByUrl = spyOn(component, <any>'checkActiveMenuByUrl');
 
+      const spySendMenus = spyOn(component.menuGlobalService, <any>'sendMenus');
+
       expectPropertiesValues(component, 'menus', validValues, validValues);
 
       tick();
 
       expect(spyCheckingRouterChildrenFragments).toHaveBeenCalled();
       expect(spyCheckActiveMenuByUrl).toHaveBeenCalled();
+      expect(spySendMenus).toHaveBeenCalled();
     }));
 
     it('menus: should update property with `[]` if values are invalid.', () => {

--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
@@ -13,6 +13,7 @@ import {
 import { PoMenuFilter } from './po-menu-filter/po-menu-filter.interface';
 import { PoMenuItem } from './po-menu-item.interface';
 import { PoMenuService } from './services/po-menu.service';
+import { PoMenuGlobalService } from './services/po-menu-global.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 
@@ -85,6 +86,8 @@ export abstract class PoMenuBaseComponent {
   /** Lista dos itens do menu. Se o valor estiver indefinido ou inválido, será inicializado como um array vazio. */
   @Input('p-menus') set menus(menus: Array<PoMenuItem>) {
     this._menus = Array.isArray(menus) ? menus : [];
+
+    this.menuGlobalService.sendMenus(menus);
 
     setTimeout(() => {
       const urlRouter = this.checkingRouterChildrenFragments();
@@ -228,7 +231,12 @@ export abstract class PoMenuBaseComponent {
     return this._shortLogo;
   }
 
-  constructor(public menuService: PoMenuService, public languageService: PoLanguageService) {}
+  constructor(
+    public menuGlobalService: PoMenuGlobalService,
+    public menuService: PoMenuService,
+    public languageService: PoLanguageService
+  ) {}
+
   private configService(service: string | PoMenuFilter) {
     if (typeof service === 'string' && service.trim()) {
       // service url

--- a/projects/ui/src/lib/components/po-menu/po-menu-item.interface.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item.interface.ts
@@ -46,4 +46,7 @@ export interface PoMenuItem {
 
   /** Lista de sub-items, criando novos níveis dentro do menu. O número máximo de níveis do menu é igual a 4. */
   subItems?: Array<PoMenuItem>;
+
+  // Identificador do Item;
+  id?: string;
 }

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
@@ -828,14 +828,24 @@ describe('PoMenuComponent:', () => {
       expect(component['subscribeToMenuItem']).toHaveBeenCalled();
     });
 
+    it(`ngAfterViewInit: should call 'menuGlobalService.sendApplicationMenu' with component instance`, () => {
+      spyOn(component['menuGlobalService'], <any>'sendApplicationMenu');
+
+      component.ngAfterViewInit();
+
+      expect(component['menuGlobalService'].sendApplicationMenu).toHaveBeenCalledWith(component);
+    });
+
     it(`ngOnDestroy: should call 'resizeListener' if has 'resizeListener`, () => {
       component['createResizeListener']();
 
       spyOn(component, <any>'resizeListener');
+      spyOn(component['menuGlobalService'], <any>'sendRemovedApplicationMenu');
 
       component.ngOnDestroy();
 
       expect(component['resizeListener']).toHaveBeenCalled();
+      expect(component['menuGlobalService'].sendRemovedApplicationMenu).toHaveBeenCalledWith(component.id);
     });
 
     it(`collapse: should call 'validateToggleMenu' with 'true'`, () => {

--- a/projects/ui/src/lib/components/po-menu/services/po-menu-global.service.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/services/po-menu-global.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Observable } from 'rxjs';
+
+import { PoMenuModule } from '../po-menu.module';
+import { PoMenuGlobalService } from './po-menu-global.service';
+
+describe('PoMenuGlobalService', () => {
+  let menuGlobalService: PoMenuGlobalService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PoMenuModule]
+    });
+
+    menuGlobalService = TestBed.inject(PoMenuGlobalService);
+  });
+
+  it('sendApplicationMenu: should call applicationMenu.next with menu', () => {
+    const menu = <any>{ id: '123', menus: [] };
+
+    spyOn(menuGlobalService['applicationMenu'], 'next');
+
+    menuGlobalService.sendApplicationMenu(menu);
+
+    expect(menuGlobalService['applicationMenu'].next).toHaveBeenCalledWith(menu);
+  });
+
+  it('sendMenus: should call menus.next with menuItem', () => {
+    const menus = [{ label: 'Item', link: '/item' }];
+
+    spyOn(menuGlobalService['menus'], 'next');
+
+    menuGlobalService.sendMenus(menus);
+
+    expect(menuGlobalService['menus'].next).toHaveBeenCalledWith(menus);
+  });
+
+  it('sendRemovedApplicationMenu: should call removedApplicationMenu.next with ID param', () => {
+    const id = '1234';
+
+    spyOn(menuGlobalService['removedApplicationMenu'], 'next');
+
+    menuGlobalService.sendRemovedApplicationMenu(id);
+
+    expect(menuGlobalService['removedApplicationMenu'].next).toHaveBeenCalledWith(id);
+  });
+});

--- a/projects/ui/src/lib/components/po-menu/services/po-menu-global.service.ts
+++ b/projects/ui/src/lib/components/po-menu/services/po-menu-global.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+
+import { Observable, Subject } from 'rxjs';
+
+import { PoMenuComponent } from '../po-menu.component';
+import { PoMenuItem } from '../po-menu-item.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PoMenuGlobalService {
+  private applicationMenu = new Subject<PoMenuComponent>();
+  private menus = new Subject<Array<PoMenuItem>>();
+  private removedApplicationMenu = new Subject<string>();
+
+  receiveApplicationMenu$ = this.applicationMenu.asObservable();
+  receiveMenus$ = this.menus.asObservable();
+  receiveRemovedApplicationMenu$ = this.removedApplicationMenu.asObservable();
+
+  sendApplicationMenu(menu: PoMenuComponent) {
+    this.applicationMenu.next(menu);
+  }
+
+  sendMenus(menus: Array<PoMenuItem>) {
+    this.menus.next(menus);
+  }
+
+  sendRemovedApplicationMenu(id: string) {
+    this.removedApplicationMenu.next(id);
+  }
+}

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.spec.ts
@@ -119,19 +119,19 @@ describe('PoNavbarBaseComponent:', () => {
       expectPropertiesValues(component, 'shadow', invalidValues, false);
     });
 
-    it('logo: should call `validateMenuLogo` if has `menu`', () => {
+    it('logo: should call `validateMenuLogo` if has `applicationMenu`', () => {
       spyOn(component, 'validateMenuLogo');
 
-      component.menu = <any>{ logo: 'logo' };
+      component.applicationMenu = <any>{ logo: 'logo' };
       component.logo = 'logo';
 
       expect(component.validateMenuLogo).toHaveBeenCalled();
     });
 
-    it('logo: shouldn`t call `validateMenuLogo` if doesn`t have `menu`', () => {
+    it('logo: shouldn`t call `validateMenuLogo` if doesn`t have `applicationMenu`', () => {
       spyOn(component, 'validateMenuLogo');
 
-      component.menu = undefined;
+      component.applicationMenu = undefined;
       component.logo = 'logo';
 
       expect(component.validateMenuLogo).not.toHaveBeenCalled();

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
@@ -143,10 +143,7 @@ export abstract class PoNavbarBaseComponent {
    * @optional
    *
    * @description
-   * *Depreciado 6.x.x*
-   *
-   * > Não há necessidade de utilizar esta propriedade, o próprio componente faz o uso do menu corrente
-   * para exibir seus itens quando estiver em resolução pequena.
+   * **Depreciado 6.x.x**
    *
    * Caso já possua um menu na aplicação o mesmo deve ser repassado para essa propriedade para que quando entre em modo
    * responsivo os items do `po-navbar` possam ser adicionados no primeiro item do menu definido.

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
@@ -29,6 +29,11 @@ export const poNavbarLiteralsDefault = {
  *
  * O componente `po-navbar` é um cabeçalho fixo que permite apresentar uma lista de links para facilitar a navegação pelas
  * páginas da aplicação. Também possui ícones com ações.
+ *
+ * Quando utilizado em uma resolução menor que `768px`, o componente utilizará o menu corrente da aplicação para
+ * incluir seus itens.
+ *
+ * Ao utilizar Navbar com Menu e ambos tiverem logo, será mantido o logo do Navbar.
  */
 @Directive()
 export abstract class PoNavbarBaseComponent {
@@ -36,8 +41,12 @@ export abstract class PoNavbarBaseComponent {
   private _items: Array<PoNavbarItem> = [];
   private _literals: PoNavbarLiterals;
   private _logo: string;
+  private _menu: PoMenuComponent;
   private _shadow: boolean = false;
   private language: string = poLocaleDefault;
+
+  // Menu que esta sendo exibido na pagina corrente.
+  applicationMenu: PoMenuComponent;
 
   /**
    * @optional
@@ -120,7 +129,7 @@ export abstract class PoNavbarBaseComponent {
   @Input('p-logo') set logo(value: string) {
     this._logo = value;
 
-    if (this.menu) {
+    if (this.applicationMenu) {
       this.validateMenuLogo();
     }
   }
@@ -129,9 +138,15 @@ export abstract class PoNavbarBaseComponent {
   }
 
   /**
+   * @deprecated 6.x.x
+   *
    * @optional
    *
    * @description
+   * *Depreciado 6.x.x*
+   *
+   * > Não há necessidade de utilizar esta propriedade, o próprio componente faz o uso do menu corrente
+   * para exibir seus itens quando estiver em resolução pequena.
    *
    * Caso já possua um menu na aplicação o mesmo deve ser repassado para essa propriedade para que quando entre em modo
    * responsivo os items do `po-navbar` possam ser adicionados no primeiro item do menu definido.

--- a/projects/ui/src/lib/components/po-navbar/po-navbar.component.html
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar.component.html
@@ -1,7 +1,7 @@
 <header class="po-navbar" [ngClass]="{ 'po-navbar-shadow': shadow }">
   <po-navbar-logo
     class="po-navbar-logo"
-    [ngClass]="{ 'po-navbar-logo-menu': !!menu, 'po-navbar-no-logo': !logo }"
+    [ngClass]="{ 'po-navbar-logo-menu': !!applicationMenu, 'po-navbar-no-logo': !logo }"
     [p-logo]="logo"
   >
   </po-navbar-logo>
@@ -20,4 +20,4 @@
   <po-navbar-actions class="po-navbar-actions" [p-icon-actions]="iconActions"> </po-navbar-actions>
 </header>
 
-<po-menu *ngIf="!menu" [p-menus]="items"> </po-menu>
+<po-menu *ngIf="!applicationMenu" [p-menus]="items"> </po-menu>


### PR DESCRIPTION
**< NAVBAR >**

**< DTHFUI-1425 >**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando utilizado o PoNavbar em resolução menor, o mesmo não incluía os itens no Menu da aplicação.
Para isto era preciso informar a propriedade p-menu, porém ao utilizar uma aplicação mais dinâmica, não era possível
passar para o navbar a referencia do menu.

**Qual o novo comportamento?**

- PoNavbar passa a utilizar o menu da aplicação para injetar os itens quando usado em resolução menor, sem a necessidade de informar a propriedade p-menu;
- Deprecia a propriedade p-menu;

**Simulação**
- Rodar o Portal e utiliza-lo em resolução menor que 768px (na master os itens do navbar não são incluídos no menu) 
- Utilizar o [App](https://github.com/po-ui/po-angular/files/6450212/app-navbar.zip), onde simula projeto com lazy loading,
com outros modulos (semelhante ao portal) e também com fonte comentado de menu fixo cm navbar onde deve funcionar tbm.

