### PR TITLE
feat(button-group): adiciona compatibilidade com outras fontes de ícones

### DIFF
--- a/projects/ui/src/lib/components/po-button-group/po-button-group-item.interface.ts
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group-item.interface.ts
@@ -1,3 +1,4 @@
+import { TemplateRef } from '@angular/core';
 /**
  * @usedBy PoButtonGroupComponent
  *
@@ -21,9 +22,39 @@ export interface PoButtonGroupItem {
   /**
    * Ícone exibido ao lado esquerdo do label do botão.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons).
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * buttons: Array<PoButtonGroupItem> = [
+   *  { label: 'Button 1', action: this.action.bind(this), icon: 'po-icon-user' },
+   * ];
+   * ```
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
+   * ```
+   * buttons: Array<PoButtonGroupItem> = [
+   *  { label: 'Button 1', action: this.action.bind(this), icon: 'fa fa-podcast' },
+   * ];
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   *
+   * component.html:
+   * ```
+   * <ng-template #iconTemplate>
+   *  <ion-icon style="font-size: inherit" name="heart"></ion-icon>
+   * </ng-template>
+   * ```
+   * component.ts:
+   * ```
+   * @ViewChild('iconTemplate', { static: true } ) iconTemplate : TemplateRef<void>;
+   * buttons: Array<PoButtonGroupItem> = [];
+   * ...
+   *
+   * this.buttons = [
+   *   { label: 'Button 1', action: this.action.bind(this), icon: this.iconTemplate }
+   * ];
+   * ```
+   * > Para o ícone enquadrar corretamente, deve-se utilizar `font-size: inherit` caso o ícone utilizado não aplique-o.
    */
-  icon?: string;
+  icon?: string | TemplateRef<void>;
 
   /** Label do botão. */
   label?: string;

--- a/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-labs/sample-po-button-group-labs.component.ts
+++ b/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-labs/sample-po-button-group-labs.component.ts
@@ -21,8 +21,8 @@ export class SamplePoButtonGroupLabsComponent implements OnInit {
   iconsOptions: Array<PoRadioGroupOption> = [
     { label: 'po-icon-news', value: 'po-icon-news' },
     { label: 'po-icon-calendar', value: 'po-icon-calendar' },
-    { label: 'po-icon-user', value: 'po-icon-user' },
-    { label: 'po-icon-telephone', value: 'po-icon-telephone' }
+    { label: 'fa fa-podcast', value: 'fa fa-podcast' },
+    { label: 'fa fa-calculator', value: 'fa fa-calculator' }
   ];
 
   readonly toggleOptions: Array<PoSelectOption> = [


### PR DESCRIPTION
**PO-BUTTON-GROUP**

**DTHFUI-4940**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não permite compatibilidade com outras fontes de ícones.

**Qual o novo comportamento?**
Permite a utilização de outras fontes de ícones no componente `po-button-group`.

**Simulação**
Através do sample labs do portal e também é possível testar no app com o código abaixo:

- app.component.html:
```
<div class="po-m-3">
  <po-divider p-label="BUTTON GROUP"></po-divider>
  <div class="po-row">
    <po-button-group class="po-md-12" [p-buttons]="buttons"> </po-button-group>
  </div>
</div>

<ng-template #icon>
  <span class="material-icons" style="font-size: inherit;">dashboard</span>
</ng-template>
```
- app.component.ts:
```
@ViewChild('icon', { static: true } ) icon: TemplateRef<void>;
  buttons: Array<PoButtonGroupItem> = [];

  constructor() {}

  ngOnInit(): void {
    this.buttons = [
      { label: 'Button FA', action: this.action.bind(this), icon: 'fa fa-calculator' },
      { label: 'Button PO', action: this.action.bind(this), icon: 'po-icon-user' },
      { label: 'Button TEMPLATE MAT', action: this.action.bind(this), icon: this.icon }
    ];
  }

  action(button) {
    alert(`${button.label}`);
  }
```
- app/index.html: 
```
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <title>App</title>
    <base href="/" />

    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <link rel="icon" type="image/x-icon" href="favicon.ico" />
    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
    <link href="https://fonts.googleapis.com/css2?family=Material+Icons" rel="stylesheet">
  </head>
  <body>
    <app-root></app-root>
  </body>
</html>
```