### PR TITLE
docs(page-login): altera url de recuperacao e autenticacao

### DIFF
--- a/projects/templates/src/lib/components/po-page-change-password/samples/sample-po-page-change-password-request/sample-po-page-change-password-request.component.html
+++ b/projects/templates/src/lib/components/po-page-change-password/samples/sample-po-page-change-password-request/sample-po-page-change-password-request.component.html
@@ -11,6 +11,6 @@
   p-secondary-logo="https://via.placeholder.com/80x24?text=SECONDARY+LOGO"
   p-token="rzDsQiSYoq"
   p-url-new-password="https://thf.totvs.com.br/sample/api/new-password"
-  [p-recovery]="{ url: 'https://thf.totvs.com.br/sample/api/users', type: 'all', contactMail: 'support@mail.com' }"
+  [p-recovery]="{ url: 'https://po-sample-api.herokuapp.com/v1/users', type: 'all', contactMail: 'support@mail.com' }"
 >
 </po-page-change-password>

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-automatic-service/sample-po-page-login-automatic-service.component.html
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-automatic-service/sample-po-page-login-automatic-service.component.html
@@ -5,8 +5,9 @@
   </div>
 </po-container>
 <po-page-login
-  p-authentication-url="https://thf.totvs.com.br/sample/api/users/authentication"
+  p-authentication-url="https://po-sample-api.herokuapp.com/v1/users/authentication"
   p-blocked-url="/documentation/po-page-blocked-user"
+  p-authentication-type="Bearer"
   p-logo="https://via.placeholder.com/160x64?text=MAIN+LOGO"
   p-secondary-logo="https://via.placeholder.com/80x24?text=SECONDARY+LOGO"
   [p-languages]="languages"

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-human-resources/sample-po-page-login-human-resources.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-human-resources/sample-po-page-login-human-resources.component.ts
@@ -29,7 +29,7 @@ export class SamplePoPageLoginHumanResourcesComponent implements OnDestroy, OnIn
   passwordErrors = [];
   params: PoPageBlockedUserReasonParams = { attempts: 3, hours: 24 };
   passwordRecovery: PoPageLoginRecovery = {
-    url: 'https://thf.totvs.com.br/sample/api/users',
+    url: 'https://po-sample-api.herokuapp.com/v1/users',
     type: PoModalPasswordRecoveryType.All,
     contactMail: 'support@mail.com'
   };


### PR DESCRIPTION
Altera url da Api de autenticação e recuperação de senha no sample de page-login
DTHFUI-2668

Simulação:
alterar em `sample-po-page-login-automatic-service.component.html ` :
de: `https://po-sample-api.herokuapp.com/v1/users/authentication`
para: `https://localhost:3000/v1/users/authentication`

`npm run build:portal`
`ng serve portal`

Para rodar localmente o po-sample-api : 
https://github.com/po-ui/po-sample-api/pull/21
`npm run start:dev`

Samples alterados:
PO Page Login - Automatic Service : Recuperação de senha
PO Page Login - Human Resources : Autenticação do usuário 
