### PR TITLE
docs(page-dynamic-detail): exibe propriedades extendidas na documentação

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-field.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/interfaces/po-page-dynamic-detail-field.interface.ts
@@ -1,6 +1,10 @@
 import { PoDynamicViewField } from '@po-ui/ng-components';
 
 /**
+ * @docsExtends PoDynamicViewField
+ *
+ * @ignoreExtendedDescription
+ *
  * @usedBy PoPageDynamicDetailComponent
  *
  * @description


### PR DESCRIPTION
**PO-PAGE-DYNAMIC-DETAIL**

**#1042**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**

Algumas propriedades da interface `PoPageDynamicDetailField` não estavam sendo exibidas.

**Qual o novo comportamento?**

Todas as propriedades  da interface são exibidas

**Simulação**

A correção pode ser validada na documentação, onde todas as propriedades disponível da interface são exibidas.

![correcao-po](https://user-images.githubusercontent.com/13375865/135672638-ed4f4db7-51fa-4030-acf6-8d5c3c34c4a6.gif)


