### PR TITLE
fix(datepicker-range): corrige calendario ao selecionar 01/mm/yyyy

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
@@ -101,6 +101,29 @@ describe('PoCalendarBaseComponent:', () => {
       expect(end.getFullYear()).toBe(year);
     });
 
+    it('setActivateDate: should set {start, end } with date param of type string if isRange is true', () => {
+      const date = '2021-09-15';
+      const day = 15;
+      const year = 2021;
+      const month = 9;
+
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+
+      component['setActivateDate'](date);
+      const { start, end } = component.activateDate;
+
+      expect(start instanceof Date).toBe(true);
+      expect(end instanceof Date).toBe(true);
+
+      expect(start.getDate()).toBe(day);
+      expect(start.getMonth()).toBe(month - 1);
+      expect(start.getFullYear()).toBe(year);
+
+      expect(end.getDate()).toBe(day);
+      expect(end.getMonth()).toBe(month);
+      expect(end.getFullYear()).toBe(year);
+    });
+
     it('setActivateDate: should set with date param if isRange is false', () => {
       const date = new Date(2019, 10, 5);
 

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
@@ -161,9 +161,9 @@ export class PoCalendarBaseComponent {
     const activateDate = date ? date : this.verifyActivateDate();
 
     if (this.isRange) {
-      const checkedStart = new Date(activateDate);
+      const checkedStart =
+        typeof activateDate === 'string' ? this.poDate.convertIsoToDate(activateDate) : new Date(activateDate);
       const checkedEnd = new Date(new Date(checkedStart).setMonth(checkedStart.getMonth() + 1));
-
       this.activateDate = { start: checkedStart, end: checkedEnd };
     } else {
       this.activateDate = new Date(activateDate);

--- a/projects/ui/src/lib/services/po-date/po-date.service.ts
+++ b/projects/ui/src/lib/services/po-date/po-date.service.ts
@@ -33,7 +33,7 @@ export class PoDateService {
    * @param minDate Definir `true` caso seja `minDate`.
    * @param maxDate Definir `true` caso seja `maxDate`.
    */
-  convertIsoToDate(dateString: string, minDate: boolean, maxDate: boolean): Date {
+  convertIsoToDate(dateString: string, minDate?: boolean, maxDate?: boolean): Date {
     if (dateString) {
       const { year, month, day } = this.getDateFromIso(dateString);
 


### PR DESCRIPTION
**DTHFUI-5296**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando seleciona o dia 01 de uma mês, o mês selecionado some e aparece o mês anterior.
Exemplo: Quando selecionar o dia 01 de setembro, o calendário passará a apresentar o mês de agosto.

**Qual o novo comportamento?**
Quando seleciona o dia 01 de uma mês, o mês selecionado se mantém sendo apresentado.

**Simulação**
Incluir o componente PoDatepickerRangeComponent no app e selecionar o primeiro dia de qualquer mês do ano.