### PR TITLE
feat(table): adicionada propriedade `PoTableColumn.sortable`

### DIFF
--- a/projects/ui/src/lib/components/po-table/interfaces/po-table-column.interface.ts
+++ b/projects/ui/src/lib/components/po-table/interfaces/po-table-column.interface.ts
@@ -165,6 +165,18 @@ export interface PoTableColumn {
   property?: string;
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Controla se a coluna será considerada como "ordenavel". Caso seja definido um valor falso, a coluna não será usada para
+   * ordenação.
+   *
+   * @default `true`
+   */
+  sortable?: boolean;
+
+  /**
    * Define um array de objetos para as colunas de legenda. Onde, `subtitles` é uma lista de objetos do tipo PoTableSubtitle na qual
    * devem ser definidas as opções de legenda. Por exemplo:
    *

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -735,7 +735,7 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   }
 
   sortColumn(column: PoTableColumn) {
-    if (!this.sort || column.type === 'detail') {
+    if (!this.sort || column.type === 'detail' || column.sortable === false) {
       return;
     }
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -86,7 +86,7 @@
           [style.width]="column.width"
           [style.max-width]="column.width"
           [style.min-width]="column.width"
-          [class.po-clickable]="sort || hasService"
+          [class.po-clickable]="(sort && column.sortable !== false) || hasService"
           [class.po-table-header-subtitle]="column.type === 'subtitle'"
           (click)="sortColumn(column)"
         >
@@ -357,7 +357,7 @@
     {{ column.label || (column.property | titlecase) }}
   </span>
   <span
-    *ngIf="sort"
+    *ngIf="sort && column.sortable !== false"
     [class.po-table-header-icon-unselected]="sortedColumn?.property !== column"
     [class.po-table-header-icon-descending]="sortedColumn?.property === column && sortedColumn.ascending"
     [class.po-table-header-icon-ascending]="sortedColumn?.property === column && !sortedColumn.ascending"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -70,7 +70,7 @@ describe('PoTableComponent:', () => {
       { property: 'id', label: 'Codigo', type: 'number' },
       { property: 'initial', label: 'Sigla' },
       { property: 'name', label: 'Nome' },
-      { property: 'total', label: 'Total', type: 'currency', format: 'BRL' },
+      { property: 'total', label: 'Total', type: 'currency', format: 'BRL', sortable: false },
       { property: 'atualization', label: 'Atualização', type: 'date' }
     ];
 
@@ -486,6 +486,34 @@ describe('PoTableComponent:', () => {
 
     columnSorted = tableElement.querySelector('.po-table-header-icon-ascending');
     expect(columnSorted).toBeTruthy();
+  });
+
+  it('should toggle column sortable as false', () => {
+    component.sort = true;
+
+    fixture.detectChanges();
+
+    const tableHeaders = fixture.nativeElement.querySelectorAll('th');
+
+    let columnSorted = tableHeaders[3].querySelector('.po-table-header-icon-unselected');
+    expect(columnSorted).toBeNull();
+
+    columnSorted = tableHeaders[3].querySelector('.po-clickable');
+    expect(columnSorted).toBeNull();
+
+    const itemSorted = component.columns[3];
+
+    component.sortColumn(itemSorted);
+    fixture.detectChanges();
+
+    columnSorted = tableElement.querySelector('.po-table-header-icon-descending');
+    expect(columnSorted).toBeNull();
+
+    component.sortColumn(itemSorted);
+    fixture.detectChanges();
+
+    columnSorted = tableElement.querySelector('.po-table-header-icon-ascending');
+    expect(columnSorted).toBeNull();
   });
 
   it('should not find subtitles columns', () => {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-components/sample-po-table-components.component.ts
@@ -64,6 +64,7 @@ export class SamplePoTableComponentsComponent {
       property: 'favorite',
       label: 'Actions',
       type: 'icon',
+      sortable: false,
       icons: [
         {
           action: this.favorite.bind(this),


### PR DESCRIPTION
PO-TABLE

Ajudaria em muito quando temos varias colunas e algumas delas são
colunas "calculadas" que não são ordenáveis. Isso evitaria de chamar
o evento "p-sort-by" para colunas que não tem ordenação.
O usuário não teria a falsa impressão que pode ordenar a coluna, mesmo
ela não sendo ordenável. Também é útil para remover das colunas que
possuem botões de ação.

#960
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Todas as colunas podem ser ordenadas.

**Qual o novo comportamento?**
Podemos remover a ordenação de colunas que não são ordenáveis através do parâmetro "sortable=false"

**Simulação**
Esta nova propriedade pode ser vista nos exemplos table (PO Table - Po Field Components)