### PR TITLE
fix(dynamic-form): corrige o "validate" ao clicar em um campo do tipo booleano

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -90,6 +90,36 @@ describe('PoDynamicFormFieldsComponent: ', () => {
     describe('onChangeField', () => {
       const changedFieldIndex = 0;
 
+      it('should call `getField` with `propertyOfVisibleFields` if field type boolean', () => {
+        const fakeVisibleField = { property: 'test1', validate: 'teste', type: 'boolean' };
+
+        component['previousValue']['test1'] = 'value';
+        component['value']['test1'] = 'new value';
+
+        const field = { changedField: fakeVisibleField, changedFieldIndex };
+        component['form'] = <any>{ touched: false };
+
+        spyOn(component, <any>'getField').and.returnValue(field);
+        component.onChangeField(fakeVisibleField);
+
+        expect(component['getField']).toHaveBeenCalledWith(fakeVisibleField.property);
+      });
+
+      it(`shouldn't call 'getField' with 'propertyOfVisibleFields' if field type not boolean and 'form.touched' is false`, () => {
+        const fakeVisibleField = { property: 'test1', validate: 'teste' };
+
+        component['previousValue']['test1'] = 'value';
+        component['value']['test1'] = 'new value';
+
+        const field = { changedField: fakeVisibleField, changedFieldIndex };
+        component['form'] = <any>{ touched: false };
+
+        spyOn(component, <any>'getField').and.returnValue(field);
+        component.onChangeField(fakeVisibleField);
+
+        expect(component['getField']).not.toHaveBeenCalledWith(fakeVisibleField.property);
+      });
+
       it('should call `getField` with `propertyOfVisibleFields` if field value changed', () => {
         const fakeVisibleField = { property: 'test1', validate: 'teste' };
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -53,6 +53,7 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
 
   async onChangeField(visibleField: PoDynamicFormField, objectValue?: any) {
     const { property } = visibleField;
+    const isBooleanType = visibleField.type === 'boolean';
     const isChangedValueField = this.previousValue[property] !== this.value[property];
 
     if (visibleField.optionsService) {
@@ -60,7 +61,7 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
     }
 
     // verifica se o formulario esta touched para não disparar o validate ao carregar a tela.
-    if (this.form.touched && isChangedValueField) {
+    if ((this.form.touched || isBooleanType) && isChangedValueField) {
       const { changedField, changedFieldIndex } = this.getField(property);
 
       if (changedField.validate) {


### PR DESCRIPTION
**DYNAMIC-FORM**

**DTHFUI-5285**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O componente não dispara o "validate" para os campos do tipo booleano


**Qual o novo comportamento?**
O componente passa a disparar o "validate" para os campos do tipo booleano


**Simulação**

`component.html`
```
<po-dynamic-form [p-fields]="fields" [p-validate]="onChangeFields.bind(this)" [p-value]="value"></po-dynamic-form>
```
`component.ts`
```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {

  value = {};

  fields: Array<any> = [
   {
     booleanTrue: 'Ativado',
     property: 'convertEntityQty',
     booleanFalse: 'Desativado',
     label: 'Converter qtd emitente',
     type: 'boolean',
   },
   {
     property: 'valueSwitch',
     label: 'valor switch',
   }
 ];

 onChangeFields(changeValue) {
   if (changeValue.property === 'convertEntityQty') {
     return {
       focus: 'valueSwitch'
     };
   }
 }
}

```
