### PR TITLE
feat(table): adiciona métodos `removeItem` e `updateItem`

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1747,6 +1747,71 @@ describe('PoTableComponent:', () => {
 
       expect(component.selectAll).toBeFalsy();
     });
+
+    describe('removeItem:', () => {
+      it('remove: should remove the item by index', () => {
+        component.items = items;
+        const firstItem = component.items[0];
+        const numberItems = component.items.length;
+        component.removeItem(0);
+        expect(component.items.length).toEqual(numberItems - 1);
+        expect(component.items).not.toContain(firstItem);
+      });
+
+      it('remove: should remove item if received an object', () => {
+        component.items = items;
+        const numberItems = component.items.length;
+        const elementRemove = component.items[0];
+        component.removeItem(elementRemove);
+        expect(component.items.length).toEqual(numberItems - 1);
+        expect(component.items).not.toContain(elementRemove);
+      });
+    });
+
+    describe('updateItem:', () => {
+      it('updateItem: should update item if pass index and updated item', () => {
+        component.items = items;
+        const updatedItem = {
+          id: 1,
+          initial: 'BR',
+          name: 'Brasil',
+          total: 90.0,
+          atualization: '2017-10-09',
+          detail: [{ property: 'teste', label: 'Label teste' }]
+        };
+        component.updateItem(0, updatedItem);
+        const itemValue = component.items[0].total;
+        expect(itemValue).toBe(updatedItem.total);
+      });
+
+      it('updateItem: should update item if pass object and updated item', () => {
+        component.items = items;
+        const updatedItem = {
+          id: 1,
+          initial: 'BR',
+          name: 'Brasil',
+          total: 90.0,
+          atualization: '2017-10-09',
+          detail: [{ property: 'teste', label: 'Label teste' }]
+        };
+        const itemChanged = component.items[0];
+        component.updateItem(itemChanged, updatedItem);
+        const newValue = component.items[0].total;
+        expect(newValue).toBe(updatedItem.total);
+      });
+
+      it('updateItem: should update item if pass object and specific value for update', () => {
+        component.items = items;
+        const updatedItem = {
+          ...items[0],
+          total: 77.0
+        };
+        const changedItem = component.items[0];
+        component.updateItem(changedItem, updatedItem);
+        const newValue = component.items[0].total;
+        expect(newValue).toBe(updatedItem.total);
+      });
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -455,6 +455,37 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.lastVisibleColumnsSelected = [...this.columns];
   }
 
+  /**
+   * Método que remove um item da tabela.
+   *
+   * @param { number | { key: value } } item Índice da linha ou o item que será removido.
+   * > Ao remover o item, a linha que o representa será excluída da tabela.
+   */
+  removeItem(item: number | { [key: string]: any }) {
+    if (item instanceof Object) {
+      this.items = this.items.filter(filterItem => filterItem !== item);
+    } else if (typeof item === 'number') {
+      const index: number = item;
+      this.items.splice(index, 1);
+    }
+  }
+
+  /**
+   * Método que atualiza um item da tabela.
+   *
+   * @param { number | { key: value } } item Índice da linha ou o item que será atualizado.
+   * @param { { key: value } } updatedItem Item que foi atualizado.
+   * > Ao atualizar o item, a informação será alterada na tabela.
+   */
+  updateItem(item: number | { [key: string]: any }, updatedItem: { [key: string]: any }) {
+    if (typeof item === 'number') {
+      this.items.splice(item, 1, updatedItem);
+    } else {
+      const index = this.items.findIndex(indexItem => indexItem === item);
+      this.items.splice(index, 1, updatedItem);
+    }
+  }
+
   public getTemplate(column: PoTableColumn): TemplateRef<any> {
     const template: PoTableColumnTemplateDirective = this.tableColumnTemplates.find(
       tableColumnTemplate => tableColumnTemplate.targetProperty === column.property

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
@@ -12,7 +12,7 @@
   [p-actions]="actions"
   [p-columns]="columns"
   [p-items]="items"
-  [p-max-columns]="6"
+  [p-max-columns]="7"
   (p-collapsed)="onCollapseDetail()"
   (p-expanded)="onExpandDetail()"
   (p-selected)="sumTotal($event)"

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
@@ -27,7 +27,8 @@ export class SamplePoTableAirfareComponent {
       label: 'Apply Discount',
       disabled: this.validateDiscount.bind(this)
     },
-    { action: this.details.bind(this), icon: 'po-icon-info', label: 'Details' }
+    { action: this.details.bind(this), icon: 'po-icon-info', label: 'Details' },
+    { action: this.remove.bind(this), icon: 'po-icon po-icon-delete', label: 'Remove' }
   ];
   columns: Array<PoTableColumn> = this.sampleAirfare.getColumns();
   detail: any;
@@ -94,10 +95,14 @@ export class SamplePoTableAirfareComponent {
     this.poModal.open();
   }
 
+  remove(item: { [key: string]: any }) {
+    this.poTable.removeItem(item);
+  }
+
   discount(item) {
     if (!item.disableDiscount) {
-      item.value = item.value - item.value * 0.2;
-      item.disableDiscount = true;
+      const updatedItem = { ...item, value: item.value - item.value * 0.2, disableDiscount: true };
+      this.poTable.updateItem(item, updatedItem);
     }
   }
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.service.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.service.ts
@@ -49,6 +49,7 @@ export class SamplePoTableAirfareService {
       },
       { property: 'date', type: 'date', width: '100px' },
       { property: 'returnDate', label: 'Return Date', type: 'date', width: '100px' },
+      { property: 'value', type: 'currency', format: 'USD', width: '100px' },
       { property: 'id', label: 'Flight Number', type: 'number', width: '150px' },
       {
         property: 'onBoardService',
@@ -60,7 +61,6 @@ export class SamplePoTableAirfareService {
           falseLabel: 'No'
         }
       },
-      { property: 'value', type: 'currency', format: 'USD', width: '100px' },
       { property: 'detail', label: 'Details', type: 'detail', detail: airfareDetail }
     ];
   }


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-5056**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não existem métodos públicos que permitam a remoção ou a atualização de um item na tabela.

**Qual o novo comportamento?**
Método `removeItem()` e `updateItem()` foram inseridos no componente `po-table`.

**Simulação**
Simular através do sample `PO Table - Airfare` no portal.