### PR TITLE
fix(textarea): realiza tratamento no placeholder caso informar undefined

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
@@ -123,6 +123,17 @@ describe('PoTextareaBase:', () => {
       const invalidValues = [null, undefined, '', 'string', {}, [], false, true];
       expectPropertiesValues(component, 'minlength', invalidValues, undefined);
     });
+
+    it('p-placeholder: should update property p-placeholder with valid value.', () => {
+      const validValues = ['Type your name', '1 number one'];
+
+      expectPropertiesValues(component, 'placeholder', validValues, validValues);
+    });
+
+    it('p-placeholder: should update property p-placeholder with empty value if set with invalid values.', () => {
+      const invalidValues = [null, undefined, '', 0, false];
+      expectPropertiesValues(component, 'placeholder', invalidValues, '');
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -28,6 +28,7 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
   private _disabled: boolean = false;
   private _maxlength: number;
   private _minlength: number;
+  private _placeholder: string = '';
   private _readonly: boolean = false;
   private _required: boolean = false;
   private _rows: number = 3;
@@ -58,7 +59,13 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
   @Input('p-help') help?: string;
 
   /** Placeholder, mensagem que aparecerá enquanto o campo não estiver preenchido. */
-  @Input('p-placeholder') placeholder?: string = '';
+  @Input('p-placeholder') set placeholder(value: string) {
+    this._placeholder = value || '';
+  }
+
+  get placeholder() {
+    return this._placeholder;
+  }
 
   /** Nome e Id do componente. */
   @Input('name') name: string;


### PR DESCRIPTION
**Textarea**

_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**


**Qual o novo comportamento?**
No componente textarea, caso informar um valor
inválido (falsy) no placeholder era exibido,
neste caso foi preciso realizar um tratamento
para caso dev informar invalido, utilizar valor em branco.

**Simulação**
```
<po-dynamic-form
  [p-fields]="fields"
  [p-value]="value"
></po-dynamic-form>
```

```
  fields = [
    { property: 'name', placeholder: 'Type your name' },
    { property: 'age' },
    { property: 'email', rows: 5 }
  ];
  
  value = {};
```