### PR TITLE
feat(notification): limita em até 5 notificações na tela

### DIFF
--- a/projects/ui/src/lib/services/po-notification/po-notification-base.service.spec.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification-base.service.spec.ts
@@ -38,6 +38,7 @@ class PoNotificationService extends PoNotificationBaseService {
   }
 
   destroyToaster(toaster: number | ComponentRef<PoToasterBaseComponent>): void {}
+  verifyLimitToaster(): void {}
 }
 
 describe('PoNotificationService ', () => {

--- a/projects/ui/src/lib/services/po-notification/po-notification-base.service.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification-base.service.ts
@@ -21,6 +21,8 @@ import { PoToasterType } from './po-toaster/po-toaster-type.enum';
  * Estas notificações serão exibidas durante 10 segundos por padrão, podendo ser alterada conforme necessidade.
  * Após este tempo a mesma é removida automaticamente.
  *
+ * O serviço possui um limite de até 5 notificações por vez, a partir do sexto a primeira notificação será removida dando lugar a nova.
+ *
  */
 export abstract class PoNotificationBaseService {
   // Array responsável por guardar a instância de po-toaster's superiores.

--- a/projects/ui/src/lib/services/po-notification/po-notification.service.spec.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification.service.spec.ts
@@ -20,6 +20,10 @@ describe('PoNotificationService:', () => {
     jasmine.clock().install();
 
     notificationService = TestBed.inject(PoNotificationService);
+    notificationService.stackTop = [];
+    notificationService.stackTop.length = 0;
+    notificationService.stackBottom = [];
+    notificationService.stackBottom.length = 0;
   });
 
   afterEach(() => {
@@ -35,7 +39,7 @@ describe('PoNotificationService:', () => {
 
     expect(notificationService.stackTop.length === 1).toBeTruthy();
 
-    tick(10001);
+    tick(10301);
 
     expect(notificationService.stackTop.length === 0).toBeTruthy();
   }));
@@ -49,7 +53,7 @@ describe('PoNotificationService:', () => {
 
     expect(notificationService.stackBottom.length === 1).toBeTruthy();
 
-    tick(3001);
+    tick(3301);
 
     expect(notificationService.stackBottom.length === 0).toBeTruthy();
   }));
@@ -64,7 +68,7 @@ describe('PoNotificationService:', () => {
 
       expect(notificationService.stackTop.length === 1).toBeTruthy();
 
-      tick(3001);
+      tick(3301);
 
       expect(notificationService.stackTop.length === 0).toBeTruthy();
     }));
@@ -84,7 +88,7 @@ describe('PoNotificationService:', () => {
 
       expect(notificationService.stackTop.length === 2).toBeTruthy();
 
-      tick(3100);
+      tick(3601);
 
       expect(notificationService.stackTop.length === 0).toBeTruthy();
     }));
@@ -99,5 +103,36 @@ describe('PoNotificationService:', () => {
       notificationService['observableOnClose'](fakeRef);
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should destroy toaster when `stackTop` is more than 5', fakeAsync(() => {
+      for (let i = 0; i < 6; i++) {
+        notificationService.success({
+          message: '',
+          orientation: PoToasterOrientation.Top,
+          action: () => {
+            alert('');
+          },
+          actionLabel: 'close'
+        });
+      }
+      tick(301);
+      expect(notificationService.stackTop.length).toBe(5);
+    }));
+
+    it('should destroy toaster when `stackBottom` is more than 5', fakeAsync(() => {
+      for (let i = 0; i < 6; i++) {
+        notificationService.success({
+          message: '',
+          orientation: PoToasterOrientation.Bottom,
+          action: () => {
+            alert('');
+          },
+          actionLabel: 'close'
+        });
+      }
+
+      tick(301);
+      expect(notificationService.stackBottom.length).toBe(5);
+    }));
   });
 });

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.html
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.html
@@ -1,20 +1,15 @@
-<div
-  #toaster
-  *ngIf="getShowToaster()"
-  class="po-toaster {{ getToasterType() }} {{ getToasterPosition() }} po-clickable"
-  (click)="close()"
->
+<div #toaster class="po-toaster {{ getToasterType() }} {{ getToasterPosition() }} po-clickable" (click)="close()">
   <div class="po-toaster-icon">
     <span class="po-icon {{ getIcon() }}"></span>
   </div>
 
   <div class="po-toaster-message">{{ message }}</div>
 
-  <div *ngIf="action && actionLabel" (click)="poToasterAction()" class="po-toaster-action">
+  <div *ngIf="action && actionLabel" (click)="poToasterAction($event)" class="po-toaster-action">
     {{ actionLabel }}
   </div>
 
-  <button class="po-toaster-close" (click)="onButtonClose()">
+  <button class="po-toaster-close" (click)="onButtonClose($event)">
     <span class="po-icon po-icon-close"></span>
   </button>
 </div>

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  OnDestroy,
+  Renderer2,
+  ViewChild
+} from '@angular/core';
 
 import { Subject } from 'rxjs';
 
@@ -20,18 +28,16 @@ import { PoToasterOrientation } from './po-toaster-orientation.enum';
   selector: 'po-toaster',
   templateUrl: './po-toaster.component.html'
 })
-export class PoToasterComponent extends PoToasterBaseComponent {
+export class PoToasterComponent extends PoToasterBaseComponent implements AfterViewInit, OnDestroy {
   /* Componente toaster */
   @ViewChild('toaster') toaster: ElementRef;
-
+  alive: boolean = true;
   /* Ícone do Toaster */
   private icon: string;
   /* Margem do Toaster referênte à sua orientação e posição*/
   private margin: number = 20;
   /* Observable para monitorar o Close to Toaster */
   private observableOnClose = new Subject<any>();
-  /* Mostra ou oculta o Toaster */
-  private showToaster: boolean = true;
   /* Posição do Toaster*/
   private toasterPosition: string = 'po-toaster-bottom';
   /* Tipo do Toaster */
@@ -40,9 +46,18 @@ export class PoToasterComponent extends PoToasterBaseComponent {
   constructor(
     languageService: PoLanguageService,
     public changeDetector: ChangeDetectorRef,
-    private elementeRef?: ElementRef
+    private elementeRef?: ElementRef,
+    private renderer?: Renderer2
   ) {
     super();
+  }
+
+  ngOnDestroy(): void {
+    this.alive = false;
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => this.renderer.addClass(this.toaster.nativeElement, 'po-toaster-visible'));
   }
 
   /* Muda a posição do Toaster na tela*/
@@ -60,8 +75,12 @@ export class PoToasterComponent extends PoToasterBaseComponent {
 
   /* Fecha o componente Toaster */
   close(): void {
-    this.showToaster = false;
     this.observableOnClose.next(true);
+  }
+
+  setFadeOut() {
+    this.renderer.removeClass(this.toaster.nativeElement, 'po-toaster-visible');
+    this.renderer.addClass(this.toaster.nativeElement, 'po-toaster-invisible');
   }
 
   /* Configura o Toaster com os atributos passados para ele */
@@ -109,10 +128,6 @@ export class PoToasterComponent extends PoToasterBaseComponent {
     this.changeDetector.detectChanges();
   }
 
-  getShowToaster() {
-    return this.showToaster;
-  }
-
   getIcon() {
     return this.icon;
   }
@@ -125,16 +140,22 @@ export class PoToasterComponent extends PoToasterBaseComponent {
     return this.toasterType;
   }
 
-  onButtonClose() {
+  onButtonClose(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
     if (this.action && !this.actionLabel) {
-      this.poToasterAction();
+      this.poToasterAction(event);
     } else {
       this.close();
     }
   }
 
   /* Chama a função passada pelo atributo `action` */
-  poToasterAction(): void {
+  poToasterAction(event): void {
+    event.preventDefault();
+    event.stopPropagation();
+
     this.action(this);
   }
 }


### PR DESCRIPTION
**PO-NOTIFICATION**

**DTHFUI-5060**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O componente de notificação pode ser empilhado de forma ilimitada.

**Qual o novo comportamento?**
O componente de notificação tem um limite de até 5 notificações por vez. Caso seja enviada uma sexta notificação, a primeira notificação será apagada dando lugar a nova.

**Simulação**
https://github.com/po-ui/po-style/pull/236

app.component:
```
import { Component } from '@angular/core';
import { PoNotificationService, PoToasterOrientation } from '../../../ui/src/lib';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {

  constructor(private notification: PoNotificationService) {}

  notificacao(type: string) {
    this.notification[type]({
      //orientation: PoToasterOrientation.Top,
      message: 'type',
      action: () => {
        alert('aa');
      },
      actionLabel: 'close'
    });
  }

  seisToaster() {
    for (let i = 0; i < 5; i++) {
      this.notification.success({
        message: 'type'
      });
    }
    this.notification.error({
      message: 'type',
      action: () => {
        alert('aa');
      },
      actionLabel: 'close'
    });
  }
}

```

app.component.html: 
```
<button (click)="notificacao('success')">Success</button>
<button (click)="notificacao('error')">Error</button>
<button (click)="notificacao('warning')">Warning</button>
<button (click)="notificacao('information')">Info</button>
<br />
<button (click)="seisToaster()">6 toaster</button>
```