### PR TITLE
feat(calendar): aplica estilo quando o mouse estiver sobre as datas

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
@@ -23,6 +23,8 @@
           class="po-calendar-day"
           [ngClass]="getDayBackgroundColor(day)"
           (click)="onSelectDate(day)"
+          (mouseenter)="onMouseEnter(day)"
+          (mouseleave)="onMouseLeave()"
           attr-calendar
         >
           <span *ngIf="day !== 0" [ngClass]="getDayForegroundColor(day)">

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.spec.ts
@@ -476,6 +476,18 @@ describe('PoCalendarWrapperComponent', () => {
       expect(component['getColorForDateRange']).toHaveBeenCalledWith(dateParam, local);
     });
 
+    it(`getDayColor: should return 'po-calendar-box-background-hover' if range is true and date between startDate and hoverValue`, () => {
+      const colorClass = 'po-calendar-box-background-hover';
+      const dateParam = new Date(2019, 4, 11);
+      const local = 'background';
+
+      component.selectedValue = { start: new Date(2019, 4, 10), end: null };
+      component.range = true;
+      component.hoverValue = new Date(2019, 4, 20);
+
+      expect(component['getDayColor'](dateParam, local)).toBe(colorClass);
+    });
+
     it(`getColorForDateRange: should return 'po-calendar-box-background-in-range' if 'poDate.validateDateRange'
       return 'true'`, () => {
       spyOn(component['poDate'], 'validateDateRange').and.returnValue(true);
@@ -581,6 +593,24 @@ describe('PoCalendarWrapperComponent', () => {
       component['onSelectDate'](date);
 
       expect(component.selectDate.emit).toHaveBeenCalledWith(date);
+    });
+
+    it(`onMouseEnter: should call 'hoverDate.next' with date param`, () => {
+      const date = new Date(2021, 5, 5);
+
+      const spyHoverDate = spyOn(component.hoverDate, <any>'next');
+
+      component['onMouseEnter'](date);
+
+      expect(spyHoverDate).toHaveBeenCalledWith(date);
+    });
+
+    it(`onMouseLeave: should call 'hoverDate.next' with null`, () => {
+      const spyHoverDate = spyOn(component.hoverDate, <any>'next');
+
+      component['onMouseLeave']();
+
+      expect(spyHoverDate).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.ts
@@ -1,18 +1,11 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  forwardRef,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  EventEmitter
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, Output, EventEmitter } from '@angular/core';
+
+import { Subject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 
 import { PoCalendarLangService } from '../services/po-calendar.lang.service';
 import { PoCalendarService } from '../services/po-calendar.service';
 import { PoDateService } from '../../../services/po-date/po-date.service';
-import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
 @Component({
   selector: 'po-calendar-wrapper',
@@ -39,9 +32,13 @@ export class PoCalendarWrapperComponent implements OnInit, OnChanges {
 
   @Input('p-max-date') maxDate;
 
+  @Input('p-hover-value') hoverValue: Date;
+
   @Output('p-header-change') headerChange = new EventEmitter<any>();
 
   @Output('p-select-date') selectDate = new EventEmitter<any>();
+
+  @Output('p-hover-date') hoverDate = new Subject<Date>().pipe(debounceTime(100));
 
   currentYear: number;
   displayDays: Array<number>;
@@ -101,8 +98,7 @@ export class PoCalendarWrapperComponent implements OnInit, OnChanges {
   constructor(
     private poCalendarService: PoCalendarService,
     private poCalendarLangService: PoCalendarLangService,
-    private poDate: PoDateService,
-    private languageService: PoLanguageService
+    private poDate: PoDateService
   ) {}
 
   ngOnInit() {
@@ -149,6 +145,14 @@ export class PoCalendarWrapperComponent implements OnInit, OnChanges {
     }
 
     this.headerChange.emit({ month: this.displayMonthNumber, year: this.displayYear });
+  }
+
+  onMouseEnter(day) {
+    (<Subject<Date>>this.hoverDate).next(day);
+  }
+
+  onMouseLeave() {
+    (<Subject<Date>>this.hoverDate).next(null);
   }
 
   // Ao selecionar uma data
@@ -247,6 +251,8 @@ export class PoCalendarWrapperComponent implements OnInit, OnChanges {
       return this.getColorForDate(date, local);
     } else if (this.range && start && end && date > start && date < end) {
       return this.getColorForDateRange(date, local);
+    } else if (this.range && start && !end && date > start && date < this.hoverValue) {
+      return `po-calendar-box-${local}-hover`;
     } else if (!this.range && this.equalsDate(date, this.value)) {
       return this.getColorForDate(date, local);
     } else if (this.equalsDate(date, this.today)) {

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.html
@@ -25,8 +25,10 @@
     [p-range]="isRange"
     [p-responsive]="isResponsive"
     [p-selected-value]="value"
+    [p-hover-value]="hoverValue"
     (p-header-change)="onHeaderChange($event, partType)"
     (p-select-date)="onSelectDate($event, partType)"
+    (p-hover-date)="onHoverDate($event)"
   >
   </po-calendar-wrapper>
 </ng-template>

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
@@ -474,6 +474,14 @@ describe('PoCalendarComponent:', () => {
 
       expect(component.activateDate).toEqual(null);
     });
+
+    it('onHoverDate: should set hoverValue', () => {
+      const expectedValue = new Date(2010, 7, 10);
+
+      component.onHoverDate(expectedValue);
+
+      expect(component.hoverValue).toBe(expectedValue);
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
@@ -59,6 +59,8 @@ const poCalendarRangeWidth = 600;
   providers
 })
 export class PoCalendarComponent extends PoCalendarBaseComponent implements OnInit, OnChanges {
+  hoverValue: Date;
+
   constructor(private changeDetector: ChangeDetectorRef, poDate: PoDateService, languageService: PoLanguageService) {
     super(poDate, languageService);
   }
@@ -110,6 +112,10 @@ export class PoCalendarComponent extends PoCalendarBaseComponent implements OnIn
     const newModel = this.convertDateToISO(this.value);
     this.updateModel(newModel);
     this.change.emit(newModel);
+  }
+
+  onHoverDate(date) {
+    this.hoverValue = date;
   }
 
   onHeaderChange({ month, year }, partType) {


### PR DESCRIPTION
**CALENDAR**

**DTHFUI-5174**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O componente `po-calendar` não exibia estilo para as datas que irão compor o range entre a data inicial e data de final.

**Qual o novo comportamento?**
O componente `po-calendar` passa a exibir um estilo para as datas que irão compor o range entre a data inicial e data de final.

**Simulação**
`app.component.html`
```
<div class="po-md-8 po-p-2">
  <po-calendar
    [(ngModel)]="calendar"
    [p-locale]="locale"
    [p-min-date]="minDate"
    [p-max-date]="maxDate"
    [p-mode]="mode"
    (p-change)="changeEvent('p-change')"
  ></po-calendar>
</div>
```

`app.component.ts` 
```
import { Component, OnInit } from '@angular/core';
import { PoCalendarMode } from '../../../ui/src/lib';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent implements OnInit {
  calendar;
  event;
  locale: string;
  maxDate: string | Date;
  minDate: string | Date;
  mode: PoCalendarMode;

  ngOnInit() {
    this.locale = 'en';
    this.maxDate = '2021-12-31';
    this.minDate = new Date();
    this.mode = PoCalendarMode.Range;
  }

  changeEvent(event: string) {
    this.event = event;
  }
}
```

`PO-STYLE`
```
https://github.com/po-ui/po-style/pull/245
```