### PR TITLE
feat(stepper): melhora identificação visual dos passos

### DIFF
--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.html
@@ -1,19 +1,16 @@
-<div
-  class="po-stepper-circle"
-  [class.po-stepper-circle-with-icon]="icons"
-  [style.height.px]="size"
-  [style.width.px]="size"
-  [tabindex]="isDisabled ? -1 : 0"
->
+<div class="po-stepper-circle" [style.height.px]="size" [style.width.px]="size" [tabindex]="isDisabled ? -1 : 0">
   <span
+    *ngIf="!isActive"
     class="po-stepper-circle-content"
-    [class.po-icon]="icons"
+    [class.po-icon]="icons || isDone"
     [class.po-icon-exclamation]="icons && isError"
     [class.po-icon-info]="icons && (isActive || isDefault || isDisabled)"
-    [class.po-icon-ok]="icons && isDone"
+    [class.po-icon-ok]="isDone"
     [class.po-stepper-circle-content-lg]="isLargeStep"
     [class.po-stepper-circle-content-md]="isMediumStep"
   >
-    {{ !icons ? content : '' }}
+    {{ !icons && !isDone ? content : '' }}
   </span>
+
+  <div *ngIf="isActive || isError" class="po-stepper-circle-active"></div>
 </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.spec.ts
@@ -206,15 +206,14 @@ describe('PoStepperCircleComponent:', () => {
       expect(stepperCircleContentLg).toBeTruthy();
     });
 
-    it('should find `po-stepper-circle-with-icon` if `icons` is `true`.', () => {
-      component.icons = true;
+    it('shouldn`t find `po-stepper-circle-content` if `isActive` is true', () => {
+      spyOnProperty(component, 'isActive').and.returnValue(true);
 
       fixture.detectChanges();
-      const StepperCircleWitchIcon = nativeElement.querySelector('.po-stepper-circle-with-icon');
-      const iconClass = nativeElement.querySelector('.po-icon');
 
-      expect(StepperCircleWitchIcon).toBeTruthy();
-      expect(iconClass).toBeTruthy();
+      const stepperCircleContent = nativeElement.querySelector('.po-stepper-circle-content');
+
+      expect(stepperCircleContent).toBeNull();
     });
 
     it('shouldn`t find `po-stepper-circle-with-icon` and `po-icon` if `icons` is `false`.', () => {
@@ -231,10 +230,6 @@ describe('PoStepperCircleComponent:', () => {
     it('should find `po-icon-info` if `status` is `Active`, `Default` or `Disabled` and `icons` is true.', () => {
       component.icons = true;
 
-      component.status = PoStepperStatus.Active;
-      fixture.detectChanges();
-      expect(PoIconInfo()).toBeTruthy();
-
       component.status = PoStepperStatus.Default;
       fixture.detectChanges();
       expect(PoIconInfo()).toBeTruthy();
@@ -246,6 +241,59 @@ describe('PoStepperCircleComponent:', () => {
       component.status = PoStepperStatus.Error;
       fixture.detectChanges();
       expect(PoIconInfo()).toBeNull();
+    });
+
+    it('should find `po-icon` if `isDone` is true.', () => {
+      component.icons = false;
+      spyOnProperty(component, 'isDone').and.returnValue(true);
+
+      fixture.detectChanges();
+
+      const poIcon = nativeElement.querySelector('.po-icon');
+      expect(poIcon).toBeTruthy();
+    });
+
+    it('shouldn`t find `po-icon` if `isDone` and `icons` is false.', () => {
+      component.icons = false;
+      spyOnProperty(component, 'isDone').and.returnValue(false);
+
+      fixture.detectChanges();
+
+      const poIcon = nativeElement.querySelector('.po-icon');
+      expect(poIcon).toBeNull();
+    });
+
+    it('should find `po-stepper-circle-active` if `isActive` is true.', () => {
+      spyOnProperty(component, 'isError').and.returnValue(false);
+      spyOnProperty(component, 'isActive').and.returnValue(true);
+
+      fixture.detectChanges();
+
+      const stepperCircleActive = nativeElement.querySelector('.po-stepper-circle-active');
+
+      expect(stepperCircleActive).toBeTruthy();
+    });
+
+    it('should find `po-stepper-circle-active` if `isError` is true.', () => {
+      spyOnProperty(component, 'isError').and.returnValue(true);
+      spyOnProperty(component, 'isActive').and.returnValue(false);
+
+      fixture.detectChanges();
+
+      const stepperCircleActive = nativeElement.querySelector('.po-stepper-circle-active');
+
+      expect(stepperCircleActive).toBeTruthy();
+    });
+
+    it('shouldn`t find `po-stepper-circle-active` if `isError` and `isActive` is false.', () => {
+      spyOnProperty(component, 'isError').and.returnValue(false);
+      spyOnProperty(component, 'isActive').and.returnValue(false);
+
+      fixture.detectChanges();
+
+      const stepperCircleActive = nativeElement.querySelector('.po-stepper-circle-active');
+
+      expect(stepperCircleActive).toBeNull();
     });
 
     it('should find `po-icon-ok` if `status` is `Done` and `icons` is true.', () => {

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
@@ -12,6 +12,8 @@
     <div
       [class.po-stepper-step-bar-bottom]="isVerticalOrientation"
       [class.po-stepper-step-bar-right]="!isVerticalOrientation"
+      [class.po-stepper-step-dashed-border]="nextStatus === 'disabled' && !isVerticalOrientation"
+      [class.po-stepper-step-dashed-border-vertical]="nextStatus === 'disabled' && isVerticalOrientation"
       [style.margin-left.px]="marginHorizontalBar"
     ></div>
   </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.spec.ts
@@ -137,10 +137,10 @@ describe('PoStepperStepComponent:', () => {
   });
 
   describe('Methods:', () => {
-    it('getStatusClass: should return `po-stepper-step-active` if status is `active`.', () => {
+    it('getStatusClass: should return `po-stepper-step-default` if status is `active`.', () => {
       const result = component.getStatusClass(PoStepperStatus.Active);
 
-      expect(result).toBe('po-stepper-step-active');
+      expect(result).toBe('po-stepper-step-default');
     });
 
     it('getStatusClass: should return `po-stepper-step-disabled` if status is `disabled`.', () => {
@@ -149,10 +149,10 @@ describe('PoStepperStepComponent:', () => {
       expect(result).toBe('po-stepper-step-disabled');
     });
 
-    it('getStatusClass: should return `po-stepper-step-done` if status is `done`.', () => {
+    it('getStatusClass: should return `po-stepper-step-default` if status is `done`.', () => {
       const result = component.getStatusClass(PoStepperStatus.Done);
 
-      expect(result).toBe('po-stepper-step-done');
+      expect(result).toBe('po-stepper-step-default');
     });
 
     it('getStatusClass: should return `po-stepper-step-default` if status is `default`.', () => {
@@ -317,14 +317,14 @@ describe('PoStepperStepComponent:', () => {
       expect(stepperCircle.style.height).toBe('24px');
     });
 
-    it('should add class `po-stepper-step-active` if step active.', () => {
+    it('should add class `po-stepper-step-default` if step active.', () => {
       component.orientation = PoStepperOrientation.Horizontal;
       component.status = PoStepperStatus.Active;
       component.label = 'Step 1';
 
       fixture.detectChanges();
 
-      expect(elementByClass('po-stepper-step-active')).toBeTruthy();
+      expect(elementByClass('po-stepper-step-default')).toBeTruthy();
     });
 
     it('should add class `po-stepper-step-disabled` if step disabled.', () => {
@@ -336,13 +336,13 @@ describe('PoStepperStepComponent:', () => {
       expect(elementByClass('po-stepper-step-disabled')).toBeTruthy();
     });
 
-    it('should add class `po-stepper-step-done` if step done.', () => {
+    it('should add class `po-stepper-step-default` if step done.', () => {
       component.status = PoStepperStatus.Done;
       component.label = 'Step 1';
 
       fixture.detectChanges();
 
-      expect(elementByClass('po-stepper-step-done')).toBeTruthy();
+      expect(elementByClass('po-stepper-step-default')).toBeTruthy();
     });
 
     it('should add class `po-stepper-step-default` if step default.', () => {
@@ -352,6 +352,28 @@ describe('PoStepperStepComponent:', () => {
       fixture.detectChanges();
 
       expect(elementByClass('po-stepper-step-default')).toBeTruthy();
+    });
+
+    it(`should create class 'po-stepper-step-dashed-border' if 'nextStatus' is disabled and position is not vertical`, () => {
+      component.orientation = PoStepperOrientation.Horizontal;
+      component.nextStatus = 'disabled';
+
+      fixture.detectChanges();
+
+      const stepperDashedBorder = elementByClass('po-stepper-step-dashed-border');
+
+      expect(stepperDashedBorder).toBeTruthy();
+    });
+
+    it(`should create class 'po-stepper-step-dashed-border-vertical' if 'nextStatus' is disabled and position is vertical`, () => {
+      component.orientation = PoStepperOrientation.Vertical;
+      component.nextStatus = 'disabled';
+
+      fixture.detectChanges();
+
+      const stepperDashedBorderVertical = elementByClass('po-stepper-step-dashed-border-vertical');
+
+      expect(stepperDashedBorderVertical).toBeTruthy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
@@ -31,6 +31,9 @@ export class PoStepperStepComponent {
   // Define a orientação de exibição.
   @Input('p-orientation') orientation: PoStepperOrientation;
 
+  // Informa o status da proxima etapa.
+  @Input('p-next-status') nextStatus;
+
   // Evento que será emitido quando o status do *step* estiver ativo (`PoStepperStatus.Active`).
   @Output('p-activated') activated = new EventEmitter<any>();
 
@@ -106,11 +109,11 @@ export class PoStepperStepComponent {
   getStatusClass(status: string): string {
     switch (status) {
       case PoStepperStatus.Active:
-        return 'po-stepper-step-active';
+        return 'po-stepper-step-default';
       case PoStepperStatus.Disabled:
         return 'po-stepper-step-disabled';
       case PoStepperStatus.Done:
-        return 'po-stepper-step-done';
+        return 'po-stepper-step-default';
       case PoStepperStatus.Error:
         return 'po-stepper-step-error';
       default:

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
@@ -9,6 +9,7 @@
       [p-status]="step.status"
       [p-step-icons]="stepIcons"
       [p-step-size]="stepSize"
+      [p-next-status]="poSteps.get(index + 1)?.status"
       (p-activated)="onStepActive(step)"
       (p-click)="changeStep(index, step)"
       (p-enter)="changeStep(index, step)"

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
@@ -815,13 +815,13 @@ describe('PoStepperComponent:', () => {
       expect(component.steps.length).toBe(0);
     });
 
-    it('should add the class `po-stepper-step-active` to the first step.', () => {
+    it('should add the class `po-stepper-step-default` to the first step.', () => {
       component.step = 1;
       component.steps = poSteps;
 
       fixture.detectChanges();
 
-      expect(elementByClass('po-stepper-step-active')).toBeTruthy();
+      expect(elementByClass('po-stepper-step-default')).toBeTruthy();
     });
 
     it('should create `po-stepper-content` if `usePoSteps` is `true`.', () => {
@@ -902,7 +902,7 @@ describe('PoStepperComponent:', () => {
 
       const steps = nativeElement.querySelectorAll('.po-stepper-step');
 
-      expect(steps[0].classList.contains('po-stepper-step-active')).toBeTruthy();
+      expect(steps[0].classList.contains('po-stepper-step-default')).toBeTruthy();
       expect(steps[1].classList.contains('po-stepper-step-default')).toBeTruthy();
       expect(steps[2].classList.contains('po-stepper-step-disabled')).toBeTruthy();
       expect(steps[3].classList.contains('po-stepper-step-disabled')).toBeTruthy();
@@ -913,8 +913,8 @@ describe('PoStepperComponent:', () => {
       fixture.detectChanges();
       flush();
 
-      expect(steps[0].classList.contains('po-stepper-step-done')).toBeTruthy();
-      expect(steps[1].classList.contains('po-stepper-step-active')).toBeTruthy();
+      expect(steps[0].classList.contains('po-stepper-step-default')).toBeTruthy();
+      expect(steps[1].classList.contains('po-stepper-step-default')).toBeTruthy();
       expect(steps[2].classList.contains('po-stepper-step-default')).toBeTruthy();
       expect(steps[3].classList.contains('po-stepper-step-disabled')).toBeTruthy();
       expect(steps[4].classList.contains('po-stepper-step-disabled')).toBeTruthy();
@@ -946,10 +946,10 @@ describe('PoStepperComponent:', () => {
 
       const steps = nativeElement.querySelectorAll('.po-stepper-step');
 
-      expect(steps[0].classList.contains('po-stepper-step-done')).toBeTruthy();
-      expect(steps[1].classList.contains('po-stepper-step-done')).toBeTruthy();
-      expect(steps[2].classList.contains('po-stepper-step-done')).toBeTruthy();
-      expect(steps[3].classList.contains('po-stepper-step-active')).toBeTruthy();
+      expect(steps[0].classList.contains('po-stepper-step-default')).toBeTruthy();
+      expect(steps[1].classList.contains('po-stepper-step-default')).toBeTruthy();
+      expect(steps[2].classList.contains('po-stepper-step-default')).toBeTruthy();
+      expect(steps[3].classList.contains('po-stepper-step-default')).toBeTruthy();
       expect(steps[4].classList.contains('po-stepper-step-default')).toBeTruthy();
 
       steps[1].dispatchEvent(eventClick);
@@ -957,8 +957,8 @@ describe('PoStepperComponent:', () => {
       fixture.detectChanges();
       flush();
 
-      expect(steps[0].classList.contains('po-stepper-step-done')).toBeTruthy();
-      expect(steps[1].classList.contains('po-stepper-step-active')).toBeTruthy();
+      expect(steps[0].classList.contains('po-stepper-step-default')).toBeTruthy();
+      expect(steps[1].classList.contains('po-stepper-step-default')).toBeTruthy();
       expect(steps[2].classList.contains('po-stepper-step-default')).toBeTruthy();
       expect(steps[3].classList.contains('po-stepper-step-disabled')).toBeTruthy();
       expect(steps[4].classList.contains('po-stepper-step-disabled')).toBeTruthy();


### PR DESCRIPTION
**Stepper**

**DTHFUI-5061**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

Alteração do visual do componente stepper conforme zeplin que contem na issue.



**Simulação**
build style : https://github.com/po-ui/po-style/pull/253


https://github.com/totvs/po-theme-totvs/pull/116
`app.ts `: 

```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  canActive() {
    //return false;
    return true;
  }
}
```

`app.html`  :

```
<po-stepper [p-step-icons]="false" p-orientation="vertical" p-step-size="44">
  <po-step p-label="Step 1"></po-step>
  <po-step p-label="Step 2"></po-step>
  <po-step p-label="Step 3" [p-can-active-next-step]="canActive.bind(this)"></po-step>
  <po-step p-label="Step 4"></po-step>
</po-stepper>

<hr />

<po-stepper [p-step-icons]="true" p-step-size="44">
  <po-step p-label="Step 1"></po-step>
  <po-step p-label="Step 2"></po-step>
  <po-step p-label="Step 3" [p-can-active-next-step]="canActive.bind(this)"></po-step>
  <po-step p-label="Step 4"></po-step>
</po-stepper>

```