### PR TITLE
feat(table): cria método applyFilters

### DIFF
--- a/projects/ui/src/lib/components/po-table/interfaces/po-table-filtered-items-params.interface.ts
+++ b/projects/ui/src/lib/components/po-table/interfaces/po-table-filtered-items-params.interface.ts
@@ -11,6 +11,11 @@ export interface PoTableFilteredItemsParams {
   filter?: string;
 
   /**
+   * Objeto utilizado para filtros personalizados.
+   */
+  queryParams?: { [key: string]: string | number | boolean };
+
+  /**
    * Controla a paginação dos dados e recebe um valor automaticamente a cada clique no botão 'Carregar mais resultados'.
    */
   page?: number;

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -11,9 +11,9 @@ import { PoTableBaseComponent, poTableLiteralsDefault } from './po-table-base.co
 import { PoTableColumn } from './interfaces/po-table-column.interface';
 import { PoTableColumnSortType } from './enums/po-table-column-sort-type.enum';
 import { PoTableService } from './services/po-table.service';
-import { HttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { Observable, of } from 'rxjs';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 @Directive()
 class PoTableComponent extends PoTableBaseComponent {
@@ -32,13 +32,14 @@ describe('PoTableBaseComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      providers: [PoTableService, PoLanguageService, PoDateService]
+      providers: [PoTableService, PoLanguageService, PoDateService],
+      imports: [HttpClientTestingModule]
     });
   });
   beforeEach(() => {
     dateService = new PoDateService();
     languageService = new PoLanguageService();
-    tableService = new PoTableService(undefined);
+    tableService = TestBed.inject(PoTableService);
     component = new PoTableComponent(dateService, languageService, tableService);
 
     actions = [
@@ -466,6 +467,22 @@ describe('PoTableBaseComponent:', () => {
     ];
 
     const itemsColors = [{ destination: 'Paris' }, { country: 'Franch' }, { city: 'Lyon' }];
+
+    describe('initializeData:', () => {
+      it('getFilteredItems should be called when `p-service-api` is used', () => {
+        spyOn(component, 'getFilteredItems').and.returnValue(of({ items: [], hasNext: false }));
+        component.hasService = true;
+        component.initializeData();
+        expect(component.getFilteredItems).toHaveBeenCalled();
+      });
+
+      it('getFilteredItems should not be called when `p-service-api` is not used', () => {
+        spyOn(component, 'getFilteredItems').and.returnValue(of({ items: [], hasNext: false }));
+        component.hasService = false;
+        component.initializeData();
+        expect(component.getFilteredItems).not.toHaveBeenCalled();
+      });
+    });
 
     it('ngOnChanges: should call `calculateHeightTableContainer` if height is changed', () => {
       spyOn(component, 'calculateHeightTableContainer');
@@ -1120,8 +1137,8 @@ describe('PoTableBaseComponent:', () => {
       it('should return object with empty filter', () => {
         const page = 1;
         const pageSize = 10;
-        const filter = '';
-        const expectedValue = { filter, page, pageSize };
+        const filter = {};
+        const expectedValue = { page, pageSize };
 
         component.page = page;
         component.pageSize = pageSize;
@@ -1161,7 +1178,7 @@ describe('PoTableBaseComponent:', () => {
       it('should call and return an Observable', () => {
         const page = 1;
         const pageSize = 10;
-        const filter = '';
+        const filter = {};
 
         spyOn(component['poTableService'], <any>'getFilteredItems').and.returnValue(of({ items, hasNext: false }));
 

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -16,6 +16,8 @@ import { PoTableService } from './services/po-table.service';
 import { PoTableResponseApi } from './interfaces/po-table-response-api.interface';
 import { PoTableFilteredItemsParams } from './interfaces/po-table-filtered-items-params.interface';
 
+export type QueryParamsType = string | number | boolean;
+
 export const poTableContainer = ['border', 'shadow'];
 export const poTableContainerDefault = 'border';
 
@@ -466,8 +468,9 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   @Input('p-service-api') set serviceApi(service: string) {
     this._serviceApi = service;
     this.setService(this.serviceApi);
-    this.hasService = service && service !== '';
+    this.hasService = !!service;
     this.showMoreDisabled = !this.hasService;
+    this.initializeData();
   }
 
   get serviceApi() {
@@ -846,6 +849,15 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     return this.hasMainColumns ? this.mainColumns.every(column => column.width && column.width.includes('px')) : false;
   }
 
+  initializeData(params?: { [key: string]: QueryParamsType }): void {
+    if (this.hasService) {
+      this.loading = true;
+      this.getFilteredItems(params).subscribe(data => {
+        this.setTableResponseProperties(data);
+      });
+    }
+  }
+
   setTableResponseProperties(data: PoTableResponseApi) {
     this.items = data.items || [];
     this.showMoreDisabled = !data.hasNext;
@@ -858,25 +870,24 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     }
   }
 
-  getFilteredItems(filter?: string): Observable<PoTableResponseApi> {
-    const filteredParams: PoTableFilteredItemsParams = this.getFilteredParams(filter);
+  getFilteredItems(queryParams?: { [key: string]: QueryParamsType }): Observable<PoTableResponseApi> {
+    const filteredParams: PoTableFilteredItemsParams = this.getFilteredParams(queryParams);
 
     return this.poTableService.getFilteredItems(filteredParams);
   }
 
-  private getFilteredParams(filter?: string) {
+  private getFilteredParams(queryParams?: { [key: string]: QueryParamsType }) {
     const { page, pageSize, sortStore } = this;
 
     const filteredParams = {};
     const order = this.getOrderParam(sortStore);
-    const params = { filter, page, pageSize, order };
+    const params = { page, pageSize, order, ...queryParams };
 
     for (const key in params) {
       if (params.hasOwnProperty(key) && params[key] !== undefined) {
         filteredParams[key] = params[key];
       }
     }
-
     return filteredParams;
   }
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1548,11 +1548,11 @@ describe('PoTableComponent:', () => {
       expect(component.changeVisibleColumns.emit).toHaveBeenCalledWith(fakeColumns);
     });
 
-    describe('initializeData', () => {
+    describe('applyFilters', () => {
       it('should be called when `p-service-api` is used', () => {
         spyOn(component, 'getFilteredItems').and.returnValue(of({ items: [], hasNext: false }));
         component.hasService = true;
-        component['initializeData']();
+        component.applyFilters({});
         expect(component.getFilteredItems).toHaveBeenCalled();
       });
     });

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -13,19 +13,18 @@ import {
   ViewChildren,
   ViewContainerRef,
   ContentChildren,
-  TemplateRef,
-  OnInit
+  TemplateRef
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { Router } from '@angular/router';
 
-import { convertToBoolean, isTypeof } from '../../utils/util';
+import { convertToBoolean } from '../../utils/util';
 import { PoDateService } from '../../services/po-date/po-date.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { PoPopupComponent } from '../po-popup/po-popup.component';
 
 import { PoTableAction } from './interfaces/po-table-action.interface';
-import { PoTableBaseComponent } from './po-table-base.component';
+import { PoTableBaseComponent, QueryParamsType } from './po-table-base.component';
 import { PoTableColumn } from './interfaces/po-table-column.interface';
 import { PoTableColumnLabel } from './po-table-column-label/po-table-column-label.interface';
 import { PoTableRowTemplateDirective } from './po-table-row-template/po-table-row-template.directive';
@@ -83,7 +82,7 @@ import { PoTableService } from './services/po-table.service';
   templateUrl: './po-table.component.html',
   providers: [PoDateService]
 })
-export class PoTableComponent extends PoTableBaseComponent implements OnInit, AfterViewInit, DoCheck, OnDestroy {
+export class PoTableComponent extends PoTableBaseComponent implements AfterViewInit, DoCheck, OnDestroy {
   private _columnManagerTarget: ElementRef;
 
   heightTableContainer: number;
@@ -221,10 +220,6 @@ export class PoTableComponent extends PoTableBaseComponent implements OnInit, Af
     this.initialized = true;
   }
 
-  ngOnInit() {
-    this.initializeData();
-  }
-
   ngDoCheck() {
     this.checkChangesItems();
     this.verifyCalculateHeightTableContainer();
@@ -238,6 +233,28 @@ export class PoTableComponent extends PoTableBaseComponent implements OnInit, Af
 
   ngOnDestroy() {
     this.removeListeners();
+  }
+
+  /**
+   * Método responsável por realizar busca no serviço de dados podendo informar filtros e com o retorno, atualiza a tabela.
+   *
+   * Caso não seja informado parâmetro, nada será adicionado ao GET, conforme abaixo:
+   * ```
+   * url + ?page=1&pageSize=10
+   * ```
+   * > Obs: os parâmetros `page` e `pageSize` sempre serão chamados independente de ser enviados outros parâmetros.
+   *
+   * Caso sejam informados os parâmetros `{ name: 'JOHN', age: '23' }`, todos serão adicionados ao GET, conforme abaixo:
+   * ```
+   * url + ?page=1&pageSize=10&name=JOHN&age=23
+   * ```
+   *
+   * @param { { key: value } } queryParams Formato do objeto a ser enviado.
+   * > Pode ser utilizada qualquer string como key, e qualquer string ou number como value.
+   */
+  applyFilters(queryParams?: { [key: string]: QueryParamsType }) {
+    this.page = 1;
+    this.initializeData(queryParams);
   }
 
   /**
@@ -538,14 +555,5 @@ export class PoTableComponent extends PoTableBaseComponent implements OnInit, Af
       return null;
     }
     return template.templateRef;
-  }
-
-  private initializeData(): void {
-    if (this.hasService) {
-      this.loading = true;
-      this.getFilteredItems().subscribe(data => {
-        this.setTableResponseProperties(data);
-      });
-    }
   }
 }

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.html
@@ -1,6 +1,48 @@
-<po-table
-  p-service-api="https://po-sample-api.herokuapp.com/v1/people"
-  [p-height]="400"
-  [p-columns]="[{ property: 'id' }, { property: 'nickname' }, { property: 'name' }, { property: 'email' }]"
->
-</po-table>
+<div class="po-row">
+  <po-input
+    class="po-md-12"
+    p-label="URL API service"
+    p-help="https://po-sample-api.herokuapp.com/v1/heroes"
+    [(ngModel)]="service"
+    (p-change)="changeService(service)"
+  >
+  </po-input>
+</div>
+<div class="po-row">
+  <po-divider class="po-md-12" p-label="Columns"></po-divider>
+  <po-textarea
+    class="po-md-12"
+    p-label="Columns"
+    p-help="[{ property: 'name' }]"
+    [(ngModel)]="stringColumns"
+    [p-rows]="5"
+    (p-change)="onChangeColumns($event)"
+  >
+  </po-textarea>
+</div>
+<div class="po-row">
+  <po-divider class="po-md-12" p-label="Filters"></po-divider>
+  <po-input class="po-md-6" p-label="Key" p-help="Object key" [(ngModel)]="key"></po-input>
+  <po-input class="po-md-6" p-label="Value" p-help="Object value" [(ngModel)]="value"></po-input>
+</div>
+<div class="po-row">
+  <po-button
+    class="po-md-3"
+    p-label="Add Filter"
+    (p-click)="addFilter(key, value)"
+    [p-disabled]="!key || !value"
+  ></po-button>
+</div>
+<div class="po-row">
+  <po-disclaimer-group
+    class="po-mt-1 po-md-12"
+    [p-disclaimers]="filters"
+    (p-remove)="removeItem($event)"
+    (p-remove-all)="removeAllItems()"
+  >
+  </po-disclaimer-group>
+</div>
+<div class="po-row">
+  <po-table class="po-mt-1 po-md-12" #table [p-columns]="columns" [p-service-api]="sampleService" [p-height]="400">
+  </po-table>
+</div>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.ts
@@ -1,7 +1,73 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { PoDisclaimerGroupRemoveAction, PoDisclaimer, PoTableComponent, PoTableColumn } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-table-with-api',
   templateUrl: './sample-po-table-with-api.component.html'
 })
-export class SamplePoTableWithApiComponent {}
+export class SamplePoTableWithApiComponent {
+  @ViewChild('table') tableComponent: PoTableComponent;
+
+  service = '';
+  key: string;
+  value: string;
+  sampleService = '';
+  params: {};
+  filters: Array<PoDisclaimer> = [];
+  columns: Array<PoTableColumn> = [{ property: 'id' }, { property: 'name' }];
+  stringColumns: string = JSON.stringify(this.columns);
+
+  private defaultColumns: Array<PoTableColumn> = [...this.columns];
+
+  addFilter(property: string, value: any) {
+    this.params = { ...this.params, [property]: value };
+
+    this.setFilters(property, value);
+
+    this.tableComponent.applyFilters(this.params);
+
+    this.resetInputs();
+  }
+
+  changeService(service) {
+    this.sampleService = service;
+  }
+
+  onChangeColumns(columns) {
+    try {
+      this.columns = JSON.parse(columns);
+    } catch (e) {
+      this.stringColumns = JSON.stringify(this.defaultColumns);
+      this.columns = [...this.defaultColumns];
+    }
+  }
+
+  removeAllItems() {
+    this.tableComponent.applyFilters({});
+  }
+
+  removeItem(item: PoDisclaimerGroupRemoveAction) {
+    delete this.params[item.removedDisclaimer.property];
+    this.tableComponent.applyFilters(this.params);
+  }
+
+  private resetInputs() {
+    this.key = undefined;
+    this.value = undefined;
+  }
+
+  private setFilters(property: string, value: string) {
+    let filter = this.filters.find(item => item.property === property);
+    if (!filter) {
+      filter = <any>{ property: property };
+    } else {
+      this.filters.splice(this.filters.indexOf(filter), 1);
+      filter = Object.assign({}, filter);
+    }
+
+    filter.value = value;
+    filter.label = `${property.charAt(0).toUpperCase() + property.slice(1)}: ${value}`;
+
+    this.filters = [...this.filters, filter];
+  }
+}


### PR DESCRIPTION
Adiciona método para filtrar dados quando utiliza a `po-table` com uma service.

Fixes DTHFUI-4949

**TABLE**

**DTHFUI-4949**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não é possível utilizar filtros quando está usando a `po-table` utilizando uma service.

**Qual o novo comportamento?**
Ao se passar um objeto do formado `{ [ key: string ]: value: string | number }` deve ser adicionado nos parâmetros do GET da service.

**Simulação**
Utilizar o sample `Sample PO Table with API` do Portal.