### PR TITLE
fix(interceptor): corrige interceptor quando a requisição é cancelada

### DIFF
--- a/projects/ui/src/lib/interceptors/po-http-request/po-http-request-interceptor.service.ts
+++ b/projects/ui/src/lib/interceptors/po-http-request/po-http-request-interceptor.service.ts
@@ -1,12 +1,11 @@
+import { HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { ComponentRef, Injectable } from '@angular/core';
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from '@angular/common/http';
 
-import { Observable, throwError } from 'rxjs';
-import { catchError, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
 
 import { PoComponentInjectorService } from '../../services/po-component-injector/po-component-injector.service';
 import { PoLoadingOverlayComponent } from '../../components/po-loading/po-loading-overlay/po-loading-overlay.component';
-
 import { PoHttpRequesControltService } from './po-http-request-control-service';
 
 const noCountPendingRequests = 'X-PO-No-Count-Pending-Requests';
@@ -118,17 +117,9 @@ export class PoHttpRequestInterceptorService implements HttpInterceptor {
     this.setCountOverlayRequests(true, requestClone);
 
     return next.handle(request).pipe(
-      tap((response: HttpEvent<any>) => {
-        if (response instanceof HttpResponse) {
-          this.setCountPendingRequests(false, requestClone);
-          this.setCountOverlayRequests(false, requestClone);
-        }
-      }),
-      catchError(error => {
+      finalize(() => {
         this.setCountPendingRequests(false, requestClone);
         this.setCountOverlayRequests(false, requestClone);
-
-        return throwError(error);
       })
     );
   }


### PR DESCRIPTION
Remove a tela de carregando e diminui o número de requisições pendentes quando a requisição é cancelada.

Fixes DTHFUI-5080

**HTTP REQUEST INTERCEPTOR**

**DTHFUI-5080**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Quando se cancela uma requisição, via unsubscribe ou até mesmo redirecionamento de rota que possui resolver, a tela de carregamento não é removida, nem o número de requests é diminuído.

**Qual o novo comportamento?**
Quando se cancela uma requisição é removida a tela de carregamento e o número de requisições pendentes é diminuído.

**Simulação**
Utilizando o APP
**Obs:** validar branch `master` para verificar o problema e depois na branch `interceptor/DTHFUI-5080` para ver a solução.
1. Código fonte `app.component.ts`:
```javascript
import { HttpClient } from '@angular/common/http';
import { Component } from '@angular/core';
import { Observable } from 'rxjs';
import { tap } from 'rxjs/operators';

@Component({
selector: 'app-root',
templateUrl: './app.component.html'
})
export class AppComponent {
  constructor(private http: HttpClient) {
    this.get().subscribe().unsubscribe();
  }

  public get(): Observable<any> {
    return this.http
      .get("https://po-sample-api.herokuapp.com/v1/people", { headers: { "X-PO-screen-lock": "true" }}) 
        .pipe(
          tap((response) => console.info(response))
          );
  }
}

```
2. Rodar o APP
`ng serve app -o`

3. Verificar se a request foi cancelada na aba Network e se o Loading foi removido.


Utilizando o Portal
**Obs:** este pode ser verificado apenas na branch `interceptor/DTHFUI-5080`, pois será verificado se não alterou o funcionamento padrão do interceptor.
1. Rodar o Portal
`npm run build: portal`
`ng serve portal -o`

2. Utilizar o `PO Http Request Interceptor Labs`
3. Ative o switch `X-PO-Screen-Lock`
