### PR TITLE
feat(notification): adiciona botão de fechar por padrão

### DIFF
--- a/projects/ui/src/lib/services/po-notification/po-notification-base.service.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification-base.service.ts
@@ -15,7 +15,7 @@ import { PoToasterType } from './po-toaster/po-toaster-type.enum';
  * - error,
  * - information.
  *
- * Cada um destes métodos recebe como parâmetro o objeto "PoNotification" que contém os dados da mensagem e o
+ * Cada um destes métodos recebe como parâmetro o objeto `PoNotification` que contém os dados da mensagem e o
  * objeto ViewContainerRef que é a representação do container do componente onde será criada a notificação.
  *
  * Estas notificações serão exibidas durante 10 segundos por padrão, podendo ser alterada conforme necessidade.

--- a/projects/ui/src/lib/services/po-notification/po-notification.interface.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification.interface.ts
@@ -5,10 +5,17 @@ import { PoToasterOrientation } from './po-toaster/po-toaster-orientation.enum';
  *
  * @description
  *
- * Interface para uso do serviço po-notification.
+ * Interface para uso do serviço PoNotification.
  */
 export interface PoNotification {
-  /** Ação para a notificação. */
+  /**
+   * Ação para a notificação.
+   *
+   * Ao utilizar esta propriedade em conjunto com a `actionLabel`,
+   * a notificação ficará fixa na página até usuário fechá-la ou clicar nesta ação.
+   *
+   * Caso não informar a propriedade `actionLabel` a ação será atribuida ao ícone de "Fechar" da notificação.
+   */
   action?: Function;
 
   /** Label do botão quando houver uma ação definida. */
@@ -20,12 +27,12 @@ export interface PoNotification {
   /**
    * @description
    *
-   * Posição da notificação na página que pode ser ```Top``` (topo) ou ```Bottom```(rodapé).
+   * Posição da notificação na página que pode ser ```Top``` (topo) ou ```Bottom```(rodapé). A posição padrão é `bottom`.
    *
    * @default `Bottom`
    */
   orientation?: PoToasterOrientation;
 
-  /** Define em milissegundos o tempo de duração que a notificação ficará disponível em tela. */
+  /** Define em milissegundos o tempo de duração que a notificação ficará disponível em tela. O padrão é 10000 milissegundos. */
   duration?: number;
 }

--- a/projects/ui/src/lib/services/po-notification/po-notification.service.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification.service.ts
@@ -51,7 +51,7 @@ export class PoNotificationService extends PoNotificationBaseService {
 
     this.observableOnClose(componentRef);
 
-    if (toaster.action === undefined) {
+    if (!(toaster.action && toaster.actionLabel)) {
       setTimeout(() => {
         this.destroyToaster(componentRef);
       }, toaster.duration);

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.html
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.html
@@ -10,7 +10,11 @@
 
   <div class="po-toaster-message">{{ message }}</div>
 
-  <div *ngIf="action !== undefined" (click)="poToasterAction()" class="po-toaster-action">
+  <div *ngIf="action && actionLabel" (click)="poToasterAction()" class="po-toaster-action">
     {{ actionLabel }}
   </div>
+
+  <button class="po-toaster-close" (click)="onButtonClose()">
+    <span class="po-icon po-icon-close"></span>
+  </button>
 </div>

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.spec.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.spec.ts
@@ -114,47 +114,46 @@ describe('PoToasterComponent', () => {
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Error and with action correctly', () => {
-    const toasterActionLabel = component['literals'].closeToaster;
-
     component.configToaster(toasterErrorWithAction);
+
     fixture.detectChanges();
+
     expect(fixture.debugElement.query(By.css('.po-toaster-error'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-icon-close'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain(
-      toasterActionLabel
-    );
+    expect(fixture.debugElement.query(By.css('.po-icon-warning'))).not.toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-close'))).toBeTruthy();
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Info and with action correctly', () => {
     component.configToaster(toasterInfoWithAction);
+
     fixture.detectChanges();
+
     expect(fixture.debugElement.query(By.css('.po-toaster-info'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-info'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain('Texto Botão');
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Success and with action correctly', () => {
-    const toasterActionLabel = component['literals'].closeToaster;
-
     component.configToaster(toasterSuccessWithAction);
+
     fixture.detectChanges();
+
     expect(fixture.debugElement.query(By.css('.po-toaster-success'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-ok'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain(
-      toasterActionLabel
-    );
+    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-close'))).toBeTruthy();
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Warning and with action correctly', () => {
-    const toasterActionLabel = component['literals'].closeToaster;
-
     component.configToaster(toasterWarningWithAction);
+
     fixture.detectChanges();
+
     expect(fixture.debugElement.query(By.css('.po-toaster-warning'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-warning'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain(
-      toasterActionLabel
-    );
+    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-close'))).toBeTruthy();
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Error and without action correctly', () => {
@@ -196,6 +195,47 @@ describe('PoToasterComponent', () => {
     component.close();
     fixture.detectChanges();
     expect(fixture.debugElement.query(By.css('.po-toaster'))).toBeNull();
+  });
+
+  describe('Methods:', () => {
+    it('onButtonClose: should call `close` if action and actionLabel are truthy', () => {
+      component.action = () => {};
+      component.actionLabel = 'Details';
+
+      const spyClose = spyOn(component, 'close');
+      const spyToasterAction = spyOn(component, 'poToasterAction');
+
+      component.onButtonClose();
+
+      expect(spyToasterAction).not.toHaveBeenCalled();
+      expect(spyClose).toHaveBeenCalled();
+    });
+
+    it('onButtonClose: should call `poToasterAction` if action is truthy and actionLabel is null', () => {
+      component.action = () => {};
+      component.actionLabel = null;
+
+      const spyToasterAction = spyOn(component, 'poToasterAction');
+      const spyClose = spyOn(component, 'close');
+
+      component.onButtonClose();
+
+      expect(spyClose).not.toHaveBeenCalled();
+      expect(spyToasterAction).toHaveBeenCalled();
+    });
+
+    it('onButtonClose: should call `close` if action and actionLabel are null', () => {
+      component.action = null;
+      component.actionLabel = null;
+
+      const spyToasterAction = spyOn(component, 'poToasterAction');
+      const spyClose = spyOn(component, 'close');
+
+      component.onButtonClose();
+
+      expect(spyClose).toHaveBeenCalled();
+      expect(spyToasterAction).not.toHaveBeenCalled();
+    });
   });
 
   describe('Properties', () => {

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
@@ -11,21 +11,6 @@ import { PoToaster } from './po-toaster.interface';
 import { PoToasterType } from './po-toaster-type.enum';
 import { PoToasterOrientation } from './po-toaster-orientation.enum';
 
-export const poToasterLiteralsDefault = {
-  en: {
-    closeToaster: 'Close'
-  },
-  es: {
-    closeToaster: 'Cerca'
-  },
-  pt: {
-    closeToaster: 'Fechar'
-  },
-  ru: {
-    closeToaster: 'близко'
-  }
-};
-
 /**
  * @docsPrivate
  *
@@ -38,10 +23,6 @@ export const poToasterLiteralsDefault = {
 export class PoToasterComponent extends PoToasterBaseComponent {
   /* Componente toaster */
   @ViewChild('toaster') toaster: ElementRef;
-
-  private literals = {
-    ...poToasterLiteralsDefault[poLocaleDefault]
-  };
 
   /* Ícone do Toaster */
   private icon: string;
@@ -62,11 +43,6 @@ export class PoToasterComponent extends PoToasterBaseComponent {
     private elementeRef?: ElementRef
   ) {
     super();
-
-    this.literals = {
-      ...this.literals,
-      ...poToasterLiteralsDefault[languageService.getShortLanguage()]
-    };
   }
 
   /* Muda a posição do Toaster na tela*/
@@ -95,7 +71,7 @@ export class PoToasterComponent extends PoToasterBaseComponent {
     this.orientation = poToaster.orientation;
     this.position = poToaster.position;
     this.action = poToaster.action;
-    this.actionLabel = poToaster.actionLabel ? poToaster.actionLabel : this.literals.closeToaster;
+    this.actionLabel = poToaster.actionLabel;
     this.componentRef = poToaster.componentRef;
 
     /* Muda a orientação do Toaster */
@@ -110,7 +86,7 @@ export class PoToasterComponent extends PoToasterBaseComponent {
     switch (this.type) {
       case PoToasterType.Error: {
         this.toasterType = 'po-toaster-error';
-        this.icon = 'po-icon-close';
+        this.icon = 'po-icon-warning';
         break;
       }
       case PoToasterType.Information: {
@@ -147,6 +123,14 @@ export class PoToasterComponent extends PoToasterBaseComponent {
 
   getToasterType() {
     return this.toasterType;
+  }
+
+  onButtonClose() {
+    if (this.action && !this.actionLabel) {
+      this.poToasterAction();
+    } else {
+      this.close();
+    }
   }
 
   /* Chama a função passada pelo atributo `action` */


### PR DESCRIPTION
**Notification**

**DTHFUI-5150**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente não possui botão de fechar na notificação, fazendo necessário adicionar uma ação para o usuário identificar que pode fechar, porem com isso, acaba deixando a notificação fixa pela regra que existe nela.

**Qual o novo comportamento?**
Adiciona botão de "Fechar" por padrão, fazendo com que torne desnecessário informar uma ação de fechar e tornar mais visual a possibilidade de fechamento.


**Simulação**
[PR STYLE](https://github.com/po-ui/po-style/pull/231)
- Portal (npm run build:portal && ng serve portal)
- App:
```
  constructor(notification: PoNotificationService) {
    setTimeout(() => {
      notification.success({
        message: 'Mensagem de apoio',
        action: () => { alert('Detalhes') },
        actionLabel: 'Detalhes'
      });
    }, 1000);
    setTimeout(() => {
      notification.error({
        message: 'Mensagem de sucesso',
        action: () => { alert('Fechar') }
      });
    }, 3000);
    notification.warning({
        message: 'Mensagem de apoio'
    });
    notification.information({
        message: 'Mensagem de apoio'
    });
  }
  ```
