### PR TITLE
fix(chart): corrige ordenação indevida das categorias

### DIFF
--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.spec.ts
@@ -139,17 +139,17 @@ describe('PoChartMathsService', () => {
       });
     });
 
-    it('getLongestDataValue: should call `sortLongestData` if type is `bar`', () => {
+    it('getLongestDataValue: should call `getLongestData` if type is `bar`', () => {
       const data = ['Vancouver', 'Otawa'];
       const type = PoChartType.Bar;
       const options = {};
 
-      const spySortLongestData = spyOn(service, <any>'sortLongestData');
+      const spyGetLongestData = spyOn(service, <any>'getLongestData');
       const spyGetAxisXLabelLongestValue = spyOn(service, <any>'getAxisXLabelLongestValue');
 
       service.getLongestDataValue(data, type, options);
 
-      expect(spySortLongestData).toHaveBeenCalledWith(data);
+      expect(spyGetLongestData).toHaveBeenCalledWith(data);
       expect(spyGetAxisXLabelLongestValue).not.toHaveBeenCalled();
     });
 
@@ -158,26 +158,26 @@ describe('PoChartMathsService', () => {
       const type = PoChartType.Line;
       const options = { axis: { gridLines: 5 } };
 
-      const spySortLongestData = spyOn(service, <any>'sortLongestData');
+      const spyGetLongestData = spyOn(service, <any>'getLongestData');
       const spyGetAxisXLabelLongestValue = spyOn(service, <any>'getAxisXLabelLongestValue');
 
       service.getLongestDataValue(data, type, options);
 
       expect(spyGetAxisXLabelLongestValue).toHaveBeenCalledWith(data, 5);
-      expect(spySortLongestData).not.toHaveBeenCalled();
+      expect(spyGetLongestData).not.toHaveBeenCalled();
     });
 
     it('getLongestDataValue: should call `getAxisXLabelLongestValue` passing data and 5 as params if options.axis is undefined', () => {
       const type = PoChartType.Line;
       const options = undefined;
 
-      const spySortLongestData = spyOn(service, <any>'sortLongestData');
+      const spyGetLongestData = spyOn(service, <any>'getLongestData');
       const spyGetAxisXLabelLongestValue = spyOn(service, <any>'getAxisXLabelLongestValue');
 
       service.getLongestDataValue(undefined, type, options);
 
       expect(spyGetAxisXLabelLongestValue).toHaveBeenCalledWith([], 5);
-      expect(spySortLongestData).not.toHaveBeenCalled();
+      expect(spyGetLongestData).not.toHaveBeenCalled();
     });
 
     it('getAxisXLabelLongestValue: should call `calculateMinAndMaxValues` passing data and allowNegativeData false as params', () => {
@@ -186,7 +186,7 @@ describe('PoChartMathsService', () => {
 
       const spyCalculateMinAndMaxValues = spyOn(service, <any>'calculateMinAndMaxValues');
       spyOn(service, <any>'range');
-      spyOn(service, <any>'sortLongestData');
+      spyOn(service, <any>'getLongestData');
 
       service['getAxisXLabelLongestValue'](data, gridLines);
 
@@ -199,25 +199,25 @@ describe('PoChartMathsService', () => {
 
       const spyCalculateMinAndMaxValues = spyOn(service, <any>'calculateMinAndMaxValues');
       spyOn(service, <any>'range');
-      spyOn(service, <any>'sortLongestData');
+      spyOn(service, <any>'getLongestData');
 
       service['getAxisXLabelLongestValue'](data, gridLines);
 
       expect(spyCalculateMinAndMaxValues).toHaveBeenCalledWith(data, true);
     });
 
-    it('getAxisXLabelLongestValue: should call `range` and `sortLongestData`', () => {
+    it('getAxisXLabelLongestValue: should call `range` and `getLongestData`', () => {
       const data = [{ data: [-30, 0, 10], type: PoChartType.Line }];
       const gridLines = 5;
 
       spyOn(service, <any>'calculateMinAndMaxValues');
       const spyRange = spyOn(service, <any>'range');
-      const spySortLongestData = spyOn(service, <any>'sortLongestData');
+      const spyGetLongestData = spyOn(service, <any>'getLongestData');
 
       service['getAxisXLabelLongestValue'](data, gridLines);
 
       expect(spyRange).toHaveBeenCalled();
-      expect(spySortLongestData).toHaveBeenCalled();
+      expect(spyGetLongestData).toHaveBeenCalled();
     });
 
     it('amountOfGridLines: should return 5 if options is undefined', () => {
@@ -244,10 +244,11 @@ describe('PoChartMathsService', () => {
       expect(service['amountOfGridLines'](options)).toBe(7);
     });
 
-    it('sortLongestData: should return 400 as longest data value', () => {
+    it('getLongestData: should return 400 as longest data value and do not change list order', () => {
       const data = [1, 2, 400, 3];
 
-      expect(service['sortLongestData'](data)).toBe(400);
+      expect(service['getLongestData'](data)).toBe(400);
+      expect(data).toEqual([1, 2, 400, 3]);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-maths.service.ts
@@ -42,7 +42,7 @@ export class PoChartMathsService {
     options: PoChartOptions
   ): number | string {
     if (type === PoChartType.Bar) {
-      return this.sortLongestData<string>(data as Array<string>);
+      return this.getLongestData<string>(data as Array<string>);
     } else {
       return this.getAxisXLabelLongestValue(data as Array<PoChartSerie>, this.amountOfGridLines(options?.axis));
     }
@@ -127,7 +127,7 @@ export class PoChartMathsService {
     const domain: PoChartMinMaxValues = this.calculateMinAndMaxValues(data, allowNegativeData);
     const axisXLabelsList: Array<number> = this.range(domain, gridLines);
 
-    return this.sortLongestData<number>(axisXLabelsList);
+    return this.getLongestData<number>(axisXLabelsList);
   }
 
   // Cálculo que retorna o valor obtido de gridLines em relação ao alcance dos valores mínimos e máximos das séries (maxMinValues)
@@ -156,7 +156,8 @@ export class PoChartMathsService {
     return (1 / value) * (100 / 1);
   }
 
-  private sortLongestData<T>(serie: Array<T>): T {
-    return serie.sort((longest, current) => current.toString().length - longest.toString().length)['0'];
+  private getLongestData<T>(serie: Array<T>): T {
+    const newSerie = [...serie];
+    return newSerie.sort((longest, current) => current.toString().length - longest.toString().length)['0'];
   }
 }


### PR DESCRIPTION
Fixes DTHFUI-4931

**Chart**

**DTHFUI-4931**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O gráfico de tabelas não respeita a ordem das categorias enviadas. Sempre mantém a categoria com maior caractere em primeiro.

**Qual o novo comportamento?**
O gráfico mantém a ordem da lista de categorias enviadas

**Simulação**

`app.component.html` :

```
<po-chart
  class="po-md-12 po-mt-2"
  p-title="Ranking of the most purchased and consumed beverages in Germany between 2018 and 2020 - in %"
  [p-height]="816"
  [p-categories]="consumptionPerCapitaItems"
  [p-series]="consumptionPerCapita"
  [p-type]="consumptionPerCapitaType"
  [p-options]="consumptionPerCapitaOptions"
>
</po-chart>
```

`app.component`:

```
import { Component } from '@angular/core';
import { PoChartOptions, PoChartSerie, PoChartType } from '../../../ui/src/lib';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  consumptionPerCapitaType: PoChartType = PoChartType.Bar;

  consumptionPerCapitaItems: Array<string> =
   ['c', 'CATEGORIAGRANDE', 'cat', 'CATEGORIAGRANDECATEGORIAGRANDE'];

  consumptionPerCapita: Array<PoChartSerie> = [
    { label: '2018', data: [40.5, 51.3, 90.6, 34.3] },
    { label: '2020', data: [10.1, 52.1, 90.3, 50.3] }
  ];

  consumptionPerCapitaOptions: PoChartOptions = {
    axis: {
      maxRange: 100,
      gridLines: 2
    }
  };
}
```
