### PR TITLE
feat(interceptor): adiciona a propriedade `detailTitle`

### DIFF
--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
@@ -122,6 +122,7 @@ const NO_MESSAGE_HEADER_PARAM = 'X-PO-No-Message';
  *    - Caso for informado, será exibido uma ação de "Ajuda" na notificação, para isso não deverá ter a propriedade `detailedMessage`.
  * - `type`: É possível informar `error`, `warning` e `information`, sendo `error` o valor padrão.
  * - `details`: Uma lista de objetos de mensagem (recursiva) com mais detalhes sobre a mensagem principal.
+ * - `detailTitle`: caso for informado, será apresentado como título dos detalhes substituindo o padrão `code - message`
  *
  * > Veja o [Guia de implementação de APIs](guides/api) para mais detalhes sobre a estrutura das mensagens.
  *

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.html
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.html
@@ -1,15 +1,27 @@
 <po-modal p-hide-close p-size="lg" [p-primary-action]="primaryAction" [p-title]="title">
   <div class="po-row">
-    <po-accordion class="po-md-12 po-mt-1 po-mb-1">
+    <po-accordion class="po-md-12 po-mt-1 po-mb-1" *ngIf="details.length > 1; else elseBlock">
       <po-accordion-item *ngFor="let detail of details" [p-label]="formatDetailItemTitle(detail)">
-        <div *ngIf="detail.type" class="po-row po-mb-1">
-          <po-tag [p-color]="typeColor(detail.type)" [p-value]="typeValue(detail.type)"></po-tag>
-        </div>
-
-        <div class="po-row">
-          <p>{{ detail.detailedMessage }}</p>
-        </div>
+        <ng-template [ngTemplateOutlet]="body" [ngTemplateOutletContext]="{detail}"></ng-template>
       </po-accordion-item>
     </po-accordion>
   </div>
 </po-modal>
+
+<ng-template #elseBlock>
+  <ng-container [ngTemplateOutlet]="body" [ngTemplateOutletContext]="{ detail: details[0] || {} }"></ng-container>
+</ng-template>
+
+<ng-template #body let-detail="detail">
+  <div *ngIf="detail.type" class="po-row po-mb-1">
+    <po-tag [p-color]="typeColor(detail.type)" [p-value]="typeValue(detail.type)"></po-tag>
+  </div>
+
+  <p *ngIf="detail.detailTitle">
+    <strong>{{ detail.code }}</strong>
+  </p>
+
+  <div class="po-row">
+    <p>{{ detail.detailedMessage }}</p>
+  </div>
+</ng-template>

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.spec.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.spec.ts
@@ -149,6 +149,7 @@ describe('PoHttpInterceptorDetailComponent:', () => {
         detailedMessage: 'test 1',
         message: 'message 1',
         type: 'success',
+        detailTitle: 'detail title 1',
         details: [],
         _messages: []
       };
@@ -157,7 +158,8 @@ describe('PoHttpInterceptorDetailComponent:', () => {
         code: '200',
         detailedMessage: 'test 1',
         message: 'message 1',
-        type: 'success'
+        type: 'success',
+        detailTitle: 'detail title 1'
       };
 
       expect(component['getValidDetailProperties'](detail)).toEqual(expectedDetail);
@@ -166,9 +168,9 @@ describe('PoHttpInterceptorDetailComponent:', () => {
     it('formatTitle: should return literals.detail if details length is 1', () => {
       const details = [{ code: '200', detailedMessage: 'test 1', message: 'message 1', type: 'success' }];
 
-      component['literals'].detail = 'Detail';
+      const expectedTitle = '200 - message 1';
 
-      expect(component['formatTitle'](details)).toBe(component['literals'].detail);
+      expect(component['formatTitle'](details)).toBe(expectedTitle);
     });
 
     it('formatTitle: should return literals.details and details legth if details length isn`t 1', () => {
@@ -203,6 +205,17 @@ describe('PoHttpInterceptorDetailComponent:', () => {
       };
 
       expect(component['formatDetailItemTitle'](detail)).toBe('1000 - message');
+    });
+
+    it('formatDetailItemTitle: should return detail title when his exists', () => {
+      const detail: PoHttpInterceptorDetail = {
+        message: 'message',
+        code: '1000',
+        detailedMessage: '',
+        detailTitle: 'title'
+      };
+
+      expect(component['formatDetailItemTitle'](detail)).toBe('title');
     });
 
     it('typeValue: should return type if poHttpInterceptorDetailLiteralsDefault not contain type', () => {

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.ts
@@ -52,7 +52,11 @@ export class PoHttpInterceptorDetailComponent {
   }
 
   formatDetailItemTitle(detail) {
-    return detail.code ? `${detail.code} - ${detail.message}` : detail.message;
+    return detail.detailTitle
+      ? detail.detailTitle
+      : detail.code
+      ? `${detail.code} - ${detail.message}`
+      : detail.message;
   }
 
   open() {
@@ -71,8 +75,10 @@ export class PoHttpInterceptorDetailComponent {
     return detail.message ? newDetails.concat(this.getValidDetailProperties(detail)) : newDetails;
   }
 
-  private getValidDetailProperties({ code, message, detailedMessage, type }: PoHttpInterceptorDetail) {
-    return { code, message, detailedMessage, type };
+  private getValidDetailProperties({ code, message, detailedMessage, type, detailTitle }: PoHttpInterceptorDetail) {
+    return detailTitle
+      ? { code, message, detailedMessage, type, detailTitle }
+      : { code, message, detailedMessage, type };
   }
 
   private filterByValidDetails(details: Array<PoHttpInterceptorDetail>) {
@@ -80,6 +86,10 @@ export class PoHttpInterceptorDetailComponent {
   }
 
   private formatTitle(details: Array<PoHttpInterceptorDetail>) {
-    return details.length > 1 ? `${this.literals.details} (${details.length})` : this.literals.detail;
+    return details.length > 1
+      ? `${this.literals.details} (${details.length})`
+      : details.length === 1
+      ? this.formatDetailItemTitle(details[0])
+      : this.literals.detail;
   }
 }

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.interface.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.interface.ts
@@ -11,6 +11,9 @@ export interface PoHttpInterceptorDetail {
   /** Código */
   code: string;
 
+  /** Título do detalhe */
+  detailTitle?: string;
+
   /** Mensagem detalhada */
   detailedMessage: string;
 

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.ts
@@ -17,6 +17,7 @@ export class SamplePoHttpInterceptorLabsComponent implements OnDestroy, OnInit {
   errorMessage = `{
     "code": "401",
     "message": "Not Authorized",
+    "detailTitle": "Invalid credentials",
     "detailedMessage": "The request has not been applied because it lacks valid authentication credentials for the target resource.",
     "type": "error",
     "helpUrl": "",
@@ -39,6 +40,7 @@ export class SamplePoHttpInterceptorLabsComponent implements OnDestroy, OnInit {
             "details": [{
               "code": "202",
               "message": "Accepted",
+              "detailTitle": "Request was received",
               "detailedMessage": "The request has been accepted for processing, but the processing has not been completed.",
               "type": "warning"
             }]


### PR DESCRIPTION
**HTTP-INTERCEPTOR**

**DTHFUI-4330**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não é possível passar um título detalhado.

**Qual o novo comportamento?**
É possível passar um título detalhado, e ele será exibido como título da modal da notificação caso tenha apenas 1 resposta, ou como título do accordion caso hajam mais itens. 

**Simulação**

Pode ser testado no `PO Http Interceptor Labs` do `HTTP Interceptor` do Portal ou no APP conforme informações abaixo:

`app.module.ts`

```typescript
import { NgModule } from '@angular/core';
import { FormsModule } from '@angular/forms';
import { BrowserModule } from '@angular/platform-browser';
import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
import { RouterModule } from '@angular/router';
import { PoCodeEditorModule } from '../../../code-editor/src/lib';

import { PoHttpInterceptorModule, PoModule } from '../../../ui/src/lib';
import {
  SamplePoHttpInterceptorLabsComponent,
} from '../../../ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component';
import { AppComponent } from './app.component';

@NgModule({
  declarations: [AppComponent, SamplePoHttpInterceptorLabsComponent],
  imports: [BrowserModule, FormsModule, RouterModule.forRoot([], { relativeLinkResolution: 'legacy' }), PoModule, PoCodeEditorModule, PoHttpInterceptorModule, BrowserAnimationsModule],
  bootstrap: [AppComponent]
})
export class AppModule {}

```

`app.component.html`

```html
<sample-po-http-interceptor-labs></sample-po-http-interceptor-labs>

```