### PR TITLE
feat(lookup): adiciona propriedade p-multiple

### DIFF
--- a/projects/app/src/app/app.component.html
+++ b/projects/app/src/app/app.component.html
@@ -1,0 +1,15 @@
+<po-lookup
+  class="po-md-4"
+  name="lookup"
+  [(ngModel)]="lookup"
+  p-field-label="label"
+  p-field-value="value"
+  p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
+  p-label="PO Lookup"
+  [p-advanced-filters]="advancedFilters"
+  [p-multiple]="true"
+></po-lookup>
+
+<p class="po-md-12">{{ lookup | json }}</p>
+
+<po-multiselect class="po-md-12" name="multiselect" p-label="PO Multiselect" [p-options]="options"></po-multiselect>

--- a/projects/app/src/app/app.component.ts
+++ b/projects/app/src/app/app.component.ts
@@ -4,4 +4,34 @@ import { Component } from '@angular/core';
   selector: 'app-root',
   templateUrl: './app.component.html'
 })
-export class AppComponent {}
+export class AppComponent {
+  lookup;
+  advancedFilters = [
+    {
+      property: 'nickname',
+      divider: 'Hero Informations',
+      optional: true,
+      gridColumns: 6,
+      label: 'Hero'
+    },
+    {
+      property: 'name',
+      optional: true,
+      gridColumns: 6
+    }
+  ];
+
+  options = [
+    { value: 'poMultiselect0', label: 'PO Multiselect 0' },
+    { value: 'poMultiselect1', label: 'PO Multiselect 1' },
+    { value: 'poMultiselect2', label: 'PO Multiselect 2' },
+    { value: 'poMultiselect3', label: 'PO Multiselect 3' },
+    { value: 'poMultiselect4', label: 'PO Multiselect 4' },
+    { value: 'poMultiselect5', label: 'PO Multiselect 5' },
+    { value: 'poMultiselect6', label: 'PO Multiselect 6' },
+    { value: 'poMultiselect7', label: 'PO Multiselect 7' },
+    { value: 'poMultiselect8', label: 'PO Multiselect 8' },
+    { value: 'poMultiselect9', label: 'PO Multiselect 9' },
+    { value: 'poMultiselect10', label: 'PO Multiselect 10' }
+  ];
+}

--- a/projects/app/src/app/app.module.ts
+++ b/projects/app/src/app/app.module.ts
@@ -3,7 +3,8 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoModule } from '@po-ui/ng-components';
+// import { PoModule } from '@po-ui/ng-components';
+import { PoModule } from '../../../ui/src/lib';
 
 import { AppComponent } from './app.component';
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-column.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-column.interface.ts
@@ -32,6 +32,8 @@ export interface PoLookupColumn {
    */
   label?: string;
 
+  value?: string | number;
+
   /** Nome identificador da coluna. */
   property?: string;
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -244,6 +244,38 @@ export abstract class PoLookupBaseComponent
   @Input('p-infinite-scroll') @InputBoolean() infiniteScroll: boolean = false;
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Ativa a funcionalidade de multipla seleção.
+   *
+   * @default `false`
+   */
+  @Input('p-multiple') @InputBoolean() multiple: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que a altura do componente será auto ajustável, possuindo uma altura minima porém a altura máxima será de acordo
+   * com o número de itens selecionados e a extensão dos mesmos, mantendo-os sempre visíveis.
+   *
+   * > O valor padrão será `true` quando houver serviço (`p-filter-service`).
+   *
+   * @default `false`
+   */
+  @Input('p-auto-height') @InputBoolean() set autoHeight(value: boolean) {
+    this._autoHeight = value;
+    this.autoHeightInitialValue = value;
+  }
+
+  get autoHeight(): boolean {
+    return this._autoHeight;
+  }
+
+  /**
    * Evento será disparado quando ocorrer algum erro na requisição de busca do item.
    * Será passado por parâmetro o objeto de erro retornado.
    */
@@ -285,6 +317,8 @@ export abstract class PoLookupBaseComponent
   private _noAutocomplete: boolean;
   private _placeholder: string = '';
   private _required?: boolean = false;
+  private _autoHeight: boolean = false;
+  private autoHeightInitialValue: boolean;
 
   private onChangePropagate: any = null;
   private validatorChange: any;
@@ -433,8 +467,9 @@ export abstract class PoLookupBaseComponent
 
   // Seleciona o valor do model.
   selectValue(valueSelected: any) {
-    this.valueToModel = valueSelected[this.fieldValue];
-
+    this.valueToModel = Array.isArray(valueSelected)
+      ? valueSelected.map(v => v[this.fieldValue])
+      : valueSelected[this.fieldValue];
     this.callOnChange(this.valueToModel);
     this.selected.emit(valueSelected);
   }
@@ -486,7 +521,8 @@ export abstract class PoLookupBaseComponent
           element => {
             if (element) {
               this.oldValue = element[this.fieldLabel];
-              this.selectValue(element);
+
+              this.selectValue(this.multiple ? [element] : element);
               this.setViewValue(this.getFormattedLabel(element), element);
             } else {
               this.cleanModel();
@@ -513,6 +549,15 @@ export abstract class PoLookupBaseComponent
   }
 
   writeValue(value: any): void {
+    if (Array.isArray(value)) {
+      this.valueToModel = value.map(v => v[this.fieldValue]);
+      const v = value.map(v => {
+        return this.getFormattedLabel(v);
+      });
+      this.setViewValue(v, v);
+      // return;
+    }
+
     if (value && value instanceof Object) {
       // Esta condição é executada quando é retornado o objeto selecionado do componente Po Lookup Modal.
       this.oldValue = value[this.fieldLabel];

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -48,10 +48,11 @@
 
     <div class="po-row po-lookup-container-table" [style.height.px]="containerHeight">
       <po-table
+        #poTable
         class="po-md-12"
         [p-selectable]="true"
         [p-hide-detail]="true"
-        [p-single-select]="true"
+        [p-single-select]="!multiple"
         [p-sort]="true"
         [p-columns]="columns"
         [p-height]="tableHeight"
@@ -60,10 +61,24 @@
         [p-loading]="isLoading"
         [p-show-more-disabled]="!hasNext"
         [p-infinite-scroll]="infiniteScroll"
+        (p-selected)="onSelect($event)"
+        (p-unselected)="onUnselect($event)"
+        (p-all-selected)="onAllSelected($event)"
+        (p-all-unselected)="onAllUnselected($event)"
         (p-show-more)="showMoreEvent()"
         (p-sort-by)="sortBy($event)"
       >
       </po-table>
+    </div>
+
+    <div class="po-row" *ngIf="multiple">
+      <po-disclaimer-group
+        class="po-md-12"
+        [p-disclaimers]="selecteds"
+        (p-remove)="onUnselect($event)"
+        (p-remove-all)="onAllUnselected($event)"
+      >
+      </po-disclaimer-group>
     </div>
   </div>
   <div [hidden]="!isAdvancedFilter">

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectorRef,
   Component,
   ComponentFactoryResolver,
   ComponentRef,
@@ -9,15 +10,13 @@ import {
   ViewContainerRef
 } from '@angular/core';
 import { NgForm } from '@angular/forms';
-
 import { fromEvent, Observable } from 'rxjs';
 import { debounceTime, filter, switchMap, tap } from 'rxjs/operators';
-import { PoDynamicFormComponent } from './../../../po-dynamic/po-dynamic-form/po-dynamic-form.component';
-
 import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
-
 import { PoLookupModalBaseComponent } from '../po-lookup-modal/po-lookup-modal-base.component';
 import { PoLanguageService } from './../../../../services/po-language/po-language.service';
+import { PoDynamicFormComponent } from './../../../po-dynamic/po-dynamic-form/po-dynamic-form.component';
+import { PoTableComponent } from './../../../po-table/po-table.component';
 
 /**
  * @docsPrivate
@@ -29,6 +28,7 @@ import { PoLanguageService } from './../../../../services/po-language/po-languag
   templateUrl: './po-lookup-modal.component.html'
 })
 export class PoLookupModalComponent extends PoLookupModalBaseComponent implements OnInit, AfterViewInit {
+  @ViewChild(PoTableComponent, { static: true }) poTable: PoTableComponent;
   @ViewChild('inpsearch') inputSearchEl: ElementRef;
   @ViewChild('container', { read: ViewContainerRef }) container: ViewContainerRef;
 
@@ -40,8 +40,12 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
   componentRef: ComponentRef<PoDynamicFormComponent>;
   dynamicForm: NgForm;
 
-  constructor(private componentFactory: ComponentFactoryResolver, poLanguage: PoLanguageService) {
-    super(poLanguage);
+  constructor(
+    private componentFactory: ComponentFactoryResolver,
+    poLanguage: PoLanguageService,
+    changeDetector: ChangeDetectorRef
+  ) {
+    super(poLanguage, changeDetector);
   }
 
   ngOnInit() {
@@ -51,6 +55,30 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
 
   ngAfterViewInit() {
     this.initializeEventInput();
+  }
+
+  onSelect(item) {
+    this.selecteds = [...this.selecteds, item];
+    this.setTableHeight();
+  }
+
+  onUnselect(item) {
+    this.poTable.unselectRowItem(item.removedDisclaimer?.value);
+    this.selecteds = this.selecteds.filter(itemSelected => itemSelected !== item);
+    this.setTableHeight();
+  }
+
+  onAllSelected(items) {
+    this.selecteds = items;
+    this.setTableHeight();
+  }
+
+  onAllUnselected(items) {
+    this.poTable.unselectRows();
+    items.forEach(item => {
+      this.selecteds = this.selecteds.filter(itemSelected => itemSelected !== item);
+    });
+    this.setTableHeight();
   }
 
   initializeEventInput(): void {
@@ -84,6 +112,15 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
   }
 
   private setTableHeight() {
+    if (this.multiple) {
+      if (this.selecteds?.length !== 0) {
+        this.tableHeight = 300;
+      } else {
+        this.tableHeight = 370;
+        this.containerHeight = 375;
+      }
+    }
+
     // precisa ser 315 por as linhas terem altura de 32px (quando tela menor que 1366px).
     // O retorno padrão é 10 itens fazendo com que gere scroll caso houver paginação, 370 não gerava.
     this.tableHeight = this.infiniteScroll ? 315 : 370;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
@@ -1,5 +1,5 @@
 <po-field-container [p-label]="label" [p-help]="help" [p-optional]="!required && optional">
-  <div class="po-field-container-content">
+  <div class="po-field-container-content" *ngIf="!disclaimers.length; else disclaimerTemplate">
     <input
       #inp
       class="po-input po-input-icon-right"
@@ -24,6 +24,46 @@
       </span>
     </div>
   </div>
-
   <po-field-container-bottom></po-field-container-bottom>
 </po-field-container>
+
+<ng-template #disclaimerTemplate>
+  <div class="po-field-container-content">
+    <div
+      #inp
+      [tabindex]="disabled ? -1 : 0"
+      class="po-input po-input-icon-right po-lookup-input"
+      [class.po-lookup-input-auto]="autoHeight"
+      [class.po-lookup-input-static]="!autoHeight"
+      [class.po-lookup-input-disabled]="disabled"
+    >
+      <span *ngIf="placeholder && !disclaimers?.length" class="po-lookup-input-placeholder">
+        {{ placeholder }}
+      </span>
+
+      <po-disclaimer
+        *ngFor="let disclaimer of visibleDisclaimers"
+        class="po-lookup-input-disclaimer"
+        [p-label]="disclaimer.label"
+        [p-value]="disclaimer.value"
+        [p-hide-close]="disclaimer.value === '' || disabled"
+        [class.po-clickable]="disclaimer.value === '' && !disabled"
+        (p-close-action)="closeDisclaimer(disclaimer.value)"
+      >
+      </po-disclaimer>
+    </div>
+
+    <div class="po-field-icon-container-right">
+      <span
+        #iconLookup
+        class="po-icon po-field-icon po-icon-search"
+        tabindex="-1"
+        [class.po-field-icon]="!disabled"
+        [class.po-field-icon-disabled]="disabled"
+        (click)="openLookup()"
+        (focus)="inp.focus()"
+      >
+      </span>
+    </div>
+  </div>
+</ng-template>

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
@@ -29,6 +29,7 @@ export class PoLookupModalService {
    * @param filterParams {any} Valor que será repassado aos métodos do serviço para auxiliar no filtro dos dados.
    * @param title {string} Definição do título da modal.
    * @param literals {PoLookupLiterals} Literais utilizadas no componente.
+   * @param selectedItems {any} Valor que está selecionado que será repassado para o modal para apresentar na tabela.
    */
   openModal(params: {
     advancedFilters: Array<PoDynamicFormField>;
@@ -38,8 +39,20 @@ export class PoLookupModalService {
     title: string;
     literals: PoLookupLiterals;
     infiniteScroll: boolean;
+    multiple: boolean;
+    selectedItems: Array<any>;
   }): void {
-    const { advancedFilters, service, columns, filterParams, title, literals, infiniteScroll } = params;
+    const {
+      advancedFilters,
+      service,
+      columns,
+      filterParams,
+      title,
+      literals,
+      infiniteScroll,
+      multiple,
+      selectedItems
+    } = params;
 
     this.componentRef = this.poComponentInjector.createComponentInApplication(PoLookupModalComponent);
     this.componentRef.instance.advancedFilters = advancedFilters;
@@ -52,6 +65,8 @@ export class PoLookupModalService {
       this.selectValue($event);
     });
     this.componentRef.instance.infiniteScroll = infiniteScroll;
+    this.componentRef.instance.multiple = multiple;
+    this.componentRef.instance.selectedItems = selectedItems;
     this.componentRef.changeDetectorRef.detectChanges();
     this.componentRef.instance.openModal();
   }

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -338,6 +338,34 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     }
   }
 
+  /**
+   * Desmarca uma linha que está selecionada.
+   */
+  unselectRowItem(valueRow) {
+    this.items.forEach(item => {
+      if (item.value === valueRow) {
+        item.$selected = false;
+      }
+    });
+  }
+
+  /**
+   * Seleciona uma linha do 'po-table'.
+   */
+  selectRowItem(valueRow) {
+    this.items.forEach(item => {
+      if (item.value === valueRow) {
+        item.$selected = true;
+      }
+    });
+
+    if (this.items.every(item => item.$selected)) {
+      this.selectAll = true;
+    } else {
+      this.selectAll = null;
+    }
+  }
+
   formatNumber(value: any, format: string) {
     if (!format) {
       return value;


### PR DESCRIPTION
**LOOKUP**

**DTHFUI-5276**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente `lookup` não funciona com múltiplas seleções na tabela.

**Qual o novo comportamento?**
Adicionado o parâmetro `p-multiple` para que o componente possa funcionar com a seleção de múltiplos itens na tabela.

**Simulação**
`app.component.html`
```
<po-lookup
  class="po-md-4"
  name="lookup"
  [(ngModel)]="lookup"
  p-field-label="label"
  p-field-value="value"
  p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
  p-label="PO Lookup"
  [p-advanced-filters]="advancedFilters"
  [p-multiple]="true"
></po-lookup>

<p class="po-md-12">{{ lookup | json }}</p>
```

`app.component.ts`
```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  lookup;
  advancedFilters = [
    {
      property: 'nickname',
      divider: 'Hero Informations',
      optional: true,
      gridColumns: 6,
      label: 'Hero'
    },
    {
      property: 'name',
      optional: true,
      gridColumns: 6
    }
  ];
}
```