### PR TITLE
feat(multiselect): permite informar url no filterService

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -23,6 +23,16 @@ const poMultiselectFilterServiceStub: PoMultiselectFilter = {
     return of([{ label: '', value: '' }]);
   }
 };
+
+const defaultService: any = {
+  url: '',
+  fieldLabel: 'label',
+  fieldValue: 'value',
+  getFilteredData: (params: any) => new Observable(),
+  getObjectByValue: (value: string | number) => new Observable(),
+  configProperties: (url: string, label: string, value: string) => {}
+};
+
 @Directive()
 class PoMultiselectTestComponent extends PoMultiselectBaseComponent {
   constructor() {
@@ -133,6 +143,44 @@ describe('PoMultiselectBaseComponent:', () => {
     spyOn(component, 'validAndSortOptions');
     component.sort = true;
     expect(component.validAndSortOptions).toHaveBeenCalled();
+  });
+
+  it('should set p-field-label with `defaultValue` if param is empty', () => {
+    component.filterService = 'http://exemple.com';
+    component.defaultService = defaultService;
+    const defaultValue = 'label';
+    component.setService(component.filterService);
+
+    expectSettersMethod(component, 'fieldLabel', '', 'fieldLabel', defaultValue);
+    expect(component.service.fieldLabel).toEqual(defaultValue);
+  });
+
+  it('should set p-field-label if param is not empty', () => {
+    component.filterService = defaultService;
+    component.service = defaultService;
+    const otherValueLabel = 'email';
+
+    expectSettersMethod(component, 'fieldLabel', 'email', 'fieldLabel', otherValueLabel);
+    expect(component.service.fieldLabel).not.toEqual(otherValueLabel);
+  });
+
+  it('should set p-field-value with `defaultValue` if param is empty', () => {
+    component.filterService = 'http://exemple.com';
+    component.defaultService = defaultService;
+    const defaultValue = 'value';
+    component.setService(component.filterService);
+
+    expectSettersMethod(component, 'fieldValue', '', 'fieldValue', defaultValue);
+    expect(component.service.fieldValue).toEqual(defaultValue);
+  });
+
+  it('should set p-field-value if param is not empty', () => {
+    component.filterService = defaultService;
+    component.service = defaultService;
+    const otherValue = 'id';
+
+    expectSettersMethod(component, 'fieldValue', 'id', 'fieldValue', otherValue);
+    expect(component.service.fieldValue).not.toEqual(otherValue);
   });
 
   it('should call updateList in OnInit', () => {
@@ -458,7 +506,7 @@ describe('PoMultiselectBaseComponent:', () => {
 
     it('writeValue: should call `updateSelectedOptions` with values if model value is `valid`.', () => {
       spyOn(component, 'updateSelectedOptions');
-      component.filterService = poMultiselectFilterServiceStub;
+      component.service = poMultiselectFilterServiceStub;
 
       const values = [{ label: '', value: '' }];
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.service.spec.ts
@@ -1,0 +1,104 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpRequest } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PoMultiselectFilterService } from './po-multiselect-filter.service';
+
+describe('PoMultiSelectFilterService ', () => {
+  let multiSelectService: PoMultiselectFilterService;
+  let httpMock: HttpTestingController;
+
+  const mockURL = 'rest/tecnologies';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PoMultiselectFilterService]
+    });
+
+    multiSelectService = TestBed.inject(PoMultiselectFilterService);
+    httpMock = TestBed.inject(HttpTestingController);
+
+    multiSelectService.configProperties(mockURL, 'label', 'value');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should return all items if param is empty', done => {
+    multiSelectService.getFilteredData({}).subscribe(response => {
+      expect(response.length).toBe(2);
+
+      done();
+    });
+
+    httpMock
+      .expectOne((req: HttpRequest<any>) => req.url === mockURL && req.method === 'GET')
+      .flush({
+        items: [
+          { label: 'Angular', value: 'components' },
+          { label: 'Service', value: 'Http' }
+        ]
+      });
+  });
+
+  it('should not return any filtered data', done => {
+    multiSelectService.getFilteredData({ property: 'test' }).subscribe(response => {
+      expect(response.length).toBe(0);
+      expect(response['items']).toBeUndefined();
+
+      done();
+    });
+
+    httpMock.expectOne((req: HttpRequest<any>) => req.url === mockURL && req.method === 'GET').flush({ items: [] });
+  });
+
+  it('should return only filtered data ', done => {
+    const param = { property: 'label', value: 'angular' };
+    multiSelectService.getFilteredData(param).subscribe(response => {
+      expect(response.length).toBe(1);
+
+      done();
+    });
+
+    httpMock
+      .expectOne((req: HttpRequest<any>) => req.url === mockURL && req.method === 'GET')
+      .flush({ items: [{ label: 'Angular', value: 'angular' }] });
+  });
+
+  it('should return the object converted to PoMultiSelectOption', done => {
+    const value = ['angular'];
+
+    multiSelectService.getObjectsByValues(value).subscribe(object => {
+      expect('label' in object[0]).toBeTruthy();
+      expect('value' in object[0]).toBeTruthy();
+
+      done();
+    });
+
+    httpMock
+      .expectOne(`${mockURL}?value=${value.toString()}`)
+      .flush({ items: [{ label: 'Angular', value: 'components' }] });
+  });
+
+  it('should return [] when parseToArrayMultiselectOptions get null', () => {
+    expect(multiSelectService['parseToArrayMultiselectOptions'](null)).toEqual([]);
+  });
+
+  it('Should add filter params and return value', done => {
+    const filteredObject = { label: 'angular', value: 'angular' };
+    const expectResponse = [{ label: 'angular', value: 'angular' }];
+    const param = ['angular', 'components'];
+    const urlWithParams = 'http://mockurl.com/?value=angular,components';
+
+    spyOn(multiSelectService, <any>'parseToMultiselectOption').and.returnValue(filteredObject);
+    spyOnProperty(multiSelectService, 'url', 'get').and.returnValue('http://mockurl.com/');
+
+    multiSelectService.getObjectsByValues(param).subscribe(response => {
+      expect(response).toEqual(expectResponse);
+      done();
+    });
+
+    httpMock.expectOne((req: HttpRequest<any>) => req.urlWithParams === urlWithParams).flush({ items: [{}] });
+  });
+});

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.service.ts
@@ -1,0 +1,58 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { PoMultiselectFilter } from './po-multiselect-filter.interface';
+import { PoMultiselectOption } from './po-multiselect-option.interface';
+
+@Injectable()
+export class PoMultiselectFilterService implements PoMultiselectFilter {
+  fieldLabel: string = 'label';
+  fieldValue: string = 'value';
+
+  private _url: string;
+  private messages = [];
+
+  get url(): string {
+    return this._url;
+  }
+
+  constructor(private http: HttpClient) {}
+
+  getFilteredData({ value }: any): Observable<Array<PoMultiselectOption>> {
+    const params = value ? { filter: value } : {};
+    return this.http
+      .get(this.url, {
+        params
+      })
+      .pipe(map(response => this.parseToArrayMultiselectOptions(response['items'])));
+  }
+
+  getObjectsByValues(value: Array<string | number>): Observable<Array<PoMultiselectOption>> {
+    return this.http
+      .get(`${this.url}?${this.fieldValue}=${value.toString()}`)
+      .pipe(map(response => this.parseToArrayMultiselectOptions(response['items'])));
+  }
+
+  configProperties(url: string, fieldLabel: string, fieldValue: string) {
+    this._url = url;
+    this.fieldLabel = fieldLabel;
+    this.fieldValue = fieldValue;
+  }
+
+  private parseToArrayMultiselectOptions(items: Array<any>): Array<PoMultiselectOption> {
+    if (items && items.length > 0) {
+      return items.map(item => this.parseToMultiselectOption(item));
+    }
+
+    return [];
+  }
+
+  private parseToMultiselectOption(item: any): PoMultiselectOption {
+    const label = item[this.fieldLabel];
+    const value = item[this.fieldValue];
+
+    return { label, value };
+  }
+}

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs';
@@ -8,42 +8,19 @@ import { PoMultiselectOption, PoMultiselectFilter } from '@po-ui/ng-components';
 
 @Injectable()
 export class SamplePoMultiselectHeroesService implements PoMultiselectFilter {
-  readonly headers: HttpHeaders = new HttpHeaders({
-    'X-PO-No-Message': 'true'
-  });
-
   constructor(private http: HttpClient) {}
 
-  getFilteredData(param: { property: 'string'; value: 'string' }): Observable<Array<PoMultiselectOption>> {
-    const params = { filter: param.value };
+  getFilteredData({ value }): Observable<Array<PoMultiselectOption>> {
+    const params = { filter: value };
 
     return this.http
-      .get(`https://po-sample-api.herokuapp.com/v1/heroes?page=1&pageSize=10`, {
-        responseType: 'json',
-        params,
-        headers: this.headers
-      })
-      .pipe(map(response => this.parseToArrayMultiselectOptions(response['items'])));
+      .get(`https://po-sample-api.herokuapp.com/v1/heroes?page=1&pageSize=10`, { params })
+      .pipe(map((response: { items: Array<PoMultiselectOption> }) => response.items));
   }
 
   getObjectsByValues(value: Array<string | number>): Observable<Array<PoMultiselectOption>> {
     return this.http
-      .get(`https://po-sample-api.herokuapp.com/v1/heroes/?value=${value.toString()}`, { headers: this.headers })
-      .pipe(map(response => this.parseToArrayMultiselectOptions(response['items'])));
-  }
-
-  private parseToArrayMultiselectOptions(items: Array<any>): Array<PoMultiselectOption> {
-    if (items && items.length > 0) {
-      return items.map(item => this.parseToMultiselectOption(item));
-    }
-
-    return [];
-  }
-
-  private parseToMultiselectOption(item: any): PoMultiselectOption {
-    const label = item.label;
-    const value = item.value;
-
-    return { label, value };
+      .get(`https://po-sample-api.herokuapp.com/v1/heroes/?value=${value.toString()}`)
+      .pipe(map((response: { items: Array<PoMultiselectOption> }) => response.items));
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
@@ -5,6 +5,9 @@
     [(ngModel)]="multiselect"
     [p-auto-height]="properties.includes('autoHeight')"
     [p-disabled]="properties.includes('disabled')"
+    [p-field-label]="fieldLabel"
+    [p-field-value]="fieldValue"
+    [p-filter-service]="filterService"
     [p-filter-mode]="filterMode"
     [p-help]="help"
     [p-hide-search]="properties.includes('hideSearch')"
@@ -78,6 +81,24 @@
       (p-change)="changeLiterals()"
     >
     </po-input>
+  </div>
+
+  <div class="po-row">
+    <po-input
+      class="po-md-12"
+      name="filterService"
+      [(ngModel)]="filterService"
+      p-clean
+      p-help="https://po-sample-api.herokuapp.com/v1/heroes"
+      p-label="Filter Service"
+    >
+    </po-input>
+  </div>
+
+  <div class="po-row">
+    <po-input class="po-md-6" name="fieldValue" [(ngModel)]="fieldValue" p-clean p-label="Field Value"> </po-input>
+
+    <po-input class="po-md-6" name="fieldLabel" [(ngModel)]="fieldLabel" p-clean p-label="Field Label"> </po-input>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
@@ -24,6 +24,9 @@ export class SamplePoMultiselectLabsComponent implements OnInit {
   placeholder: string;
   placeholderSearch: string;
   properties: Array<string>;
+  filterService: string;
+  fieldLabel: string;
+  fieldValue: string;
 
   public readonly filterModeOptions: Array<PoRadioGroupOption> = [
     { label: 'Starts With', value: 'startsWith' },
@@ -70,6 +73,9 @@ export class SamplePoMultiselectLabsComponent implements OnInit {
     this.placeholder = '';
     this.placeholderSearch = undefined;
     this.properties = [];
+    this.filterService = '';
+    this.fieldLabel = '';
+    this.fieldValue = '';
 
     this.option = { label: undefined, value: undefined };
     this.options = [];


### PR DESCRIPTION
**MultiSelect**

**DTHFUI-5250**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não permite passar uma `string` como parâmetro para utilizar um serviço.

**Qual o novo comportamento?**
Permite informar url como `string` para utilizar um serviço no `multiselect`.

**Simulação**
`app.component.html`:

```
<po-multiselect
  class="po-md-6"
  name="multiselect"
  p-label="Search a Hero"
  [(ngModel)]="heroes"
  p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
  [p-debounce-time]="debounce"
>
</po-multiselect>
```

`app.component.ts`:

```
import { Component } from '@angular/core';
import { PoMultiselectFilter, PoTableColumn } from '../../../ui/src/lib';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  debounce = 500;
  heroes: Array<string>;
  multiselect: Array<string> = ['1495831666871', '1405833068599'];

  filterService: PoMultiselectFilter;

}
```