### PR TITLE
feat(datepicker-range): adiciona calendário para selecionar a data

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar-header/po-calendar-header.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-header/po-calendar-header.component.html
@@ -6,7 +6,7 @@
   >
   </span>
 
-  <div class="po-calendar-header-title">
+  <div class="po-calendar-header-title" attr-calendar>
     <ng-content></ng-content>
   </div>
 

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
@@ -2,7 +2,7 @@
   <ng-container *ngIf="isDayVisible">
     <po-calendar-header
       [p-hide-previous]="isEndPart"
-      [p-hide-next]="isStartPart"
+      [p-hide-next]="isStartPart && !responsive"
       (p-previous)="onPreviousMonth()"
       (p-next)="onNextMonth()"
     >
@@ -23,6 +23,7 @@
           class="po-calendar-day"
           [ngClass]="getDayBackgroundColor(day)"
           (click)="onSelectDate(day)"
+          attr-calendar
         >
           <span *ngIf="day != 0" [ngClass]="getDayForegroundColor(day)">
             {{ day.getDate() }}
@@ -51,6 +52,7 @@
           class="po-calendar-month"
           [ngClass]="getBackgroundColor(i, displayMonthNumber)"
           (click)="onSelectMonth(displayYear, i)"
+          attr-calendar
         >
           <span [ngClass]="getForegroundColor(i, displayMonthNumber)">
             {{ month }}

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.ts
@@ -52,6 +52,8 @@ export class PoCalendarWrapperComponent implements OnInit, OnChanges {
 
   @Input('p-mode') mode: 'day' | 'month' | 'year' = 'day';
 
+  @Input('p-responsive') responsive: boolean = false;
+
   @Input('p-part-type') partType: 'start' | 'end';
 
   @Input('p-range') range: boolean = false;

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.html
@@ -3,10 +3,11 @@
 <ng-template #rangeTemplate>
   <div class="po-calendar-range">
     <ng-container *ngTemplateOutlet="calendarWrapper; context: { partType: 'start' }"></ng-container>
-    <ng-container *ngTemplateOutlet="calendarWrapper; context: { partType: 'end' }"></ng-container>
+    <ng-container *ngIf="!isResponsive">
+      <ng-container *ngTemplateOutlet="calendarWrapper; context: { partType: 'end' }"></ng-container>
+    </ng-container>
   </div>
 </ng-template>
-
 <ng-template #calendarTemplate>
   <div class="po-calendar">
     <ng-template [ngTemplateOutlet]="calendarWrapper"></ng-template>
@@ -22,6 +23,7 @@
     [p-max-date]="maxDate"
     [p-part-type]="partType"
     [p-range]="isRange"
+    [p-responsive]="isResponsive"
     [p-selected-value]="value"
     (p-header-change)="onHeaderChange($event, partType)"
     (p-select-date)="onSelectDate($event, partType)"

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
@@ -492,5 +492,23 @@ describe('PoCalendarComponent:', () => {
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-calendar')).toBeTruthy();
     });
+
+    it('should show 1 po-calendar-wrapper if isResponsive is true and mode is range', () => {
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+      spyOnProperty(component, 'isResponsive').and.returnValue(true);
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelectorAll('po-calendar-wrapper').length).toBe(1);
+    });
+
+    it('should show 2 po-calendar-wrapper if isResponsive is false and mode is range', () => {
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+      spyOnProperty(component, 'isResponsive').and.returnValue(false);
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelectorAll('po-calendar-wrapper').length).toBe(2);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
@@ -22,6 +22,8 @@ const providers = [
   }
 ];
 
+const poCalendarRangeWidth = 600;
+
 /**
  * @docsExtends PoCalendarBaseComponent
  *
@@ -51,6 +53,10 @@ const providers = [
 export class PoCalendarComponent extends PoCalendarBaseComponent implements OnInit {
   constructor(private changeDetector: ChangeDetectorRef, poDate: PoDateService, languageService: PoLanguageService) {
     super(poDate, languageService);
+  }
+
+  get isResponsive() {
+    return window.innerWidth < poCalendarRangeWidth;
   }
 
   ngOnInit() {
@@ -169,7 +175,7 @@ export class PoCalendarComponent extends PoCalendarBaseComponent implements OnIn
   }
 
   private convertDateFromIso(stringDate: string) {
-    if (typeof stringDate === 'string') {
+    if (stringDate && typeof stringDate === 'string') {
       const { year, month, day } = this.poDate.getDateFromIso(stringDate);
       const date = new Date(year, month - 1, day);
       this.poDate.setYearFrom0To100(date, year);

--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -46,4 +46,6 @@ export * from './po-upload/po-upload.component';
 export * from './po-url/po-url.component';
 
 export * from './po-checkbox-group/po-checkbox-group.module';
+export * from './po-datepicker/po-datepicker.module';
+
 export * from './po-field.module';

--- a/projects/ui/src/lib/components/po-field/po-clean/po-clean.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-clean/po-clean.module.ts
@@ -1,0 +1,16 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { PoCleanComponent } from './po-clean.component';
+
+/**
+ * @description
+ *
+ * Módulo do componente `po-clean`.
+ */
+@NgModule({
+  imports: [CommonModule],
+  exports: [PoCleanComponent],
+  declarations: [PoCleanComponent]
+})
+export class PoCleanModule {}

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -70,7 +70,8 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   private onChangeModel: any;
   private validatorChange: any;
 
-  protected dateRange: PoDatepickerRange = { start: '', end: '' };
+  dateRange: PoDatepickerRange = { start: '', end: '' };
+
   protected format: any = 'dd/mm/yyyy';
   protected isDateRangeInputFormatValid: boolean = true;
   protected isStartDateRangeInputValid: boolean = true;

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
@@ -43,10 +43,22 @@
     </div>
 
     <div class="po-datepicker-range-icon">
-      <span class="po-icon po-field-icon po-icon-calendar" [class.po-field-icon-disabled]="disabled || readonly">
+      <span
+        #iconCalendar
+        class="po-icon po-field-icon po-icon-calendar"
+        [class.po-clickable]="!disabled && !readonly"
+        [class.po-field-icon-disabled]="disabled || readonly"
+        (click)="toggleCalendar()"
+      >
       </span>
     </div>
   </div>
 
   <po-field-container-bottom [p-error-pattern]="getErrorMessage"></po-field-container-bottom>
 </po-field-container>
+
+<ng-container *ngIf="isCalendarVisible">
+  <div #calendarPicker class="po-calendar-range-picker">
+    <po-calendar p-mode="range" [ngModel]="dateRange" (ngModelChange)="onCalendarChange($event)"></po-calendar>
+  </div>
+</ng-container>

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -17,6 +17,8 @@ import { PoDatepickerIsoFormat } from './enums/po-datepicker-iso-format.enum';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
 
+import { PoDatepickerModule } from './po-datepicker.module';
+
 function keyboardEvents(event: string, keyCode: number) {
   const eventKeyBoard = document.createEvent('KeyboardEvent');
   eventKeyBoard.initEvent(event, true, true);
@@ -30,13 +32,7 @@ describe('PoDatepickerComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        PoDatepickerComponent,
-        PoFieldContainerComponent,
-        PoCleanComponent,
-        PoCalendarComponent,
-        PoFieldContainerBottomComponent
-      ],
+      imports: [PoDatepickerModule],
       providers: [PoCalendarService, PoCalendarLangService]
     });
   });
@@ -259,15 +255,8 @@ describe('PoDatepicker mocked with form', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule],
-      declarations: [
-        ContentProjectionComponent,
-        PoDatepickerComponent,
-        PoFieldContainerComponent,
-        PoCleanComponent,
-        PoCalendarComponent,
-        PoFieldContainerBottomComponent
-      ],
+      imports: [PoDatepickerModule],
+      declarations: [ContentProjectionComponent],
       providers: [PoCalendarService, PoCalendarLangService]
     });
   });
@@ -295,13 +284,7 @@ describe('PoDatepickerComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        PoDatepickerComponent,
-        PoFieldContainerComponent,
-        PoCleanComponent,
-        PoCalendarComponent,
-        PoFieldContainerBottomComponent
-      ],
+      imports: [PoDatepickerModule],
       providers: [PoCalendarService, PoCalendarLangService]
     });
   });

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.module.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { PoFieldContainerModule } from '../po-field-container/po-field-container.module';
+import { PoCleanModule } from '../po-clean/po-clean.module';
+
+import { PoCalendarComponent } from './po-calendar/po-calendar.component';
+import { PoDatepickerComponent } from './po-datepicker.component';
+
+/**
+ * @description
+ *
+ * Módulo do componente `po-datepicker`.
+ */
+@NgModule({
+  imports: [CommonModule, FormsModule, PoFieldContainerModule, PoCleanModule],
+  exports: [PoDatepickerComponent],
+  declarations: [PoDatepickerComponent, PoCalendarComponent]
+})
+export class PoDatepickerModule {}

--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -7,6 +7,9 @@ import { PoButtonGroupModule } from '../po-button-group/index';
 import { PoButtonModule } from '../po-button/index';
 import { PoCheckboxGroupModule } from './po-checkbox-group/po-checkbox-group.module';
 import { PoContainerModule } from '../po-container/index';
+import { PoCalendarModule } from '../po-calendar/po-calendar.module';
+import { PoCleanModule } from './po-clean/po-clean.module';
+import { PoDatepickerModule } from './po-datepicker/po-datepicker.module';
 import { PoDisclaimerGroupModule } from './../po-disclaimer-group/po-disclaimer-group.module';
 import { PoDisclaimerModule } from './../po-disclaimer/po-disclaimer.module';
 import { PoFieldContainerModule } from './po-field-container/po-field-container.module';
@@ -18,8 +21,6 @@ import { PoTableModule } from '../po-table/po-table.module';
 import { PoTooltipModule } from './../../directives/po-tooltip/po-tooltip.module';
 import { PoIconModule } from '../po-icon/po-icon.module';
 
-import { PoCalendarComponent } from './po-datepicker/po-calendar/po-calendar.component';
-import { PoCleanComponent } from './po-clean/po-clean.component';
 import { PoCheckboxComponent } from './po-checkbox/po-checkbox.component';
 import { PoComboComponent } from './po-combo/po-combo.component';
 import { PoComboOptionTemplateDirective } from './po-combo/po-combo-option-template/po-combo-option-template.directive';
@@ -72,8 +73,11 @@ import { PoUrlComponent } from './po-url/po-url.component';
     HttpClientModule,
     PoButtonGroupModule,
     PoButtonModule,
+    PoCleanModule,
+    PoCalendarModule,
     PoCheckboxGroupModule,
     PoContainerModule,
+    PoDatepickerModule,
     PoDisclaimerGroupModule,
     PoDisclaimerModule,
     PoFieldContainerModule,
@@ -86,13 +90,13 @@ import { PoUrlComponent } from './po-url/po-url.component';
     PoIconModule
   ],
   exports: [
-    PoCheckboxComponent,
     PoCheckboxGroupModule,
-    PoCleanComponent,
+    PoCleanModule,
+    PoDatepickerModule,
+    PoCheckboxComponent,
     PoComboComponent,
     PoComboOptionTemplateDirective,
     PoDecimalComponent,
-    PoDatepickerComponent,
     PoDatepickerRangeComponent,
     PoEmailComponent,
     PoFieldContainerModule,
@@ -113,13 +117,10 @@ import { PoUrlComponent } from './po-url/po-url.component';
     PoUrlComponent
   ],
   declarations: [
-    PoCalendarComponent,
-    PoCleanComponent,
     PoCheckboxComponent,
     PoComboComponent,
     PoComboOptionTemplateDirective,
     PoDecimalComponent,
-    PoDatepickerComponent,
     PoDatepickerRangeComponent,
     PoEmailComponent,
     PoInputComponent,


### PR DESCRIPTION
**< DATEPICKER RANGE >**

**<DTHFUI-1855>**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Não tinha calendario para auxiliar a seleção de datas

**Qual o novo comportamento?**
Adiciona o calendario para auxiliar na seleção de datas

[**PR STYLE**](https://github.com/po-ui/po-style/pull/221)

**Simulação**
npm run build:portal
ng serve portal

```
range;

<po-datepicker-range p-label="Range Picker" class="po-md-12" name="range" [(ngModel)]="range">
</po-datepicker-range> 
```