### PR TITLE
feat(page-login): retira exibição de icone caso a dica seja vazia

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
@@ -28,6 +28,9 @@
         <div class="po-page-login-hint po-page-login-info-container">
           <po-login
             class="po-page-login-info-field"
+            [class.po-page-login-info-field-dynamic]="
+              !pageLoginLiterals.loginHint && !pageLoginLiterals.rememberUserHint
+            "
             name="login"
             [(ngModel)]="login"
             p-auto-focus
@@ -41,8 +44,15 @@
           >
           </po-login>
 
-          <div class="po-page-login-info-icon-container">
+          <div
+            *ngIf="pageLoginLiterals.loginHint || pageLoginLiterals.rememberUserHint"
+            class="po-page-login-info-icon-container"
+            [class.po-page-login-info-icon-container-dynamic]="
+              !pageLoginLiterals.loginHint && !pageLoginLiterals.rememberUserHint
+            "
+          >
             <span
+              *ngIf="pageLoginLiterals.loginHint"
               class="po-icon po-field-icon po-icon-info"
               p-tooltip-position="right"
               [p-tooltip]="pageLoginLiterals.loginHint"
@@ -66,6 +76,9 @@
         <div class="po-page-login-password-container">
           <po-password
             class="po-page-login-field-size po-page-login-password-item"
+            [class.po-page-login-field-size-dynamic]="
+              !pageLoginLiterals.loginHint && !pageLoginLiterals.rememberUserHint
+            "
             name="password"
             [(ngModel)]="password"
             p-required
@@ -77,7 +90,10 @@
             (p-change-model)="changePasswordModel()"
           >
           </po-password>
-          <div class="po-page-login-password-item po-page-login-password-popover-container">
+          <div
+            *ngIf="pageLoginLiterals.loginHint || pageLoginLiterals.rememberUserHint"
+            class="po-page-login-password-item po-page-login-password-popover-container"
+          >
             <po-page-login-popover
               *ngIf="showExceededAttemptsWarning && exceededAttemptsWarning"
               [p-literals]="pageLoginLiterals"
@@ -101,6 +117,7 @@
 
       <po-input
         *ngIf="customField && customFieldType === 'input'"
+        [class.po-page-login-field-size-dynamic]="!pageLoginLiterals.loginHint && !pageLoginLiterals.rememberUserHint"
         class="po-page-login-field-size po-lg-12"
         name="customFieldInput"
         [(ngModel)]="customFieldObject.value"
@@ -114,6 +131,7 @@
 
       <po-combo
         *ngIf="customField && customFieldType === 'combo'"
+        [class.po-page-login-field-size-dynamic]="!pageLoginLiterals.loginHint && !pageLoginLiterals.rememberUserHint"
         class="po-page-login-field-size po-lg-12"
         name="customFieldCombo"
         [(ngModel)]="customFieldObject.value"
@@ -126,6 +144,7 @@
 
       <po-select
         *ngIf="customField && customFieldType === 'select'"
+        [class.po-page-login-field-size-dynamic]="!pageLoginLiterals.loginHint && !pageLoginLiterals.rememberUserHint"
         class="po-page-login-field-size po-lg-12"
         name="customFieldSelect"
         [(ngModel)]="customFieldObject.value"
@@ -148,8 +167,13 @@
           >
           </po-switch>
 
-          <div class="po-page-login-info-icon-container po-page-login-info-icon-remember-user">
+          <div
+            *ngIf="pageLoginLiterals.loginHint || pageLoginLiterals.rememberUserHint"
+            class="po-page-login-info-icon-container po-page-login-info-icon-remember-user"
+            [class.po-page-login-info-icon-container-dynamic]="!pageLoginLiterals.rememberUserHint"
+          >
             <span
+              *ngIf="pageLoginLiterals.rememberUserHint"
               class="po-icon po-field-icon po-icon-info"
               p-tooltip-position="right"
               [p-tooltip]="pageLoginLiterals.rememberUserHint"
@@ -160,6 +184,7 @@
       </div>
 
       <po-button
+        [class.po-page-login-button-dynamic]="!pageLoginLiterals.loginHint && !pageLoginLiterals.rememberUserHint"
         class="po-lg-12 po-page-login-button po-page-login-field-size"
         p-type="primary"
         [p-disabled]="loginForm.invalid"

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
@@ -162,6 +162,82 @@ describe('PoPageLoginComponent: ', () => {
     expect(divRegisterUrl.innerHTML).toContain(component.pageLoginLiterals.registerUrl);
   });
 
+  it('Should show a icon if not send literals', () => {
+    fixture.detectChanges();
+
+    const spanLoginHint = nativeElement.querySelector('span.po-icon-info');
+
+    expect(spanLoginHint).not.toBeNull();
+  });
+
+  it('Should show a icon if send literals', () => {
+    component.literals = {
+      loginHint: 'test'
+    };
+
+    fixture.detectChanges();
+
+    const spanLoginHint = nativeElement.querySelector('span.po-icon-info');
+
+    expect(spanLoginHint).not.toBeNull();
+  });
+
+  it('shouldn`t show a icon if literals is empty', () => {
+    component.literals = {
+      loginHint: '',
+      rememberUserHint: ''
+    };
+
+    fixture.detectChanges();
+
+    const spanLoginHint = nativeElement.querySelector('span.po-icon-info');
+
+    expect(spanLoginHint).toBeNull();
+  });
+
+  it('Should contain dynamic class in login and password fields if literals is empty', () => {
+    component.literals = {
+      loginHint: '',
+      rememberUserHint: ''
+    };
+
+    fixture.detectChanges();
+
+    const loginField = nativeElement.querySelector('po-login.po-page-login-info-field');
+    const passwordHint = nativeElement.querySelector('po-password.po-page-login-field-size');
+
+    expect(loginField).toHaveClass('po-page-login-info-field-dynamic');
+    expect(passwordHint).toHaveClass('po-page-login-field-size-dynamic');
+  });
+
+  it('shouldn`t contain dynamic class in login and password fields if contain literals', () => {
+    component.literals = {
+      loginHint: 'test',
+      rememberUserHint: 'test'
+    };
+
+    fixture.detectChanges();
+
+    const loginField = nativeElement.querySelector('po-login.po-page-login-info-field');
+    const passwordHint = nativeElement.querySelector('po-password.po-page-login-field-size');
+
+    expect(loginField).not.toHaveClass('po-page-login-info-field-dynamic');
+    expect(passwordHint).not.toHaveClass('po-page-login-field-size-dynamic');
+  });
+
+  it('Should contain dynamic class in `remember-user` field if `literals.loginHint` not is empty', () => {
+    component.literals = {
+      loginHint: 'test',
+      rememberUserHint: ''
+    };
+
+    fixture.detectChanges();
+
+    const divRememberUser = nativeElement.querySelector('div.po-page-login-info-icon-remember-user');
+
+    expect(divRememberUser).toHaveClass('po-page-login-info-icon-container-dynamic');
+  });
+
   describe('Methods:', () => {
     describe('ngOnInit:', () => {
       it('should call checkingForRouteMetadata', () => {
@@ -1038,6 +1114,52 @@ describe('PoPageLoginComponent: ', () => {
       expect(nativeElement.querySelector('.po-page-login-recovery-link').innerHTML).toContain(
         component.literals.forgotPassword
       );
+    });
+
+    it('should contain class `po-page-login-field-size-dynamic` in `po-combo` if literals is empty and `customField` is combo', () => {
+      customField = {
+        property: 'domain',
+        placeholder: 'Enter your domain',
+        url: 'https://po-ui.io/sample/api/comboOption/heroes',
+        fieldValue: 'nickname'
+      };
+      component.customField = customField;
+
+      component.literals = {
+        loginHint: '',
+        rememberUserHint: ''
+      };
+
+      fixture.detectChanges();
+
+      const poCombo = nativeElement.querySelector('po-combo');
+
+      expect(poCombo).toHaveClass('po-page-login-field-size-dynamic');
+    });
+
+    it('should contain class `po-page-login-field-size-dynamic` in `po-select` if literals is empty and `customField` is select', () => {
+      customField = {
+        property: 'domain',
+        placeholder: 'Enter your domain',
+        options: [
+          { label: 'Option 1', value: '1' },
+          { label: 'Option 2', value: '2' }
+        ],
+        url: 'https://po-ui.io/sample/api/comboOption/heroes',
+        fieldValue: 'nickname'
+      };
+      component.customField = customField;
+
+      component.literals = {
+        loginHint: '',
+        rememberUserHint: ''
+      };
+
+      fixture.detectChanges();
+
+      const poSelect = nativeElement.querySelector('po-select');
+
+      expect(poSelect).toHaveClass('po-page-login-field-size-dynamic');
     });
   });
 


### PR DESCRIPTION
**page-login**

**DTHFUI-5136**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao atribuir valor vazio para as propriedades `loginHint` e `rememberUserHint` o ícone continua aparecendo mesmo sem dica.

**Qual o novo comportamento?**
Ao atribuir valor vazio para as propriedades `loginHint` e `rememberUserHint` o ícone não é exibido.

**Obs:** Em telas menores que 540px os campos vão manter 100% de largura caso não contenha nenhum ícone.
Caso tenha apenas o primeiro ícone, o  campo para entrar automaticamente fica com 100% de largura.
Caso tenha apenas o segundo ícone, os campos de login e senha mantém a largura (menor que 100%) .

**Simulação**
Style : https://github.com/po-ui/po-style/pull/243
`app.component.html` :

```
<po-page-login [p-literals]="{loginHint: '', rememberUserHint: ''}">
</po-page-login>
```