### PR TITLE
feat(lookup): adiciona a propriedade p-clean

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -243,6 +243,9 @@ export abstract class PoLookupBaseComponent
    */
   @Input('p-infinite-scroll') @InputBoolean() infiniteScroll: boolean = false;
 
+  /** Exibe um ícone que permite limpar o campo. */
+  @Input('p-clean') @InputBoolean() clean: boolean = false;
+
   /**
    * Evento será disparado quando ocorrer algum erro na requisição de busca do item.
    * Será passado por parâmetro o objeto de erro retornado.
@@ -409,6 +412,11 @@ export abstract class PoLookupBaseComponent
     this.setControl();
   }
 
+  cleanModel() {
+    this.cleanViewValue();
+    this.callOnChange(undefined);
+  }
+
   // Função implementada do ControlValueAccessor
   // Usada para interceptar os estados de habilitado via forms api
   setDisabledState(isDisabled: boolean) {
@@ -524,11 +532,6 @@ export abstract class PoLookupBaseComponent
     } else {
       this.cleanViewValue();
     }
-  }
-
-  protected cleanModel() {
-    this.cleanViewValue();
-    this.callOnChange(undefined);
   }
 
   protected cleanViewValue() {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
@@ -2,8 +2,9 @@
   <div class="po-field-container-content">
     <input
       #inp
-      class="po-input po-input-icon-right"
+      class="po-input"
       type="text"
+      [ngClass]="clean && inp.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
       [autocomplete]="autocomplete"
       [disabled]="disabled"
       [placeholder]="placeholder"
@@ -12,6 +13,8 @@
     />
 
     <div class="po-field-icon-container-right">
+      <po-clean *ngIf="clean && !disabled" [p-element-ref]="inputEl" (p-change-event)="cleanModel()"> </po-clean>
+
       <span
         #iconLookup
         class="po-icon po-field-icon po-icon-search"

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -477,6 +477,24 @@ describe('PoLookupComponent:', () => {
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-field-optional')).toBeNull();
     });
+
+    it('should find .po-input-double-icon-right if clean and inputValue are truthy', () => {
+      component.clean = true;
+      component.inputEl.nativeElement.value = 'abc';
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('.po-input-double-icon-right')).toBeTruthy();
+    });
+
+    it('should find .po-input-icon-right if clean and inputValue are falsy', () => {
+      component.clean = false;
+      component.inputEl.nativeElement.value = '';
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('.po-input-icon-right')).toBeTruthy();
+    });
   });
 
   describe('Integration', () => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -1,6 +1,7 @@
 <po-lookup
   name="lookup"
   [(ngModel)]="lookup"
+  [p-clean]="properties.includes('clean')"
   [p-columns]="columns"
   [p-disabled]="properties.includes('disabled')"
   [p-field-label]="fieldLabel"

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
@@ -52,6 +52,7 @@ export class SamplePoLookupLabsComponent implements OnInit {
   ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
+    { value: 'clean', label: 'Clean' },
     { value: 'disabled', label: 'Disabled' },
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },


### PR DESCRIPTION
**< Lookup >**

**< #775  >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o componente não possui a opção de limpar o campo a partir de um ícone

**Qual o novo comportamento?**
Adiciona a propriedade p-clean que permite utilizar um ícone para limpar o campo

**Simulação**
npm run build:portal && ng serve portal
Testar no Po Lookup Labs