### PR TITLE
feat(po-page-dynamic-table): adiciona a propriedade icon a interface PoPageDynamicTableCustomAction 

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-action.interface.ts
@@ -1,3 +1,5 @@
+import { TemplateRef } from '@angular/core';
+
 /**
  * @usedBy PoPageDynamicTableComponent
  *
@@ -40,4 +42,46 @@ export interface PoPageDynamicTableCustomAction {
    * o botão de ação caso nenhum recurso for selecionado.
    */
   selectable?: boolean;
+
+  /**
+   * @description
+   *
+   * Define um ícone que será exibido ao lado esquerdo do rótulo.
+   *
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'PO ICON', icon: 'po-icon-news' }]">
+   * </po-component>
+   * ```
+   *
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'FA ICON', icon: 'fa fa-icon-podcast' }]">
+   * </po-component>
+   * ```
+   *
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * component.html:
+   * ```
+   * <ng-template #iconTemplate>
+   *   <ion-icon name="heart"></ion-icon>
+   * </ng-template>
+   *
+   * <po-component [p-property]="myProperty"></po-component>
+   * ```
+   * component.ts:
+   * ```
+   * @ViewChild('iconTemplate', { static: true } ) iconTemplate : TemplateRef<void>;
+   *
+   * myProperty = [
+   *  {
+   *    label: 'FA ICON',
+   *    icon: this.iconTemplate
+   *  }
+   * ];
+   * ```
+   */
+  icon?: string | TemplateRef<void>;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -800,7 +800,8 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     return customActions.map(customAction => ({
       label: customAction.label,
       action: this.callPageCustomAction.bind(this, customAction),
-      disabled: this.isDisablePageCustomAction.bind(this, customAction)
+      disabled: this.isDisablePageCustomAction.bind(this, customAction),
+      ...(customAction.icon && { icon: customAction.icon })
     }));
   }
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -70,8 +70,12 @@ export class SamplePoPageDynamicTableUsersComponent {
   ];
 
   pageCustomActions: Array<PoPageDynamicTableCustomAction> = [
-    { label: 'Print', action: this.printPage.bind(this) },
-    { label: 'Download .csv', action: this.usersService.downloadCsv.bind(this.usersService, this.serviceApi) }
+    { label: 'Print', action: this.printPage.bind(this), icon: 'po-icon-print' },
+    {
+      label: 'Download .csv',
+      action: this.usersService.downloadCsv.bind(this.usersService, this.serviceApi),
+      icon: 'po-icon-download'
+    }
   ];
 
   tableCustomActions: Array<PoPageDynamicTableCustomTableAction> = [


### PR DESCRIPTION
**PoPageDynamicTable**

**#987**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**

A interface `PoPageDynamicTableCustomAction` não permite informar o ícone dos botões de ação.

**Qual o novo comportamento?**

É possível adicionar ícones as ações do `page-dynamic-table` via as custom actions da página, conforme ilustrado abaixo:

![image](https://user-images.githubusercontent.com/37978726/132067256-9554b7cd-81e5-46ff-b399-3a49193c22cf.png)

**Simulação**

Basta informar a chave `icon` no objeto de configuração:

.ts
```
readonly customActions: PoPageDynamicTableCustomAction[] = [
    {
      label: 'Home',
      action: () => console.log('Você clicou na home'),
      icon: 'po-icon-home',
    }
];
```

.html
```
<po-page-dynamic-table
    [p-page-custom-actions]="customActions"
></po-page-dynamic-table>
```
