### PR TITLE
fix(sync): corrige envio do body vazio a partir da v4.2.0

### DIFF
--- a/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.spec.ts
+++ b/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.spec.ts
@@ -743,12 +743,38 @@ describe('PoEventSourcingService:', () => {
       expect(eventSourcingService['poHttpClient']['createRequest']).toHaveBeenCalledWith(poHttpRequestData);
     });
 
-    it('createPoHttpRequestData: should return newRequestData', async () => {
+    it('createPoHttpRequestData: should return newRequestData if record.body', async () => {
+      const url = 'http://url.com/customers';
+      const method = PoHttpRequestType.POST;
+      const record = { body: { title: 'New note', text: 'test' } };
+      const headers = [{ name: 'test', value: 'teste1' }];
+
       const poHttpRequestData: PoHttpRequestData = {
-        url: 'http://url.com/customers',
-        method: PoHttpRequestType.POST,
-        headers: [{ name: 'test', value: 'teste1' }],
-        body: {}
+        url,
+        method,
+        body: record.body,
+        headers
+      };
+
+      spyOn(eventSourcingService, <any>'createFormData');
+
+      const result = await eventSourcingService['createPoHttpRequestData'](url, method, record, headers);
+
+      expect(result).toEqual(poHttpRequestData);
+      expect(eventSourcingService['createFormData']).not.toHaveBeenCalled();
+    });
+
+    it('createPoHttpRequestData: should return newRequestData if record.body is undefined', async () => {
+      const url = 'http://url.com/customers';
+      const method = PoHttpRequestType.POST;
+      const record = { title: 'New note', text: 'test' };
+      const headers = [{ name: 'test', value: 'teste1' }];
+
+      const poHttpRequestData: PoHttpRequestData = {
+        url,
+        method,
+        body: record,
+        headers
       };
 
       spyOn(eventSourcingService, <any>'createFormData');

--- a/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.ts
+++ b/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.ts
@@ -462,7 +462,7 @@ export class PoEventSourcingService {
     record?: PoEventSourcingItem['record'],
     headers?: Array<PoHttpHeaderOption>
   ): Promise<PoHttpRequestData> {
-    let body = record.body;
+    let body = record.body ?? record;
 
     if (record.bodyType === 'File') {
       body = await this.createFormData(body, record.fileName, record.mimeType, record.formField);


### PR DESCRIPTION
**PO-SYNC**

**DTHFUI-4906**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A partir da versão 4.2 do PoSync ocorre um problema no envio do body para Post. O body é enviado vazio.

**Qual o novo comportamento?**
Corrigido envio do body vazio.

**Simulação**
Simular através do po-sample-app-conference:
- Faça login na aplicação
- Entre na página de schedule
- Clique em uma palestra para abrir os detalhes da mesma
- No canto inferior direito clique no ícone de notas
- Adicione uma nota e salve
- Verifique a requisição feita na aba network e verifique o envio do body.
- Testar também a inclusão de novas fotos na gallery e o envio correto do body.