### PR TITLE
fix(email): corrige o limite de caracteres

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-email/po-email.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-email/po-email.component.spec.ts
@@ -162,6 +162,7 @@ describe('PoEmailComponent:', () => {
     it(`should return null on validate if email is valid`, () => {
       expect(component.validate(new FormControl('JOHN@EMAIL.COM'))).toBe(null);
       expect(component.validate(new FormControl('JOHN@email.com'))).toBe(null);
+      expect(component.validate(new FormControl('JOHN@EMAIL.EMAILEXTENSION'))).toBe(null);
     });
 
     it(`should return '{ pattern: { valid: false } }' on validate if email is invalid`, () => {
@@ -170,6 +171,11 @@ describe('PoEmailComponent:', () => {
       expect(component.validate(new FormControl('JOHN@'))).toEqual(patternError);
       expect(component.validate(new FormControl('JOHN@EMAIL.'))).toEqual(patternError);
       expect(component.validate(new FormControl('JOHN'))).toEqual(patternError);
+      expect(
+        component.validate(
+          new FormControl('JOHN@EMAIL.EMAILEXTENSIONWITHMORETHANSIXTYSIXCHARACTERSBECAUSEWENEEDANERRORCONDITION')
+        )
+      ).toEqual(patternError);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-email/po-email.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-email/po-email.component.ts
@@ -55,7 +55,27 @@ export class PoEmailComponent extends PoInputGeneric implements AfterViewInit, O
 
   type = 'email';
 
-  pattern = '^([\\w-]+(?:\\.[\\w-]+)*)@((?:[\\w-]+\\.)*\\w[\\w-]{0,66})\\.([A-Za-z]{2,6}(?:\\.[A-Za-z]{2})?)$';
+  // Consideramos o uso do nosso pattern com a seguinte expressão.
+  // Antes do símbolo @:
+  // - não há limite de caracteres.
+  // - não pode haver espaços em branco, caracteres acentuados, caracteres especiais ou símbolos.
+  // - pode começar com letras, números, hífen ou undescore (underline).
+  //
+  // Depois do símbolo @:
+  // - o domínio tem um limite de até 66 caracteres após um separador.
+  // - separador deve ser um 'ponto' (.).
+  // - o primeiro bloco pode conter letras, números, hífen ou underscore (underline).
+  // - após o primeiro separador é permitido apenas letras.
+  // - não pode haver espaços em branco, caracteres acentuados, caracteres especiais ou símbolos.
+  //
+  // Limite total de 254 caracteres para o e-mail.
+  //
+  // As recomendações foram consultadas nas RFC 1034, RFC 5321 e RFC 5322.
+  //
+  // RFC 1034 - https://datatracker.ietf.org/doc/html/rfc1034#section-3
+  // RFC 5321 - https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1
+  // RFC 5322 - https://datatracker.ietf.org/doc/html/rfc5322#section-3.4
+  pattern = '^([\\w-]+(?:\\.[\\w-]+)*)@((?:[\\w-]+\\.)*\\w[\\w-]{0,66})\\.([A-Za-z]{2,66}(?:\\.[A-Za-z]{2})?)$';
 
   mask = '';
 


### PR DESCRIPTION
**PO-EMAIL**

**DTHFUI-5088**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O componente ```po-email``` limita a quantidade de caracteres após o último ponto.
Limite de 6 caracteres.

**Qual o novo comportamento?**
O componente teve o limite alterado e agora permite até 66 caracteres após o último ponto.

**Simulação**
```app.component.html```
```
<po-page-default p-title="PO UI - Email">
    <div class="po-row">
      <po-email
        class="po-lg-12"
        name="email"
        [(ngModel)]="email"
        p-clean
        p-error-pattern="Invalid e-mail"
        p-label="Email"
        p-placeholder="Enter your e-mail"
        p-required
      >
      </po-email>
      <po-info
        class="po-lg-12"
        p-label='Quantidade de caracteres'
        p-label-size=11
        p-orientation=horizontal
        p-value={{email.length}}
      >
      </po-info>
    </div>
</po-page-default>
```

```app.component.ts```
```
export class AppComponent {
  email: string = '';
}
```
