### PR TITLE
docs(page-dynamic-table): adiciona propriedade faltante em interface

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-field.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-field.interface.ts
@@ -1,4 +1,4 @@
-import { PoDynamicFormField } from '@po-ui/ng-components';
+import { PoDynamicFormField, PoTableColumnLabel } from '@po-ui/ng-components';
 
 /**
  * @docsExtends PoDynamicFormField
@@ -21,4 +21,23 @@ export interface PoPageDynamicTableField extends PoDynamicFormField {
    * > Quando for `false`, será desconsiderado.
    */
   allowColumnsManager?: boolean;
+
+  /**
+   * Lista de objetos do tipo `PoTableColumnLabel` que representa as labels disponíveis na coluna do tipo `label`.
+   *
+   * Exemplo de utilização
+   *
+   * ```
+   * {
+   *   property: 'uf',
+   *   label: 'Estados',
+   *   type: 'label',
+   *   labels: [
+   *     { value: 'SC', label: 'SANTA CATARINA', color: 'color-02' },
+   *     { value: 'SP', label: 'SAO PAULO', color: 'color-10' }
+   *   ],
+   * }
+   * ```
+   */
+  labels?: Array<PoTableColumnLabel>;
 }

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
@@ -1,5 +1,5 @@
 /**
- * @usedBy PoTableComponent
+ * @usedBy PoTableComponent, PoPageDynamicTableComponent
  *
  * @description
  *


### PR DESCRIPTION
Implementa propriedade labels na interface PoPageDynamicTableField

**PO-PAGE-DYNAMIC-TABLE**

**#1038**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**

A interface não exibe a propriedade `PoPageDynamicTableField` na documentação.

**Qual o novo comportamento?**

A propriedade é exibida na documentação com exemplo de utilização.

**Simulação**

Simular através do **portal**

![image](https://user-images.githubusercontent.com/13375865/135700183-eab2bfd8-f44a-4df2-a34e-ffd2dd921671.png)

