### PR TITLE
feat(multiselect): permite utilizar com serviço

### DIFF
--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -28,6 +28,7 @@ export * from './po-lookup/po-lookup.component';
 export * from './po-multiselect/po-multiselect-filter-mode.enum';
 export * from './po-multiselect/po-multiselect-literals.interface';
 export * from './po-multiselect/po-multiselect-option.interface';
+export * from './po-multiselect/po-multiselect-filter.interface';
 export * from './po-multiselect/po-multiselect.component';
 export * from './po-number/po-number.component';
 export * from './po-password/po-password.component';

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -1,6 +1,9 @@
 import { EventEmitter, Input, OnInit, Output, Directive } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 
+import { Observable, Subject, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs/operators';
+
 import {
   convertToBoolean,
   removeDuplicatedOptions,
@@ -15,6 +18,9 @@ import { PoMultiselectFilterMode } from './po-multiselect-filter-mode.enum';
 import { PoMultiselectLiterals } from './po-multiselect-literals.interface';
 import { PoMultiselectOption } from './po-multiselect-option.interface';
 import { InputBoolean } from '../../../decorators';
+import { PoMultiselectFilter } from './po-multiselect-filter.interface';
+
+const PO_MULTISELECT_DEBOUNCE_TIME_DEFAULT = 400;
 
 export const poMultiselectLiteralsDefault = {
   en: <PoMultiselectLiterals>{
@@ -46,6 +52,8 @@ export const poMultiselectLiteralsDefault = {
  *
  * Este componente também não deve ser utilizado em casos onde a seleção seja única. Nesses casos, deve-se utilizar o
  * po-select, po-combo ou po-radio-group.
+ *
+ * Com ele também é possível definir uma lista à partir da requisição de um serviço definido em `p-filter-service`.
  */
 @Directive()
 export abstract class PoMultiselectBaseComponent implements ControlValueAccessor, OnInit, Validator {
@@ -61,18 +69,6 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * @default `false`
    */
   @Input('p-auto-focus') @InputBoolean() autoFocus: boolean = false;
-
-  /**
-   * @optional
-   *
-   * @description
-   *
-   * Define que a altura do componente será auto ajustável, possuindo uma altura minima porém a altura máxima será de acordo
-   * com o número de itens selecionados e a extensão dos mesmos, mantendo-os sempre visíveis.
-   *
-   * @default `false`
-   */
-  @Input('p-auto-height') @InputBoolean() autoHeight: boolean = false;
 
   /** Label no componente. */
   @Input('p-label') label?: string;
@@ -124,13 +120,19 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   selectedOptions: Array<PoMultiselectOption> = [];
   visibleOptionsDropdown: Array<PoMultiselectOption> = [];
   visibleDisclaimers = [];
+  isServerSearching = false;
+  isFirstFilter: boolean = true;
+  filterSubject = new Subject();
 
   // eslint-disable-next-line
   protected onModelTouched: any = null;
 
   protected clickOutListener: () => void;
   protected resizeListener: () => void;
+  protected getObjectsByValuesSubscription: Subscription;
 
+  private _filterService?: PoMultiselectFilter;
+  private _debounceTime?: number = 400;
   private _disabled?: boolean = false;
   private _filterMode?: PoMultiselectFilterMode = PoMultiselectFilterMode.startsWith;
   private _hideSearch?: boolean = false;
@@ -138,11 +140,72 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   private _options: Array<PoMultiselectOption>;
   private _required?: boolean = false;
   private _sort?: boolean = false;
+  private _autoHeight: boolean = false;
   private language: string;
 
   private lastLengthModel;
   private onModelChange: any;
   private validatorChange: any;
+  private autoHeightInitialValue: boolean;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Nesta propriedade deve ser informado um serviço implementando a interface PoMultiselectFilter.
+   *
+   * > Definirá por padrão a propriedade `p-auto-height` como `true`, mas a mesma pode ser redefinida caso necessário.
+   */
+  @Input('p-filter-service') set filterService(value: PoMultiselectFilter) {
+    this._filterService = value;
+    this.autoHeight = this.autoHeightInitialValue !== undefined ? this.autoHeightInitialValue : true;
+    this.options = [];
+  }
+
+  get filterService() {
+    return this._filterService;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que a altura do componente será auto ajustável, possuindo uma altura minima porém a altura máxima será de acordo
+   * com o número de itens selecionados e a extensão dos mesmos, mantendo-os sempre visíveis.
+   *
+   * > O valor padrão será `true` quando houver serviço (`p-filter-service`).
+   *
+   * @default `false`
+   */
+  @Input('p-auto-height') @InputBoolean() set autoHeight(value: boolean) {
+    this._autoHeight = value;
+    this.autoHeightInitialValue = value;
+  }
+
+  get autoHeight(): boolean {
+    return this._autoHeight;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   * Esta propriedade define em quanto tempo (em milissegundos), aguarda para acionar o evento de filtro após cada pressionamento de tecla.
+   *
+   * > Será utilizada apenas quando houver serviço (`p-filter-service`) e somente será aceito valor maior do que *zero*.
+   *
+   * @default `400`
+   */
+  @Input('p-debounce-time') set debounceTime(value: number) {
+    const parsedValue = parseInt(<any>value, 10);
+
+    this._debounceTime = !isNaN(parsedValue) && parsedValue > 0 ? parsedValue : PO_MULTISELECT_DEBOUNCE_TIME_DEFAULT;
+  }
+
+  get debounceTime(): number {
+    return this._debounceTime;
+  }
 
   /**
    * @optional
@@ -330,6 +393,18 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   }
 
   ngOnInit() {
+    if (this.filterService) {
+      this.filterSubject
+        .pipe(
+          debounceTime(this.debounceTime),
+          distinctUntilChanged(),
+          tap(() => (this.isServerSearching = true)),
+          switchMap((search: string) => this.applyFilter(search)),
+          tap(() => (this.isServerSearching = false))
+        )
+        .subscribe();
+    }
+
     this.updateList(this.options);
   }
 
@@ -429,16 +504,20 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
     return null;
   }
 
-  updateSelectedOptions(values) {
+  updateSelectedOptions(newOptions: Array<any>, options = this.options) {
     this.selectedOptions = [];
 
-    values.forEach(value => {
-      this.options.forEach(option => {
-        if (option.value === value) {
-          this.selectedOptions.push(option);
-        }
+    if (this.filterService) {
+      this.selectedOptions = newOptions;
+    } else {
+      newOptions.forEach(newOption => {
+        options.forEach(option => {
+          if (option.value === newOption.value) {
+            this.selectedOptions.push(option);
+          }
+        });
       });
-    });
+    }
 
     this.updateVisibleItems();
   }
@@ -446,11 +525,18 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   writeValue(values: any): void {
     values = values || [];
 
-    // Validar se todos os items existem entre os options, senão atualizar o model
-    this.updateSelectedOptions(values);
+    if (this.filterService && values.length) {
+      this.getObjectsByValuesSubscription = this.filterService.getObjectsByValues(values).subscribe(options => {
+        this.updateSelectedOptions(options);
+        this.callOnChange(this.selectedOptions);
+      });
+    } else {
+      // Validar se todos os items existem entre os options, senão atualizar o model
+      this.updateSelectedOptions(values.map(value => ({ value })));
 
-    if (this.selectedOptions.length < values.length) {
-      this.callOnChange(this.selectedOptions);
+      if (this.selectedOptions && this.selectedOptions.length < values.length) {
+        this.callOnChange(this.selectedOptions);
+      }
     }
   }
 
@@ -478,5 +564,6 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
     }
   }
 
+  abstract applyFilter(value?: string): Observable<Array<PoMultiselectOption>>;
   abstract updateVisibleItems(): void;
 }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
@@ -1,7 +1,7 @@
 <div #container class="po-multiselect-container" [hidden]="!show">
   <po-multiselect-search
     #searchElement
-    *ngIf="!hideSearch && hasOptions"
+    *ngIf="!hideSearch"
     [p-literals]="literals"
     [p-placeholder]="placeholderSearch"
     (p-change)="callChangeSearch($event)"
@@ -9,16 +9,22 @@
   </po-multiselect-search>
 
   <ul class="po-multiselect-items-container" [scrollTop]="scrollTop" #ulElement>
-    <div *ngIf="!visibleOptions.length" class="po-multiselect-container-no-data po-text-center">
+    <div *ngIf="!visibleOptions.length && !isServerSearching" class="po-multiselect-container-no-data po-text-center">
       <span> {{ literals.noData }}</span>
     </div>
 
-    <po-multiselect-item
-      *ngFor="let option of visibleOptions"
-      [p-label]="option.label"
-      [p-selected]="isSelectedItem(option)"
-      (p-change)="clickItem($event, option)"
-    >
-    </po-multiselect-item>
+    <div *ngIf="isServerSearching" class="po-multiselect-container-loading po-text-center">
+      <po-loading></po-loading>
+    </div>
+
+    <ng-container *ngIf="!isServerSearching">
+      <po-multiselect-item
+        *ngFor="let option of visibleOptions"
+        [p-label]="option.label"
+        [p-selected]="isSelectedItem(option)"
+        (p-change)="clickItem($event, option)"
+      >
+      </po-multiselect-item>
+    </ng-container>
   </ul>
 </div>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.spec.ts
@@ -49,13 +49,13 @@ describe('PoMultiselectDropdownComponent:', () => {
   });
 
   it('should return true in isSelectedItem', () => {
-    component.selectedValues = [1, 2];
+    component.selectedOptions = [{ value: 1 }, { value: 2 }];
     const selected = component.isSelectedItem({ label: 'label1', value: 1 });
     expect(selected).toBeTruthy();
   });
 
   it('should return false in isSelectedItem', () => {
-    component.selectedValues = [1, 2];
+    component.selectedOptions = [1, 2];
     const selected = component.isSelectedItem({ label: 'label3', value: 3 });
     expect(selected).toBeFalsy();
   });
@@ -78,21 +78,21 @@ describe('PoMultiselectDropdownComponent:', () => {
     expect(component.searchElement.setFocus).not.toHaveBeenCalled();
   });
 
-  it('should add value to selectedValues and emit change', () => {
-    component['selectedValues'] = [];
+  it('should add value to selectedOptions and emit change', () => {
+    component['selectedOptions'] = [];
 
     spyOn(component.change, 'emit');
     component.updateSelectedValues(true, { label: 'label1', value: 1 });
-    expect(component['selectedValues'].length).toBe(1);
+    expect(component['selectedOptions'].length).toBe(1);
     expect(component.change.emit).toHaveBeenCalled();
   });
 
-  it('should remove value to selectedValues and emit change', () => {
-    component['selectedValues'] = [1];
+  it('should remove value to selectedOptions and emit change', () => {
+    component['selectedOptions'] = [{ value: 1 }];
 
     spyOn(component.change, 'emit');
     component.updateSelectedValues(false, { label: 'label1', value: 1 });
-    expect(component['selectedValues'].length).toBe(0);
+    expect(component['selectedOptions'].length).toBe(0);
     expect(component.change.emit).toHaveBeenCalled();
   });
 
@@ -235,13 +235,12 @@ describe('PoMultiselectDropdownComponent:', () => {
       expect(fixture.nativeElement.querySelector('.po-multiselect-container-no-data')).toBeTruthy();
     });
 
-    it('shouldn`t show `po-multiselect-search` if haven`t options', () => {
-      component.options = [];
-      component.hideSearch = false;
+    it('shouldn`t show `po-multiselect-search` if `hideSearch` is `true`', () => {
+      component.hideSearch = true;
 
       fixture.detectChanges();
 
-      expect(fixture.debugElement.query(By.css('po-multiselect-search'))).toBe(null);
+      expect(fixture.debugElement.query(By.css('po-multiselect-search'))).toEqual(null);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
@@ -16,6 +16,9 @@ import { PoMultiselectSearchComponent } from './../po-multiselect-search/po-mult
   templateUrl: './po-multiselect-dropdown.component.html'
 })
 export class PoMultiselectDropdownComponent {
+  /** Propriedade que indica se deve exibir o loading. */
+  @Input('p-searching') isServerSearching?: boolean = false;
+
   /** Propriedade que indica se o campo de pesquisa deverá ser escondido. */
   @Input('p-hide-search') hideSearch?: boolean = false;
 
@@ -26,7 +29,7 @@ export class PoMultiselectDropdownComponent {
   @Input('p-placeholder-search') placeholderSearch: string;
 
   /** Propriedade que recebe a lista de opções selecionadas. */
-  @Input('p-selected-values') selectedValues: Array<any> = [];
+  @Input('p-selected-options') selectedOptions: Array<any> = [];
 
   /** Propriedade que recebe a lista com todas as opções. */
   @Input('p-options') options: Array<PoMultiselectOption> = [];
@@ -70,7 +73,7 @@ export class PoMultiselectDropdownComponent {
   }
 
   isSelectedItem(option: PoMultiselectOption) {
-    return this.selectedValues.some(selectedItem => selectedItem === option.value);
+    return this.selectedOptions.some(selectedItem => selectedItem.value === option.value);
   }
 
   clickItem(check, option) {
@@ -83,13 +86,12 @@ export class PoMultiselectDropdownComponent {
 
   updateSelectedValues(checked, option) {
     if (checked) {
-      this.selectedValues.push(option.value);
+      this.selectedOptions.push(option);
     } else {
-      const indexSelectedValues = this.selectedValues.indexOf(option.value);
-      this.selectedValues.splice(indexSelectedValues, 1);
+      this.selectedOptions = this.selectedOptions.filter(selectedOption => selectedOption.value !== option.value);
     }
 
-    this.change.emit(this.selectedValues);
+    this.change.emit(this.selectedOptions);
   }
 
   callChangeSearch(event) {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.interface.ts
@@ -1,0 +1,28 @@
+import { Observable } from 'rxjs';
+
+import { PoMultiselectOption } from './po-multiselect-option.interface';
+
+/**
+ * @usedBy PoMultiselectComponent
+ *
+ * @description
+ *
+ * Interface para os serviços que serão utilizados no po-multiselect.
+ */
+export interface PoMultiselectFilter {
+  /**
+   * Método que será chamado ao realizar uma busca no componente, deve retornar um Observable que contém uma coleção de objetos que seguem
+   * a interface `PoMultiselectOption`, será informado por parametro o campo e o valor a ser pesquisado.
+   *
+   * @param {{ property: string, value: string }} params Objeto contendo a propriedade e o valor responsável por realizar o filtro.
+   */
+  getFilteredData(params: { property: string; value: string }): Observable<Array<PoMultiselectOption>>;
+
+  /**
+   * Método que será chamado ao iniciar o componente com valor, deve retornar um Observable que contém apenas os objetos filtrados que
+   * seguem a interface `PoMultiselectOption`, será informado por parâmetro valor a ser pesquisado.
+   *
+   * @param {Array<string | number>} values Array com os valores a serem buscados.
+   */
+  getObjectsByValues(values: Array<string | number>): Observable<Array<PoMultiselectOption>>;
+}

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -41,11 +41,12 @@
 
   <po-multiselect-dropdown
     #dropdownElement
+    [p-searching]="isServerSearching"
     [p-hide-search]="hideSearch"
     [p-literals]="literals"
     [p-options]="options"
     [p-visible-options]="visibleOptionsDropdown"
-    [p-selected-values]="getValuesFromOptions(selectedOptions)"
+    [p-selected-options]="selectedOptions"
     [p-placeholder-search]="placeholderSearch"
     (p-change)="changeItems($event)"
     (p-change-search)="changeSearch($event)"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.component.html
@@ -1,0 +1,23 @@
+<div class="po-row">
+  <po-multiselect
+    class="po-md-6"
+    name="multiselect"
+    [(ngModel)]="multiselect"
+    p-label="Search a Hero"
+    [p-filter-service]="filterService"
+    [p-debounce-time]="debounce"
+    (p-change)="changeOptions($event)"
+  >
+  </po-multiselect>
+
+  <po-container class="po-md-6 po-mt-4">
+    <po-table
+      [p-columns]="columns"
+      [p-items]="heroes"
+      [p-height]="220"
+      [p-striped]="true"
+      [p-hide-columns-manager]="true"
+    >
+    </po-table>
+  </po-container>
+</div>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.component.ts
@@ -1,0 +1,39 @@
+import { Component } from '@angular/core';
+import { PoTableColumn, PoMultiselectFilter } from '@po-ui/ng-components';
+
+import { SamplePoMultiselectHeroesService } from './sample-po-multiselect-heroes.service';
+
+@Component({
+  selector: 'sample-po-multiselect-heroes',
+  templateUrl: './sample-po-multiselect-heroes.component.html',
+  providers: [SamplePoMultiselectHeroesService]
+})
+export class SamplePoMultiselectHeroesComponent {
+  debounce = 500;
+  filterService: PoMultiselectFilter;
+  heroes: Array<any>;
+  multiselect: Array<string> = ['1495831666871', '1405833068599'];
+  columns: Array<PoTableColumn> = [
+    { property: 'value', label: 'id' },
+    {
+      property: 'label',
+      label: 'Name',
+      type: 'link',
+      action: value => {
+        this.openLink(value);
+      }
+    }
+  ];
+
+  constructor(public samplePoMultiselectHeroesService: SamplePoMultiselectHeroesService) {
+    this.filterService = samplePoMultiselectHeroesService;
+  }
+
+  changeOptions(event): void {
+    this.heroes = event;
+  }
+
+  openLink(value) {
+    window.open(`http://google.com/search?q=${value}`, '_blank');
+  }
+}

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.service.ts
@@ -1,0 +1,49 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { PoMultiselectOption, PoMultiselectFilter } from '@po-ui/ng-components';
+
+@Injectable()
+export class SamplePoMultiselectHeroesService implements PoMultiselectFilter {
+  readonly headers: HttpHeaders = new HttpHeaders({
+    'X-PO-No-Message': 'true'
+  });
+
+  constructor(private http: HttpClient) {}
+
+  getFilteredData(param: { property: 'string'; value: 'string' }): Observable<Array<PoMultiselectOption>> {
+    const params = { filter: param.value };
+
+    return this.http
+      .get(`https://po-sample-api.herokuapp.com/v1/heroes?page=1&pageSize=10`, {
+        responseType: 'json',
+        params,
+        headers: this.headers
+      })
+      .pipe(map(response => this.parseToArrayMultiselectOptions(response['items'])));
+  }
+
+  getObjectsByValues(value: Array<string | number>): Observable<Array<PoMultiselectOption>> {
+    return this.http
+      .get(`https://po-sample-api.herokuapp.com/v1/heroes/?value=${value.toString()}`, { headers: this.headers })
+      .pipe(map(response => this.parseToArrayMultiselectOptions(response['items'])));
+  }
+
+  private parseToArrayMultiselectOptions(items: Array<any>): Array<PoMultiselectOption> {
+    if (items && items.length > 0) {
+      return items.map(item => this.parseToMultiselectOption(item));
+    }
+
+    return [];
+  }
+
+  private parseToMultiselectOption(item: any): PoMultiselectOption {
+    const label = item.label;
+    const value = item.value;
+
+    return { label, value };
+  }
+}


### PR DESCRIPTION
**PO MULTISELECT**

**DTHFUI-1104**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Não permite a utilização com serviço.

**Qual o novo comportamento?**
Possível utilizar serviço no componente para recuperar os dados do servidor.

**Simulação**
1. Baixar o projeto e subir a aplicação **po-sample-api** localmente através do [PR](https://github.com/po-ui/po-sample-api/pull/22).
2. Buildar o [PR](https://github.com/po-ui/po-style/pull/238) do **po-style** e colocar a dist style dentro da pasta _@po-ui_ na _node_modules_ dentro do projeto po-angular.
3. Alterar as URLs da API no serviço `sample-po-multiselect-heroes.service.ts` no projeto **po-angular**, substituir nas linhas 21 e 31 as URLs:
-  `https://po-sample-api.herokuapp.com/v1/heroes?page=1&pageSize=10` por `http://localhost:3000/v1/heroes?page=1&pageSize=10`
-  `https://po-sample-api.herokuapp.com/v1/heroes/?value=${value.toString()}`  por  `http://localhost:3000/v1/heroes/?value=${value.toString()}`
4. `npm run build: portal && ng serve portal -o`
5. Simular através do sample do Portal `Heroes With Api`