### PR TITLE
fix(chart): corrige erro no firefox ao inicia-lo escondido

### DIFF
--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.spec.ts
@@ -48,7 +48,9 @@ describe('PoChartContainerComponent', () => {
   describe('Methods', () => {
     it('ngOnChanges: should call `setViewBox` if type has new value and apply value to `viewBox`', () => {
       const changes = { type: { firstChange: true } };
+
       const spySetViewBox = spyOn(component, <any>'setViewBox').and.callThrough();
+      const spySetSvgSpace = spyOn(component, <any>'setSvgSpace').and.callThrough();
       component.type = PoChartType.Donut;
 
       component.ngOnChanges(<any>changes);
@@ -56,6 +58,7 @@ describe('PoChartContainerComponent', () => {
       const expectedResult = `1 -1 ${containerSize.svgWidth} ${containerSize.svgHeight}`;
 
       expect(spySetViewBox).toHaveBeenCalled();
+      expect(spySetSvgSpace).toHaveBeenCalled();
       expect(component.viewBox).toEqual(expectedResult);
     });
 
@@ -72,14 +75,16 @@ describe('PoChartContainerComponent', () => {
       expect(component.viewBox).toEqual(expectedResult);
     });
 
-    it('ngOnChanges: shouldn`t call `setViewBox`', () => {
+    it('ngOnChanges: shouldn`t call `setViewBox` and `setSvgSpace^', () => {
       const changes = { type: undefined, containerSize: undefined };
 
       const spySetViewBox = spyOn(component, <any>'setViewBox');
+      const spySetSvgSpace = spyOn(component, <any>'setSvgSpace');
 
       component.ngOnChanges(<any>changes);
 
       expect(spySetViewBox).not.toHaveBeenCalled();
+      expect(spySetSvgSpace).not.toHaveBeenCalled();
     });
 
     it('onSerieClick: should emit `serieClick`', () => {
@@ -240,6 +245,36 @@ describe('PoChartContainerComponent', () => {
       component.getCategoriesCoordinates(value);
 
       expect(component.categoriesCoordinates).toEqual(value);
+    });
+
+    it('setSvgSpace: should set svgSpace with { svgPoint, svgDomMatrix }', () => {
+      const inverseMatrix = { a: 1, b: 2, c: 3 };
+
+      const svgPointMock = { x: 0, y: 0 };
+      const screenCTMMock = { inverse: () => inverseMatrix };
+
+      component.svgSpace = undefined;
+
+      spyOn(component.svgELement.nativeElement, 'createSVGPoint').and.returnValue(svgPointMock);
+      spyOn(component.svgELement.nativeElement, 'getScreenCTM').and.returnValue(screenCTMMock);
+
+      component['setSvgSpace']();
+
+      expect(component.svgSpace).toEqual({ svgPoint: svgPointMock, svgDomMatrix: inverseMatrix });
+    });
+
+    it('setSvgSpace: should not throw error if getScreenCTM return null', () => {
+      const svgPointMock = { x: 0, y: 0 };
+      const screenCTMMock = null;
+
+      component.svgSpace = undefined;
+
+      spyOn(component.svgELement.nativeElement, 'createSVGPoint').and.returnValue(svgPointMock);
+      spyOn(component.svgELement.nativeElement, 'getScreenCTM').and.returnValue(null);
+
+      const fnError = () => component['setSvgSpace']();
+
+      expect(fnError).not.toThrow();
     });
   });
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.ts
@@ -68,7 +68,7 @@ export class PoChartContainerComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.type || changes.containerSize) {
       this.setViewBox();
-      this.getSvgMatrix();
+      this.setSvgSpace();
     }
   }
 
@@ -98,12 +98,12 @@ export class PoChartContainerComponent implements OnChanges {
     return { ...domain, ...updatedDomainValues };
   }
 
-  private getSvgMatrix() {
+  private setSvgSpace() {
     // Representa um ponto 2D dentro do viewport do SVG. Ele é a representação do cursor do mouse para comparação de coordenadas com cada dado de série.
     const svgPoint = this.svgELement.nativeElement.createSVGPoint();
     // Retorna um DOMMatrix representando as matrizes 2D e 3D transformadas a partir das coordenadas do elemento, em relação ao document, para coordenadas relativas ao viewport do SVG.
     // É utilizado nos gráficos do tipo área para que seja possível equiparar as coordenadas do evento com cada dado de série, para assim ativar o ponto de dado equivalente.
-    const svgDomMatrix = this.svgELement.nativeElement.getScreenCTM().inverse();
+    const svgDomMatrix = this.svgELement.nativeElement.getScreenCTM()?.inverse();
 
     this.svgSpace = { svgPoint, svgDomMatrix };
   }


### PR DESCRIPTION
**PoChart**

**DTHFUI-4993, #874**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao utilizar o componente no Firefox, iniciando-o escondido (dentro de um PoTab,PoAccordion) estava ocasionando erro ao executar o metodo .inverse no momento de capturar o svgDomMatrix.

Erro acontece também no Portal rodando no Firefox

**Qual o novo comportamento?**
Verifica se o método getScreenCTM retorna valor para executar o método .inverse()



**Simulação**
Rodar o portal e avaliar o sample do gráfico no Firefox.
```
npm run build:portal
ng serve portal
```