### PR TITLE
feat(list-view): adiciona compatibilidade com outras fontes de ícones

### DIFF
--- a/projects/ui/src/lib/components/po-list-view/interfaces/po-list-view-action.interface.ts
+++ b/projects/ui/src/lib/components/po-list-view/interfaces/po-list-view-action.interface.ts
@@ -1,71 +1,15 @@
+import { PoPopupAction } from '../../po-popup/po-popup-action.interface';
+
 /**
- * @usedBy PoListViewComponent
- *
  * @description
  *
  * Interface que define as ações do componente `po-list-view`.
+ *
+ * > As propriedades `separator`, `url` e `selected` serão vistas a partir da terceira ação e somente quando
+ * definir quatro ações ou mais.
+ *
+ * @docsExtends PoPopupAction
+ *
+ * @usedBy PoListViewComponent
  */
-export interface PoListViewAction {
-  /** Rótulo da ação. */
-  label: string;
-
-  /** Ação que será executada, sendo possível passar o nome ou a referência da função. */
-  action?: Function;
-
-  /**
-   * @description
-   *
-   * Ícone que será exibido ao lado esquerdo do rótulo.
-   *
-   * > Veja os valores válidos na [Biblioteca de ícones](/guides/icons).
-   */
-  icon?: string;
-
-  /**
-   * Atribui uma linha separadora acima do item.
-   *
-   * > Pode ser utilizado apenas com 3 ou mais ações.
-   */
-  separator?: boolean;
-
-  /**
-   * Função que deve retornar um booleano para habilitar ou desabilitar a ação para o registro selecionado.
-   *
-   * Também é possível informar diretamente um valor booleano que vai habilitar ou desabilitar a ação para todos os registros.
-   */
-  disabled?: boolean | Function;
-
-  /**
-   * @description
-   *
-   * Define a cor do item, sendo `default` o padrão.
-   *
-   * Valores válidos:
-   *  - `default`
-   *  - `danger`
-   */
-  type?: string;
-
-  /**
-   * URL utilizada no redirecionamento das páginas.
-   *
-   * > Pode ser utilizado apenas com 3 ou mais ações.
-   */
-  url?: string;
-
-  /**
-   * Define se a ação está selecionada.
-   *
-   * > Pode ser utilizado apenas com 3 ou mais ações.
-   */
-  selected?: boolean;
-
-  /**
-   * @description
-   *
-   * Define se a ação será visível.
-   *
-   * > Caso o valor não seja especificado a ação será visível.
-   */
-  visible?: boolean;
-}
+export interface PoListViewAction extends PoPopupAction {}

--- a/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-labs/sample-po-list-view-labs.component.ts
+++ b/projects/ui/src/lib/components/po-list-view/samples/sample-po-list-view-labs/sample-po-list-view-labs.component.ts
@@ -41,7 +41,9 @@ export class SamplePoListViewLabsComponent implements OnInit {
   readonly iconOptions: Array<PoSelectOption> = [
     { value: 'po-icon-news', label: 'po-icon-news' },
     { value: 'po-icon-search', label: 'po-icon-search' },
-    { value: 'po-icon-world', label: 'po-icon-world' }
+    { value: 'po-icon-world', label: 'po-icon-world' },
+    { value: 'fa fa-calculator', label: 'fa fa-calculator' },
+    { value: 'fa fa-podcast', label: 'fa fa-podcast' }
   ];
 
   readonly propertyTitleOptions: Array<PoSelectOption> = [


### PR DESCRIPTION
**PO-LIST-VIEW**

**DTHFUI-5055**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Hoje a documentação da interface PoListViewAction sobrescreve a interface PoPopupAction e isso está impedindo que o list-view utilize a funcionalidade de permitir outras fontes de ícones por não estender a interface.

**Qual o novo comportamento?**
Estende a interface PoPopupAction, possibilitando a utilização de outras fontes de ícones.

**Simulação**
Verificar documentação no portal e utilizar o sample labs com os ícones do Font Awesome.