### PR TITLE
feat(navbar): adiciona compatibilidade com outras fontes de ícones

### DIFF
--- a/projects/ui/src/lib/components/po-navbar/interfaces/po-navbar-icon-action.interface.ts
+++ b/projects/ui/src/lib/components/po-navbar/interfaces/po-navbar-icon-action.interface.ts
@@ -1,3 +1,5 @@
+import { TemplateRef } from '@angular/core';
+
 /**
  * @usedBy PoNavbarComponent
  *
@@ -16,13 +18,36 @@ export interface PoNavbarIconAction {
   action?: Function;
 
   /**
-   * @description
-   *
    * Ícone exibido.
    *
-   * > Veja os valores válidos na [Biblioteca de ícones](/guides/icons).
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-navbar
+   *   [p-icon-actions]="[{ link: '/', icon: 'po-icon-news' }]">
+   * </po-navbar>
+   * ```
+   *
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
+   * ```
+   * <po-navbar
+   *   [p-icon-actions]="[{ link: '/', icon: 'fa fa-podcast' }]">
+   * </po-navbar>
+   * ```
+   *
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * component.html:
+   * ```
+   * <ng-template #iconTemplate>
+   *   <ion-icon name="heart"></ion-icon>
+   * </ng-template>
+   *
+   * <po-navbar
+   *   [p-icon-actions]="[{ link: '/', icon: iconTemplate }]">
+   * </po-navbar>
+   * ```
+   *
    */
-  icon?: string;
+  icon?: string | TemplateRef<void>;
 
   /** Rótulo da ação, será exibido quando o mesmo for aberto no popup. */
   label: string;

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.html
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.html
@@ -1,3 +1,7 @@
-<div tabindex="0" class="po-navbar-action-content po-clickable" (click)="click()">
-  <span class="po-icon {{ icon }}" [p-tooltip]="tooltip"> </span>
-</div>
+<po-icon
+  tabindex="0"
+  class="po-navbar-action-content po-clickable"
+  [p-icon]="icon"
+  [p-tooltip]="tooltip"
+  (click)="click()"
+></po-icon>

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewContainerRef } from '@angular/core';
+import { Component, Input, TemplateRef, ViewContainerRef } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { callFunction, isExternalLink, openExternalLink } from '../../../../utils/util';
@@ -10,7 +10,7 @@ import { callFunction, isExternalLink, openExternalLink } from '../../../../util
 export class PoNavbarActionComponent {
   @Input('p-action') action?: Function;
 
-  @Input('p-icon') icon: string;
+  @Input('p-icon') icon: string | TemplateRef<void>;
 
   @Input('p-label') label: string;
 

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-actions.module.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-actions.module.ts
@@ -6,9 +6,10 @@ import { PoNavbarActionPopupComponent } from './po-navbar-action-popup/po-navbar
 import { PoNavbarActionsComponent } from './po-navbar-actions.component';
 import { PoPopupModule } from '../../po-popup/po-popup.module';
 import { PoTooltipModule } from '../../../directives/po-tooltip/po-tooltip.module';
+import { PoIconModule } from './../../po-icon/po-icon.module';
 
 @NgModule({
-  imports: [CommonModule, PoPopupModule, PoTooltipModule],
+  imports: [CommonModule, PoPopupModule, PoTooltipModule, PoIconModule],
   declarations: [PoNavbarActionComponent, PoNavbarActionPopupComponent, PoNavbarActionsComponent],
   exports: [PoNavbarActionsComponent]
 })

--- a/projects/ui/src/lib/components/po-navbar/po-navbar.module.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar.module.ts
@@ -7,6 +7,7 @@ import { PoNavbarComponent } from './po-navbar.component';
 import { PoNavbarItemsModule } from './po-navbar-items/po-navbar-items.module';
 import { PoNavbarLogoComponent } from './po-navbar-logo/po-navbar-logo.component';
 import { PoNavbarItemNavigationModule } from './po-navbar-item-navigation/po-navbar-item-navigation.module';
+import { PoIconModule } from './../po-icon/po-icon.module';
 
 /**
  * @description
@@ -40,7 +41,14 @@ import { PoNavbarItemNavigationModule } from './po-navbar-item-navigation/po-nav
  * ```
  */
 @NgModule({
-  imports: [CommonModule, PoNavbarActionsModule, PoNavbarItemsModule, PoNavbarItemNavigationModule, PoMenuModule],
+  imports: [
+    CommonModule,
+    PoNavbarActionsModule,
+    PoNavbarItemsModule,
+    PoNavbarItemNavigationModule,
+    PoMenuModule,
+    PoIconModule
+  ],
   declarations: [PoNavbarComponent, PoNavbarLogoComponent],
   exports: [PoNavbarComponent]
 })


### PR DESCRIPTION
PO-NAVBAR

DTHFUI-5137
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Não permite compatibilidade com outras fontes de ícones.

**Qual o novo comportamento?**
Permite a utilização de outras fontes de ícones no componente `po-navbar`

**Simulação**

Style: https://github.com/po-ui/po-style/pull/232
Importar `BrowserAnimationsModule` no `app.module.ts`

`index.html`
```
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <title>App</title>
    <base href="/" />

    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <link rel="icon" type="image/x-icon" href="favicon.ico" />
    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
    <link href="https://fonts.googleapis.com/css2?family=Material+Icons" rel="stylesheet">
  </head>
  <body>
    <app-root></app-root>
  </body>
</html>

```
`app.component.html`

```
<ng-template #iconTemplate>
  <span class="material-icons" style="font-size: inherit;">article</span>
</ng-template>

<po-navbar
  p-shadow [p-icon-actions]="[{ link: '/', icon: iconTemplate }, { link: '/', icon: 'po-icon-news' }, { link: '/', icon: 'fa fa-podcast' }]">
</po-navbar>
```
