### PR TITLE
feat(menu): adiciona compatibilidade com outras fontes de ícones

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu-item.interface.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item.interface.ts
@@ -1,3 +1,4 @@
+import { TemplateRef } from '@angular/core';
 import { PoMenuItemBadge } from './po-menu-item/po-menu-item-badge.interface';
 
 /**
@@ -32,11 +33,45 @@ export interface PoMenuItem {
   action?: Function;
 
   /**
-   * Ícone para o item de menu, os [ícones aceitos](/guides/icons) são os definidos no guia de estilo da PO.
-   * São exibidos apenas no primeiro nível de menu e serão visíveis apenas se todos os itens de primeiro nível possuírem ícones.
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-menu
+   *  [p-menus]="[{ link: '/', label: 'PO ICON', icon: 'po-icon-news' }]">
+   * </po-menu>
+   * ```
+   *
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
+   * ```
+   * <po-menu
+   *  [p-menus]="[{ link: '/', label: 'FA ICON', icon: 'fa fa-podcast' }]">
+   * </po-menu>
+   * ```
+   *
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * component.html:
+   * ```
+   * <ng-template #iconTemplate>
+   *   <ion-icon name="heart"></ion-icon>
+   * </ng-template>
+   *
+   * <po-menu [p-menus]="myProperty"></po-menu>
+   * ```
+   * component.ts:
+   * ```
+   * @ViewChild('iconTemplate', { static: true } ) iconTemplate : TemplateRef<void>;
+   *
+   * myProperty = [
+   *  {
+   *    link: '/',
+   *    label: 'Icon',
+   *    icon: this.iconTemplate
+   *  }
+   * ];
+   * ```
+   * > São exibidos apenas no primeiro nível de menu e serão visíveis apenas se todos os itens de primeiro nível possuírem ícones.
    * O menu colapsado também aparecerá somente se todos os itens de primeiro nível de menu possuírem ícones e textos curtos.
    */
-  icon?: string;
+  icon?: string | TemplateRef<void>;
 
   /**
    * Texto curto para o item que aparece quando o menu estiver colapsado.

--- a/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.html
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.html
@@ -53,7 +53,7 @@
       [p-value]="badgeValue"
     >
     </po-badge>
-    <span *ngIf="level === 1 && icon" class="po-icon {{ icon }} po-menu-icon-item"></span>
+    <po-icon *ngIf="level === 1 && icon" class="po-menu-icon-item" [p-icon]="icon"></po-icon>
     <div
       *ngIf="badgeAlert"
       class="po-color-07"

--- a/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.spec.ts
@@ -10,6 +10,7 @@ import { configureTestSuite, expectPropertiesValues } from './../../../util-test
 import { PoBadgeComponent } from '../../po-badge';
 import { PoMenuItemsService } from '../services/po-menu-items.service';
 import { PoMenuItemComponent } from './po-menu-item.component';
+import { PoIconModule } from '../../po-icon/po-icon.module';
 
 @Component({ template: 'Search' })
 export class SearchComponent {}
@@ -30,7 +31,7 @@ describe('PoMenuItemComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes(routes)],
+      imports: [RouterTestingModule.withRoutes(routes), PoIconModule],
       declarations: [SearchComponent, HomeComponent, PoMenuItemComponent, PoBadgeComponent],
       providers: [PoMenuItemsService]
     });

--- a/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
 import { Subscription } from 'rxjs';
 
@@ -35,7 +35,7 @@ export class PoMenuItemComponent implements OnDestroy, OnInit {
   @Input('p-collapsed-menu') collapsedMenu: boolean;
 
   // Ícone de menu
-  @Input('p-icon') icon: string;
+  @Input('p-icon') icon: string | TemplateRef<void>;
 
   // Identificador do item.
   @Input('p-id') id: string;

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.html
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.html
@@ -29,7 +29,7 @@
         <div *ngIf="noData" class="po-menu-item-wrapper">
           <div class="po-menu-item-first">
             <div class="po-menu-icon-container po-menu-item-no-data">
-              <span class="po-icon po-icon-info po-menu-icon-item po-lg-2"></span>
+              <po-icon class="po-icon po-icon-info po-menu-icon-item po-lg-2"></po-icon>
               <div class="po-lg-10 po-menu-icon-label">{{ literals.itemNotFound }}</div>
             </div>
           </div>

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
@@ -12,6 +12,7 @@ import { configureTestSuite } from './../../util-test/util-expect.spec';
 import { PoCleanComponent } from './../po-field/po-clean/po-clean.component';
 
 import { PoLoadingModule } from '../po-loading/po-loading.module';
+import { PoIconModule } from '../po-icon/po-icon.module';
 
 import { PoBadgeComponent } from '../po-badge';
 import { PoMenuComponent } from './po-menu.component';
@@ -43,7 +44,7 @@ describe('PoMenuComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes(routes), PoLoadingModule],
+      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes(routes), PoLoadingModule, PoIconModule],
       declarations: [
         PoCleanComponent,
         PoMenuComponent,
@@ -467,7 +468,7 @@ describe('PoMenuComponent:', () => {
 
   it('should not call updateMenu if it has been initialized and not changed', () => {
     component['menuInitialized'] = true;
-    component['menuPrevious'] = JSON.stringify(component.menus);
+    component['menuPrevious'] = component['stringify'](component.menus);
     spyOn(component, <any>'updateMenu');
 
     component.ngDoCheck();
@@ -486,17 +487,17 @@ describe('PoMenuComponent:', () => {
     expect(component['setMenuExtraProperties']).toHaveBeenCalled();
     expect(component['validateMenus']).toHaveBeenCalled();
     expect(component.filteredItems).toEqual(component.menus);
-    expect(component['menuPrevious']).toBe(JSON.stringify(component.menus));
+    expect(component['menuPrevious']).toEqual(component['stringify'](component.menus));
     expect(component['menuInitialized']).toBeTruthy();
   });
 
   it('should set the value of menuPrevious to menuCurrent if it is null', () => {
     component['menuPrevious'] = null;
-    const menuCurrent = JSON.stringify(component.menus);
+    const menuCurrent = component['stringify'](component.menus);
 
     component.ngDoCheck();
 
-    expect(component['menuPrevious']).toBe(menuCurrent);
+    expect(component['menuPrevious']).toEqual(menuCurrent);
   });
 
   it('itemSubscription: should `unsubscribe` `itemSubscription` on destroy.', () => {

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.ts
@@ -132,7 +132,7 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
 
   private filteringItems: boolean = false;
   private menuInitialized: boolean = false;
-  private menuPrevious: string = null;
+  private menuPrevious = null;
   private resizeListener: () => void;
 
   private itemSubscription: Subscription;
@@ -176,7 +176,7 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
       return;
     }
 
-    const menuCurrent = JSON.stringify(this.menus);
+    const menuCurrent = this.stringify(this.menus);
 
     if (this.menuPrevious !== menuCurrent || !this.menuInitialized) {
       this.updateMenu();
@@ -534,6 +534,15 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
     this.noData = this.filteredItems.length === 0;
   }
 
+  private stringify(menus: Array<PoMenuItem>): string {
+    // não faz o stringify da propriedade icon, pois pode conter objeto complexo e disparar um erro.
+    return JSON.stringify(this.menus, (key, value) => {
+      if (key !== 'icon') {
+        return value;
+      }
+    });
+  }
+
   private toggleGroupedMenuItem() {
     this.groupedMenuItem['isOpened'] = !this.collapsed && this.allowCollapseMenu;
   }
@@ -579,7 +588,7 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
     this.menuInitialized = true;
     this.setMenuExtraProperties();
     this.filteredItems = [...this.menus];
-    this.menuPrevious = JSON.stringify(this.menus);
+    this.menuPrevious = this.stringify(this.menus);
     this.validateMenus(this.menus);
   }
 }

--- a/projects/ui/src/lib/components/po-menu/po-menu.module.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.module.ts
@@ -10,6 +10,7 @@ import { PoMenuComponent } from './po-menu.component';
 import { PoMenuFilterComponent } from './po-menu-filter/po-menu-filter.component';
 import { PoMenuHeaderTemplateDirective } from './po-menu-header-template/po-menu-header-template.directive';
 import { PoMenuItemComponent } from './po-menu-item/po-menu-item.component';
+import { PoIconModule } from '../po-icon/po-icon.module';
 
 /**
  * @description
@@ -17,7 +18,7 @@ import { PoMenuItemComponent } from './po-menu-item/po-menu-item.component';
  * Módulo do componente po-menu.
  */
 @NgModule({
-  imports: [CommonModule, RouterModule, PoBadgeModule, PoFieldModule, PoLoadingModule],
+  imports: [CommonModule, RouterModule, PoBadgeModule, PoFieldModule, PoLoadingModule, PoIconModule],
   declarations: [PoMenuComponent, PoMenuFilterComponent, PoMenuHeaderTemplateDirective, PoMenuItemComponent],
   exports: [PoMenuComponent, PoMenuHeaderTemplateDirective]
 })

--- a/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.html
+++ b/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.html
@@ -87,16 +87,15 @@
       </div>
 
       <div class="po-row">
-        <po-radio-group
-          class="po-lg-12"
+        <po-select
+          class="po-md-4"
           name="icon"
           [(ngModel)]="icon"
-          p-columns="3"
           p-label="Icon"
           [p-disabled]="parent"
           [p-options]="iconsOptions"
         >
-        </po-radio-group>
+        </po-select>
       </div>
 
       <div class="po-row">

--- a/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.ts
+++ b/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.ts
@@ -67,13 +67,15 @@ export class SamplePoMenuLabsComponent implements OnInit {
     { label: 'color-12', value: 'color-12' }
   ];
 
-  public readonly iconsOptions: Array<PoRadioGroupOption> = [
+  public readonly iconsOptions: Array<PoSelectOption> = [
     { label: 'po-icon-news', value: 'po-icon-news' },
     { label: 'po-icon-camera', value: 'po-icon-camera' },
     { label: 'po-icon-calendar', value: 'po-icon-calendar' },
     { label: 'po-icon-user', value: 'po-icon-user' },
     { label: 'po-icon-message', value: 'po-icon-message' },
-    { label: 'po-icon-stock', value: 'po-icon-stock' }
+    { label: 'po-icon-stock', value: 'po-icon-stock' },
+    { value: 'fa fa-calculator', label: 'fa fa-calculator' },
+    { value: 'fa fa-podcast', label: 'fa fa-podcast' }
   ];
 
   constructor(private changeDetector: ChangeDetectorRef) {}


### PR DESCRIPTION
**PO-MENU**

**DTHFUI-5097**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Não permite compatibilidade com outras fontes de ícones.

**Qual o novo comportamento?**
Permite a utilização de outras fontes de ícones no componente `po-menu`

**Simulação**
Testar no `sample labs` do Portal ou utilizando o `app` com as informações abaixo:

`index.html`

```
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <title>App</title>
    <base href="/" />

    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <link rel="icon" type="image/x-icon" href="favicon.ico" />
    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
    <link href="https://fonts.googleapis.com/css2?family=Material+Icons" rel="stylesheet">
  </head>
  <body>
    <app-root></app-root>
  </body>
</html>
```

`app.component.html`
```
<ng-template #iconTemplate>
  <span class="material-icons" style="font-size: inherit;">dashboard</span>
</ng-template>

<po-menu [p-menus]="menus" p-filter="true">
</po-menu>

```

`app.component.ts`
```
  @ViewChild('iconTemplate', { static: true } ) iconTemplate: TemplateRef<void>;

  menus: Array<PoMenuItem>;

  ngOnInit() {
    this.menus  = [
      { link: '/', label: 'PO ICON', icon: 'po-icon-news' },
      { link: '/', label: 'FA ICON', icon: 'fa fa-podcast', subItems: [
        { link: '/', label: 'SUB PO ICON', icon: 'po-icon-news' },
        { link: '/', label: 'SUB FA ICON', icon: 'fa fa-podcast' },
      ]},
      { link: '/', label: 'ION ICON', icon: this.iconTemplate },
    ];
  }
```
