### PR TITLE
feat(multiselect): adiciona propriedade `p-auto-height`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
 
     - run: npm i
     - run: npm run build
+    - run: npm run build:portal:docs
+    - run: npm run build:portal:prod
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: portal
+        path: dist/portal
 
   test-ui:
     name: Test ui

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -259,14 +259,6 @@ describe('PoMultiselectBaseComponent:', () => {
     expect(component.getLabelByValue(2)).toBe('Label 2');
   });
 
-  it('should call updateSelectedOptions and callOnChange', () => {
-    spyOn(component, 'updateSelectedOptions');
-    spyOn(component, 'callOnChange');
-    component.changeItems([]);
-    expect(component.updateSelectedOptions).toHaveBeenCalled();
-    expect(component.callOnChange).toHaveBeenCalled();
-  });
-
   it('should search and find options by label', () => {
     component.visibleOptionsDropdown = [];
     const options = [

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -62,6 +62,18 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    */
   @Input('p-auto-focus') @InputBoolean() autoFocus: boolean = false;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que a altura do componente será auto ajustável, possuindo uma altura minima porém a altura máxima será de acordo
+   * com o número de itens selecionados e a extensão dos mesmos, mantendo-os sempre visíveis.
+   *
+   * @default `false`
+   */
+  @Input('p-auto-height') @InputBoolean() autoHeight: boolean = false;
+
   /** Label no componente. */
   @Input('p-label') label?: string;
 
@@ -368,11 +380,6 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   getLabelByValue(value) {
     const index = this.options.findIndex(option => option.value === value);
     return this.options[index].label;
-  }
-
-  changeItems(selectedValues) {
-    this.updateSelectedOptions(selectedValues);
-    this.callOnChange(this.selectedOptions);
   }
 
   searchByLabel(search: string, options: Array<PoMultiselectOption>, filterMode: PoMultiselectFilterMode) {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -1,30 +1,24 @@
 <po-field-container [p-label]="label" [p-help]="help" [p-optional]="!required && optional">
   <div class="po-field-container-content" [class.po-multiselect-show]="dropdownOpen">
-    <input
+    <div
       #inputElement
+      [tabindex]="disabled ? -1 : 0"
       class="po-input po-input-icon-right po-multiselect-input po-clickable"
-      readonly
-      type="text"
-      [value]="getPlaceholder()"
-      [disabled]="disabled"
+      [class.po-multiselect-input-auto]="autoHeight"
+      [class.po-multiselect-input-static]="!autoHeight"
+      [class.po-multiselect-input-disabled]="disabled"
+      (keyup.enter)="toggleDropdownVisibility()"
       (keydown)="onKeyDown($event)"
       (click)="toggleDropdownVisibility()"
       (blur)="onBlur()"
-    />
-
-    <div class="po-field-icon-container-right">
-      <span
-        #iconElement
-        class="po-icon po-field-icon {{ dropdownIcon }}"
-        [ngClass]="disabled ? 'po-field-icon-disabled' : ''"
-        (click)="toggleDropdownVisibility()"
-      >
+    >
+      <span *ngIf="placeholder && !visibleDisclaimers?.length" class="po-multiselect-input-placeholder">
+        {{ placeholder }}
       </span>
-    </div>
 
-    <div #disclaimerContainer class="po-multiselect-field" [class.po-multiselect-field-disabled]="disabled">
       <po-disclaimer
         *ngFor="let disclaimer of visibleDisclaimers"
+        class="po-multiselect-input-disclaimer"
         [p-label]="disclaimer.label"
         [p-value]="disclaimer.value"
         [p-hide-close]="disclaimer.value === '' || disabled"
@@ -33,6 +27,15 @@
         (p-close-action)="closeDisclaimer(disclaimer.value)"
       >
       </po-disclaimer>
+
+      <div class="po-field-icon-container-right">
+        <span
+          #iconElement
+          class="po-icon po-field-icon {{ dropdownIcon }}"
+          [ngClass]="disabled ? 'po-field-icon-disabled' : ''"
+        >
+        </span>
+      </div>
     </div>
   </div>
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -71,7 +71,6 @@ const providers = [
 export class PoMultiselectComponent extends PoMultiselectBaseComponent implements AfterViewInit, DoCheck, OnDestroy {
   @ViewChild('dropdownElement', { read: ElementRef, static: true }) dropdownElement: ElementRef;
   @ViewChild('dropdownElement', { static: true }) dropdown;
-  @ViewChild('disclaimerContainer', { read: ElementRef, static: true }) disclaimerContainerElement: ElementRef;
   @ViewChild('iconElement', { read: ElementRef, static: true }) iconElement: ElementRef;
   @ViewChild('inputElement', { read: ElementRef, static: true }) inputElement: ElementRef;
 
@@ -189,6 +188,16 @@ export class PoMultiselectComponent extends PoMultiselectBaseComponent implement
     }
   }
 
+  changeItems(selectedValues) {
+    this.updateSelectedOptions(selectedValues);
+    this.callOnChange(this.selectedOptions);
+
+    if (this.autoHeight && this.dropdownOpen) {
+      this.changeDetector.detectChanges();
+      this.adjustContainerPosition();
+    }
+  }
+
   updateVisibleItems() {
     this.visibleDisclaimers = [].concat(this.selectedOptions);
 
@@ -201,10 +210,12 @@ export class PoMultiselectComponent extends PoMultiselectBaseComponent implement
   }
 
   debounceResize() {
-    clearTimeout(this.timeoutResize);
-    this.timeoutResize = setTimeout(() => {
-      this.calculateVisibleItems();
-    }, 200);
+    if (!this.autoHeight) {
+      clearTimeout(this.timeoutResize);
+      this.timeoutResize = setTimeout(() => {
+        this.calculateVisibleItems();
+      }, 200);
+    }
   }
 
   onBlur() {
@@ -261,10 +272,6 @@ export class PoMultiselectComponent extends PoMultiselectBaseComponent implement
     setTimeout(() => this.adjustContainerPosition());
   }
 
-  getPlaceholder() {
-    return this.placeholder && !this.visibleDisclaimers.length ? this.placeholder : '';
-  }
-
   closeDisclaimer(value) {
     const index = this.selectedOptions.findIndex(option => option.value === value);
     this.selectedOptions.splice(index, 1);
@@ -275,11 +282,10 @@ export class PoMultiselectComponent extends PoMultiselectBaseComponent implement
 
   wasClickedOnToggle(event: MouseEvent): void {
     if (
+      this.dropdownOpen &&
       !this.inputElement.nativeElement.contains(event.target) &&
       !this.iconElement.nativeElement.contains(event.target) &&
-      !this.dropdownElement.nativeElement.contains(event.target) &&
-      !this.disclaimerContainerElement.nativeElement.contains(event.target) &&
-      this.dropdownOpen
+      !this.dropdownElement.nativeElement.contains(event.target)
     ) {
       this.controlDropdownVisibility(false);
     }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
@@ -3,6 +3,7 @@
     class="po-md-12"
     name="PO Multiselect"
     [(ngModel)]="multiselect"
+    [p-auto-height]="properties.includes('autoHeight')"
     [p-disabled]="properties.includes('disabled')"
     [p-filter-mode]="filterMode"
     [p-help]="help"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
@@ -36,6 +36,7 @@ export class SamplePoMultiselectLabsComponent implements OnInit {
     { value: 'disabled', label: 'Disabled' },
     { value: 'optional', label: 'Optional' },
     { value: 'hideSearch', label: 'Hide Search' },
+    { value: 'autoHeight', label: 'Auto Height' },
     { value: 'sort', label: 'Sort' }
   ];
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-vacation-reactive-form/sample-po-multiselect-vacation-reactive-form.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-vacation-reactive-form/sample-po-multiselect-vacation-reactive-form.component.html
@@ -25,28 +25,27 @@
   </div>
 
   <div class="po-row">
-    <po-radio-group
-      class="po-lg-12"
-      name="days"
-      formControlName="days"
-      p-help="Maximum of days that employs can choose"
-      p-label="How many days of vacation the employees will be able to have?"
-      p-required
-      [p-options]="daysOptions"
-    >
-    </po-radio-group>
-  </div>
-
-  <div class="po-row">
     <po-multiselect
-      class="po-md-12"
+      class="po-md-4"
       name="employeesVacations"
       formControlName="employeesVacations"
       p-label="Select your employees for collective vacations"
+      [p-auto-height]="true"
       [p-options]="employees"
-      p-required
+      [p-required]="true"
     >
     </po-multiselect>
+
+    <po-radio-group
+      class="po-lg-8"
+      name="days"
+      formControlName="days"
+      p-label="How many days of vacation the employees will be able to have?"
+      p-required
+      [p-options]="daysOptions"
+      [p-columns]="3"
+    >
+    </po-radio-group>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-vacation-reactive-form/sample-po-multiselect-vacation-reactive-form.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-vacation-reactive-form/sample-po-multiselect-vacation-reactive-form.component.ts
@@ -20,6 +20,8 @@ export class SamplePoMultiselectVacationReactiveFormComponent implements OnInit 
     { value: '518734', label: 'Alice' },
     { value: '986237', label: 'Bradley' },
     { value: '941278', label: 'Jackie' },
+    { value: '112333', label: 'Jane' },
+    { value: '989898', label: 'John' },
     { value: '897643', label: 'Phillip' },
     { value: '423767', label: 'Reynold' },
     { value: '423837', label: 'Robert' }


### PR DESCRIPTION
**< MULTISELECT >**

**< DTHFUI-5063 >**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
-

**Qual o novo comportamento?**
Permite ao componente ter uma altura auto ajustavel,
conforme a largura, quantidade de itens selecionados e a
extensão dos mesmos, sempre mantendo visível os itens selecionados.


**Simulação**
PR STYLE https://github.com/po-ui/po-style/pull/229

npm run build:portal && ng serve portal
