### PR TITLE
page-login/romuloSramos

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/po-page-login.service.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.service.ts
@@ -15,7 +15,7 @@ export class PoPageLoginService {
       loginForm.password = btoa(loginForm.password);
       return this.http.post(url, loginForm);
     } else {
-      const user = `(${loginForm.login}:${loginForm.password})`;
+      const user = `${loginForm.login}:${loginForm.password}`;
       const headers = new HttpHeaders({
         'Authorization': `${type} ` + btoa(user)
       });


### PR DESCRIPTION
fix(page-login): não adicionar parênteses quando concatenar login e password 

Quando o tipo de autenticação é Basic o método onLogin coloca a o texto concatenado "login:password" entre parênteses . e posteriormente codifica em base64
para montar o cabeçalho das requisições. 
headers {
 Authorization: Basic base64("(login:password)")
}
.
removi os parênteses na geração da string concatenada.

