### PR TITLE
fix(datepicker-range): corrige para permitir apenas datas válidas

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/interfaces/po-datepicker-range-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/interfaces/po-datepicker-range-literals.interface.ts
@@ -11,4 +11,7 @@ export interface PoDatepickerRangeLiterals {
 
   /** Data inicial maior que data final. */
   startDateGreaterThanEndDate?: string;
+
+  /** Data inválida. */
+  invalidDate?: string;
 }

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -269,6 +269,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
 
         spyOn(component, <any>'convertPatternDateFormat');
         spyOn(component, <any>'requiredDateRangeFailed');
+        spyOn(component, <any>'verifyValidDate');
         spyOn(component, <any>'dateRangeFormatFailed');
         spyOn(component, <any>'dateRangeFailed');
 
@@ -301,12 +302,13 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         expect(component.disabled).toBe(expectedValue);
       });
 
-      it(`should call 'dateRangeObjectFailed', set 'errorMessage' as 'literals.invalidFormat'
+      it(`should call 'dateRangeFormatFailed', set 'errorMessage' as 'literals.invalidFormat'
         and return 'invalidDateRangeError'.`, () => {
         component.literals = poDatepickerRangeLiteralsDefault.pt;
 
         spyOn(component, <any>'dateRangeFormatFailed').and.returnValue(true);
         spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(false);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
         spyOn(component, <any>'requiredDateRangeFailed');
         spyOn(component, <any>'dateRangeFailed');
 
@@ -321,7 +323,9 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         and return 'invalidDateRangeError'.`, () => {
         component.literals = poDatepickerRangeLiteralsDefault.pt;
 
+        spyOn(component, <any>'dateRangeFormatFailed').and.returnValue(false);
         spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(true);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
         spyOn(component, <any>'requiredDateRangeFailed');
         spyOn(component, <any>'dateRangeFailed');
 
@@ -338,6 +342,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
 
         spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(false);
         spyOn(component, <any>'dateRangeFailed').and.returnValue(true);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
         spyOn(component, <any>'requiredDateRangeFailed');
         spyOn(component, <any>'dateRangeFormatFailed');
 
@@ -354,6 +359,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         const returnNull = null;
 
         spyOn(component, <any>'requiredDateRangeFailed').and.returnValue(spyOnReturns);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
         spyOn(component, <any>'dateRangeFormatFailed').and.returnValue(spyOnReturns);
         spyOn(component, <any>'dateRangeFailed').and.returnValue(spyOnReturns);
 
@@ -699,6 +705,91 @@ describe('PoDatepickerRangeBaseComponent:', () => {
       const date = '2018-10-25';
 
       expect(component['convertPatternDateFormat'](date)).toBe(date);
+    });
+
+    it(`should call 'verifyValidDate with startDate valid and return true`, () => {
+      const date = '2021-10-04';
+
+      expect(component['verifyValidDate'](date, '')).toBeTruthy();
+    });
+    it(`should call 'verifyValidDate with startDate invalid and return false`, () => {
+      const date = '2021-02-29';
+
+      expect(component['verifyValidDate'](date, '')).toBeFalsy();
+    });
+    it(`should call 'verifyValidDate with endDate valid and return true`, () => {
+      const date = '2021-10-04';
+
+      expect(component['verifyValidDate']('', date)).toBeTruthy();
+    });
+    it(`should call 'verifyValidDate with endDate invalid and return false`, () => {
+      const date = '2021-02-29';
+
+      expect(component['verifyValidDate']('', date)).toBeFalsy();
+    });
+    it(`should call 'verifyValidDate with startDate e endDate valid and return true`, () => {
+      const startDate = '2021-02-27';
+      const endDate = '2021-02-28';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeTruthy();
+    });
+    it(`should call 'verifyValidDate with startDate e endDate invalid and return false`, () => {
+      const startDate = '2021-02-29';
+      const endDate = '2021-03-32';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeFalsy();
+    });
+    it('should call dateIsValid with a date that is with a month that is 31 days', () => {
+      const date = '2021-03-10';
+
+      expect(component['dateIsValid'](date)).toBeTruthy();
+    });
+    it('should call dateIsValid with a date that is with a month that is 30 days', () => {
+      const date = '2021-09-10';
+
+      expect(component['dateIsValid'](date)).toBeTruthy();
+    });
+    it('should call dateIsValid with a date with leap year date', () => {
+      const date = '2020-02-29';
+      expect(component['dateIsValid'](date)).toBeTruthy();
+    });
+    it('should call dateIsValid with a date without a leap year date', () => {
+      const date = '2021-02-28';
+
+      expect(component['dateIsValid'](date)).toBeTruthy();
+    });
+
+    it('should call dateIsValid with a invalid date that is with a month that is 31 days', () => {
+      const date = '2021-03-32';
+
+      expect(component['dateIsValid'](date)).toBeFalsy();
+    });
+    it('should call dateIsValid with a invalid date that is with a month that is 30 days', () => {
+      const date = '2021-09-31';
+
+      expect(component['dateIsValid'](date)).toBeFalsy();
+    });
+    it('should call dateIsValid with a invalid date with leap year date', () => {
+      const date = '2020-02-30';
+
+      expect(component['dateIsValid'](date)).toBeFalsy();
+    });
+
+    it(`should call 'verifyValidDate', set 'errorMessage' as 'literals.invalidFormat'`, () => {
+      component.literals = poDatepickerRangeLiteralsDefault.pt;
+
+      spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(false);
+      spyOn(component, <any>'dateRangeFailed').and.returnValue(false);
+      spyOn(component, <any>'verifyValidDate').and.returnValue(false);
+      spyOn(component, <any>'requiredDateRangeFailed');
+      spyOn(component, <any>'dateRangeFormatFailed');
+
+      const value = { value: { start: '2021-02-29', end: '' } };
+
+      component.validate(<any>value);
+
+      expect(component['verifyValidDate']).toHaveBeenCalled();
+      expect(component.errorMessage).toEqual(component.literals.invalidDate);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -336,9 +336,9 @@ export class PoDatepickerRangeComponent
     isStartDateTargetEvent: boolean
   ): { isValid: boolean; dateRangeModel: PoDatepickerRange } {
     this.setDateRangeInputValidation(startDate, endDate);
-
     return {
-      isValid: this.isDateRangeInputFormatValid && this.isStartDateRangeInputValid,
+      isValid:
+        this.isDateRangeInputFormatValid && this.isStartDateRangeInputValid && this.verifyValidDate(startDate, endDate),
       dateRangeModel: this.getValidatedModel(startDate, endDate, isStartDateTargetEvent)
     };
   }

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.literals.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.literals.ts
@@ -3,18 +3,22 @@ import { PoDatepickerRangeLiterals } from './interfaces/po-datepicker-range-lite
 export const poDatepickerRangeLiteralsDefault = {
   en: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Date in invalid format',
-    startDateGreaterThanEndDate: 'Start date greater than end date'
+    startDateGreaterThanEndDate: 'Start date greater than end date',
+    invalidDate: 'Invalid date'
   },
   es: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Fecha en formato no válido',
-    startDateGreaterThanEndDate: 'Fecha de inicio mayor que fecha final'
+    startDateGreaterThanEndDate: 'Fecha de inicio mayor que fecha final',
+    invalidDate: 'Fecha invalida'
   },
   pt: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Data no formato inválido',
-    startDateGreaterThanEndDate: 'Data inicial maior que data final'
+    startDateGreaterThanEndDate: 'Data inicial maior que data final',
+    invalidDate: 'Data inválida'
   },
   ru: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Дата в неверном формате',
-    startDateGreaterThanEndDate: 'Дата начала больше даты окончания'
+    startDateGreaterThanEndDate: 'Дата начала больше даты окончания',
+    invalidDate: 'Недействительная дата'
   }
 };


### PR DESCRIPTION
fix(datepicker-range): corrige para permitir apenas datas válidas

O componente estava permitindo inserir valores inválidos via digitação,
como exemplo 31/02/2021, sendo que Fevereiro é até dia 28.

Fixes DTHFUI-5127

**< DatepickerRange>**

**< DTHFUI-5127 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente está permitindo inserir uma data inválida via digitação, como exemplo 31/02/2021 sendo que fevereiro é até o dia 28.

**Qual o novo comportamento?**
Componente apresenta mensagem "Data inválida" quando insere no campo uma data inválida, como exemplo 31/02/2021.

**Simulação**

- component.html

```
<po-datepicker-range
  name="datepickerRange"
  p-auto-focus="boolean"
  p-clean="true"
  p-disabled="false"
  p-help="Help teste"
  p-label="Teste Datepicker Range"
  p-required="true"
  [(ngModel)]="teste"
  (p-change)="changeEvent($event)"
  >
</po-datepicker-range>

```

-  component.ts

```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  teste;
 changeEvent(event) {
    console.log(event)
  }
}
```