### PR TITLE
Removida classe .po-clickable do link

### DIFF
--- a/projects/ui/src/lib/components/po-button/po-button.component.html
+++ b/projects/ui/src/lib/components/po-button/po-button.component.html
@@ -6,7 +6,6 @@
   [class.po-button-link]="type === 'link'"
   [class.po-button-primary]="type === 'primary'"
   [class.po-button-sm]="small"
-  [class.po-clickable]="type === 'link'"
   [disabled]="disabled || loading"
   (click)="onClick()"
 >


### PR DESCRIPTION
A classe .po-clickable obrigava o cursor pointer até mesmo no modo disabled, onde a ação de clique não está disponível.

**po-button**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A classe .po-clickable aplica o cursor pointer como !important

**Qual o novo comportamento?**
Removida a classe pois a trativa de cursor já é feita via css

**Simulação**
Adicionar po-button do tipo link como o modo disable true. É possível verificar que o cursor mantêm-se como pointer.
