### PR TITLE
feat(toolbar): permite uso outras fontes de icones na prop actionsIcon

### DIFF
--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-actions/po-toolbar-actions.component.html
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-actions/po-toolbar-actions.component.html
@@ -1,5 +1,7 @@
-<div class="po-toolbar-actions po-clickable" (click)="popup.toggle()">
-  <span #toolbarActions class="po-icon {{ actionsIcon }} po-toolbar-icon"></span>
+<div class="po-toolbar-actions" (click)="popup.toggle()">
+  <span #toolbarActions>
+    <po-icon class="po-toolbar-icon po-clickable" [p-icon]="actionsIcon"></po-icon>
+  </span>
 </div>
 
 <po-popup #popup [p-actions]="actions" [p-target]="toolbarActions"> </po-popup>

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-actions/po-toolbar-actions.component.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-actions/po-toolbar-actions.component.ts
@@ -1,7 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, TemplateRef } from '@angular/core';
 
 import { isTypeof } from '../../../utils/util';
-import { PoControlPositionService } from '../../../services/po-control-position/po-control-position.service';
 
 import { PoToolbarAction } from '../po-toolbar-action.interface';
 
@@ -18,18 +17,17 @@ const poToolbarActionsIconDefault = 'po-icon-more';
  */
 @Component({
   selector: 'po-toolbar-actions',
-  templateUrl: './po-toolbar-actions.component.html',
-  providers: [PoControlPositionService]
+  templateUrl: './po-toolbar-actions.component.html'
 })
 export class PoToolbarActionsComponent {
-  private _actionsIcon?: string = poToolbarActionsIconDefault;
+  private _actionsIcon?: string | TemplateRef<void> = poToolbarActionsIconDefault;
 
   /** Define uma lista de ações. */
   @Input('p-actions') actions?: Array<PoToolbarAction>;
 
   /** Define o ícone das ações. */
-  @Input('p-actions-icon') set actionsIcon(icon: string) {
-    this._actionsIcon = isTypeof(icon, 'string') ? icon : poToolbarActionsIconDefault;
+  @Input('p-actions-icon') set actionsIcon(icon: string | TemplateRef<void>) {
+    this._actionsIcon = isTypeof(icon, 'string') || icon instanceof TemplateRef ? icon : poToolbarActionsIconDefault;
   }
 
   get actionsIcon() {

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-base.component.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-base.component.ts
@@ -1,4 +1,4 @@
-import { Input, Directive } from '@angular/core';
+import { Input, Directive, TemplateRef } from '@angular/core';
 
 import { convertToInt } from '../../utils/util';
 
@@ -30,11 +30,29 @@ export class PoToolbarBaseComponent {
    *
    * Define um [ícone](/guides/icons) para a propriedade `p-actions`.
    *
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-toolbar p-actions-icon="po-icon-user" [p-actions]="actions"></po-toolbar>
+   * ```
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
+   * ```
+   * <po-toolbar p-actions-icon="far fa-comment-alt" [p-actions]="actions"></po-toolbar>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-toolbar [p-actions-icon]="template" [p-actions]="actions"></po-toolbar>
+   *
+   * <ng-template #template>
+   *  <ion-icon style="font-size: inherit" name="heart"></ion-icon>
+   * </ng-template>
+   * ```
+   * > Para o ícone enquadrar corretamente, deve-se utilizar `font-size: inherit` caso o ícone utilizado não aplique-o.
+   *
    * > Caso não haja ações definidas em `p-actions`, o ícone não será exibido.
    *
    * @default `po-icon-more`
    */
-  @Input('p-actions-icon') actionsIcon?: string;
+  @Input('p-actions-icon') actionsIcon?: string | TemplateRef<void>;
 
   /** Define o objeto que será o cabeçalho da lista de ações com as informações do perfil. */
   @Input('p-profile') profile?: PoToolbarProfile;

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar.module.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { PoAvatarModule } from './../po-avatar/po-avatar.module';
+import { PoIconModule } from './../po-icon/po-icon.module';
 import { PoPopupModule } from '../po-popup/po-popup.module';
 import { PoToolbarActionsComponent } from './po-toolbar-actions/po-toolbar-actions.component';
 import { PoToolbarComponent } from './po-toolbar.component';
@@ -15,7 +16,7 @@ import { PoToolbarProfileComponent } from './po-toolbar-profile/po-toolbar-profi
  *
  */
 @NgModule({
-  imports: [CommonModule, PoAvatarModule, PoPopupModule],
+  imports: [CommonModule, PoAvatarModule, PoPopupModule, PoIconModule],
   declarations: [
     PoToolbarActionsComponent,
     PoToolbarComponent,

--- a/projects/ui/src/lib/components/po-toolbar/samples/sample-po-toolbar-labs/sample-po-toolbar-labs.component.ts
+++ b/projects/ui/src/lib/components/po-toolbar/samples/sample-po-toolbar-labs/sample-po-toolbar-labs.component.ts
@@ -36,16 +36,15 @@ export class SamplePoToolbarLabsComponent implements OnInit {
     { value: 'po-icon-exit', label: 'po-icon-exit' },
     { value: 'po-icon-lock', label: 'po-icon-lock' },
     { value: 'fa fa-calculator', label: 'fa fa-calculator' },
-    { value: 'fa fa-podcast', label: 'fa fa-podcast' }
+    { value: 'far fa-comment-alt', label: 'far fa-comment-alt' }
   ];
 
   public readonly actionsIconOptions: Array<PoSelectOption> = [
-    { value: 'po-icon-chat', label: 'po-icon-chat' },
     { value: 'po-icon-clock', label: 'po-icon-clock' },
     { value: 'po-icon-exit', label: 'po-icon-exit' },
     { value: 'po-icon-lock', label: 'po-icon-lock' },
     { value: 'po-icon-settings', label: 'po-icon-settings' },
-    { value: 'po-icon-star', label: 'po-icon-star' }
+    { value: 'far fa-comment-alt', label: 'far fa-comment-alt' }
   ];
 
   public readonly toolbarActionTypes: Array<PoRadioGroupOption> = [


### PR DESCRIPTION
**TOOLBAR**

**DTHFUI-5057**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**


**Qual o novo comportamento?**
Permite icones de outras fontes na proprieade p-actions-icon.

[**PR STYLE**](https://github.com/po-ui/po-style/pull/224)

**Simulação**
npm run build:portal && ng serve portal

```
    <link
      rel="stylesheet"
      href="https://use.fontawesome.com/releases/v5.3.1/css/all.css"
      integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU"
      crossorigin="anonymous"
    />
    <link href="https://fonts.googleapis.com/css2?family=Material+Icons" rel="stylesheet">
    <script src="https://unpkg.com/ionicons@5.4.0/dist/ionicons.js"></script>
```
```
<po-toolbar p-title="PO ICON" [p-actions]="actions" [p-notification-actions]="actions">
</po-toolbar>

<hr>

<po-toolbar p-title="ION ICON" [p-actions-icon]="icontemplate" [p-actions]="actions" [p-notification-actions]="actions">
</po-toolbar>

<ng-template #icontemplate>
  <ion-icon style="font-size: inherit;" name="heart"></ion-icon>
</ng-template>

<hr>

<po-toolbar p-title="MATERIAL ICON" [p-actions-icon]="iconetemplate" [p-actions]="actions" [p-notification-actions]="actions">
</po-toolbar>

<ng-template #iconetemplate>
  <span class="material-icons" style="font-size: inherit;">trending_up</span>
</ng-template>

<hr>

<po-toolbar p-title="FA ICON" p-actions-icon="far fa-calendar-alt" [p-actions]="actions" [p-notification-actions]="actions">
</po-toolbar>
```
```
  actions: Array<any> = [
    { label: 'Start cash register', action: item => this.showAction(item) },
    { label: 'Finalize cash register', action: item => this.showAction(item) },
    { label: 'Cash register options', action: item => this.showAction(item) }
  ];
```