### PR TITLE
fix(menu): corrige item de menu que não estava ativando

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
@@ -509,6 +509,16 @@ describe('PoMenuComponent:', () => {
     expect(component['itemSubscription'].unsubscribe).toHaveBeenCalled();
   });
 
+  it('routeSubscription: should `unsubscribe` `routeSubscription` on destroy.', () => {
+    component['routeSubscription'] = <any>{ unsubscribe: () => {} };
+
+    spyOn(component['routeSubscription'], <any>'unsubscribe');
+
+    component.ngOnDestroy();
+
+    expect(component['routeSubscription'].unsubscribe).toHaveBeenCalled();
+  });
+
   it('should set menu item not found with `literals.itemNotFound`.', () => {
     component.noData = true;
 
@@ -820,12 +830,14 @@ describe('PoMenuComponent:', () => {
   });
 
   describe('Methods:', () => {
-    it(`ngOnInit: should call 'subscribeToMenuItem'`, () => {
+    it(`ngOnInit: should call 'subscribeToMenuItem' and 'subscribeToRoute'`, () => {
       spyOn(component, 'subscribeToMenuItem');
+      spyOn(component, 'subscribeToRoute');
 
       component.ngOnInit();
 
       expect(component['subscribeToMenuItem']).toHaveBeenCalled();
+      expect(component['subscribeToRoute']).toHaveBeenCalled();
     });
 
     it(`ngAfterViewInit: should call 'menuGlobalService.sendApplicationMenu' with component instance`, () => {

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.ts
@@ -10,7 +10,7 @@ import {
   Renderer2
 } from '@angular/core';
 
-import { Router } from '@angular/router';
+import { NavigationCancel, NavigationEnd, Router } from '@angular/router';
 
 import { map } from 'rxjs/operators';
 import { Subscription } from 'rxjs';
@@ -136,6 +136,7 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
   private resizeListener: () => void;
 
   private itemSubscription: Subscription;
+  private routeSubscription: Subscription;
 
   constructor(
     public changeDetector: ChangeDetectorRef,
@@ -185,6 +186,7 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
 
   ngOnDestroy() {
     this.itemSubscription.unsubscribe();
+    this.routeSubscription.unsubscribe();
 
     if (this.resizeListener) {
       this.resizeListener();
@@ -195,6 +197,7 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
 
   ngOnInit() {
     this.subscribeToMenuItem();
+    this.subscribeToRoute();
   }
 
   ngAfterViewInit() {
@@ -256,6 +259,15 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
   subscribeToMenuItem() {
     this.itemSubscription = this.menuItemsService.receiveFromChildMenuClicked().subscribe((menu: PoMenuItem) => {
       this.clickMenuItem(menu);
+    });
+  }
+
+  subscribeToRoute() {
+    this.routeSubscription = this.router.events.subscribe(val => {
+      if (val instanceof NavigationEnd || val instanceof NavigationCancel) {
+        const urlRouter = this.checkingRouterChildrenFragments();
+        this.checkActiveMenuByUrl(urlRouter);
+      }
     });
   }
 


### PR DESCRIPTION
**MENU**

**DTHFUI-5058, #852**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Em rotas com menu dinâmico o componente estava ativando o menu item corretamente, porém em redirecionamentos e estrutura mais simples não estava ativando corretamente


**Qual o novo comportamento?**
Ativa o menu item conforme a rota da aplicação.

**Simulação**
1. Estrutura dinâmica:
- npm run build:portal && ng serve portal

2. Projeto com menu estatico:
3. Redirecionamentos (Mesmo projeto porem as rotas estão comentadas)
[app.zip](https://github.com/po-ui/po-angular/files/6717898/app.zip)

