### PR TITLE
feat(po-page-dynamic-table): inclui icon e disabled a interface custom table action

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
@@ -31,6 +31,13 @@ export interface PoPageDynamicTableCustomTableAction {
   action?: string | ((resource?: any) => any);
 
   /**
+   * Função que deve retornar um booleano para habilitar ou desabilitar a ação para o registro selecionado.
+   *
+   * Também é possível informar diretamente um valor booleano que vai habilitar ou desabilitar a ação para todos os registros.
+   */
+  disabled?: boolean | Function;
+
+  /**
    * Rota para o qual será redirecionado ao clicar no botão.
    *
    * > Ao utilizar a propriedade `url` e a `action`, somente a `action` será executada.

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
@@ -1,3 +1,5 @@
+import { TemplateRef } from '@angular/core';
+
 /**
  * @usedBy PoPageDynamicTableComponent
  *
@@ -34,4 +36,46 @@ export interface PoPageDynamicTableCustomTableAction {
    * > Ao utilizar a propriedade `url` e a `action`, somente a `action` será executada.
    */
   url?: string;
+
+  /**
+   * @description
+   *
+   * Define um ícone que será exibido ao lado esquerdo do rótulo.
+   *
+   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'PO ICON', icon: 'po-icon-news' }]">
+   * </po-component>
+   * ```
+   *
+   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'FA ICON', icon: 'fa fa-icon-podcast' }]">
+   * </po-component>
+   * ```
+   *
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * component.html:
+   * ```
+   * <ng-template #iconTemplate>
+   *   <ion-icon name="heart"></ion-icon>
+   * </ng-template>
+   *
+   * <po-component [p-property]="myProperty"></po-component>
+   * ```
+   * component.ts:
+   * ```
+   * @ViewChild('iconTemplate', { static: true } ) iconTemplate : TemplateRef<void>;
+   *
+   * myProperty = [
+   *  {
+   *    label: 'FA ICON',
+   *    icon: this.iconTemplate
+   *  }
+   * ];
+   * ```
+   */
+  icon?: string | TemplateRef<void>;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -808,6 +808,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   private transformTableCustomActionsToTableActions(tableCustomActions: Array<PoPageDynamicTableCustomTableAction>) {
     return tableCustomActions.map(tableCustomAction => ({
       label: tableCustomAction.label,
+      icon: tableCustomAction.icon,
       action: this.callTableCustomAction.bind(this, tableCustomAction)
     }));
   }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -805,11 +805,14 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     }));
   }
 
-  private transformTableCustomActionsToTableActions(tableCustomActions: Array<PoPageDynamicTableCustomTableAction>) {
+  private transformTableCustomActionsToTableActions(
+    tableCustomActions: Array<PoPageDynamicTableCustomTableAction>
+  ): Array<PoTableAction> {
     return tableCustomActions.map(tableCustomAction => ({
       label: tableCustomAction.label,
       icon: tableCustomAction.icon,
-      action: this.callTableCustomAction.bind(this, tableCustomAction)
+      action: this.callTableCustomAction.bind(this, tableCustomAction),
+      disabled: tableCustomAction.disabled
     }));
   }
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -79,7 +79,7 @@ export class SamplePoPageDynamicTableUsersComponent {
   ];
 
   tableCustomActions: Array<PoPageDynamicTableCustomTableAction> = [
-    { label: 'Details', action: this.onClickUserDetail.bind(this) }
+    { label: 'Details', action: this.onClickUserDetail.bind(this), icon: 'po-icon-user' }
   ];
 
   constructor(private usersService: SamplePoPageDynamicTableUsersService) {}

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -79,7 +79,12 @@ export class SamplePoPageDynamicTableUsersComponent {
   ];
 
   tableCustomActions: Array<PoPageDynamicTableCustomTableAction> = [
-    { label: 'Details', action: this.onClickUserDetail.bind(this), icon: 'po-icon-user' }
+    {
+      label: 'Details',
+      action: this.onClickUserDetail.bind(this),
+      disabled: this.isUserInactive.bind(this),
+      icon: 'po-icon-user'
+    }
   ];
 
   constructor(private usersService: SamplePoPageDynamicTableUsersService) {}
@@ -90,7 +95,7 @@ export class SamplePoPageDynamicTableUsersComponent {
         { property: 'id', key: true, visible: true, filter: true },
         { property: 'name', label: 'Name', filter: true, gridColumns: 6 },
         { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true },
-        { property: 'search', initValue: '0748093840433' },
+        { property: 'search', initValue: 'São Paulo' },
         {
           property: 'birthdate',
           label: 'Birthdate',
@@ -101,6 +106,10 @@ export class SamplePoPageDynamicTableUsersComponent {
         }
       ]
     };
+  }
+
+  isUserInactive(person) {
+    return person.status === 'inactive';
   }
 
   printPage() {


### PR DESCRIPTION
**Po Page Dynamic Table**

**#1014**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**

Não existe forma de incluir ícones as ações customizadas da tabela.

**Qual o novo comportamento?**

Permite incluir ícones as ações customizadas da tabela através da interface PoPageDynamicTableCustomTableAction.

**Simulação**

Atualizar o portal localmente e ver o exemplo PO Page Dynamic Table - Users.

![image](https://user-images.githubusercontent.com/11772148/134062984-1b7f2c61-3489-44c9-899d-334071175b76.png)
