### PR TITLE
docs(portal): estende propriedades/metodos/docs

### DIFF
--- a/HOW_TO_DOCUMENT.md
+++ b/HOW_TO_DOCUMENT.md
@@ -142,6 +142,16 @@ classe que se deseja herdar, conforme o exemplo a seguir:
  */
 ```
 
+É possivel ignorar a descrição da classe ou interface estendida. Para isso, adicione a tag `@ignoreExtendedDescription` na classe ou interface mãe, conforme o exemplo a seguir:
+
+``` typescript
+/**
+ * @docExtends PoButtonBaseComponent
+ * 
+ * @ignoreExtendedDescription
+ */
+```
+
 ## Samples
 
 Os samples podem ser incluídos na documentação através da tag `@example` e incluindo o exemplo dentro de `<example></example>`. 

--- a/projects/portal/docs/configuration.js
+++ b/projects/portal/docs/configuration.js
@@ -57,6 +57,7 @@ module.exports = {
     { name: 'examplePrivate' },
     { name: 'description' },
     { name: 'docsExtends' },
+    { name: 'ignoreExtendedDescription' },
     { name: 'usedBy' },
     { name: 'optional' },
     { name: 'default' }

--- a/projects/portal/docs/processors/helpers/functions.js
+++ b/projects/portal/docs/processors/helpers/functions.js
@@ -7,15 +7,33 @@ module.exports = {
     classDoc.methods = [];
 
     //Extends
+    const resolvePropertiesRecursive = (classDoc, properties) => {
+      if (classDoc.docsExtends) {
+        let extendedDoc = allDocs.filter(doc => doc.name == classDoc.docsExtends)[0];
+
+        properties = resolvePropertiesRecursive(extendedDoc, properties);
+      }
+
+      properties = properties.concat(this.resolveProperties(classDoc));
+
+      return properties;
+    }
+
     if (classDoc.docsExtends) {
       let extendedDoc = allDocs.filter(doc => doc.name == classDoc.docsExtends)[0];
 
       if (extendedDoc) {
         let description = classDoc.description;
 
-        classDoc.description = `${extendedDoc.description} ${description}`;
-        classDoc.properties = this.resolveProperties(extendedDoc);
+        classDoc.properties = resolvePropertiesRecursive(extendedDoc, []);
         classDoc.methods = this.resolveMethods(extendedDoc);
+
+        if (classDoc.ignoreExtendedDescription == null) {
+          classDoc.description = `${extendedDoc.description} ${description}`;
+        } else {
+          classDoc.description = `${description}`;
+        }
+
       } else {
         console.warn(`Classe ${classDoc.docsExtends} extended by ${classDoc.name} não encontrada!`.red);
       }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-field.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-field.interface.ts
@@ -1,11 +1,8 @@
 import { PoDynamicFormField } from '@po-ui/ng-components';
 
 /**
- * @usedBy PoPageDynamicTableComponent
+ * @docsExtends PoDynamicFormField
  *
- * @description
- *
- * Interface dos fields usados para compor o template `po-page-dynamic-table`.
  */
 export interface PoPageDynamicTableField extends PoDynamicFormField {
   /** Indica se o campo será duplicado caso seja executada a ação de duplicação. */

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-filters.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-filters.interface.ts
@@ -1,7 +1,11 @@
 import { PoPageDynamicTableField } from '../../..';
 
 /**
+ * @docsExtends PoPageDynamicTableField
+ *
  * @usedBy PoPageDynamicTableComponent
+ *
+ * @ignoreExtendedDescription
  *
  * @description
  *

--- a/projects/ui/src/lib/components/po-page/po-page-action.interface.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-action.interface.ts
@@ -9,6 +9,8 @@ import { PoPopupAction } from '../po-popup/po-popup-action.interface';
  *
  * @docsExtends PoPopupAction
  *
+ * @ignoreExtendedDescription
+ *
  * @usedBy PoPageDefaultComponent, PoPageListComponent
  */
 export interface PoPageAction extends PoPopupAction {}


### PR DESCRIPTION
**DTHFUI-4296**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Documentação não estende propriedades.

**Qual o novo comportamento?**
Documentação estende propriedades.

**Simulação**

- subir o portal e ver documentação
Exemplo : 
- Ver documentação do componente : `po-page-dynamic-table` (http://localhost:4200/documentation/po-page-dynamic-table)
- Interface `PoPageDynamicTableFilters` estende propriedades da interface `PoPageDynamicTableField` e `PoDynamicFormField`
