### PR TITLE
feat(fields): adiciona compatibilidade com outras fontes de ícones

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -1,5 +1,5 @@
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
-import { EventEmitter, Input, OnInit, Output, Directive } from '@angular/core';
+import { EventEmitter, Input, OnInit, Output, Directive, TemplateRef } from '@angular/core';
 
 import { convertToBoolean, isTypeof, validValue } from '../../../utils/util';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
@@ -303,9 +303,25 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * Define o ícone que será exibido no início do campo.
    *
-   * > Veja a disponibilidade de ícones em [biblioteca de ícones](guides/icons).
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-combo p-icon="po-icon-user" p-label="PO combo"></po-combo>
+   * ```
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
+   * ```
+   * <po-combo p-icon="fa fa-podcast" p-label="PO combo"></po-combo>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-combo [p-icon]="template" p-label="combo template ionic"></po-combo>
+   *
+   * <ng-template #template>
+   *  <ion-icon style="font-size: inherit" name="heart"></ion-icon>
+   * </ng-template>
+   * ```
+   * > Para o ícone enquadrar corretamente, deve-se utilizar `font-size: inherit` caso o ícone utilizado não aplique-o.
    */
-  @Input('p-icon') icon?: string;
+  @Input('p-icon') icon?: string | TemplateRef<void>;
 
   /** Indica que a lista definida na propriedade p-options será ordenada pela descrição. */
   @Input('p-sort') set sort(sort: boolean) {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -1,7 +1,7 @@
 <po-field-container [p-label]="label" [p-help]="help" [p-optional]="!required && optional">
   <div class="po-field-container-content">
     <div *ngIf="icon" class="po-field-icon-container-left">
-      <span class="po-icon po-field-icon {{ icon }}" [class.po-field-icon-disabled]="disabled"></span>
+      <po-icon class="po-field-icon" [class.po-field-icon-disabled]="disabled" [p-icon]="icon"></po-icon>
     </div>
 
     <input

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -11,6 +11,7 @@ import { PoLoadingModule } from '../../po-loading/po-loading.module';
 
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
+import { PoIconModule } from '../../po-icon';
 
 import { PoComboComponent } from './po-combo.component';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
@@ -32,7 +33,7 @@ describe('PoComboComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [PoLoadingModule],
+      imports: [PoLoadingModule, PoIconModule],
       declarations: [PoComboComponent, PoFieldContainerComponent, PoFieldContainerBottomComponent, PoCleanComponent],
       providers: [HttpClient, HttpHandler]
     });

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
@@ -46,9 +46,9 @@ export class SamplePoComboLabsComponent implements OnInit {
   ];
 
   public readonly iconsOptions: Array<PoRadioGroupOption> = [
-    { label: 'Company', value: 'po-icon-company' },
-    { label: 'Gas', value: 'po-icon-gas' },
-    { label: 'Light', value: 'po-icon-light' }
+    { label: 'po-icon-company', value: 'po-icon-company' },
+    { label: 'po-icon-gas', value: 'po-icon-gas' },
+    { label: 'fa fa-calculator', value: 'fa fa-calculator' }
   ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
@@ -1,7 +1,7 @@
 <po-field-container [p-label]="label" [p-help]="help" [p-optional]="!required && optional">
   <div class="po-field-container-content">
     <div *ngIf="icon" class="po-field-icon-container-left">
-      <span class="po-icon po-field-icon {{ icon }}" [class.po-field-icon-disabled]="disabled"></span>
+      <po-icon class="po-field-icon" [class.po-field-icon-disabled]="disabled" [p-icon]="icon"></po-icon>
     </div>
 
     <input

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -8,6 +8,7 @@ import { PoDecimalComponent } from './po-decimal.component';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
 import { PoLanguageService } from '../../../services';
+import { PoIconModule } from '../../po-icon';
 
 describe('PoDecimalComponent:', () => {
   let component: PoDecimalComponent;
@@ -20,6 +21,7 @@ describe('PoDecimalComponent:', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
+        imports: [PoIconModule],
         declarations: [
           PoDecimalComponent,
           PoFieldContainerComponent,

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
@@ -31,7 +31,7 @@ export class SamplePoDecimalLabsComponent implements OnInit {
   public readonly iconOptions: Array<PoSelectOption> = [
     { value: 'po-icon-cart', label: 'po-icon-cart' },
     { value: 'po-icon-finance-secure', label: 'po-icon-finance-secure' },
-    { value: 'po-icon-debit-payment', label: 'po-icon-debit-payment' }
+    { value: 'fa fa-calculator', label: 'fa fa-calculator' }
   ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [

--- a/projects/ui/src/lib/components/po-field/po-email/po-email.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-email/po-email.component.spec.ts
@@ -7,6 +7,7 @@ import { PoEmailComponent } from './po-email.component';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
 import { PoCleanComponent } from './../po-clean/po-clean.component';
+import { PoIconModule } from '../../po-icon';
 
 describe('PoEmailComponent:', () => {
   let component: PoEmailComponent;
@@ -14,6 +15,7 @@ describe('PoEmailComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
+      imports: [PoIconModule],
       declarations: [PoEmailComponent, PoFieldContainerComponent, PoCleanComponent, PoFieldContainerBottomComponent]
     });
   });

--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -16,6 +16,7 @@ import { PoProgressModule } from './../po-progress/po-progress.module';
 import { PoServicesModule } from '../../services/services.module';
 import { PoTableModule } from '../po-table/po-table.module';
 import { PoTooltipModule } from './../../directives/po-tooltip/po-tooltip.module';
+import { PoIconModule } from '../po-icon/po-icon.module';
 
 import { PoCalendarComponent } from './po-datepicker/po-calendar/po-calendar.component';
 import { PoCleanComponent } from './po-clean/po-clean.component';
@@ -81,7 +82,8 @@ import { PoUrlComponent } from './po-url/po-url.component';
     PoProgressModule,
     PoServicesModule,
     PoTableModule,
-    PoTooltipModule
+    PoTooltipModule,
+    PoIconModule
   ],
   exports: [
     PoCheckboxComponent,

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Input, Output, Directive } from '@angular/core';
+import { EventEmitter, Input, Output, Directive, TemplateRef } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 
 import { convertToBoolean } from '../../../utils/util';
@@ -52,9 +52,25 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    *
    * Define o ícone que será exibido no início do campo.
    *
-   * > Veja a disponibilidade de ícones em [biblioteca de ícones](guides/icons).
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-input p-icon="po-icon-user" p-label="PO input"></po-input>
+   * ```
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
+   * ```
+   * <po-input p-icon="fa fa-podcast" p-label="PO input"></po-input>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-input [p-icon]="template" p-label="input template ionic"></po-input>
+   *
+   * <ng-template #template>
+   *  <ion-icon style="font-size: inherit" name="heart"></ion-icon>
+   * </ng-template>
+   * ```
+   * > Para o ícone enquadrar corretamente, deve-se utilizar `font-size: inherit` caso o ícone utilizado não aplique-o.
    */
-  @Input('p-icon') icon?: string;
+  @Input('p-icon') icon?: string | TemplateRef<void>;
 
   /** Rótulo do campo. */
   @Input('p-label') label?: string;

--- a/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
@@ -1,7 +1,7 @@
 <po-field-container [p-help]="help" [p-label]="label" [p-optional]="!required && optional">
   <div class="po-field-container-content">
     <div *ngIf="icon" class="po-field-icon-container-left">
-      <span class="po-icon po-field-icon {{ icon }}" [class.po-field-icon-disabled]="disabled"></span>
+      <po-icon class="po-field-icon" [class.po-field-icon-disabled]="disabled" [p-icon]="icon"></po-icon>
     </div>
 
     <input

--- a/projects/ui/src/lib/components/po-field/po-input/po-input.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input.component.spec.ts
@@ -6,6 +6,7 @@ import { PoInputComponent } from './po-input.component';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
 import { PoCleanComponent } from './../po-clean/po-clean.component';
+import { PoIconModule } from '../../po-icon';
 
 describe('PoInputComponent: ', () => {
   let component: PoInputComponent;
@@ -14,6 +15,7 @@ describe('PoInputComponent: ', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
+      imports: [PoIconModule],
       declarations: [PoInputComponent, PoFieldContainerComponent, PoCleanComponent, PoFieldContainerBottomComponent]
     });
   });

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
@@ -23,7 +23,7 @@ export class SamplePoInputLabsComponent implements OnInit {
   public readonly iconOptions: Array<PoSelectOption> = [
     { value: 'po-icon-news', label: 'po-icon-news' },
     { value: 'po-icon-search', label: 'po-icon-search' },
-    { value: 'po-icon-world', label: 'po-icon-world' }
+    { value: 'fa fa-calculator', label: 'fa fa-calculator' }
   ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
@@ -1,7 +1,7 @@
 <po-field-container [p-help]="help" [p-label]="label" [p-optional]="!required && optional">
   <div class="po-field-container-content">
     <div *ngIf="icon" class="po-field-icon-container-left">
-      <span class="po-icon po-field-icon {{ icon }}" [class.po-field-icon-disabled]="disabled"></span>
+      <po-icon class="po-field-icon" [class.po-field-icon-disabled]="disabled" [p-icon]="icon"></po-icon>
     </div>
     <input
       #inp

--- a/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.ts
@@ -23,8 +23,8 @@ export class SamplePoNumberLabsComponent implements OnInit {
 
   public readonly iconOptions: Array<PoSelectOption> = [
     { value: 'po-icon-finance', label: 'po-icon-finance' },
-    { value: 'po-icon-calculator', label: 'po-icon-calculator' },
-    { value: 'po-icon-finance-bitcoin', label: 'po-icon-finance-bitcoin' }
+    { value: 'po-icon-finance-bitcoin', label: 'po-icon-finance-bitcoin' },
+    { value: 'fa fa-calculator', label: 'fa fa-calculator' }
   ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [

--- a/projects/ui/src/lib/components/po-field/po-url/po-url.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-url/po-url.component.spec.ts
@@ -6,6 +6,7 @@ import { PoUrlComponent } from './po-url.component';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
 import { PoCleanComponent } from './../po-clean/po-clean.component';
+import { PoIconModule } from '../../po-icon';
 
 describe('PoUrlComponent:', () => {
   let component: PoUrlComponent;
@@ -13,6 +14,7 @@ describe('PoUrlComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
+      imports: [PoIconModule],
       declarations: [PoUrlComponent, PoFieldContainerComponent, PoCleanComponent, PoFieldContainerBottomComponent]
     });
   });


### PR DESCRIPTION
**FIELDS: PO-COMBO, PO-INPUT, PO-NUMBER E PO-DECIMAL**

**DTHFUI-4388**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente não é possível utilizar outras fontes de ícones nos componentes de fields.

**Qual o novo comportamento?**
Adicionada nova funcionalidade para permitir a utilização de outras fontes de ícones.

**Simulação**
Possui PR no [po-style](https://github.com/po-ui/po-style/pull/214).
Samples do Portal, ou utilizar o código abaixo no app:

- app.html:
```
<div class="po-m-3">
  <po-divider p-label="COMBO"></po-divider>
  <div class="po-row">
    <po-combo p-icon="po-icon-server" p-label="PO COMBO"></po-combo>
    <po-combo p-icon="fa fa-calculator" p-label="FA COMBO"></po-combo>
    <po-combo [p-icon]="icon" p-label="MAT COMBO"></po-combo>
  </div>
  <div class="po-row">
    <po-combo [p-disabled]="true" p-icon="po-icon-server" p-label="PO COMBO"></po-combo>
    <po-combo [p-disabled]="true" p-icon="fa fa-calculator" p-label="FA COMBO"></po-combo>
    <po-combo [p-disabled]="true" [p-icon]="icon" p-label="MAT COMBO"></po-combo>
  </div>
  <po-divider p-label="INPUT"></po-divider>
  <div class="po-row">
    <po-input p-icon="po-icon-device-tablet" p-label="PO INPUT"></po-input>
    <po-input p-icon="fa fa-ad" p-label="FA INPUT"></po-input>
    <po-input [p-icon]="icon" p-label="MAT INPUT"></po-input>
  </div>
  <div class="po-row">
    <po-input [p-disabled]="true" p-icon="po-icon-device-tablet" p-label="PO INPUT"></po-input>
    <po-input [p-disabled]="true" p-icon="fa fa-ad" p-label="FA INPUT"></po-input>
    <po-input [p-disabled]="true" [p-icon]="icon" p-label="MAT INPUT"></po-input>
  </div>
  <po-divider p-label="NUMBER"></po-divider>
  <div class="po-row">
    <po-number p-icon="po-icon-device-tablet" p-label="PO NUMBER"></po-number>
    <po-number p-icon="fa fa-ad" p-label="FA NUMBER"></po-number>
    <po-number [p-icon]="icon" p-label="MAT NUMBER"></po-number>
  </div>
  <div class="po-row">
    <po-number [p-disabled]="true" p-icon="po-icon-device-tablet" p-label="PO NUMBER"></po-number>
    <po-number [p-disabled]="true" p-icon="fa fa-ad" p-label="FA NUMBER"></po-number>
    <po-number [p-disabled]="true" [p-icon]="icon" p-label="MAT NUMBER"></po-number>
  </div>
  <po-divider p-label="DECIMAL"></po-divider>
  <div class="po-row">
    <po-decimal p-icon="po-icon-device-tablet" p-label="PO DECIMAL"></po-decimal>
    <po-decimal p-icon="fa fa-ad" p-label="FA DECIMAL"></po-decimal>
    <po-decimal [p-icon]="icon" p-label="MAT DECIMAL"></po-decimal>
  </div>
  <div class="po-row">
    <po-decimal [p-disabled]="true" p-icon="po-icon-device-tablet" p-label="PO DECIMAL"></po-decimal>
    <po-decimal [p-disabled]="true" p-icon="fa fa-ad" p-label="FA DECIMAL"></po-decimal>
    <po-decimal [p-disabled]="true" [p-icon]="icon" p-label="MAT DECIMAL"></po-decimal>
  </div>
</div>

<ng-template #icon>
  <span class="material-icons" style="font-size: inherit;">dashboard</span>
</ng-template>
```

- app/index.html:

```
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <title>App</title>
    <base href="/" />

    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <link rel="icon" type="image/x-icon" href="favicon.ico" />
    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
    <link href="https://fonts.googleapis.com/css2?family=Material+Icons" rel="stylesheet">
  </head>
  <body>
    <app-root></app-root>
  </body>
</html>
```
