### PR TITLE
feat(lookup): adiciona p-infinite-scroll ao componente lookup

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -84,6 +84,13 @@ describe('PoLookupBaseComponent:', () => {
     expectSettersMethod(component, 'required', undefined, 'required', false);
   });
 
+  it('p-infinite-scroll: should update property `p-infinite-scroll`', () => {
+    const booleanValidTrueValues = [true, 'true', 1, ''];
+    const booleanInvalidValues = [undefined, null, NaN, 2, 'string'];
+    expectPropertiesValues(component, 'infiniteScroll', booleanInvalidValues, false);
+    expectPropertiesValues(component, 'infiniteScroll', booleanValidTrueValues, true);
+  });
+
   it('should register function OnChangePropagate', () => {
     component['onChangePropagate'] = undefined;
     const func = () => true;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -233,6 +233,17 @@ export abstract class PoLookupBaseComponent
   @Input('p-advanced-filters') advancedFilters: Array<PoLookupAdvancedFilter>;
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Ativa a funcionalidade de scroll infinito para a tabela exibida no retorno da consulta.
+   *
+   * @default `false`
+   */
+  @Input('p-infinite-scroll') @InputBoolean() infiniteScroll: boolean = false;
+
+  /**
    * Evento será disparado quando ocorrer algum erro na requisição de busca do item.
    * Será passado por parâmetro o objeto de erro retornado.
    */

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
@@ -492,5 +492,12 @@ describe('PoLookupModalBaseComponent:', () => {
       expect(component.disclaimer).toEqual(expectedValueDisclaimer);
       expect(component.disclaimerGroup.disclaimers).toEqual(expectedValueDisclaimerGroup.disclaimers);
     });
+
+    it('p-infinite-scroll: should update property `p-infinite-scroll`', () => {
+      const booleanValidTrueValues = [true, 'true', 1, ''];
+      const booleanInvalidValues = [undefined, null, NaN, 2, 'string'];
+      expectPropertiesValues(component, 'infiniteScroll', booleanInvalidValues, false);
+      expectPropertiesValues(component, 'infiniteScroll', booleanValidTrueValues, true);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -3,6 +3,8 @@ import { EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, Directive } 
 import { Observable, Subscription, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
+import { InputBoolean } from '../../../../decorators';
+
 import { isTypeof } from '../../../../utils/util';
 import { poLocaleDefault } from '../../../../services/po-language/po-language.constant';
 import { PoModalAction } from '../../../../components/po-modal';
@@ -120,6 +122,9 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
 
   /** Classe de serviço com a implementação do cliente. */
   @Input('p-filter-params') filterParams: any;
+
+  /** Se verdadeiro, ativa a funcionalidade de scroll infinito para a tabela exibida no retorno da consulta. */
+  @Input('p-infinite-scroll') @InputBoolean() infiniteScroll: boolean = false;
 
   /** Evento utilizado ao selecionar um registro da tabela. */
   @Output('p-change-model') model: EventEmitter<any> = new EventEmitter<any>();

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -59,6 +59,7 @@
         [p-literals]="tableLiterals"
         [p-loading]="isLoading"
         [p-show-more-disabled]="!hasNext"
+        [p-infinite-scroll]="infiniteScroll"
         (p-show-more)="showMoreEvent()"
         (p-sort-by)="sortBy($event)"
       >

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
@@ -47,6 +47,7 @@ describe('PoLookupModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PoLookupModalComponent);
     component = fixture.componentInstance;
+    component.infiniteScroll = false;
     component.filterService = {
       getFilteredItems: () =>
         of({
@@ -181,6 +182,26 @@ describe('PoLookupModalComponent', () => {
 
     expect(component.tableHeight).toBe(defaultTableHeight);
     expect(component.containerHeight).toBe(defaultContainerHeight);
+  });
+
+  it('shouldn`t set tableHeight with Infinite Scroll enabled', () => {
+    changeBrowserInnerHeight(650);
+
+    component.tableHeight = defaultTableHeight;
+    component.infiniteScroll = true;
+    component['setTableHeight']();
+
+    expect(component.tableHeight).toBe(315);
+  });
+
+  it('shouldn`t set tableHeight with Infinite Scroll disabled', () => {
+    changeBrowserInnerHeight(650);
+
+    component.tableHeight = defaultTableHeight;
+    component.infiniteScroll = false;
+    component['setTableHeight']();
+
+    expect(component.tableHeight).toBe(defaultTableHeight);
   });
 
   describe('AdvancedSearch: ', () => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
@@ -35,7 +35,7 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
   keyUpObservable: Observable<any> = null;
 
   containerHeight: number = 375;
-  tableHeight: number = 370;
+  tableHeight: number;
 
   componentRef: ComponentRef<PoDynamicFormComponent>;
   dynamicForm: NgForm;
@@ -84,6 +84,9 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
   }
 
   private setTableHeight() {
+    // precisa ser 315 por as linhas terem altura de 32px (quando tela menor que 1366px).
+    // O retorno padrão é 10 itens fazendo com que gere scroll caso houver paginação, 370 não gerava.
+    this.tableHeight = this.infiniteScroll ? 315 : 370;
     if (window.innerHeight < 615) {
       this.tableHeight -= 50;
       this.containerHeight -= 50;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -388,9 +388,18 @@ describe('PoLookupComponent:', () => {
         component.service = lookupFilterService;
         component.label = 'Estabelecimento';
         component.literals = undefined;
+        component.infiniteScroll = false;
 
-        const { advancedFilters, service, columns, filterParams, literals } = component;
-        const params = { advancedFilters, service, columns, filterParams, title: component.label, literals };
+        const { advancedFilters, service, columns, filterParams, literals, infiniteScroll } = component;
+        const params = {
+          advancedFilters,
+          service,
+          columns,
+          filterParams,
+          title: component.label,
+          literals,
+          infiniteScroll
+        };
 
         spyOn(component['poLookupModalService'], 'openModal');
         spyOn(component, <any>'isAllowedOpenModal').and.returnValue(true);

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -149,7 +149,7 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
 
   openLookup(): void {
     if (this.isAllowedOpenModal()) {
-      const { advancedFilters, service, columns, filterParams, literals } = this;
+      const { advancedFilters, service, columns, filterParams, literals, infiniteScroll } = this;
 
       this.poLookupModalService.openModal({
         advancedFilters,
@@ -157,7 +157,8 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
         columns,
         filterParams,
         title: this.label,
-        literals
+        literals,
+        infiniteScroll
       });
 
       if (!this.modalSubscription) {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -15,6 +15,7 @@
   [p-optional]="properties.includes('optional')"
   [p-placeholder]="placeholder"
   [p-required]="properties.includes('required')"
+  [p-infinite-scroll]="properties.includes('infiniteScroll')"
   (p-error)="changeEvent('p-error')"
   (p-selected)="changeEvent('p-selected')"
   (p-change)="changeEvent('p-change')"

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
@@ -55,7 +55,8 @@ export class SamplePoLookupLabsComponent implements OnInit {
     { value: 'disabled', label: 'Disabled' },
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'infiniteScroll', label: 'Infinite Scroll' }
   ];
 
   private readonly columnsDefinition = {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-sw-films/sample-po-lookup-sw-films.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-sw-films/sample-po-lookup-sw-films.component.html
@@ -23,6 +23,7 @@
     [p-columns]="entityColumns"
     [p-filter-params]="filterParams"
     [p-filter-service]="filterService"
+    [p-infinite-scroll]="true"
     (p-selected)="onSelected($event)"
   >
   </po-lookup>

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
@@ -38,7 +38,8 @@ describe('PoLookupModalService:', () => {
     columns: [],
     filterParams: undefined,
     title: 'Teste',
-    literals: undefined
+    literals: undefined,
+    infiniteScroll: false
   };
 
   beforeEach(() => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
@@ -37,8 +37,9 @@ export class PoLookupModalService {
     filterParams: any;
     title: string;
     literals: PoLookupLiterals;
+    infiniteScroll: boolean;
   }): void {
-    const { advancedFilters, service, columns, filterParams, title, literals } = params;
+    const { advancedFilters, service, columns, filterParams, title, literals, infiniteScroll } = params;
 
     this.componentRef = this.poComponentInjector.createComponentInApplication(PoLookupModalComponent);
     this.componentRef.instance.advancedFilters = advancedFilters;
@@ -50,6 +51,7 @@ export class PoLookupModalService {
     this.componentRef.instance.model.subscribe($event => {
       this.selectValue($event);
     });
+    this.componentRef.instance.infiniteScroll = infiniteScroll;
     this.componentRef.changeDetectorRef.detectChanges();
     this.componentRef.instance.openModal();
   }


### PR DESCRIPTION
Adicionado a funcionalidade de Infinite Scroll na tabela apresentada no componente Lookup

**Lookup**

**#653**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
A opção de paginação do componente Lookup não possui a funcionalidade de infinite scroll já existente no PO-Table

**Qual o novo comportamento?**
Ao usar a diretiva p-infinite-scroll como "true", a tabela apresentada irá possuir o comportamento do infinite scroll já existente no PO-Table.

**Simulação**

Utilizar o sample Labs ou Star Wars films