### PR TITLE
feat(combo): adiciona propriedade para desabilitar busca por tab

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -161,6 +161,17 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @description
    *
+   * Se verdadeiro, desabilitará a busca de um item via TAB.
+   *
+   * @default `false`
+   */
+  @Input('p-disabled-tab-filter') @InputBoolean() disabledTabFilter?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Deve ser informada uma função que será disparada quando houver alterações no ngModel. A função receberá como argumento o model modificado.
    *
    * > Pode-se optar pelo recebimento do objeto selecionado ao invés do model através da propriedade `p-emit-object-value`.

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -109,14 +109,14 @@ describe('PoComboComponent:', () => {
   }));
 
   it('should call apply filter when is not processing "getObjectByValue"', () => {
-    component.isProcessingGetObjectByValue = false;
+    component.isProcessingValueByTab = false;
     spyOn(component, 'applyFilter');
     component.controlApplyFilter('valor');
     expect(component.applyFilter).toHaveBeenCalledWith('valor');
   });
 
   it('shouldn`t call apply filter when is processing "getObjectByValue"', () => {
-    component.isProcessingGetObjectByValue = true;
+    component.isProcessingValueByTab = true;
     spyOn(component, 'applyFilter');
     component.controlApplyFilter('valor');
     expect(component.applyFilter).not.toHaveBeenCalled();
@@ -152,7 +152,7 @@ describe('PoComboComponent:', () => {
 
   it('should update SelectedValue to null', fakeAsync((): void => {
     component.debounceTime = 10;
-    component.isProcessingGetObjectByValue = true;
+    component.isProcessingValueByTab = true;
     component.selectedValue = null;
 
     spyOn(component, 'updateSelectedValue');
@@ -161,7 +161,7 @@ describe('PoComboComponent:', () => {
 
     tick(11);
 
-    expect(component.isProcessingGetObjectByValue).toBeFalsy();
+    expect(component.isProcessingValueByTab).toBeFalsy();
   }));
 
   it('selectPreviousOption: should select a previous value when a selected value already exists', () => {
@@ -1998,7 +1998,7 @@ describe('PoComboComponent - with service:', () => {
     it('controlApplyFilter: should call applyFilter if value is not equal selectedOption.label', fakeAsync((): void => {
       const value = 'abc';
 
-      component.isProcessingGetObjectByValue = false;
+      component.isProcessingValueByTab = false;
       component.selectedOption = { label: 'po', value: 'po' };
 
       spyOn(component, 'applyFilter');
@@ -2006,6 +2006,19 @@ describe('PoComboComponent - with service:', () => {
       component.controlApplyFilter(value);
 
       expect(component.applyFilter).toHaveBeenCalled();
+    }));
+
+    it(`controlApplyFilter: shouldn't call applyFilter if isProcessingValueByTab is true`, fakeAsync((): void => {
+      const value = 'abc';
+
+      component.isProcessingValueByTab = true;
+      component.selectedOption = { label: 'abc', value: 'abc' };
+
+      spyOn(component, 'applyFilter');
+
+      component.controlApplyFilter(value);
+
+      expect(component.applyFilter).not.toHaveBeenCalled();
     }));
 
     it(`onKeyUp: should call 'updateComboList' with 'cacheOptions' if has 'service', 'selectedValue'

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -107,7 +107,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   comboIcon: string = 'po-icon-arrow-down';
   comboOpen: boolean = false;
   differ: any;
-  isProcessingGetObjectByValue: boolean = false;
+  isProcessingValueByTab: boolean = false;
   scrollTop = 0;
   service: PoComboFilterService;
   shouldMarkLetters: boolean = true;
@@ -213,7 +213,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     const inputValue = event.target.value;
 
     // busca um registro quando acionar o tab
-    if (this.service && key === PoKeyCodeEnum.tab && inputValue) {
+    if (this.service && key === PoKeyCodeEnum.tab && inputValue && !this.disabledTabFilter) {
       this.controlComboVisibility(false);
       return this.getObjectByValue(inputValue);
     }
@@ -245,7 +245,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
 
       this.controlComboVisibility(false);
       this.verifyValidOption();
-
+      this.isProcessingValueByTab = true;
       if (!this.service) {
         // caso for changeOnEnter e nao ter selectedValue deve limpar o selectedView para reinicia-lo.
         this.selectedView = this.changeOnEnter && !this.selectedValue ? undefined : this.selectedView;
@@ -335,9 +335,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   controlApplyFilter(value) {
-    if (!this.isProcessingGetObjectByValue && (!this.selectedOption || value !== this.selectedOption.label)) {
+    if (!this.isProcessingValueByTab && (!this.selectedOption || value !== this.selectedOption.label)) {
       this.applyFilter(value);
     }
+    this.isProcessingValueByTab = false;
   }
 
   applyFilter(value: string) {
@@ -372,7 +373,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
 
   getObjectByValue(value) {
     if (this.selectedValue !== value && this.selectedOption?.label !== value) {
-      this.isProcessingGetObjectByValue = true;
+      this.isProcessingValueByTab = true;
 
       this.getSubscription = this.service.getObjectByValue(value, this.filterParams).subscribe(
         item => this.updateOptionByFilteredValue(item),
@@ -390,7 +391,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }
 
     setTimeout(() => {
-      this.isProcessingGetObjectByValue = false;
+      this.isProcessingValueByTab = false;
     }, this.debounceTime);
   }
 

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -7,6 +7,7 @@
   [p-debounce-time]="debounceTime"
   [p-disabled]="properties.includes('disabled')"
   [p-disabled-init-filter]="properties.includes('disableInitFilter')"
+  [p-disabled-tab-filter]="properties.includes('disabledTabFilter')"
   [p-field-label]="fieldLabel"
   [p-field-value]="fieldValue"
   [p-filter-minlength]="filterMinlength"

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
@@ -58,7 +58,8 @@ export class SamplePoComboLabsComponent implements OnInit {
     { value: 'disabledInitFilter', label: 'Disabled Init Filter' },
     { value: 'required', label: 'Required' },
     { value: 'sort', label: 'Sort' },
-    { value: 'clean', label: 'Clean' }
+    { value: 'clean', label: 'Clean' },
+    { value: 'disabledTabFilter', label: 'Disabled Tab Filter' }
   ];
 
   ngOnInit() {


### PR DESCRIPTION
**Combo**

**DTHFUI-4405**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Não permite desabilitar a busca por TAB quando houver serviço, podendo realizar uma chamada para uma API com valor inválido.

**Qual o novo comportamento?**
Permiti desabilitar a busca por TAB quando houver serviço.

**Simulação**
Visualizar a aba de network e verificar se faz chamada via TAB para algum valor digitado.
`app.component.html:`

```
<po-combo
   name="heroName"
   [(ngModel)]="heroName"
   p-field-label="name"
   p-field-value="name"
   p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
   p-label="Search a Hero"
   [p-disabled-tab-filter]="true">

</po-combo>

{{heroName }}

```

`app.component:`
```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
heroName: any ;
}
```
