### PR TITLE
fix(page-dynamic-table): corrige key no final da url no beforeRemove

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/po-page-dynamic-detail.component.spec.ts
@@ -859,28 +859,30 @@ describe('PoPageDynamicDetailComponent:', () => {
     });
 
     describe('remove', () => {
-      const uniqueKey = '1';
-
       it('remove: should call `formatUniqueKey`', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: '' };
+        const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = { allowAction: false };
         component.model = { id: 1, name: 'Angular' };
 
         spyOn(component, <any>'formatUniqueKey');
+        spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['formatUniqueKey']).toHaveBeenCalledWith(component.model);
       });
 
       it('shouldn`t call executeRemove if allowAction is false', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: '' };
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = { allowAction: false };
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
         spyOn(component, <any>'executeRemove');
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['executeRemove']).not.toHaveBeenCalled();
       });
@@ -888,6 +890,8 @@ describe('PoPageDynamicDetailComponent:', () => {
       it('shouldn`t call executeRemove if removeAction is a function', () => {
         const removeAction = jasmine.createSpy('removeAction');
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = { allowAction: true };
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
@@ -900,105 +904,122 @@ describe('PoPageDynamicDetailComponent:', () => {
       });
 
       it('should call executeRemove if allowAction is true', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: 'test' };
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = { allowAction: true };
+
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
         spyOn(component, <any>'executeRemove').and.returnValue(of({}));
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['executeRemove']).toHaveBeenCalledWith(actions.remove, uniqueKey);
       });
 
-      it('should call executeRemove if allowAction is undefined', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+      it('should call executeRemove if beforeRemoveResult.allowAction is undefined', () => {
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: 'test' };
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = { allowAction: undefined };
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
         spyOn(component, <any>'executeRemove').and.returnValue(of({}));
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['executeRemove']).toHaveBeenCalledWith(actions.remove, uniqueKey);
       });
 
       it('should call executeRemove if allowAction is null', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: 'test' };
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = { allowAction: null };
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
         spyOn(component, <any>'executeRemove').and.returnValue(of({}));
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['executeRemove']).toHaveBeenCalledWith(actions.remove, uniqueKey);
       });
 
       it('should call executeRemove with newUrl if it has a defined value', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: 'test' };
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = { newUrl: 'newUrl' };
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
         spyOn(component, <any>'executeRemove').and.returnValue(of({}));
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['executeRemove']).toHaveBeenCalledWith(returnBeforeRemove.newUrl, uniqueKey);
       });
 
       it('should call executeRemove with removeAction if newUrl is undefined', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: 'test' };
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = { newUrl: undefined };
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
         spyOn(component, <any>'executeRemove').and.returnValue(of({}));
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['executeRemove']).toHaveBeenCalledWith(actions.remove, uniqueKey);
       });
 
       it('should call executeRemove with removeAction if newUrl is null', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: 'test' };
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = { newUrl: null };
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
         spyOn(component, <any>'executeRemove').and.returnValue(of({}));
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['executeRemove']).toHaveBeenCalledWith(actions.remove, uniqueKey);
       });
 
       it('should call executeRemove with removeAction if returnBeforeRemove is null', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: 'test' };
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = null;
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
         spyOn(component, <any>'executeRemove').and.returnValue(of({}));
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['executeRemove']).toHaveBeenCalledWith(actions.remove, uniqueKey);
       });
 
       it('should call executeRemove with removeAction if returnBeforeRemove is undefined', () => {
-        const actions: PoPageDynamicDetailActions = { remove: 'people/list/' };
+        const actions: PoPageDynamicDetailActions = { remove: 'people/list/', beforeRemove: 'test' };
         const returnBeforeRemove: PoPageDynamicDetailBeforeRemove = undefined;
+        component.model = { id: 1, name: 'Angular' };
+        const uniqueKey = '1';
 
         spyOn(component, <any>'formatUniqueKey').and.returnValue(uniqueKey);
         spyOn(component['poPageDynamicDetailActionsService'], 'beforeRemove').and.returnValue(of(returnBeforeRemove));
         spyOn(component, <any>'executeRemove').and.returnValue(of({}));
 
-        component['remove'](actions.remove);
+        component['remove'](actions.remove, actions.beforeRemove);
 
         expect(component['executeRemove']).toHaveBeenCalledWith(actions.remove, uniqueKey);
       });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -1364,7 +1364,7 @@ describe('PoPageDynamicTableComponent:', () => {
 
         expect(component['poNotification'].success).toHaveBeenCalled();
         expect(component['formatUniqueKey']).toHaveBeenCalled();
-        expect(component['poPageDynamicService'].deleteResource).toHaveBeenCalledWith(uniqueKey, '/teste');
+        expect(component['poPageDynamicService'].deleteResource).toHaveBeenCalledWith(undefined, '/teste');
       }));
 
       it(`should call 'deleteResource' with other url if beforeRemove return newUrl and remove is a function`, fakeAsync(() => {
@@ -1386,7 +1386,7 @@ describe('PoPageDynamicTableComponent:', () => {
 
         expect(component['poNotification'].success).toHaveBeenCalled();
         expect(component['formatUniqueKey']).toHaveBeenCalled();
-        expect(component['poPageDynamicService'].deleteResource).toHaveBeenCalledWith(uniqueKey, '/teste');
+        expect(component['poPageDynamicService'].deleteResource).toHaveBeenCalledWith(undefined, '/teste');
       }));
 
       it(`should call 'poNotification.success' if remove is a function and return true`, fakeAsync(() => {
@@ -1964,6 +1964,15 @@ describe('PoPageDynamicTableComponent:', () => {
       component['updateFilterValue'](filter);
 
       expect(component.fields).toEqual(expectedFields);
+    });
+
+    it('updateTableActions: ', () => {
+      const actions = [{ label: 'detail' }];
+      component['_defaultTableActions'] = actions;
+
+      component['updateTableActions']();
+
+      expect(component.tableActions).toEqual(actions);
     });
   });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -698,10 +698,11 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     const allow = allowAction ?? true;
 
     if (allow) {
-      const uniqueKey = this.formatUniqueKey(item);
+      let uniqueKey = this.formatUniqueKey(item);
       const resourceToRemoveKey = this.returnResourcesKeys([item]);
 
       if (typeof actionRemove === 'boolean' || newUrl) {
+        uniqueKey = newUrl ? undefined : uniqueKey;
         return this.poPageDynamicService
           .deleteResource(uniqueKey, newUrl)
           .pipe(map(() => this.removeFromUI(resourceToRemoveKey, this.literals.removeSuccessNotification)));

--- a/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic.service.spec.ts
+++ b/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic.service.spec.ts
@@ -214,6 +214,18 @@ describe('PoPageDynamicService:', () => {
         req.flush({});
         tick();
       }));
+
+      it('should delete a resource passing undefined id.', fakeAsync(() => {
+        poPageDynamicService.deleteResource(undefined, '/test').subscribe();
+
+        const req = httpMock.expectOne(request => request.url === '/test');
+
+        expect(req.request.method).toBe('DELETE');
+        expect(req.request.headers.get('X-PO-SCREEN-LOCK')).toBe('true');
+
+        req.flush({});
+        tick();
+      }));
     });
 
     describe('deleteResource', () => {

--- a/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic.service.ts
+++ b/projects/templates/src/lib/services/po-page-dynamic/po-page-dynamic.service.ts
@@ -84,8 +84,10 @@ export class PoPageDynamicService {
   }
 
   // Deleta um único recurso
-  deleteResource(id, endpoint?: string): Observable<any> {
-    return this.http.delete(`${this.getLocalEndPoint(endpoint, true)}/${id}`, { headers: this.headers });
+  deleteResource(id?, endpoint?: string): Observable<any> {
+    const localEndPoint = this.getLocalEndPoint(endpoint, true);
+    const url = id ? `${localEndPoint}/${id}` : localEndPoint;
+    return this.http.delete(url, { headers: this.headers });
   }
 
   // Deleta recursos em lote


### PR DESCRIPTION
Corrige concatenação indevida da key com a propriedade newUrl da action beforeRemove.

Fixes 

**PO-PAGE-DYNAMIC-TABLE**

**DTHFUI-4664**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Concatenação indevida da key no remove quando é utilizado o beforeRemove e uma newUrl é retornada.

**Qual o novo comportamento?**
Quando é retornada uma newUrl no beforeRemove a key não é concatenada na requisição, já que o desenvolvedor poderá customizar a url inclusive passando os parâmetros que ele quiser.

**Simulação**
[app-dynamic-table.zip](https://github.com/po-ui/po-angular/files/6468409/app-dynamic-table.zip)
Validar também o funcionamento do componente `po-dynamic-detail` que é afetado pelo serviço alterado.