### PR TITLE
feat(calendar): adiciona a propriedade `p-mode`

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/index.ts
+++ b/projects/ui/src/lib/components/po-calendar/index.ts
@@ -1,2 +1,3 @@
+export * from './po-calendar-mode.enum';
 export * from './po-calendar.component';
 export * from './po-calendar.module';

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
@@ -1,6 +1,7 @@
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 import { PoDateService } from './../../services/po-date/po-date.service';
 
+import { PoCalendarMode } from './po-calendar-mode.enum';
 import { PoCalendarBaseComponent } from './po-calendar-base.component';
 import { PoCalendarLangService } from './services/po-calendar.lang.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
@@ -8,33 +9,34 @@ import { PoLanguageService } from '../../services/po-language/po-language.servic
 describe('PoCalendarBaseComponent:', () => {
   let component: PoCalendarBaseComponent;
   let poDate: PoDateService;
-  let poCalendarLangService: PoCalendarLangService;
   let languageService: PoLanguageService;
 
   beforeEach(() => {
     poDate = new PoDateService();
-    poCalendarLangService = new PoCalendarLangService();
     languageService = new PoLanguageService();
-    component = new PoCalendarBaseComponent(poDate, poCalendarLangService, languageService);
+    component = new PoCalendarBaseComponent(poDate, languageService);
     component['shortLanguage'] = 'pt';
   });
 
   describe('Properties:', () => {
-    it('p-locale: should update with valid values and call `initializeLanguage`', () => {
-      const validValues = ['pt', 'es', 'en', 'ru'];
+    it('p-mode: should set mode and call `setActivateDate`', () => {
+      spyOn(component, <any>'setActivateDate');
 
-      spyOn(component, 'initializeLanguage');
+      component.mode = PoCalendarMode.Range;
 
-      expectPropertiesValues(component, 'locale', validValues, validValues);
-      expect(component.initializeLanguage).toHaveBeenCalled();
+      expect(component['setActivateDate']).toHaveBeenCalled();
     });
 
-    it('p-locale: should update to `pt` if invalid values and call `initializeLanguage`', () => {
+    it('p-locale: should update with valid values', () => {
+      const validValues = ['pt', 'es', 'en', 'ru'];
+
+      expectPropertiesValues(component, 'locale', validValues, validValues);
+    });
+
+    it('p-locale: should update to `pt` if invalid values', () => {
       const invalidValues = [undefined, null, '', true, false, 0, 1, 'string', [], {}];
-      spyOn(component, 'initializeLanguage');
 
       expectPropertiesValues(component, 'locale', invalidValues, 'pt');
-      expect(component.initializeLanguage).toHaveBeenCalled();
     });
 
     it('p-max-date: should call `poDate.getDateForDateRange` with `maxDate` and `false`', () => {
@@ -63,24 +65,76 @@ describe('PoCalendarBaseComponent:', () => {
   });
 
   describe('Methods:', () => {
-    it(`initializeLanguage: should call 'setLanguage', 'getWeekDaysArray' and 'getMonthsArray' of
-      the 'poCalendarLangService' and set the value of displayWeekDays and displayMonths`, () => {
-      const weekDays = ['sun', 'mon', 'tue'];
-      const months = ['jan', 'feb', 'mar'];
-      component.locale = 'en';
+    it('setActivateDate: should set { start, end } with today date if isRange is true and date param is undefined', () => {
+      spyOnProperty(component, 'isRange').and.returnValue(true);
 
-      spyOn(component.poCalendarLangService, 'setLanguage');
-      spyOn(component.poCalendarLangService, 'getWeekDaysArray').and.returnValue(weekDays);
-      spyOn(component.poCalendarLangService, 'getMonthsArray').and.returnValue(months);
+      component['setActivateDate']();
 
-      component.initializeLanguage();
+      const { start, end } = component.activateDate;
 
-      expect(component.poCalendarLangService.setLanguage).toHaveBeenCalledWith(component.locale);
-      expect(component.poCalendarLangService.getWeekDaysArray).toHaveBeenCalled();
-      expect(component.poCalendarLangService.getMonthsArray).toHaveBeenCalled();
+      expect(start instanceof Date).toBe(true);
+      expect(end instanceof Date).toBe(true);
+    });
 
-      expect(component.displayWeekDays).toEqual(weekDays);
-      expect(component.displayMonths).toEqual(months);
+    it('setActivateDate: should set { start, end } with date param if isRange is true', () => {
+      const year = 2020;
+      const month = 10;
+      const day = 10;
+
+      const date = new Date(`${year}-${month}-${day}T00:00:00`);
+
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+
+      component['setActivateDate'](date);
+
+      const { start, end } = component.activateDate;
+
+      expect(start instanceof Date).toBe(true);
+      expect(end instanceof Date).toBe(true);
+
+      expect(start.getDate()).toBe(day);
+      expect(start.getMonth()).toBe(date.getMonth());
+      expect(start.getFullYear()).toBe(year);
+
+      expect(end.getDate()).toBe(day);
+      expect(end.getMonth()).toBe(date.getMonth() + 1);
+      expect(end.getFullYear()).toBe(year);
+    });
+
+    it('setActivateDate: should set with date param if isRange is false', () => {
+      const date = new Date(2019, 10, 5);
+
+      spyOnProperty(component, 'isRange').and.returnValue(false);
+
+      component['setActivateDate'](date);
+
+      expect(component.activateDate instanceof Date).toBe(true);
+      expect(component.activateDate.getFullYear()).toBe(date.getFullYear());
+      expect(component.activateDate.getMonth()).toBe(date.getMonth());
+    });
+
+    it('setActivateDate: should set with today date if isRange is false and date param is undefined', () => {
+      const today = new Date();
+
+      spyOnProperty(component, 'isRange').and.returnValue(false);
+
+      component['setActivateDate']();
+
+      expect(component.activateDate instanceof Date).toBe(true);
+      expect(component.activateDate.getFullYear()).toBe(today.getFullYear());
+      expect(component.activateDate.getMonth()).toBe(today.getMonth());
+    });
+
+    it('setActivateDate: should set with date iso if isRange is false and date param is string', () => {
+      const date = '2010-10-10';
+
+      spyOnProperty(component, 'isRange').and.returnValue(false);
+
+      component['setActivateDate'](date);
+
+      expect(component.activateDate instanceof Date).toBe(true);
+      expect(component.activateDate.getFullYear()).toBe(2010);
+      expect(component.activateDate.getMonth()).toBe(9);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-header/po-calendar-header.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-header/po-calendar-header.component.html
@@ -1,0 +1,19 @@
+<div class="po-calendar-header">
+  <span
+    *ngIf="previous?.observers && !hidePrevious"
+    class="po-calendar-header-left po-icon po-icon-arrow-left"
+    (click)="previous.emit()"
+  >
+  </span>
+
+  <div class="po-calendar-header-title">
+    <ng-content></ng-content>
+  </div>
+
+  <span
+    *ngIf="next?.observers.length && !hideNext"
+    class="po-calendar-header-right po-icon po-icon-arrow-right"
+    (click)="next.emit()"
+  >
+  </span>
+</div>

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-header/po-calendar-header.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-header/po-calendar-header.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PoCalendarHeaderComponent } from './po-calendar-header.component';
+
+describe('PoCalendarHeaderComponent', () => {
+  let component: PoCalendarHeaderComponent;
+  let fixture: ComponentFixture<PoCalendarHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PoCalendarHeaderComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoCalendarHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-header/po-calendar-header.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-header/po-calendar-header.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'po-calendar-header',
+  templateUrl: './po-calendar-header.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PoCalendarHeaderComponent {
+  @Input('p-hide-previous') hidePrevious = false;
+
+  @Input('p-hide-next') hideNext = false;
+
+  @Output('p-previous') previous = new EventEmitter<void>();
+
+  @Output('p-next') next = new EventEmitter<void>();
+
+  constructor() {}
+}

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-mode.enum.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-mode.enum.ts
@@ -1,0 +1,11 @@
+/**
+ * @usedBy PoCalendarComponent
+ *
+ * @description
+ *
+ * *Enum* `PoCalendarMode` para especificar os modos de visualização do calendário.
+ */
+export enum PoCalendarMode {
+  /** Define que o calendário será exibido em modo faixa de seleção. */
+  Range = 'range'
+}

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
@@ -1,0 +1,90 @@
+<div class="po-calendar-wrapper">
+  <ng-container *ngIf="isDayVisible">
+    <po-calendar-header
+      [p-hide-previous]="isEndPart"
+      [p-hide-next]="isStartPart"
+      (p-previous)="onPreviousMonth()"
+      (p-next)="onNextMonth()"
+    >
+      <span class="po-clickable po-mr-1" (click)="selectDisplayMode('month')">{{ displayMonth }}</span>
+      <span class="po-clickable" (click)="selectDisplayMode('year')">{{ displayYear }}</span>
+    </po-calendar-header>
+
+    <div class="po-calendar-content">
+      <div class="po-calendar-labels">
+        <div class="po-calendar-label" *ngFor="let weekDay of displayWeekDays">
+          {{ weekDay }}
+        </div>
+      </div>
+
+      <div class="po-calendar-content-list-day">
+        <div
+          *ngFor="let day of displayDays"
+          class="po-calendar-day"
+          [ngClass]="getDayBackgroundColor(day)"
+          (click)="onSelectDate(day)"
+        >
+          <span *ngIf="day != 0" [ngClass]="getDayForegroundColor(day)">
+            {{ day.getDate() }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+
+  <ng-container *ngIf="isMonthVisible">
+    <po-calendar-header (p-previous)="updateYear(-1)" (p-next)="updateYear(1)">
+      <span class="po-clickable" (click)="selectDisplayMode('year')">
+        {{ displayYear }}
+      </span>
+    </po-calendar-header>
+
+    <div class="po-calendar-content">
+      <div class="po-calendar-labels">
+        <div class="po-calendar-label">
+          {{ monthLabel }}
+        </div>
+      </div>
+      <div class="po-calendar-content-list-month">
+        <div
+          *ngFor="let month of displayMonths; let i = index"
+          class="po-calendar-month"
+          [ngClass]="getBackgroundColor(i, displayMonthNumber)"
+          (click)="onSelectMonth(displayYear, i)"
+        >
+          <span [ngClass]="getForegroundColor(i, displayMonthNumber)">
+            {{ month }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+
+  <ng-container *ngIf="isYearVisible">
+    <po-calendar-header (p-previous)="updateYear(-10)" (p-next)="updateYear(10)">
+      {{ displayStartDecade }} - {{ displayFinalDecade }}
+    </po-calendar-header>
+
+    <div class="po-calendar-content">
+      <div class="po-calendar-labels">
+        <div class="po-calendar-label">
+          {{ yearLabel }}
+        </div>
+      </div>
+
+      <div class="po-calendar-content-list-year">
+        <div
+          *ngFor="let year of displayDecade; let i = index"
+          class="po-calendar-year"
+          [ngClass]="getBackgroundColor(year, currentYear)"
+          (click)="onSelectYear(year, displayMonthNumber)"
+          attr-calendar
+        >
+          <span [ngClass]="getForegroundColor(year, currentYear)">
+            {{ year }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.spec.ts
@@ -1,0 +1,586 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { configureTestSuite } from './../../../util-test/util-expect.spec';
+
+import { PoDateService } from '../../../services/po-date/po-date.service';
+
+import { PoCalendarHeaderComponent } from '../po-calendar-header/po-calendar-header.component';
+import { PoCalendarWrapperComponent } from './po-calendar-wrapper.component';
+import { PoCalendarService } from '../services/po-calendar.service';
+
+describe('PoCalendarWrapperComponent', () => {
+  let component: PoCalendarWrapperComponent;
+  let fixture: ComponentFixture<PoCalendarWrapperComponent>;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [PoCalendarWrapperComponent, PoCalendarHeaderComponent],
+      providers: [PoCalendarService, PoDateService]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoCalendarWrapperComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Methods:', () => {
+    it('ngOnChanges: shouldn`t call updateDate if activateDate.currentValue is falsy', () => {
+      const changes = {};
+
+      spyOn(component, <any>'updateDate');
+
+      component.ngOnChanges(changes);
+
+      expect(component['updateDate']).not.toHaveBeenCalled();
+    });
+
+    it('ngOnChanges: should call updateDate if activateDate.currentValue is truthy', () => {
+      const today = new Date();
+
+      const changes = {
+        activateDate: { currentValue: today }
+      };
+
+      spyOn(component, <any>'updateDate');
+
+      component.ngOnChanges(changes);
+
+      expect(component['updateDate']).toHaveBeenCalledWith(today);
+    });
+
+    it(`initializeLanguage: should call 'setLanguage', 'getWeekDaysArray' and 'getMonthsArray' of
+      the 'poCalendarLangService' and set the value of displayWeekDays and displayMonths`, () => {
+      const weekDays = ['sun', 'mon', 'tue'];
+      const months = ['jan', 'feb', 'mar'];
+      component.locale = 'en';
+
+      spyOn(component['poCalendarLangService'], 'setLanguage');
+      spyOn(component['poCalendarLangService'], 'getWeekDaysArray').and.returnValue(weekDays);
+      spyOn(component['poCalendarLangService'], 'getMonthsArray').and.returnValue(months);
+
+      component['initializeLanguage']();
+
+      expect(component['poCalendarLangService'].setLanguage).toHaveBeenCalledWith(component.locale);
+      expect(component['poCalendarLangService'].getWeekDaysArray).toHaveBeenCalled();
+      expect(component['poCalendarLangService'].getMonthsArray).toHaveBeenCalled();
+
+      expect(component.displayWeekDays).toEqual(weekDays);
+      expect(component.displayMonths).toEqual(months);
+    });
+
+    it(`updateYear: should call 'updateDisplay' with '2007' and '11'`, () => {
+      component.displayYear = 1997;
+      component.displayMonthNumber = 11;
+      const value = 10;
+      const yearExpected = 2007;
+
+      spyOn(component, <any>'updateDisplay');
+      component.updateYear(value);
+
+      expect(component['updateDisplay']).toHaveBeenCalledWith(yearExpected, 11);
+    });
+
+    it(`updateYear: should call 'updateDisplay' with '1987' and '11'`, () => {
+      component.displayYear = 1997;
+      component.displayMonthNumber = 11;
+
+      spyOn(component, <any>'updateDisplay');
+      component.updateYear(-10);
+
+      expect(component['updateDisplay']).toHaveBeenCalledWith(1987, 11);
+    });
+
+    it(`onSelectYear: should call 'updateDisplay' and 'selectDisplayMode' with 'month' if 'lastDisplay' is equal to 'month'`, () => {
+      component['lastDisplay'] = 'month';
+
+      spyOn(component, 'selectDisplayMode');
+      spyOn(component, <any>'updateDisplay');
+
+      component.onSelectYear(2015, 10);
+
+      expect(component.selectDisplayMode).toHaveBeenCalledWith('month');
+      expect(component['updateDisplay']).toHaveBeenCalledWith(2015, 10);
+    });
+
+    it(`onSelectYear: should call 'updateDisplay' and 'selectDisplayMode' with 'day' if 'lastDisplay' is different to 'month'`, () => {
+      component['lastDisplay'] = '';
+
+      spyOn(component, 'selectDisplayMode');
+      spyOn(component, <any>'updateDisplay');
+
+      component.onSelectYear(2015, 10);
+
+      expect(component.selectDisplayMode).toHaveBeenCalledWith('day');
+      expect(component['updateDisplay']).toHaveBeenCalledWith(2015, 10);
+    });
+
+    it(`onSelectYear: should set 'currentYear' to the value of 'yearParam'`, () => {
+      const yearParam = 2018;
+
+      spyOn(component, 'selectDisplayMode');
+      spyOn(component, <any>'updateDisplay');
+
+      component.onSelectYear(yearParam, 10);
+
+      expect(component.currentYear).toBe(yearParam);
+    });
+
+    it('getBackgroundColor: should return `po-calendar-box-background-selected` if displayValue is equal propertyValue', () => {
+      expect(component.getBackgroundColor(10, 10)).toBe('po-calendar-box-background-selected');
+    });
+
+    it('getBackgroundColor: should return `po-calendar-box-background` if displayValue is not equal propertyValue', () => {
+      expect(component.getBackgroundColor(11, 10)).toBe('po-calendar-box-background');
+    });
+
+    it('getDayBackgroundColor: should call `getDayColor` with `date` and `background`', () => {
+      const date = new Date(2018, 5, 5);
+
+      spyOn(component, <any>'getDayColor');
+
+      component.getDayBackgroundColor(date);
+
+      expect(component['getDayColor']).toHaveBeenCalledWith(date, 'background');
+    });
+
+    it('getDayForegroundColor: should call `getDayColor` with `date` and `foreground`', () => {
+      const date = new Date(2018, 5, 5);
+
+      spyOn(component, <any>'getDayColor');
+
+      component.getDayForegroundColor(date);
+
+      expect(component['getDayColor']).toHaveBeenCalledWith(date, 'foreground');
+    });
+
+    it('getForegroundColor: should return `po-calendar-box-foreground-selected` if displayValue is equal propertyValue', () => {
+      expect(component.getForegroundColor(10, 10)).toBe('po-calendar-box-foreground-selected');
+    });
+
+    it('getForegroundColor: should return `po-calendar-box-foreground` if displayValue is not equal propertyValue', () => {
+      expect(component.getForegroundColor(11, 10)).toBe('po-calendar-box-foreground');
+    });
+
+    it(`monthLabel: should call 'poCalendarLangService.getMonthLabel'`, () => {
+      spyOn(component['poCalendarLangService'], 'getMonthLabel').and.callThrough();
+
+      const monthLabel = component.monthLabel;
+      expect(typeof monthLabel === 'string').toBe(true);
+      expect(component['poCalendarLangService'].getMonthLabel).toHaveBeenCalled();
+    });
+
+    it(`yearLabel: should call 'poCalendarLangService.getYearLabel'`, () => {
+      spyOn(component['poCalendarLangService'], 'getYearLabel').and.callThrough();
+
+      const yearLabel = component.yearLabel;
+      expect(typeof yearLabel === 'string').toBe(true);
+      expect(component['poCalendarLangService'].getYearLabel).toHaveBeenCalled();
+    });
+
+    it(`onNextMonth: should call 'updateDisplay' with 'displayYear' and 'displayMonthNumber +1' if displayMonthNumber
+      is less then 11`, () => {
+      component.displayYear = 1997;
+      component.displayMonthNumber = 10;
+
+      spyOn(component, <any>'updateDisplay');
+      component.onNextMonth();
+
+      expect(component['updateDisplay']).toHaveBeenCalledWith(1997, 11);
+    });
+
+    it(`onNextMonth: should call 'updateDisplay' with 'displayYear +1' and 0 if displayMonthNumber is greater or equal
+      then 11`, () => {
+      component.displayYear = 1997;
+      component.displayMonthNumber = 11;
+
+      spyOn(component, <any>'updateDisplay');
+      component.onNextMonth();
+
+      expect(component['updateDisplay']).toHaveBeenCalledWith(1998, 0);
+    });
+
+    it(`onPreviousMonth: should call 'updateDisplay' with 'displayYear' and 'displayMonthNumber -1' if displayMonthNumber is
+      greater then 0`, () => {
+      component.displayYear = 1997;
+      component.displayMonthNumber = 10;
+
+      spyOn(component, <any>'updateDisplay');
+      component.onPreviousMonth();
+
+      expect(component['updateDisplay']).toHaveBeenCalledWith(1997, 9);
+    });
+
+    it(`onPreviousMonth: should call 'updateDisplay' with 'displayYear -1' and 11 if displayMonthNumber is equal or less then 0`, () => {
+      component.displayYear = 1997;
+      component.displayMonthNumber = 0;
+
+      spyOn(component, <any>'updateDisplay');
+      component.onPreviousMonth();
+
+      expect(component['updateDisplay']).toHaveBeenCalledWith(1996, 11);
+    });
+
+    it(`onSelectMonth: should call 'selectDisplayMode' with 'day' and 'updateDisplay' with year and month`, () => {
+      spyOn(component, 'selectDisplayMode');
+      spyOn(component, <any>'updateDisplay');
+
+      component.onSelectMonth(2015, 10);
+
+      expect(component.selectDisplayMode).toHaveBeenCalledWith('day');
+      expect(component['updateDisplay']).toHaveBeenCalledWith(2015, 10);
+    });
+
+    it(`addAllYearsInDecade: should update 'displayDecade' with 10 years`, () => {
+      component.displayDecade = [];
+
+      component['addAllYearsInDecade'](2011);
+
+      expect(component.displayDecade).toEqual([2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020]);
+    });
+
+    it(`equalsDate: should return 'true' if date1 is equal date2`, () => {
+      const date1 = new Date(2018, 5, 5);
+      const date2 = new Date(2018, 5, 5);
+
+      expect(component['equalsDate'](date1, date2)).toBeTruthy();
+    });
+
+    it(`equalsDate: should return 'false' if date1 is different from the date2`, () => {
+      expect(component['equalsDate'](new Date(2018, 5, 5), new Date(2018, 5, 6))).toBeFalsy();
+    });
+
+    it(`getDecadeArray: should set 'displayDecade' to instance of 'Array' and call 'updateDecade' with 'year' if 'year'
+      is multiple of 10`, () => {
+      const year = 2000;
+      component['displayDecade'] = undefined;
+
+      spyOn(component, <any>'updateDecade');
+
+      component['getDecadeArray'](year);
+
+      expect(component['updateDecade']).toHaveBeenCalledWith(year);
+      expect(component['displayDecade'] instanceof Array).toBeTruthy();
+    });
+
+    it(`getDecadeArray: should set 'displayDecade' to instance of 'Array' and call 'updateDecade' with 'yearMultipleTen'
+      if 'year' not is multiple of 10`, () => {
+      const year = 1995;
+      const yearMultipleTen = 1990;
+      component['displayDecade'] = undefined;
+
+      spyOn(component, <any>'updateDecade');
+
+      component['getDecadeArray'](year);
+
+      expect(component['updateDecade']).toHaveBeenCalledWith(yearMultipleTen);
+      expect(component['displayDecade'] instanceof Array).toBeTruthy();
+    });
+
+    it(`getColorForDate: should return 'po-calendar-box-background-selected' if 'poDate.validateDateRange'
+      return 'true'`, () => {
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(true);
+
+      const result = component['getColorForDate'](new Date(), 'background');
+
+      expect(result).toBe('po-calendar-box-background-selected');
+    });
+
+    it(`getColorForDate: should return 'po-calendar-box-background-selected-disabled' if 'poDate.validateDateRange'
+      return 'false'`, () => {
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(false);
+
+      const result = component['getColorForDate'](new Date(), 'background');
+
+      expect(result).toBe('po-calendar-box-background-selected-disabled');
+    });
+
+    it(`getColorForDate: should call 'poDate.validateDateRange' with 'date', 'minDate' and 'maxDate'`, () => {
+      const date = new Date();
+      component.minDate = new Date(2018, 4, 3);
+      component.maxDate = new Date(2018, 4, 8);
+
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(false);
+
+      component['getColorForDate'](date, 'background');
+
+      expect(component['poDate'].validateDateRange).toHaveBeenCalledWith(date, component.minDate, component.maxDate);
+    });
+
+    it(`getColorForDefaultDate: should return 'po-calendar-box-background' if 'poDate.validateDateRange'
+      return 'true'`, () => {
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(true);
+
+      const result = component['getColorForDefaultDate'](new Date(), 'background');
+
+      expect(result).toBe('po-calendar-box-background');
+    });
+
+    it(`getColorForDefaultDate: should return 'po-calendar-box-background-disabled' if 'poDate.validateDateRange'
+      return 'false'`, () => {
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(false);
+
+      const result = component['getColorForDefaultDate'](new Date(), 'background');
+
+      expect(result).toBe('po-calendar-box-background-disabled');
+    });
+
+    it(`getColorForDefaultDate: should call 'poDate.validateDateRange' with 'date', 'minDate' and 'maxDate'`, () => {
+      const date = new Date();
+      component.minDate = new Date(2018, 4, 3);
+      component.maxDate = new Date(2018, 4, 8);
+
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(false);
+
+      component['getColorForDefaultDate'](date, 'background');
+
+      expect(component['poDate'].validateDateRange).toHaveBeenCalledWith(date, component.minDate, component.maxDate);
+    });
+
+    it(`getColorForToday: should return 'po-calendar-box-background-today' if 'poDate.validateDateRange'
+      return 'true'`, () => {
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(true);
+
+      const result = component['getColorForToday'](new Date(), 'background');
+
+      expect(result).toBe('po-calendar-box-background-today');
+    });
+
+    it(`getColorForToday: should return 'po-calendar-box-background-today-disabled' if 'poDate.validateDateRange'
+      return 'false'`, () => {
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(false);
+
+      const result = component['getColorForToday'](new Date(), 'background');
+
+      expect(result).toBe('po-calendar-box-background-today-disabled');
+    });
+
+    it(`getColorForToday: should call 'poDate.validateDateRange' with 'date', 'minDate' and 'maxDate'`, () => {
+      const date = new Date();
+      component.minDate = new Date(2018, 4, 3);
+      component.maxDate = new Date(2018, 4, 8);
+
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(false);
+
+      component['getColorForToday'](date, 'background');
+
+      expect(component['poDate'].validateDateRange).toHaveBeenCalledWith(date, component.minDate, component.maxDate);
+    });
+
+    it(`getDayColor: should return value of the 'getColorForDate' if 'equalsDate' return 'true'`, () => {
+      const colorClass = 'po-calendar-box-background-selected';
+      const dateParam = new Date(2018, 5, 6);
+
+      spyOn(component, <any>'equalsDate').and.returnValue(true);
+      spyOn(component, <any>'getColorForDate').and.returnValue(colorClass);
+
+      const result = component['getDayColor'](dateParam, 'background');
+
+      expect(result).toBe(colorClass);
+    });
+
+    it(`getDayColor: should call 'equalsDate' with 'dateParam' and 'this.date' and return value of the 'getColorForDate'
+      if 'equalsDate' return 'true'`, () => {
+      const colorClass = 'po-calendar-box-background-selected';
+      const dateParam = new Date(2018, 5, 6);
+
+      spyOn(component, <any>'equalsDate').and.returnValue(true);
+      spyOn(component, <any>'getColorForDate').and.returnValue(colorClass);
+
+      const result = component['getDayColor'](dateParam, 'background');
+
+      expect(result).toBe(colorClass);
+      expect(component['equalsDate']).toHaveBeenCalledWith(dateParam, component['date']);
+    });
+
+    it(`getDayColor: should call 'equalsDate' with 'dateParam' and 'this.today' and return 'po-calendar-box-background-today'
+      if 'equalsDate' return 'true'`, () => {
+      const colorClass = 'po-calendar-box-background-today';
+      const dateParam = new Date(2018, 5, 6);
+
+      spyOn(component, <any>'equalsDate').and.returnValues(false, true);
+      spyOn(component, <any>'getColorForToday').and.returnValue(colorClass);
+
+      const result = component['getDayColor'](dateParam, 'background');
+
+      expect(result).toBe(colorClass);
+      expect(component['equalsDate']).toHaveBeenCalledWith(dateParam, component['today']);
+    });
+
+    it(`getDayColor: should call 'equalsDate', 'getColorForDefaultDate' and return value of the 'getColorForDefaultDate' if
+      'equalsDate' return 'false'`, () => {
+      const colorClass = 'po-calendar-box-background';
+      const dateParam = new Date(2018, 5, 6);
+      const local = 'background';
+
+      spyOn(component, <any>'equalsDate').and.returnValue(false);
+      spyOn(component, <any>'getColorForDefaultDate').and.returnValue(colorClass);
+
+      const result = component['getDayColor'](dateParam, local);
+
+      expect(result).toBe(colorClass);
+      expect(component['equalsDate']).toHaveBeenCalledWith(dateParam, component['today']);
+      expect(component['equalsDate']).toHaveBeenCalledWith(dateParam, component['date']);
+      expect(component['getColorForDefaultDate']).toHaveBeenCalledWith(dateParam, local);
+    });
+
+    it(`getDayColor: should call 'getColorForDate' if range is true and date param is equal to selectedValue.start`, () => {
+      const colorClass = 'po-calendar-box-background-selected';
+      const dateParam = new Date(2020, 5, 6);
+      const local = 'background';
+
+      component.selectedValue = { start: new Date(2020, 5, 6), end: null };
+      component.range = true;
+
+      spyOn(component, <any>'equalsDate').and.callThrough();
+      spyOn(component, <any>'getColorForDate').and.callThrough();
+
+      expect(component['getDayColor'](dateParam, local)).toBe(colorClass);
+      expect(component['equalsDate']).toHaveBeenCalledWith(dateParam, component.selectedValue.start);
+      expect(component['getColorForDate']).toHaveBeenCalledWith(dateParam, local);
+    });
+
+    it(`getDayColor: should call 'getColorForDate' if range is true and date param is equal to selectedValue.end`, () => {
+      const colorClass = 'po-calendar-box-background-selected';
+      const dateParam = new Date(2020, 5, 6);
+      const local = 'background';
+
+      component.selectedValue = { start: new Date(2019, 4, 10), end: new Date(2020, 5, 6) };
+      component.range = true;
+
+      spyOn(component, <any>'equalsDate').and.callThrough();
+      spyOn(component, <any>'getColorForDate').and.callThrough();
+
+      expect(component['getDayColor'](dateParam, local)).toBe(colorClass);
+      expect(component['equalsDate']).toHaveBeenCalled();
+      expect(component['getColorForDate']).toHaveBeenCalledWith(dateParam, local);
+    });
+
+    it(`getDayColor: should call 'getColorForDateRange' if range is true and date param is between start and end date`, () => {
+      const colorClass = 'po-calendar-box-background-in-range';
+      const dateParam = new Date(2020, 1, 6);
+      const local = 'background';
+
+      component.selectedValue = { start: new Date(2019, 4, 10), end: new Date(2020, 5, 6) };
+      component.range = true;
+
+      spyOn(component, <any>'equalsDate').and.callThrough();
+      spyOn(component, <any>'getColorForDateRange').and.callThrough();
+
+      expect(component['getDayColor'](dateParam, local)).toBe(colorClass);
+      expect(component['equalsDate']).toHaveBeenCalled();
+      expect(component['getColorForDateRange']).toHaveBeenCalledWith(dateParam, local);
+    });
+
+    it(`getColorForDateRange: should return 'po-calendar-box-background-in-range' if 'poDate.validateDateRange'
+      return 'true'`, () => {
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(true);
+
+      const clazz = component['getColorForDateRange'](new Date(), 'background');
+
+      expect(clazz).toBe('po-calendar-box-background-in-range');
+    });
+
+    it(`getColorForDateRange: should return 'po-calendar-box-background-in-range-disabled' if 'poDate.validateDateRange'
+      return 'false'`, () => {
+      spyOn(component['poDate'], 'validateDateRange').and.returnValue(false);
+
+      const clazz = component['getColorForDateRange'](new Date(), 'background');
+
+      expect(clazz).toBe('po-calendar-box-background-in-range-disabled');
+    });
+
+    it(`init: should call 'updateDate' with activateDate, selectDisplayMode with 'day' and initializeLanguage`, () => {
+      component['activateDate'] = new Date(2018, 5, 6);
+
+      spyOn(component, <any>'updateDate');
+      spyOn(component, <any>'selectDisplayMode');
+      spyOn(component, <any>'initializeLanguage');
+
+      component['init']();
+
+      expect(component['initializeLanguage']).toHaveBeenCalled();
+      expect(component['updateDate']).toHaveBeenCalledWith(component['activateDate']);
+      expect(component['selectDisplayMode']).toHaveBeenCalledWith('day');
+    });
+
+    it(`updateDate: should set 'currentMonthNumber' and 'currentYear' to 'date.getMonth()' and 'date.getFullYear()' and
+      call 'updateDisplay'`, () => {
+      const date = new Date();
+
+      spyOn(component, <any>'updateDisplay');
+
+      component['updateDate'](date);
+
+      expect(component['currentMonthNumber']).toBe(date.getMonth());
+      expect(component.currentYear).toBe(date.getFullYear());
+      expect(component['updateDisplay']).toHaveBeenCalledWith(component.currentYear, component['currentMonthNumber']);
+    });
+
+    it(`updateDate: should set 'currentMonthNumber' and 'currentYear' with today default date andbcall 'updateDisplay'`, () => {
+      const today = new Date();
+
+      spyOn(component, <any>'updateDisplay');
+
+      component['updateDate']();
+
+      expect(component['currentMonthNumber']).toBe(today.getMonth());
+      expect(component.currentYear).toBe(today.getFullYear());
+      expect(component['updateDisplay']).toHaveBeenCalledWith(component.currentYear, component['currentMonthNumber']);
+    });
+
+    it(`updateDecade: should call 'addAllYearsInDecade' and update 'displayStartDecade' and 'displayFinalDecade'`, () => {
+      spyOn(component, <any>'addAllYearsInDecade');
+
+      component['updateDecade'](2000);
+
+      expect(component['displayStartDecade']).toBe(2000);
+      expect(component['displayFinalDecade']).toBe(2009);
+      expect(component['addAllYearsInDecade']).toHaveBeenCalledWith(2000);
+    });
+
+    it(`updateDisplay: should call 'poCalendarService.monthDays' to set 'displayDays'`, () => {
+      const monthDays = [1, 2, 3, 4];
+      const year = 2018;
+      const month = 2;
+
+      spyOn(component['poCalendarService'], 'monthDays').and.returnValue([...monthDays]);
+
+      component['updateDisplay'](year, month);
+
+      expect(component['displayDays']).toEqual(monthDays);
+      expect(component['poCalendarService']['monthDays']).toHaveBeenCalledWith(year, month);
+    });
+
+    it(`updateDisplay: should set 'displayMonthNumber', 'displayMonth', 'displayYear' and call 'getDecadeArray'
+      with 'year'`, () => {
+      const monthDays = [1, 2, 3, 4];
+      const year = 2018;
+      const month = 2;
+
+      spyOn(component['poCalendarService'], 'monthDays').and.returnValue([...monthDays]);
+      spyOn(component, <any>'getDecadeArray');
+
+      component['updateDisplay'](year, month);
+
+      expect(component.displayMonthNumber).toEqual(month);
+      expect(component['displayMonth']).toEqual(component['displayMonths'][month]);
+      expect(component['displayYear']).toEqual(year);
+      expect(component['getDecadeArray']).toHaveBeenCalledWith(year);
+    });
+
+    it(`onSelectDate: should call 'selectDate.emit' with date param`, () => {
+      const date = new Date();
+
+      spyOn(component.selectDate, 'emit');
+
+      component['onSelectDate'](date);
+
+      expect(component.selectDate.emit).toHaveBeenCalledWith(date);
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.ts
@@ -1,0 +1,292 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  EventEmitter
+} from '@angular/core';
+
+import { PoCalendarLangService } from '../services/po-calendar.lang.service';
+import { PoCalendarService } from '../services/po-calendar.service';
+import { PoDateService } from '../../../services/po-date/po-date.service';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+
+@Component({
+  selector: 'po-calendar-wrapper',
+  templateUrl: './po-calendar-wrapper.component.html',
+  providers: [PoCalendarService],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PoCalendarWrapperComponent implements OnInit, OnChanges {
+  private _locale: string;
+
+  currentYear: number;
+  displayDays: Array<number>;
+  displayDecade: Array<number>;
+  displayFinalDecade: number;
+  displayMonth: any;
+  displayMonthNumber: number;
+  displayMonths: Array<any> = Array();
+  displayStartDecade: number;
+  displayWeekDays: Array<any> = Array();
+  displayYear: number;
+
+  protected currentMonthNumber: number;
+  protected date: Date;
+  protected lastDisplay: string;
+  protected today: Date = new Date();
+
+  @Input('p-value') value;
+
+  @Input('p-locale') set locale(value: string) {
+    this._locale = value;
+    this.initializeLanguage();
+  }
+
+  get locale() {
+    return this._locale;
+  }
+
+  @Input('p-mode') mode: 'day' | 'month' | 'year' = 'day';
+
+  @Input('p-part-type') partType: 'start' | 'end';
+
+  @Input('p-range') range: boolean = false;
+
+  @Input('p-activate-date') activateDate = new Date();
+
+  @Input('p-selected-value') selectedValue;
+
+  @Input('p-min-date') minDate;
+
+  @Input('p-max-date') maxDate;
+
+  @Output('p-header-change') headerChange = new EventEmitter<any>();
+
+  @Output('p-select-date') selectDate = new EventEmitter<any>();
+
+  get monthLabel() {
+    return this.poCalendarLangService.getMonthLabel();
+  }
+
+  get yearLabel() {
+    return this.poCalendarLangService.getYearLabel();
+  }
+
+  get isDayVisible() {
+    return this.mode === 'day';
+  }
+
+  get isMonthVisible() {
+    return this.mode === 'month';
+  }
+
+  get isYearVisible() {
+    return this.mode === 'year';
+  }
+
+  get isStartPart() {
+    return this.partType === 'start';
+  }
+
+  get isEndPart() {
+    return this.partType === 'end';
+  }
+
+  constructor(
+    private poCalendarService: PoCalendarService,
+    private poCalendarLangService: PoCalendarLangService,
+    private poDate: PoDateService,
+    private languageService: PoLanguageService
+  ) {}
+
+  ngOnInit() {
+    this.init();
+  }
+
+  ngOnChanges(changes) {
+    const { activateDate } = changes;
+
+    if (activateDate) {
+      this.updateDate(activateDate.currentValue);
+    }
+  }
+
+  getBackgroundColor(displayValue: number, propertyValue: number) {
+    return displayValue === propertyValue ? 'po-calendar-box-background-selected' : 'po-calendar-box-background';
+  }
+
+  getDayBackgroundColor(date: Date) {
+    return this.getDayColor(date, 'background');
+  }
+
+  getDayForegroundColor(date: Date) {
+    return this.getDayColor(date, 'foreground');
+  }
+
+  getForegroundColor(displayValue: number, propertyValue: number) {
+    return displayValue === propertyValue ? 'po-calendar-box-foreground-selected' : 'po-calendar-box-foreground';
+  }
+
+  onNextMonth() {
+    this.displayMonthNumber < 11
+      ? this.updateDisplay(this.displayYear, this.displayMonthNumber + 1)
+      : this.updateDisplay(this.displayYear + 1, 0);
+
+    this.headerChange.emit({ month: this.displayMonthNumber, year: this.displayYear });
+  }
+
+  onPreviousMonth() {
+    if (this.displayMonthNumber > 0) {
+      this.updateDisplay(this.displayYear, this.displayMonthNumber - 1);
+    } else {
+      this.updateDisplay(this.displayYear - 1, 11);
+    }
+
+    this.headerChange.emit({ month: this.displayMonthNumber, year: this.displayYear });
+  }
+
+  // Ao selecionar uma data
+  onSelectDate(date: Date) {
+    this.selectDate.emit(date);
+  }
+
+  // Ao selecionar um mês
+  onSelectMonth(year: number, month: number) {
+    this.selectDisplayMode('day');
+    this.updateDisplay(year, month);
+
+    this.headerChange.emit({ month, year });
+  }
+
+  // Ao selecionar um ano
+  onSelectYear(year: number, month: number) {
+    // Se veio da tela de seleção de mês
+    this.selectDisplayMode(this.lastDisplay === 'month' ? 'month' : 'day');
+
+    this.currentYear = year;
+    this.updateDisplay(year, month);
+
+    this.headerChange.emit({ month, year });
+  }
+
+  selectDisplayMode(mode: 'month' | 'day' | 'year') {
+    this.lastDisplay = this.mode;
+    this.mode = mode;
+  }
+
+  updateYear(value: number) {
+    this.updateDisplay(this.displayYear + value, this.displayMonthNumber);
+  }
+
+  private addAllYearsInDecade(year: number) {
+    let i;
+    for (i = year; i < year + 10; i++) {
+      this.displayDecade.push(i);
+    }
+  }
+
+  private equalsDate(date1: Date, date2: Date): boolean {
+    try {
+      return (
+        date1.getFullYear() === date2.getFullYear() &&
+        date1.getMonth() === date2.getMonth() &&
+        date1.getDate() === date2.getDate()
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+
+  // Obtém um array de todos os anos desta década
+  private getDecadeArray(year) {
+    this.displayDecade = Array();
+
+    if (year % 10 !== 0) {
+      while (year % 10 !== 0) {
+        year--;
+      }
+    }
+    this.updateDecade(year);
+  }
+
+  private getColorForDate(date: Date, local: string) {
+    return this.poDate.validateDateRange(date, this.minDate, this.maxDate)
+      ? `po-calendar-box-${local}-selected`
+      : `po-calendar-box-${local}-selected-disabled`;
+  }
+
+  private getColorForDefaultDate(date: Date, local: string) {
+    return this.poDate.validateDateRange(date, this.minDate, this.maxDate)
+      ? `po-calendar-box-${local}`
+      : `po-calendar-box-${local}-disabled`;
+  }
+
+  private getColorForToday(date: Date, local: string) {
+    return this.poDate.validateDateRange(date, this.minDate, this.maxDate)
+      ? `po-calendar-box-${local}-today`
+      : `po-calendar-box-${local}-today-disabled`;
+  }
+
+  private getColorForDateRange(date: Date, local: string) {
+    return this.poDate.validateDateRange(date, this.minDate, this.maxDate)
+      ? `po-calendar-box-${local}-in-range`
+      : `po-calendar-box-${local}-in-range-disabled`;
+  }
+
+  private getDayColor(date: Date, local: string) {
+    const start = this.selectedValue?.start;
+    const end = this.selectedValue?.end;
+
+    if (this.range && (this.equalsDate(date, start) || this.equalsDate(date, end))) {
+      return this.getColorForDate(date, local);
+    } else if (this.range && start && end && date > start && date < end) {
+      return this.getColorForDateRange(date, local);
+    } else if (!this.range && this.equalsDate(date, this.value)) {
+      return this.getColorForDate(date, local);
+    } else if (this.equalsDate(date, this.today)) {
+      return this.getColorForToday(date, local);
+    } else {
+      return this.getColorForDefaultDate(date, local);
+    }
+  }
+
+  private init() {
+    this.updateDate(this.activateDate);
+    this.initializeLanguage();
+    this.selectDisplayMode('day');
+  }
+
+  private initializeLanguage() {
+    this.poCalendarLangService.setLanguage(this.locale);
+    this.displayWeekDays = this.poCalendarLangService.getWeekDaysArray();
+    this.displayMonths = this.poCalendarLangService.getMonthsArray();
+    this.displayMonth = this.displayMonths[this.displayMonthNumber];
+  }
+
+  private updateDate(value: Date = new Date()) {
+    const date = new Date(value);
+
+    this.currentMonthNumber = date.getMonth();
+    this.currentYear = date.getFullYear();
+    this.updateDisplay(this.currentYear, this.currentMonthNumber);
+  }
+
+  private updateDecade(year: number) {
+    this.addAllYearsInDecade(year);
+    this.displayStartDecade = year;
+    this.displayFinalDecade = year + 9;
+  }
+
+  private updateDisplay(year: number, month: number) {
+    const calendarArray = this.poCalendarService.monthDays(year, month);
+    this.displayDays = [].concat.apply([], calendarArray);
+    this.displayMonthNumber = month;
+    this.displayMonth = this.displayMonths[month];
+    this.displayYear = year;
+    this.getDecadeArray(year);
+  }
+}

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.html
@@ -1,87 +1,30 @@
-<div class="po-calendar">
-  <div *ngIf="dayVisible">
-    <div class="po-calendar-nav">
-      <span class="po-calendar-nav-left po-icon po-icon-arrow-left" (click)="onPreviousMonth()"></span>
-      <div class="po-calendar-nav-title" attr-calendar>
-        <span class="po-clickable po-mr-1" (click)="selectMonth()">{{ displayMonth }}</span>
-        <span class="po-clickable" (click)="selectYear()">{{ displayYear }}</span>
-      </div>
-      <span class="po-calendar-nav-right po-icon po-icon-arrow-right" (click)="onNextMonth()"></span>
-    </div>
-    <div class="po-calendar-content">
-      <div class="po-calendar-labels">
-        <div class="po-calendar-label" *ngFor="let day of displayWeekDays">
-          {{ day.toLowerCase() }}
-        </div>
-      </div>
-      <div class="po-calendar-content-list-day">
-        <div
-          *ngFor="let day of displayDays"
-          class="po-calendar-day"
-          [ngClass]="getDayBackgroundColor(day)"
-          (click)="onSelectDate(day)"
-        >
-          <span *ngIf="day != 0" [ngClass]="getDayForegroundColor(day)">
-            {{ day.getDate() }}
-          </span>
-        </div>
-      </div>
-    </div>
+<ng-container *ngIf="isRange; then rangeTemplate; else calendarTemplate"></ng-container>
+
+<ng-template #rangeTemplate>
+  <div class="po-calendar-range">
+    <ng-container *ngTemplateOutlet="calendarWrapper; context: { partType: 'start' }"></ng-container>
+    <ng-container *ngTemplateOutlet="calendarWrapper; context: { partType: 'end' }"></ng-container>
   </div>
-  <div *ngIf="monthVisible">
-    <div class="po-calendar-nav">
-      <span class="po-calendar-nav-left po-icon po-icon-arrow-left" (click)="updateYear(-1)"></span>
-      <div class="po-calendar-nav-title" attr-calendar>
-        <span class="po-clickable" (click)="selectYear()">{{ displayYear }}</span>
-      </div>
-      <span class="po-calendar-nav-right po-icon po-icon-arrow-right" (click)="updateYear(1)"></span>
-    </div>
-    <div class="po-calendar-content">
-      <div class="po-calendar-labels">
-        <div class="po-calendar-label">
-          {{ getMonthLabel() }}
-        </div>
-      </div>
-      <div class="po-calendar-content-list-month">
-        <div
-          *ngFor="let month of displayMonths; let i = index"
-          class="po-calendar-month"
-          [ngClass]="getBackgroundColor(i, displayMonthNumber)"
-          (click)="onSelectMonth(displayYear, i)"
-          attr-calendar
-        >
-          <span [ngClass]="getForegroundColor(i, displayMonthNumber)">
-            {{ month }}
-          </span>
-        </div>
-      </div>
-    </div>
+</ng-template>
+
+<ng-template #calendarTemplate>
+  <div class="po-calendar">
+    <ng-template [ngTemplateOutlet]="calendarWrapper"></ng-template>
   </div>
-  <div *ngIf="yearVisible">
-    <div class="po-calendar-nav">
-      <span class="po-calendar-nav-left po-icon po-icon-arrow-left" (click)="updateYear(-10)"></span>
-      <div class="po-calendar-nav-title">{{ displayStartDecade }} - {{ displayFinalDecade }}</div>
-      <span class="po-calendar-nav-right po-icon po-icon-arrow-right" (click)="updateYear(10)"></span>
-    </div>
-    <div class="po-calendar-content">
-      <div class="po-calendar-labels">
-        <div class="po-calendar-label">
-          {{ getYearLabel() }}
-        </div>
-      </div>
-      <div class="po-calendar-content-list-year">
-        <div
-          *ngFor="let year of displayDecade; let i = index"
-          class="po-calendar-year"
-          [ngClass]="getBackgroundColor(year, currentYear)"
-          (click)="onSelectYear(year, displayMonthNumber)"
-          attr-calendar
-        >
-          <span [ngClass]="getForegroundColor(year, currentYear)">
-            {{ year }}
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+</ng-template>
+
+<ng-template #calendarWrapper let-partType="partType">
+  <po-calendar-wrapper
+    [p-value]="getValue(partType)"
+    [p-activate-date]="getActivateDate(partType)"
+    [p-locale]="locale"
+    [p-min-date]="minDate"
+    [p-max-date]="maxDate"
+    [p-part-type]="partType"
+    [p-range]="isRange"
+    [p-selected-value]="value"
+    (p-header-change)="onHeaderChange($event, partType)"
+    (p-select-date)="onSelectDate($event, partType)"
+  >
+  </po-calendar-wrapper>
+</ng-template>

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
@@ -4,9 +4,11 @@ import { PoDateService } from '../../services/po-date/po-date.service';
 
 import { configureTestSuite } from './../../util-test/util-expect.spec';
 
+import { PoCalendarWrapperComponent } from './po-calendar-wrapper/po-calendar-wrapper.component';
+import { PoCalendarHeaderComponent } from './po-calendar-header/po-calendar-header.component';
+
 import { PoCalendarBaseComponent } from './po-calendar-base.component';
 import { PoCalendarComponent } from './po-calendar.component';
-import { PoCalendarLangService } from './services/po-calendar.lang.service';
 import { PoCalendarService } from './services/po-calendar.service';
 
 describe('PoCalendarComponent:', () => {
@@ -16,8 +18,8 @@ describe('PoCalendarComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      declarations: [PoCalendarComponent],
-      providers: [PoCalendarService, PoCalendarLangService, PoDateService]
+      declarations: [PoCalendarComponent, PoCalendarWrapperComponent, PoCalendarHeaderComponent],
+      providers: [PoCalendarService, PoDateService]
     });
   });
 
@@ -25,7 +27,6 @@ describe('PoCalendarComponent:', () => {
     fixture = TestBed.createComponent(PoCalendarComponent);
     component = fixture.componentInstance;
     nativeElement = fixture.debugElement.nativeElement;
-    fixture.detectChanges();
   });
 
   it('should be created', () => {
@@ -34,190 +35,222 @@ describe('PoCalendarComponent:', () => {
   });
 
   describe('Methods:', () => {
-    it('ngOnInit: should call `init`', () => {
-      spyOn(component, <any>'init');
+    it('ngOnInit: should call `setActivateDate`', () => {
+      spyOn(component, <any>'setActivateDate');
 
       component.ngOnInit();
 
-      expect(component['init']).toHaveBeenCalled();
+      expect(component['setActivateDate']).toHaveBeenCalled();
     });
 
-    it('getBackgroundColor: should return `po-calendar-box-background-selected` if displayValue is equal propertyValue', () => {
-      expect(component.getBackgroundColor(10, 10)).toBe('po-calendar-box-background-selected');
+    it('getActivateDate: should get activateDate if range is true', () => {
+      const expectedValue = new Date(2020, 10, 10);
+      component.activateDate = { start: expectedValue, end: new Date(2020, 11, 10) };
+
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+
+      expect(component.getActivateDate('start')).toBe(expectedValue);
     });
 
-    it('getBackgroundColor: should return `po-calendar-box-background` if displayValue is not equal propertyValue', () => {
-      expect(component.getBackgroundColor(11, 10)).toBe('po-calendar-box-background');
+    it('getActivateDate: should get `null` if range is true', () => {
+      component.activateDate = null;
+
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+
+      expect(component.getActivateDate('start')).toBe(null);
     });
 
-    it('getDayBackgroundColor: should call `getDayColor` with `date` and `background`', () => {
-      const date = new Date(2018, 5, 5);
+    it('getActivateDate: should get `activateDate` if range is false', () => {
+      component.activateDate = new Date();
 
-      spyOn(component, <any>'getDayColor');
+      spyOnProperty(component, 'isRange').and.returnValue(false);
 
-      component.getDayBackgroundColor(date);
-
-      expect(component['getDayColor']).toHaveBeenCalledWith(date, 'background');
+      expect(component.getActivateDate('start')).toEqual(component.activateDate);
     });
 
-    it('getDayForegroundColor: should call `getDayColor` with `date` and `foreground`', () => {
-      const date = new Date(2018, 5, 5);
+    it('getValue: should get value if range is true and value is truthy', () => {
+      const expectedValue = new Date(2020, 10, 10);
+      component.value = { start: expectedValue, end: new Date(2021, 5, 10) };
 
-      spyOn(component, <any>'getDayColor');
+      spyOnProperty(component, 'isRange').and.returnValue(true);
 
-      component.getDayForegroundColor(date);
-
-      expect(component['getDayColor']).toHaveBeenCalledWith(date, 'foreground');
+      expect(component.getValue('start')).toBe(expectedValue);
     });
 
-    it('getForegroundColor: should return `po-calendar-box-foreground-selected` if displayValue is equal propertyValue', () => {
-      expect(component.getForegroundColor(10, 10)).toBe('po-calendar-box-foreground-selected');
+    it('getValue: should get `null` if range is true and value is null', () => {
+      component.value = null;
+
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+
+      expect(component.getValue('start')).toBe(null);
     });
 
-    it('getForegroundColor: should return `po-calendar-box-foreground` if displayValue is not equal propertyValue', () => {
-      expect(component.getForegroundColor(11, 10)).toBe('po-calendar-box-foreground');
+    it('getValue: should get `value` if range is false', () => {
+      component.value = new Date();
+
+      spyOnProperty(component, 'isRange').and.returnValue(false);
+
+      expect(component.getValue('start')).toEqual(component.value);
     });
 
-    it(`getMonthLabel: should call 'poCalendarLangService.getMonthLabel'`, () => {
-      spyOn(component.poCalendarLangService, 'getMonthLabel');
-      component.getMonthLabel();
+    it('getValueFromSelectedDate: should return { start, end: null } if component.value is null', () => {
+      const selectedDate = new Date(2020, 10, 10);
+      const expectedValue = { start: selectedDate, end: null };
 
-      expect(component.poCalendarLangService.getMonthLabel).toHaveBeenCalled();
+      component.value = null;
+
+      expect(component['getValueFromSelectedDate'](selectedDate)).toEqual(expectedValue);
     });
 
-    it(`getYearLabel: should call 'poCalendarLangService.getYearLabel'`, () => {
-      spyOn(component.poCalendarLangService, 'getYearLabel');
-      component.getYearLabel();
+    it('getValueFromSelectedDate: should return { start, end: null } if component.value.start and component.value.end are truthy', () => {
+      const selectedDate = new Date(2020, 10, 10);
+      const expectedValue = { start: selectedDate, end: null };
 
-      expect(component.poCalendarLangService.getYearLabel).toHaveBeenCalled();
+      component.value = { start: new Date(2020, 8, 10), end: new Date(2020, 9, 5) };
+
+      expect(component['getValueFromSelectedDate'](selectedDate)).toEqual(expectedValue);
     });
 
-    it(`onNextMonth: should call 'updateDisplay' with 'displayYear' and 'displayMonthNumber +1' if displayMonthNumber
-      is less then 11`, () => {
-      component.displayYear = 1997;
-      component.displayMonthNumber = 10;
+    it('getValueFromSelectedDate: should return { start, end: null } if component.value.start > selectedDate', () => {
+      const selectedDate = new Date(2020, 10, 10);
+      const expectedValue = { start: selectedDate, end: null };
 
-      spyOn(component, <any>'updateDisplay');
-      component.onNextMonth();
+      component.value = { start: new Date(2020, 11, 10), end: null };
 
-      expect(component['updateDisplay']).toHaveBeenCalledWith(1997, 11);
+      expect(component['getValueFromSelectedDate'](selectedDate)).toEqual(expectedValue);
     });
 
-    it(`onNextMonth: should call 'updateDisplay' with 'displayYear +1' and 0 if displayMonthNumber is greater or equal
-      then 11`, () => {
-      component.displayYear = 1997;
-      component.displayMonthNumber = 11;
+    it('getValueFromSelectedDate: should return { start, end } if component.value.end is falsy', () => {
+      const start = new Date(2020, 9, 10);
+      const selectedDate = new Date(2020, 10, 10);
+      const expectedValue = { start, end: selectedDate };
 
-      spyOn(component, <any>'updateDisplay');
-      component.onNextMonth();
+      component.value = { start, end: null };
 
-      expect(component['updateDisplay']).toHaveBeenCalledWith(1998, 0);
+      expect(component['getValueFromSelectedDate'](selectedDate)).toEqual(expectedValue);
     });
 
-    it(`onPreviousMonth: should call 'updateDisplay' with 'displayYear' and 'displayMonthNumber -1' if displayMonthNumber is
-      greater then 0`, () => {
-      component.displayYear = 1997;
-      component.displayMonthNumber = 10;
+    it(`onSelectDate: should set component.value with selectedDate if isRange is false'`, () => {
+      const selectedDate = new Date(2018, 6, 5);
 
-      spyOn(component, <any>'updateDisplay');
-      component.onPreviousMonth();
+      spyOnProperty(component, 'isRange').and.returnValue(false);
 
-      expect(component['updateDisplay']).toHaveBeenCalledWith(1997, 9);
+      component.onSelectDate(selectedDate);
+
+      expect(component.value).toBe(selectedDate);
     });
 
-    it(`onPreviousMonth: should call 'updateDisplay' with 'displayYear -1' and 11 if displayMonthNumber is equal or less then 0`, () => {
-      component.displayYear = 1997;
-      component.displayMonthNumber = 0;
+    it(`onSelectDate: should set component.value with { start, end } if isRange is true'`, () => {
+      const selectedDate = new Date(2018, 6, 5);
+      component.value = null;
 
-      spyOn(component, <any>'updateDisplay');
-      component.onPreviousMonth();
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+      spyOn(component, <any>'getValueFromSelectedDate').and.callThrough();
 
-      expect(component['updateDisplay']).toHaveBeenCalledWith(1996, 11);
+      component.onSelectDate(selectedDate);
+
+      expect(component['getValueFromSelectedDate']).toHaveBeenCalled();
+      expect(component.value).toEqual({ start: selectedDate, end: null });
     });
 
-    it(`onSelectDate: should call 'convertDateToISO' to set 'dateIso' and set 'date' to 'dateparam'`, () => {
-      const dateParam = new Date(2018, 6, 5);
-      const isoExtended = '2018-07-05T03:00:00.000Z';
+    it(`onSelectDate: should call setActivateDate with selectedDate if isRange is true and component.value is falsy`, () => {
+      const selectedDate = new Date(2018, 6, 5);
+      component.value = null;
 
-      spyOn(component.poDate, 'convertDateToISO').and.returnValue(isoExtended);
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+      spyOn(component, <any>'setActivateDate').and.callThrough();
 
-      component.onSelectDate(dateParam);
+      component.onSelectDate(selectedDate, 'end');
 
-      expect(component['dateIso']).toBe(isoExtended);
-      expect(component['date']).toBe(dateParam);
+      expect(component['setActivateDate']).toHaveBeenCalledWith(selectedDate);
     });
 
-    it(`onSelectDate: should call 'change.emit' with dateparam`, () => {
-      const dateParam = new Date(2018, 6, 5);
-      const result = '2018-07-05';
+    it(`onSelectDate: should call setActivateDate with selectedDate if isRange is true and { start, end } are truthy`, () => {
+      const selectedDate = new Date(2018, 6, 5);
+      component.value = { start: new Date(2018, 4, 5), end: new Date(2018, 5, 5) };
 
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+      spyOn(component, <any>'setActivateDate').and.callThrough();
+
+      component.onSelectDate(selectedDate, 'end');
+
+      expect(component['setActivateDate']).toHaveBeenCalledWith(selectedDate);
+    });
+
+    it(`onSelectDate: should call 'convertDateToISO' to set 'dateIso' and call updateModel with new value`, () => {
+      const selectedDate = new Date(2018, 6, 5);
+      const isoDate = '2018-07-05';
+
+      spyOnProperty(component, 'isRange').and.returnValue(false);
       spyOn(component.change, 'emit');
+      spyOn(component, <any>'updateModel');
 
-      component.onSelectDate(dateParam);
+      component.onSelectDate(selectedDate);
 
-      expect(component.change.emit).toHaveBeenCalledWith(result);
+      expect(component.value).toBe(selectedDate);
+      expect(component['updateModel']).toHaveBeenCalledWith(isoDate);
+      expect(component.change.emit).toHaveBeenCalledWith(isoDate);
     });
 
-    it(`onSelectDate: should call 'propagateChange' with 'isoExtended' if 'propagateChange' is defined`, () => {
-      const dateParam = new Date(2018, 6, 5);
-      const isoExtended = '2018-07-05T03:00:00.000Z';
+    it(`convertDateFromIso: should return null if date param is not string`, () => {
+      const dateFromIso = component['convertDateFromIso'](<any>{});
+
+      expect(dateFromIso).toBe(null);
+    });
+
+    it(`convertDateFromIso: should return converted date from iso if date param is string`, () => {
+      const dateParam = '2018-07-05';
+
+      const dateFromIso = component['convertDateFromIso'](dateParam);
+
+      expect(dateFromIso.toISOString().substring(0, 10)).toBe(dateParam);
+    });
+
+    it(`updateModel: should call propagateChange with model param`, () => {
+      const expectedValue = new Date();
       component['propagateChange'] = () => {};
 
-      spyOn(component.poDate, 'convertDateToISO').and.returnValue(isoExtended);
       spyOn(component, <any>'propagateChange');
 
-      component.onSelectDate(dateParam);
+      component['updateModel'](expectedValue);
 
-      expect(component['propagateChange']).toHaveBeenCalledWith(isoExtended);
+      expect(component['propagateChange']).toHaveBeenCalledWith(expectedValue);
     });
 
-    it(`onSelectMonth: should call 'selectDay' and 'updateDisplay' with year and month`, () => {
-      spyOn(component, 'selectDay');
-      spyOn(component, <any>'updateDisplay');
-      component.onSelectMonth(2015, 10);
+    it(`convertDateToISO: should convert { start, end } date to null if invalid value and range is true`, () => {
+      const date = { start: 123, end: 12 };
+      const expectedValue = { start: null, end: null };
 
-      expect(component.selectDay).toHaveBeenCalled();
-      expect(component['updateDisplay']).toHaveBeenCalledWith(2015, 10);
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+
+      expect(component['convertDateToISO'](date)).toEqual(expectedValue);
     });
 
-    it(`onSelectYear: should call 'updateDisplay' and 'selectMonth' if 'lastDisplay' is equal to 'month'`, () => {
-      component['lastDisplay'] = 'month';
+    it(`convertDateToISO: should return { start: null, end: null } if date is null`, () => {
+      const date = null;
+      const expectedValue = { start: null, end: null };
 
-      spyOn(component, 'selectMonth');
-      spyOn(component, 'selectDay');
-      spyOn(component, <any>'updateDisplay');
+      spyOnProperty(component, 'isRange').and.returnValue(true);
 
-      component.onSelectYear(2015, 10);
-
-      expect(component.selectMonth).toHaveBeenCalled();
-      expect(component.selectDay).not.toHaveBeenCalled();
-      expect(component['updateDisplay']).toHaveBeenCalledWith(2015, 10);
+      expect(component['convertDateToISO'](date)).toEqual(expectedValue);
     });
 
-    it(`onSelectYear: should call 'updateDisplay' and 'selectDay' if 'lastDisplay' is different to 'month'`, () => {
-      component['lastDisplay'] = '';
+    it(`convertDateToISO: should convert { start, end } date to iso if range is true`, () => {
+      const date = { start: new Date(2020, 6, 5), end: new Date(2021, 6, 5) };
+      const expectedValue = { start: '2020-07-05', end: '2021-07-05' };
 
-      spyOn(component, 'selectMonth');
-      spyOn(component, 'selectDay');
-      spyOn(component, <any>'updateDisplay');
+      spyOnProperty(component, 'isRange').and.returnValue(true);
 
-      component.onSelectYear(2015, 10);
-
-      expect(component.selectMonth).not.toHaveBeenCalled();
-      expect(component.selectDay).toHaveBeenCalled();
-      expect(component['updateDisplay']).toHaveBeenCalledWith(2015, 10);
+      expect(component['convertDateToISO'](date)).toEqual(expectedValue);
     });
 
-    it(`onSelectYear: should set 'currentYear' to the value of 'yearParam'`, () => {
-      const yearParam = 2018;
+    it(`convertDateToISO: should convert simple date to iso if range is false`, () => {
+      const date = new Date(2020, 6, 5);
+      const expectedValue = '2020-07-05';
 
-      spyOn(component, 'selectMonth');
-      spyOn(component, 'selectDay');
-      spyOn(component, <any>'updateDisplay');
+      spyOnProperty(component, 'isRange').and.returnValue(false);
 
-      component.onSelectYear(yearParam, 10);
-
-      expect(component.currentYear).toBe(yearParam);
+      expect(component['convertDateToISO'](date)).toBe(expectedValue);
     });
 
     it('registerOnChange: should set `propagateChange` with value of the `fnParam`', () => {
@@ -236,81 +269,6 @@ describe('PoCalendarComponent:', () => {
       expect(component['onTouched']).toBe(fnParam);
     });
 
-    it('registerOnValidatorChange: should set `validatorChange` with value of the `fnParam`', () => {
-      const fnParam = () => {};
-
-      component.registerOnValidatorChange(fnParam);
-
-      expect(component['validatorChange']).toBe(fnParam);
-    });
-
-    it(`selectDay: should set 'dayVisible' to 'true', 'monthVisible' to 'false', 'yearVisible' to 'false' and
-      'lastDisplay' to 'day'`, () => {
-      component.selectDay();
-
-      expect(component.dayVisible).toBeTruthy();
-      expect(component.monthVisible).toBeFalsy();
-      expect(component.yearVisible).toBeFalsy();
-      expect(component['lastDisplay']).toBe('day');
-    });
-
-    it(`selectMonth: should set 'dayVisible' to 'false', 'monthVisible' to 'true', 'yearVisible' to 'false' and
-      'lastDisplay' to 'month'`, () => {
-      component.selectMonth();
-
-      expect(component.dayVisible).toBeFalsy();
-      expect(component.monthVisible).toBeTruthy();
-      expect(component.yearVisible).toBeFalsy();
-      expect(component['lastDisplay']).toBe('month');
-    });
-
-    it(`selectYear: should set 'dayVisible' to 'false', 'monthVisible' to 'false' and 'yearVisible' to 'true'`, () => {
-      component.selectYear();
-
-      expect(component.dayVisible).toBeFalsy();
-      expect(component.monthVisible).toBeFalsy();
-      expect(component.yearVisible).toBeTruthy();
-    });
-
-    it(`updateYear: should call 'updateDisplay' with '2007' and '11'`, () => {
-      component.displayYear = 1997;
-      component.displayMonthNumber = 11;
-      const value = 10;
-      const yearExpected = 2007;
-
-      spyOn(component, <any>'updateDisplay');
-      component.updateYear(value);
-
-      expect(component['updateDisplay']).toHaveBeenCalledWith(yearExpected, 11);
-    });
-
-    it(`updateYear: should call 'updateDisplay' with '1987' and '11'`, () => {
-      component.displayYear = 1997;
-      component.displayMonthNumber = 11;
-
-      spyOn(component, <any>'updateDisplay');
-      component.updateYear(-10);
-
-      expect(component['updateDisplay']).toHaveBeenCalledWith(1987, 11);
-    });
-
-    it('validateModel: should call `validatorChange` to validateModel if `validatorChange` is a function', () => {
-      component['validatorChange'] = () => {};
-      const model = ['value'];
-
-      spyOn(component, <any>'validatorChange');
-
-      component['validateModel'](model);
-
-      expect(component['validatorChange']).toHaveBeenCalledWith(model);
-    });
-
-    it('validateModel: shouldn`t call `validatorChange` when it is falsy', () => {
-      component['validateModel']([]);
-
-      expect(component['validatorChange']).toBeUndefined();
-    });
-
     it('validate: should return null', () => {
       expect(component['validate'](undefined)).toBeNull();
     });
@@ -325,720 +283,214 @@ describe('PoCalendarComponent:', () => {
       expect(component['writeDate']).toHaveBeenCalledWith(value);
     });
 
-    it(`writeValue: should set 'date' to 'undefined', call 'updateDate' with 'today' and not call 'writeDate' if value
-      is undefined`, () => {
+    it('writeValue: should set component.value with null if value param is undefined', () => {
       const value = undefined;
 
       spyOn(component, <any>'writeDate');
-      spyOn(component, <any>'updateDate');
 
       component.writeValue(value);
 
-      expect(component['writeDate']).not.toHaveBeenCalled();
-      expect(component['updateDate']).toHaveBeenCalledWith(component['today']);
-      expect(component['date']).toBeUndefined();
+      expect(component['writeDate']).not.toHaveBeenCalledWith(value);
     });
 
-    it(`addAllYearsInDecade: should update 'displayDecade' with 10 years`, () => {
-      component.displayDecade = [];
+    it(`writeDate: should set { start, end } with null if param is undefined`, () => {
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+      spyOn(component, <any>'convertDateFromIso').and.callThrough();
 
-      component['addAllYearsInDecade'](2011);
+      component['writeDate'](undefined);
 
-      expect(component.displayDecade).toEqual([2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020]);
+      expect(component.value.start).toBe(null);
+      expect(component.value.end).toBe(null);
+      expect(component['convertDateFromIso']).toHaveBeenCalled();
     });
 
-    it(`equalsDate: should return 'true' if date1 is equal date2`, () => {
-      const date1 = new Date(2018, 5, 5);
-      const date2 = new Date(2018, 5, 5);
+    it(`writeDate: should set value and call 'convertDateFromIso' if value.start and value.end are not Date`, () => {
+      const value = { start: '2018-07-05T03:00:00.000', end: '2019-04-05T03:00:00.000' };
 
-      expect(component['equalsDate'](date1, date2)).toBeTruthy();
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+      spyOn(component, <any>'convertDateFromIso').and.callThrough();
+
+      component['writeDate'](value);
+
+      expect(component.value.start instanceof Date).toBe(true);
+      expect(component.value.end instanceof Date).toBe(true);
+      expect(component['convertDateFromIso']).toHaveBeenCalled();
     });
 
-    it(`equalsDate: should return 'false' if date1 is different from the date2`, () => {
-      expect(component['equalsDate'](new Date(2018, 5, 5), new Date(2018, 5, 6))).toBeFalsy();
+    it(`writeDate: should set value and not call 'convertDateFromIso' if value.start and value.end are Date`, () => {
+      const value = { start: new Date(2018, 7, 5), end: new Date(2019, 9, 5) };
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+      spyOn(component, <any>'convertDateFromIso').and.callThrough();
+
+      component['writeDate'](value);
+
+      expect(component.value.start instanceof Date).toBe(true);
+      expect(component.value.end instanceof Date).toBe(true);
+      expect(component['convertDateFromIso']).not.toHaveBeenCalled();
     });
 
-    it(`getDecadeArray: should set 'displayDecade' to instance of 'Array' and call 'updateDecade' with 'year' if 'year'
-      is multiple of 10`, () => {
-      const year = 2000;
-      component['displayDecade'] = undefined;
+    it(`writeDate: should set value and call 'convertDateFromIso' if value param is not a Date`, () => {
+      const value = '2018-07-05T03:00:00.000';
 
-      spyOn(component, <any>'updateDecade');
+      spyOnProperty(component, <any>'isRange').and.returnValue(false);
+      spyOn(component, <any>'convertDateFromIso').and.callThrough();
 
-      component['getDecadeArray'](year);
+      component['writeDate'](value);
 
-      expect(component['updateDecade']).toHaveBeenCalledWith(year);
-      expect(component['displayDecade'] instanceof Array).toBeTruthy();
+      expect(component.value instanceof Date).toBe(true);
+      expect(component['convertDateFromIso']).toHaveBeenCalled();
     });
 
-    it(`getDecadeArray: should set 'displayDecade' to instance of 'Array' and call 'updateDecade' with 'yearMultipleTen'
-      if 'year' not is multiple of 10`, () => {
-      const year = 1995;
-      const yearMultipleTen = 1990;
-      component['displayDecade'] = undefined;
-
-      spyOn(component, <any>'updateDecade');
-
-      component['getDecadeArray'](year);
-
-      expect(component['updateDecade']).toHaveBeenCalledWith(yearMultipleTen);
-      expect(component['displayDecade'] instanceof Array).toBeTruthy();
-    });
-
-    it(`getColorForDate: should return 'po-calendar-box-background-selected' if 'poDate.validateDateRange'
-      return 'true'`, () => {
-      spyOn(component.poDate, 'validateDateRange').and.returnValue(true);
-
-      const result = component['getColorForDate'](new Date(), 'background');
-
-      expect(result).toBe('po-calendar-box-background-selected');
-    });
-
-    it(`getColorForDate: should return 'po-calendar-box-background-selected-disabled' if 'poDate.validateDateRange'
-      return 'false'`, () => {
-      spyOn(component.poDate, 'validateDateRange').and.returnValue(false);
-
-      const result = component['getColorForDate'](new Date(), 'background');
-
-      expect(result).toBe('po-calendar-box-background-selected-disabled');
-    });
-
-    it(`getColorForDate: should call 'poDate.validateDateRange' with 'date', 'minDate' and 'maxDate'`, () => {
-      const date = new Date();
-      component.minDate = new Date(2018, 4, 3);
-      component.maxDate = new Date(2018, 4, 8);
-
-      spyOn(component.poDate, 'validateDateRange').and.returnValue(false);
-
-      component['getColorForDate'](date, 'background');
-
-      expect(component.poDate.validateDateRange).toHaveBeenCalledWith(date, component.minDate, component.maxDate);
-    });
-
-    it(`getColorForDateRange: should return 'po-calendar-box-background' if 'poDate.validateDateRange'
-      return 'true'`, () => {
-      spyOn(component.poDate, 'validateDateRange').and.returnValue(true);
-
-      const result = component['getColorForDateRange'](new Date(), 'background');
-
-      expect(result).toBe('po-calendar-box-background');
-    });
-
-    it(`getColorForDateRange: should return 'po-calendar-box-background-disabled' if 'poDate.validateDateRange'
-      return 'false'`, () => {
-      spyOn(component.poDate, 'validateDateRange').and.returnValue(false);
-
-      const result = component['getColorForDateRange'](new Date(), 'background');
-
-      expect(result).toBe('po-calendar-box-background-disabled');
-    });
-
-    it(`getColorForDateRange: should call 'poDate.validateDateRange' with 'date', 'minDate' and 'maxDate'`, () => {
-      const date = new Date();
-      component.minDate = new Date(2018, 4, 3);
-      component.maxDate = new Date(2018, 4, 8);
-
-      spyOn(component.poDate, 'validateDateRange').and.returnValue(false);
-
-      component['getColorForDateRange'](date, 'background');
-
-      expect(component.poDate.validateDateRange).toHaveBeenCalledWith(date, component.minDate, component.maxDate);
-    });
-
-    it(`getColorForToday: should return 'po-calendar-box-background-today' if 'poDate.validateDateRange'
-      return 'true'`, () => {
-      spyOn(component.poDate, 'validateDateRange').and.returnValue(true);
-
-      const result = component['getColorForToday'](new Date(), 'background');
-
-      expect(result).toBe('po-calendar-box-background-today');
-    });
-
-    it(`getColorForToday: should return 'po-calendar-box-background-today-disabled' if 'poDate.validateDateRange'
-      return 'false'`, () => {
-      spyOn(component.poDate, 'validateDateRange').and.returnValue(false);
-
-      const result = component['getColorForToday'](new Date(), 'background');
-
-      expect(result).toBe('po-calendar-box-background-today-disabled');
-    });
-
-    it(`getColorForToday: should call 'poDate.validateDateRange' with 'date', 'minDate' and 'maxDate'`, () => {
-      const date = new Date();
-      component.minDate = new Date(2018, 4, 3);
-      component.maxDate = new Date(2018, 4, 8);
-
-      spyOn(component.poDate, 'validateDateRange').and.returnValue(false);
-
-      component['getColorForToday'](date, 'background');
-
-      expect(component.poDate.validateDateRange).toHaveBeenCalledWith(date, component.minDate, component.maxDate);
-    });
-
-    it(`getDayColor: should return value of the 'getColorForDate' if 'equalsDate' return 'true'`, () => {
-      const colorClass = 'po-calendar-box-background-selected';
-      const dateParam = new Date(2018, 5, 6);
-
-      spyOn(component, <any>'equalsDate').and.returnValue(true);
-      spyOn(component, <any>'getColorForDate').and.returnValue(colorClass);
-
-      const result = component['getDayColor'](dateParam, 'background');
-
-      expect(result).toBe(colorClass);
-    });
-
-    it(`getDayColor: should call 'equalsDate' with 'dateParam' and 'this.date' and return value of the 'getColorForDate'
-      if 'equalsDate' return 'true'`, () => {
-      const colorClass = 'po-calendar-box-background-selected';
-      const dateParam = new Date(2018, 5, 6);
-
-      spyOn(component, <any>'equalsDate').and.returnValue(true);
-      spyOn(component, <any>'getColorForDate').and.returnValue(colorClass);
-
-      const result = component['getDayColor'](dateParam, 'background');
-
-      expect(result).toBe(colorClass);
-      expect(component['equalsDate']).toHaveBeenCalledWith(dateParam, component['date']);
-    });
-
-    it(`getDayColor: should call 'equalsDate' with 'dateParam' and 'this.today' and return 'po-calendar-box-background-today'
-      if 'equalsDate' return 'true'`, () => {
-      const colorClass = 'po-calendar-box-background-today';
-      const dateParam = new Date(2018, 5, 6);
-
-      spyOn(component, <any>'equalsDate').and.returnValues(false, true);
-      spyOn(component, <any>'getColorForToday').and.returnValue(colorClass);
-
-      const result = component['getDayColor'](dateParam, 'background');
-
-      expect(result).toBe(colorClass);
-      expect(component['equalsDate']).toHaveBeenCalledWith(dateParam, component['today']);
-    });
-
-    it(`getDayColor: should call 'equalsDate', 'getColorForDateRange' and return value of the 'getColorForDateRange' if
-      'equalsDate' return 'false'`, () => {
-      const colorClass = 'po-calendar-box-background';
-      const dateParam = new Date(2018, 5, 6);
-      const local = 'background';
-
-      spyOn(component, <any>'equalsDate').and.returnValue(false);
-      spyOn(component, <any>'getColorForDateRange').and.returnValue(colorClass);
-
-      const result = component['getDayColor'](dateParam, local);
-
-      expect(result).toBe(colorClass);
-      expect(component['equalsDate']).toHaveBeenCalledWith(dateParam, component['today']);
-      expect(component['equalsDate']).toHaveBeenCalledWith(dateParam, component['date']);
-      expect(component['getColorForDateRange']).toHaveBeenCalledWith(dateParam, local);
-    });
-
-    it(`init: should call 'updateDate' with today date if 'this.date' is undefined and 'poDate.isValidIso'
-      return 'false'`, () => {
-      component['date'] = undefined;
-      component['today'] = new Date(2018, 5, 6);
-
-      spyOn(component, <any>'updateDate');
-      spyOn(component.poDate, 'isValidIso').and.returnValue(false);
-
-      component['init']();
-
-      expect(component['updateDate']).toHaveBeenCalledWith(component['today']);
-    });
-
-    it(`init: should call 'updateDate' with today date if 'this.date' is defined and 'poDate.isValidIso'
-      return 'false'`, () => {
-      component['date'] = new Date(2018, 4, 10);
-      component['today'] = new Date(2018, 5, 6);
-
-      spyOn(component, <any>'updateDate');
-      spyOn(component.poDate, 'isValidIso').and.returnValue(false);
-
-      component['init']();
-
-      expect(component['updateDate']).toHaveBeenCalledWith(component['today']);
-    });
-
-    it(`init: should call 'updateDate' with today date if 'this.date' is undefined and 'poDate.isValidIso'
-      return 'true'`, () => {
-      component['date'] = undefined;
-      component['today'] = new Date(2018, 5, 6);
-
-      spyOn(component, <any>'updateDate');
-      spyOn(component.poDate, 'isValidIso').and.returnValue(true);
-
-      component['init']();
-
-      expect(component['updateDate']).toHaveBeenCalledWith(component['today']);
-    });
-
-    it(`init: should call 'updateDate' with 'this.date' date if 'this.date' is defined and 'poDate.isValidIso'
-      return 'true'`, () => {
-      component['date'] = new Date(2018, 4, 10);
-
-      spyOn(component, <any>'updateDate');
-      spyOn(component.poDate, 'isValidIso').and.returnValue(true);
-
-      component['init']();
-
-      expect(component['updateDate']).toHaveBeenCalledWith(component['date']);
-    });
-
-    it(`init: should call 'poDate.convertDateToISO' with 'this.date', 'initializeLanguage' and 'selectDay'`, () => {
-      component['date'] = new Date(2018, 4, 10);
-
-      spyOn(component, <any>'updateDate');
-      const initializeLanguageSpy = spyOn(component, <any>'initializeLanguage');
-      const selectDaySpy = spyOn(component, <any>'selectDay');
-      spyOn(component.poDate, 'convertDateToISO');
-
-      component['init']();
-
-      expect(component.poDate.convertDateToISO).toHaveBeenCalledWith(component['date']);
-      expect(initializeLanguageSpy).toHaveBeenCalled();
-      expect(selectDaySpy).toHaveBeenCalled();
-      expect(component['updateDate']).toHaveBeenCalledBefore(selectDaySpy);
-      expect(component['updateDate']).toHaveBeenCalledBefore(initializeLanguageSpy);
-    });
-
-    it(`selectDateFromDate: should set 'this.date' with dateParam and call 'onSelectDate' with 'this.date'`, () => {
-      const dateParam = new Date();
-
-      spyOn(component, 'onSelectDate');
-
-      component['selectDateFromDate'](dateParam);
-
-      expect(component['date']).toEqual(dateParam);
-      expect(component.onSelectDate).toHaveBeenCalledWith(dateParam);
-    });
-
-    it(`selectDateFromIso: should set 'this.date' with 'dateExpected' and call 'onSelectDate' with 'this.date'`, () => {
-      const dateParam = '2018-07-05';
-
-      spyOn(component, 'onSelectDate');
-
-      component['selectDateFromIso'](dateParam);
-
-      expect(component['date'].toISOString().substring(0, 10)).toBe(dateParam);
-      expect(component.onSelectDate).toHaveBeenCalledWith(component['date']);
-    });
-
-    it(`updateDate: should set 'currentMonthNumber' and 'currentYear' to 'date.getMonth()' and 'date.getFullYear()' and
-      call 'updateDisplay'`, () => {
-      const date = new Date();
-
-      spyOn(component, <any>'updateDisplay');
-
-      component['updateDate'](date);
-
-      expect(component['currentMonthNumber']).toBe(date.getMonth());
-      expect(component.currentYear).toBe(date.getFullYear());
-      expect(component['updateDisplay']).toHaveBeenCalledWith(component.currentYear, component['currentMonthNumber']);
-    });
-
-    it(`updateDate: shouldn't call 'updateDisplay' if not have date`, () => {
-      const date = undefined;
-
-      spyOn(component, <any>'updateDisplay');
-
-      component['updateDate'](date);
-
-      expect(component['updateDisplay']).not.toHaveBeenCalled();
-    });
-
-    it(`updateDecade: should call 'addAllYearsInDecade' and update 'displayStartDecade' and 'displayFinalDecade'`, () => {
-      spyOn(component, <any>'addAllYearsInDecade');
-
-      component['updateDecade'](2000);
-
-      expect(component['displayStartDecade']).toBe(2000);
-      expect(component['displayFinalDecade']).toBe(2009);
-      expect(component['addAllYearsInDecade']).toHaveBeenCalledWith(2000);
-    });
-
-    it(`updateDisplay: should call 'poCalendarService.monthDays' to set 'displayDays'`, () => {
-      const monthDays = [1, 2, 3, 4];
-      const year = 2018;
-      const month = 2;
-
-      spyOn(component['poCalendarService'], 'monthDays').and.returnValue([...monthDays]);
-
-      component['updateDisplay'](year, month);
-
-      expect(component['displayDays']).toEqual(monthDays);
-      expect(component['poCalendarService']['monthDays']).toHaveBeenCalledWith(year, month);
-    });
-
-    it(`updateDisplay: should set 'displayMonthNumber', 'displayMonth', 'displayYear' and call 'getDecadeArray'
-      with 'year'`, () => {
-      const monthDays = [1, 2, 3, 4];
-      const year = 2018;
-      const month = 2;
-
-      spyOn(component['poCalendarService'], 'monthDays').and.returnValue([...monthDays]);
-      spyOn(component, <any>'getDecadeArray');
-
-      component['updateDisplay'](year, month);
-
-      expect(component.displayMonthNumber).toEqual(month);
-      expect(component['displayMonth']).toEqual(component['displayMonths'][month]);
-      expect(component['displayYear']).toEqual(year);
-      expect(component['getDecadeArray']).toHaveBeenCalledWith(year);
-    });
-
-    it(`writeDate: should call 'selectDateFromDate' with 'value' if 'value' is instance of 'Date' and call
-      'updateDate' with 'this.date'`, () => {
+    it(`writeDate: should set value and not call 'convertDateFromIso' if value param is a Date`, () => {
       const value = new Date();
-      component['date'] = new Date();
 
-      spyOn(component, <any>'selectDateFromDate');
-      spyOn(component, <any>'updateDate');
-      spyOn(component, <any>'writeDateIso');
+      spyOnProperty(component, <any>'isRange').and.returnValue(false);
+      spyOn(component, <any>'convertDateFromIso').and.callThrough();
 
       component['writeDate'](value);
 
-      expect(component['selectDateFromDate']).toHaveBeenCalledWith(value);
-      expect(component['writeDateIso']).not.toHaveBeenCalled();
-      expect(component['updateDate']).toHaveBeenCalledWith(component['date']);
+      expect(component.value instanceof Date).toBe(true);
+      expect(component['convertDateFromIso']).not.toHaveBeenCalled();
     });
 
-    it(`writeDate: should call 'writeDateIso' with 'value' if 'value' not is instance of 'Date' and call
-      'updateDate' with 'this.date'`, () => {
-      const value = '2018-07-05T03:00:00.000';
-      component['date'] = new Date();
+    it(`getValidateStartDate: should return null if range is true and value param is undefined`, () => {
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
 
-      spyOn(component, <any>'selectDateFromDate');
-      spyOn(component, <any>'updateDate');
-      spyOn(component, <any>'writeDateIso');
-
-      component['writeDate'](value);
-
-      expect(component['selectDateFromDate']).not.toHaveBeenCalled();
-      expect(component['writeDateIso']).toHaveBeenCalledWith(value);
-      expect(component['updateDate']).toHaveBeenCalledWith(component['date']);
+      expect(component['getValidateStartDate'](undefined)).toBe(null);
     });
 
-    it(`writeDateIso: should call 'selectDateFromIso' with 'value' if 'poDate.isValidIso'
-      return 'true'`, () => {
-      const value = '2018-07-05T03:00:00.000';
+    it(`getValidateStartDate: should return start date if range is true and value param is valid`, () => {
+      const today = new Date();
+
+      const date = { start: today };
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+
+      expect(component['getValidateStartDate'](date)).toEqual(today);
+    });
+
+    it(`getValidateStartDate: should return date if range is false and value param is Date`, () => {
       const date = new Date();
-      component['date'] = date;
+      spyOnProperty(component, <any>'isRange').and.returnValue(false);
 
-      spyOn(component.poDate, 'isValidIso').and.returnValue(true);
-      spyOn(component, <any>'selectDateFromIso');
-
-      component['writeDateIso'](value);
-
-      expect(component['selectDateFromIso']).toHaveBeenCalledWith(value);
-      expect(component.poDate.isValidIso).toHaveBeenCalledWith(value);
-      expect(component['date']).toEqual(date);
+      expect(component['getValidateStartDate'](date)).toEqual(date);
     });
 
-    it(`writeDateIso: should not call 'selectDateFromIso' with 'value' and set 'this.date' to 'undefined'
-      if 'poDate.isValidIso' return 'false'`, () => {
-      const value = '2018-07-05T03:00:00.000';
-      component['date'] = new Date();
+    it(`getValidateStartDate:  should return date if range is false and value param is string`, () => {
+      const date = '2010-10-10';
+      spyOnProperty(component, <any>'isRange').and.returnValue(false);
 
-      spyOn(component.poDate, 'isValidIso').and.returnValue(false);
-      spyOn(component, <any>'selectDateFromIso');
+      expect(component['getValidateStartDate'](date)).toEqual(date);
+    });
 
-      component['writeDateIso'](value);
+    it(`getValidateStartDate: should return null if range is false and value param is undefined`, () => {
+      spyOnProperty(component, <any>'isRange').and.returnValue(false);
 
-      expect(component['selectDateFromIso']).not.toHaveBeenCalled();
-      expect(component.poDate.isValidIso).toHaveBeenCalledWith(value);
-      expect(component['date']).toBeUndefined();
+      expect(component['getValidateStartDate'](undefined)).toEqual(null);
+    });
+
+    it(`onHeaderChange: `, () => {
+      const start = new Date(2010, 8, 10);
+      const end = new Date(2010, 9, 10);
+
+      component.activateDate = { start, end };
+
+      const nextMonth = 7;
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+
+      component.onHeaderChange({ month: nextMonth, year: 2010 }, 'start');
+
+      expect(component.activateDate.start.getMonth()).toEqual(nextMonth);
+      expect(component.activateDate.start.getFullYear()).toEqual(2010);
+
+      expect(component.activateDate.end.getMonth()).toEqual(8);
+      expect(component.activateDate.end.getFullYear()).toEqual(2010);
+    });
+
+    it(`onHeaderChange: `, () => {
+      const start = new Date(2011, 0, 10);
+      const end = new Date(2011, 1, 10);
+
+      component.activateDate = { start, end };
+
+      const nextMonth = 11;
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+
+      component.onHeaderChange({ month: nextMonth, year: 2010 }, 'start');
+
+      expect(component.activateDate.start.getMonth()).toEqual(nextMonth);
+      expect(component.activateDate.start.getFullYear()).toEqual(2010);
+
+      expect(component.activateDate.end.getMonth()).toEqual(0);
+      expect(component.activateDate.end.getFullYear()).toEqual(2011);
+    });
+
+    it(`onHeaderChange: `, () => {
+      const start = new Date(2010, 10, 10);
+      const end = new Date(2010, 11, 10);
+
+      component.activateDate = { start, end };
+
+      const nextMonth = 0;
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+
+      component.onHeaderChange({ month: nextMonth, year: 2011 }, 'end');
+
+      expect(component.activateDate.start.getMonth()).toEqual(11);
+      expect(component.activateDate.start.getFullYear()).toEqual(2010);
+
+      expect(component.activateDate.end.getMonth()).toEqual(nextMonth);
+      expect(component.activateDate.end.getFullYear()).toEqual(2011);
+    });
+
+    it(`onHeaderChange: `, () => {
+      const start = new Date(2010, 7, 10);
+      const end = new Date(2010, 8, 10);
+
+      component.activateDate = { start, end };
+
+      const nextMonth = 9;
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+
+      component.onHeaderChange({ month: nextMonth, year: 2010 }, 'end');
+
+      expect(component.activateDate.start.getMonth()).toEqual(8);
+      expect(component.activateDate.start.getFullYear()).toEqual(2010);
+
+      expect(component.activateDate.end.getMonth()).toEqual(nextMonth);
+      expect(component.activateDate.end.getFullYear()).toEqual(2010);
+    });
+
+    it(`onHeaderChange: should set activateDate if isRange is false`, () => {
+      component.activateDate = null;
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(false);
+
+      component.onHeaderChange({ month: 10, year: 2010 }, 'start');
+
+      expect(component.activateDate).toEqual(null);
     });
   });
 
   describe('Templates:', () => {
-    describe('Day visible:', () => {
-      it('should show `po-calendar-content-list-day`', () => {
-        component.dayVisible = true;
-        fixture.detectChanges();
-        expect(nativeElement.querySelector('.po-calendar-content-list-day')).toBeTruthy();
-      });
+    it('should show `po-calendar-range` if isRange is true', () => {
+      spyOnProperty(component, 'isRange').and.returnValue(true);
 
-      it('should call `onPreviousMonth` on `po-calendar-nav-left` click', () => {
-        component.dayVisible = true;
-        spyOn(component, 'onPreviousMonth');
+      fixture.detectChanges();
 
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-nav-left');
-        calendarNav.click();
-
-        expect(component.onPreviousMonth).toHaveBeenCalled();
-      });
-
-      it('should call `selectMonth` on `.po-calendar-nav-title > .po-clickable` click and show `displayMonth`', () => {
-        component.dayVisible = true;
-        spyOn(component, 'selectMonth');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-nav-title > .po-clickable');
-        calendarNav.click();
-
-        expect(component.selectMonth).toHaveBeenCalled();
-        expect(calendarNav.innerHTML).toContain(component.displayMonth);
-      });
-
-      it('should call `selectYear` on `.po-calendar-nav-title > .po-clickable:nth-of-type(2)` click and show `displayYear`', () => {
-        component.dayVisible = true;
-        spyOn(component, 'selectYear');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector(
-          '.po-calendar-nav-title > .po-clickable:nth-of-type(2)'
-        );
-        calendarNav.click();
-
-        expect(component.selectYear).toHaveBeenCalled();
-        expect(calendarNav.innerHTML).toContain(component.displayYear);
-      });
-
-      it('should call `onNextMonth` on `.po-calendar-nav-right` click', () => {
-        component.dayVisible = true;
-        spyOn(component, 'onNextMonth');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-nav-right');
-        calendarNav.click();
-
-        expect(component.onNextMonth).toHaveBeenCalled();
-      });
-
-      it('should show `po-calendar-label` for each day of `displayWeekDays`', () => {
-        component.dayVisible = true;
-        component.displayWeekDays = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
-
-        fixture.detectChanges();
-
-        expect(nativeElement.querySelectorAll('.po-calendar-label').length).toBe(7);
-      });
-
-      it('should show `po-calendar-day` for each day of `displayDays`, call `getDayBackgroundColor` and `getDayForegroundColor`', () => {
-        spyOn(component, 'getDayBackgroundColor');
-        spyOn(component, 'getDayForegroundColor');
-
-        const calendarArray = component['poCalendarService'].monthDays(2018, 10);
-        component.displayDays = [].concat.apply([], calendarArray);
-        component.dayVisible = true;
-
-        fixture.detectChanges();
-
-        expect(component.getDayBackgroundColor).toHaveBeenCalled();
-        expect(component.getDayForegroundColor).toHaveBeenCalled();
-        expect(nativeElement.querySelectorAll('.po-calendar-day').length).toBe(35); // 31 days and 4 empty days
-      });
-
-      it('should call `onSelectDate` on `.po-calendar-day` click', () => {
-        component.dayVisible = true;
-        spyOn(component, 'onSelectDate');
-
-        fixture.detectChanges();
-
-        const calendarDay = fixture.debugElement.nativeElement.querySelector('.po-calendar-day');
-        calendarDay.click();
-
-        expect(component.onSelectDate).toHaveBeenCalled();
-      });
+      expect(fixture.debugElement.nativeElement.querySelector('.po-calendar-range')).toBeTruthy();
     });
 
-    describe('Month visible:', () => {
-      it('should show `po-calendar-content-list-month`', () => {
-        component.dayVisible = false;
-        component.monthVisible = true;
+    it('should show `po-calendar` if isRange is false ', () => {
+      spyOnProperty(component, 'isRange').and.returnValue(false);
 
-        fixture.detectChanges();
+      fixture.detectChanges();
 
-        expect(nativeElement.querySelector('.po-calendar-content-list-month')).toBeTruthy();
-      });
-
-      it('should call `updateYear` with -1 on `po-calendar-nav-left` click', () => {
-        component.dayVisible = false;
-        component.monthVisible = true;
-
-        spyOn(component, 'updateYear');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-nav-left');
-        calendarNav.click();
-
-        expect(component.updateYear).toHaveBeenCalledWith(-1);
-      });
-
-      it('should call `selectYear` on `.po-calendar-nav-title > .po-clickable` click and show `displayYear`', () => {
-        component.dayVisible = false;
-        component.monthVisible = true;
-
-        spyOn(component, 'selectYear');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-nav-title > .po-clickable');
-        calendarNav.click();
-
-        expect(component.selectYear).toHaveBeenCalled();
-        expect(calendarNav.innerHTML).toContain(component.displayYear);
-      });
-
-      it('should call `updateYear` with 1 on `.po-calendar-nav-right` click', () => {
-        component.dayVisible = false;
-        component.monthVisible = true;
-
-        spyOn(component, 'updateYear');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-nav-right');
-        calendarNav.click();
-
-        expect(component.updateYear).toHaveBeenCalledWith(1);
-      });
-
-      it('should show `po-calendar-label` for `getMonthLabel`', () => {
-        component.dayVisible = false;
-        component.monthVisible = true;
-        const month = 'July';
-
-        spyOn(component, 'getMonthLabel').and.returnValue(month);
-
-        fixture.detectChanges();
-
-        expect(component.getMonthLabel).toHaveBeenCalled();
-        expect(nativeElement.querySelector('.po-calendar-label').innerHTML).toContain(month);
-      });
-
-      it('should show `po-calendar-month` for each month of `displayMonths`, call `getBackgroundColor` and `getForegroundColor`', () => {
-        spyOn(component, 'getBackgroundColor');
-        spyOn(component, 'getForegroundColor');
-
-        component.dayVisible = false;
-        component.monthVisible = true;
-
-        fixture.detectChanges();
-
-        expect(component.getBackgroundColor).toHaveBeenCalled();
-        expect(component.getForegroundColor).toHaveBeenCalled();
-        expect(nativeElement.querySelectorAll('.po-calendar-month').length).toBe(12);
-      });
-
-      it('should call `onSelectMonth` on `.po-calendar-month` click', () => {
-        component.dayVisible = false;
-        component.monthVisible = true;
-
-        spyOn(component, 'onSelectMonth');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-month');
-        calendarNav.click();
-
-        expect(component.onSelectMonth).toHaveBeenCalled();
-      });
-    });
-
-    describe('Year visible:', () => {
-      it('po-calendar-content-list-year`', () => {
-        component.dayVisible = false;
-        component.monthVisible = false;
-        component.yearVisible = true;
-
-        fixture.detectChanges();
-        expect(nativeElement.querySelector('.po-calendar-content-list-year')).toBeTruthy();
-      });
-
-      it('should call `updateYear` with -10 on `po-calendar-nav-left` click', () => {
-        component.dayVisible = false;
-        component.monthVisible = false;
-        component.yearVisible = true;
-
-        spyOn(component, 'updateYear');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-nav-left');
-        calendarNav.click();
-
-        expect(component.updateYear).toHaveBeenCalledWith(-10);
-      });
-
-      it('should show `displayStartDecade` - `displayFinalDecade` on `.po-calendar-nav-title`', () => {
-        component.dayVisible = false;
-        component.monthVisible = false;
-        component.yearVisible = true;
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-nav-title');
-
-        expect(calendarNav.innerHTML).toContain(`${component.displayStartDecade} - ${component.displayFinalDecade}`);
-      });
-
-      it('should call `updateYear` with 10 on `.po-calendar-nav-right` click', () => {
-        component.dayVisible = false;
-        component.monthVisible = false;
-        component.yearVisible = true;
-
-        spyOn(component, 'updateYear');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-nav-right');
-        calendarNav.click();
-
-        expect(component.updateYear).toHaveBeenCalledWith(10);
-      });
-
-      it('should show `po-calendar-label` for `getYearLabel`', () => {
-        component.dayVisible = false;
-        component.monthVisible = false;
-        component.yearVisible = true;
-
-        const year = '2018';
-
-        spyOn(component, 'getYearLabel').and.returnValue(year);
-
-        fixture.detectChanges();
-
-        expect(component.getYearLabel).toHaveBeenCalled();
-        expect(nativeElement.querySelector('.po-calendar-label').innerHTML).toContain(year);
-      });
-
-      it('should show `po-calendar-year` for each year of `displayDecade`, call `getBackgroundColor` and `getForegroundColor`', () => {
-        spyOn(component, 'getBackgroundColor');
-        spyOn(component, 'getForegroundColor');
-
-        component['updateDisplay'](2018, 7);
-
-        component.dayVisible = false;
-        component.monthVisible = false;
-        component.yearVisible = true;
-
-        fixture.detectChanges();
-
-        expect(component.getBackgroundColor).toHaveBeenCalled();
-        expect(component.getForegroundColor).toHaveBeenCalled();
-        expect(nativeElement.querySelectorAll('.po-calendar-year').length).toBe(10);
-      });
-
-      it('should call `onSelectYear` on `.po-calendar-year` click', () => {
-        component.dayVisible = false;
-        component.monthVisible = false;
-        component.yearVisible = true;
-
-        spyOn(component, 'onSelectYear');
-
-        fixture.detectChanges();
-
-        const calendarNav = fixture.debugElement.nativeElement.querySelector('.po-calendar-year');
-        calendarNav.click();
-
-        expect(component.onSelectYear).toHaveBeenCalled();
-      });
+      expect(fixture.debugElement.nativeElement.querySelector('.po-calendar')).toBeTruthy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.module.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.module.ts
@@ -2,8 +2,8 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { PoCalendarComponent } from './po-calendar.component';
-import { PoCalendarLangService } from './services/po-calendar.lang.service';
-import { PoCalendarService } from './services/po-calendar.service';
+import { PoCalendarHeaderComponent } from './po-calendar-header/po-calendar-header.component';
+import { PoCalendarWrapperComponent } from './po-calendar-wrapper/po-calendar-wrapper.component';
 
 /**
  * @description
@@ -11,8 +11,7 @@ import { PoCalendarService } from './services/po-calendar.service';
  */
 @NgModule({
   imports: [CommonModule],
-  declarations: [PoCalendarComponent],
-  exports: [PoCalendarComponent],
-  providers: [PoCalendarLangService, PoCalendarService]
+  declarations: [PoCalendarComponent, PoCalendarHeaderComponent, PoCalendarWrapperComponent],
+  exports: [PoCalendarComponent]
 })
 export class PoCalendarModule {}

--- a/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-labs/sample-po-calendar-labs.component.html
+++ b/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-labs/sample-po-calendar-labs.component.html
@@ -1,16 +1,19 @@
-<po-calendar
-  [(ngModel)]="calendar"
-  [p-locale]="locale"
-  [p-min-date]="minDate"
-  [p-max-date]="maxDate"
-  (p-change)="changeEvent('p-change')"
->
-</po-calendar>
+<div class="po-md-8 po-p-2">
+  <po-calendar
+    [(ngModel)]="calendar"
+    [p-locale]="locale"
+    [p-min-date]="minDate"
+    [p-max-date]="maxDate"
+    [p-mode]="mode"
+    (p-change)="changeEvent('p-change')"
+  >
+  </po-calendar>
+</div>
 
 <hr />
 
 <div class="po-row">
-  <po-info class="po-md-6" p-label="Model" [p-value]="calendar"> </po-info>
+  <po-info class="po-md-6" p-label="Model" p-value="{{ calendar | json }}"> </po-info>
   <po-info class="po-md-6" p-label="Event" [p-value]="event"> </po-info>
 </div>
 
@@ -19,7 +22,7 @@
 <form #f="ngForm">
   <div class="po-row">
     <po-datepicker
-      class="po-md-6"
+      class="po-md-4"
       name="minDate"
       [(ngModel)]="minDate"
       p-clean
@@ -29,7 +32,7 @@
     </po-datepicker>
 
     <po-datepicker
-      class="po-md-6"
+      class="po-md-4"
       name="maxDate"
       [(ngModel)]="maxDate"
       p-clean
@@ -37,6 +40,9 @@
       [p-min-date]="minDate"
     >
     </po-datepicker>
+
+    <po-radio-group class="po-md-4" name="mode" [(ngModel)]="mode" p-label="Mode" [p-options]="calendarModeOptions">
+    </po-radio-group>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-labs/sample-po-calendar-labs.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/samples/sample-po-calendar-labs/sample-po-calendar-labs.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoRadioGroupOption } from '@po-ui/ng-components';
+import { PoRadioGroupOption, PoCalendarMode } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-calendar-labs',
@@ -12,12 +12,18 @@ export class SamplePoCalendarLabsComponent implements OnInit {
   locale: string;
   maxDate: string | Date;
   minDate: string | Date;
+  mode: PoCalendarMode;
 
   readonly localeOptions: Array<PoRadioGroupOption> = [
     { label: 'pt', value: 'pt' },
     { label: 'es', value: 'es' },
     { label: 'en', value: 'en' },
     { label: 'ru', value: 'ru' }
+  ];
+
+  readonly calendarModeOptions: Array<PoRadioGroupOption> = [
+    { label: 'Range', value: PoCalendarMode.Range },
+    { label: 'Unset', value: null }
   ];
 
   ngOnInit() {
@@ -34,5 +40,6 @@ export class SamplePoCalendarLabsComponent implements OnInit {
     this.locale = undefined;
     this.maxDate = undefined;
     this.minDate = undefined;
+    this.mode = undefined;
   }
 }

--- a/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.spec.ts
@@ -79,7 +79,7 @@ describe('PoCalendarLangService:', () => {
   it('should get array of week days', () => {
     service['language'] = 'pt';
 
-    const weekDays = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
+    const weekDays = ['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb'];
 
     expect(service.getWeekDaysArray().toString()).toBe(weekDays.toString());
   });

--- a/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.ts
+++ b/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 
 import { poLocales, poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class PoCalendarLangService {
   private language = poLocaleDefault;
 
@@ -163,7 +165,8 @@ export class PoCalendarLangService {
   getWeekDaysArray() {
     const arrWeekDays = Array();
     for (let i = 0; i < this.shortWeekDays.length; i++) {
-      arrWeekDays.push(this.shortWeekDays[i][this.language]);
+      const weekDay = this.shortWeekDays[i][this.language];
+      arrWeekDays.push(weekDay.toLowerCase());
     }
     return arrWeekDays;
   }

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.html
@@ -1,13 +1,13 @@
 <div class="po-calendar-overlay" [class.po-invisible]="overlayInvisible"></div>
 <div *ngIf="visible" [ngClass]="setMobileVisualization()">
   <div *ngIf="dayVisible" #days>
-    <div class="po-calendar-nav">
-      <span (click)="onPrevMonth()" class="po-calendar-nav-left po-icon po-icon-arrow-left"></span>
-      <div class="po-calendar-nav-title" attr-calendar>
+    <div class="po-calendar-header">
+      <span (click)="onPrevMonth()" class="po-calendar-header-left po-icon po-icon-arrow-left"></span>
+      <div class="po-calendar-header-title" attr-calendar>
         <span class="po-clickable po-mr-1" (click)="selectMonth()">{{ displayMonth }}</span>
         <span class="po-clickable" (click)="selectYear()">{{ displayYear }}</span>
       </div>
-      <span (click)="onNextMonth()" class="po-calendar-nav-right po-icon po-icon-arrow-right"></span>
+      <span (click)="onNextMonth()" class="po-calendar-header-right po-icon po-icon-arrow-right"></span>
     </div>
     <div class="po-calendar-content">
       <div class="po-calendar-labels">
@@ -30,12 +30,12 @@
     </div>
   </div>
   <div *ngIf="monthVisible" #months>
-    <div class="po-calendar-nav">
-      <span (click)="updateYear(-1)" class="po-calendar-nav-left po-icon po-icon-arrow-left"></span>
-      <div class="po-calendar-nav-title" attr-calendar>
+    <div class="po-calendar-header">
+      <span (click)="updateYear(-1)" class="po-calendar-header-left po-icon po-icon-arrow-left"></span>
+      <div class="po-calendar-header-title" attr-calendar>
         <span class="po-clickable" (click)="selectYear()">{{ displayYear }}</span>
       </div>
-      <span (click)="updateYear(1)" class="po-calendar-nav-right po-icon po-icon-arrow-right"></span>
+      <span (click)="updateYear(1)" class="po-calendar-header-right po-icon po-icon-arrow-right"></span>
     </div>
     <div class="po-calendar-content">
       <div class="po-calendar-labels">
@@ -59,10 +59,10 @@
     </div>
   </div>
   <div *ngIf="yearVisible" #years>
-    <div class="po-calendar-nav">
-      <span (click)="updateYear(-10)" class="po-calendar-nav-left po-icon po-icon-arrow-left"></span>
-      <div class="po-calendar-nav-title">{{ displayStartDecade }} - {{ displayFinalDecade }}</div>
-      <span (click)="updateYear(10)" class="po-calendar-nav-right po-icon po-icon-arrow-right"></span>
+    <div class="po-calendar-header">
+      <span (click)="updateYear(-10)" class="po-calendar-header-left po-icon po-icon-arrow-left"></span>
+      <div class="po-calendar-header-title">{{ displayStartDecade }} - {{ displayFinalDecade }}</div>
+      <span (click)="updateYear(10)" class="po-calendar-header-right po-icon po-icon-arrow-right"></span>
     </div>
     <div class="po-calendar-content">
       <div class="po-calendar-labels">

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.spec.ts
@@ -563,9 +563,9 @@ describe('PoCalendarComponent:', () => {
 
       fixture.detectChanges();
 
-      const poCalendarDayVibled = nativeElement.querySelector('.po-calendar-nav');
+      const poCalendarDayVibled = nativeElement.querySelector('.po-calendar-header');
 
-      expect(poCalendarDayVibled.querySelector('div.po-calendar-nav-title > span.po-mr-1')).toBeTruthy();
+      expect(poCalendarDayVibled.querySelector('div.po-calendar-header-title > span.po-mr-1')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
**CALENDAR**

**DTHFUI-4917**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente não há o modo "Range", que permita escolher uma faixa de datas.

**Qual o novo comportamento?**
Adiciona a propriedade p-mode, onde é possível informar "Range", possibilitando selecionar uma faixa de datas.

Obs: Hover e Estilo das datas entre o start e end não serão contemplados agora.

**Simulação**
1. Gerar build da PR no po-style https://github.com/po-ui/po-style/pull/215

2.
npm run build:portal
ng serve portal

Teste local:
```
<po-calendar [p-mode]="mode" name="cal" [(ngModel)]="cal" (p-change)="onchange($event)"></po-calendar>

<hr>
{{ cal | json }}
<hr>

<po-select name="mode" [(ngModel)]="mode" [p-options]="[{ label: 'Range', value: 'range' }, { label: 'Unset', value: '' }]">
</po-select>

<hr>

<po-button [p-label]="'ALTERAR'" (p-click)="clean()"></po-button>
```  

```
  cal;
  mode;

  clean() {
    // this.cal = undefined;
    // SINGLE
    // this.cal = '2011-05-05';
    // this.cal = new Date();
    // RANGES
    // this.cal = { "start": "2021-10-02", "end": "2021-08-30" };
    // this.cal = { "start": "2021-12-02" };
    // this.cal = { start: new Date(), end: null };
    // this.cal = { start: null, end: null };
  }

  onchange(e) {
    console.log("CHANGE:: ", e);
  }
```