### PR TITLE
feat(dynamic-form): add range to interface dynamic form

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -350,6 +350,20 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(result).toBe('12/08/2020');
     });
 
+    it('getFilterValueToDisclaimer: should return formated date if field type is PoDynamicFieldType.Date with range', () => {
+      const field = { type: PoDynamicFieldType.Date, property: '1', label: 'date', range: true };
+      const originalValue = { start: '2020-08-12', end: '2020-08-12' };
+      const formatedDateStart = '12/08/2020';
+      const formatedDateEnd = '15/08/2021';
+      const formatedDateRange = '12/08/2020 - 15/08/2021';
+
+      spyOn(component, <any>'formatDate').and.returnValues(formatedDateStart, formatedDateEnd);
+
+      const result = component['getFilterValueToDisclaimer'](field, originalValue);
+
+      expect(result).toBe(formatedDateRange);
+    });
+
     it('getFilterValueToDisclaimer: should return label of option if options and label are defined', () => {
       const field = {
         property: '1',

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -224,7 +224,7 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
     }
 
     if (field.type === PoDynamicFieldType.Date) {
-      return this.formatDate(value);
+      return field.range ? this.formatDate(value.start) + ' - ' + this.formatDate(value.end) : this.formatDate(value);
     }
 
     if (field.options && value) {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -275,4 +275,11 @@ export interface PoDynamicFormField extends PoDynamicField {
    * > A propriedade será repassada para os componentes que suportam a mesma.
    */
   locale?: string;
+
+  /**
+   * O controle passa a permitir a entrada de um intervalo ao invés de um único valor.
+   *
+   * > Atualmente essa propriedade está disponível apenas para o tipo 'date' e 'dateTime'.
+   */
+  range?: boolean;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -478,9 +478,29 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         expect(component['compareTo']).toHaveBeenCalledWith(field.type, PoDynamicFieldType.Date);
       });
 
+      it('should call `compareTo` and return `datepickerrange` if type is `date` and range is `true`', () => {
+        const expectedValue = 'datepickerrange';
+        const field = { type: 'date', property: 'code', range: true };
+
+        spyOn(component, <any>'compareTo').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['compareTo']).toHaveBeenCalledWith(field.type, PoDynamicFieldType.Date);
+      });
+
       it('should call `compareTo` and return `datepicker` if type is `dateTime`', () => {
         const expectedValue = 'datepicker';
         const field = { type: 'dateTime', property: 'code' };
+
+        spyOn(component, <any>'compareTo').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['compareTo']).toHaveBeenCalledWith('datetime', PoDynamicFieldType.DateTime);
+      });
+
+      it('should call `compareTo` and return `datepickerrange` if type is `dateTime` and range is `true`', () => {
+        const expectedValue = 'datepickerrange';
+        const field = { type: 'dateTime', property: 'code', range: true };
 
         spyOn(component, <any>'compareTo').and.callThrough();
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -154,7 +154,7 @@ export class PoDynamicFormFieldsBaseComponent {
     } else if (this.compareTo(type, PoDynamicFieldType.Boolean)) {
       return 'switch';
     } else if (this.compareTo(type, PoDynamicFieldType.Date) || this.compareTo(type, PoDynamicFieldType.DateTime)) {
-      return 'datepicker';
+      return field.range ? 'datepickerrange' : 'datepicker';
     } else if (this.compareTo(type, PoDynamicFieldType.Time)) {
       field.mask = field.mask || '99:99';
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -25,6 +25,23 @@
     >
     </po-datepicker>
 
+    <po-datepicker-range
+      #component
+      *ngIf="compareTo(field.control, 'datepickerrange')"
+      [name]="field.property"
+      [(ngModel)]="value[field.property]"
+      [ngClass]="field.componentClass"
+      p-clean
+      [p-disabled]="isDisabled(field)"
+      [p-auto-focus]="field.focus"
+      [p-help]="field.help"
+      [p-label]="field.label"
+      [p-optional]="field.optional"
+      [p-required]="field.required"
+      (p-change)="onChangeField(field)"
+    >
+    </po-datepicker-range>
+
     <po-input
       #component
       *ngIf="compareTo(field.control, 'input')"

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -82,12 +82,27 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       ]
     },
     { property: 'city', disabled: true, gridColumns: 6 },
-    { property: 'entryTime', label: 'Entry time', type: 'time', divider: 'Work data', gridColumns: 6 },
-    { property: 'exitTime', label: 'Exit time', type: 'time', gridColumns: 6 },
+    {
+      property: 'vacation',
+      type: 'date',
+      divider: 'Work data',
+      range: true,
+      gridColumns: 5,
+      gridSmColumns: 12
+    },
+    {
+      property: 'entryTime',
+      label: 'Entry time',
+      type: 'time',
+      gridColumns: 2,
+      gridSmColumns: 6
+    },
+    { property: 'exitTime', label: 'Exit time', type: 'time', gridColumns: 2, gridSmColumns: 6 },
     {
       property: 'wage',
       type: 'currency',
-      gridColumns: 6,
+      gridColumns: 3,
+      gridSmColumns: 12,
       decimalsLength: 2,
       thousandMaxlength: 7,
       icon: 'po-icon-finance'


### PR DESCRIPTION
**Dynamic Form**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**

Atualmente não permite utilizar intervalos de datas com o componente datepicker range.

**Qual o novo comportamento?**

Através da propriedade range da interface PoDynamicFormField é possível transformar o componente datepicker em datepicker range.

Para o componente Page Dynamic Search, já foi feito um tratamento para os disclaimers aparecerem corretamente.

**Simulação**

Utilizar o sample do Dynamic Form. Também é possível usar essa propriedade com Page Dynamic Search, Page Dynamic Table e Page Dynamic Edit.