### PR TITLE
feat(datepicker-range): adiciona campo locale

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -126,6 +126,7 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   private _readonly: boolean = false;
   private _required?: boolean = false;
   private _startDate?;
+  private _locale?: string;
 
   private language;
   private onChangeModel: any;
@@ -313,6 +314,27 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
 
   get startDate() {
     return this._startDate;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Idioma que o calendário utilizará para exibir as datas.
+   *
+   * > O locale padrão será recuperado com base no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
+   */
+  @Input('p-locale') set locale(value: string) {
+    if (value) {
+      this._locale = value.length >= 2 ? value : poLocaleDefault;
+    } else {
+      this._locale = this.language;
+    }
+  }
+
+  get locale(): string {
+    return this._locale || this.language;
   }
 
   constructor(protected poDateService: PoDateService, languageService: PoLanguageService) {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
@@ -59,6 +59,7 @@
 
 <ng-container *ngIf="isCalendarVisible">
   <div #calendarPicker class="po-calendar-range-picker">
-    <po-calendar p-mode="range" [ngModel]="dateRange" (ngModelChange)="onCalendarChange($event)"></po-calendar>
+    <po-calendar p-mode="range" [ngModel]="dateRange" (ngModelChange)="onCalendarChange($event)" [p-locale]="locale">
+    </po-calendar>
   </div>
 </ng-container>

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
@@ -14,6 +14,7 @@
   [p-required]="properties.includes('required')"
   [p-start-date]="startDate"
   (p-change)="changeEvent('p-change')"
+  [p-locale]="locale"
 >
 </po-datepicker-range>
 
@@ -54,6 +55,11 @@
       [p-options]="propertiesOptions"
     >
     </po-checkbox-group>
+  </div>
+
+  <div class="po-row">
+    <po-select class="po-lg-6 po-md-12" p-label="Locales" [(ngModel)]="locale" [p-options]="poDefaultLanguages">
+    </po-select>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
@@ -1,6 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoCheckboxGroupOption, PoDatepickerRange, PoDatepickerRangeLiterals } from '@po-ui/ng-components';
+import {
+  PoCheckboxGroupOption,
+  PoDatepickerRange,
+  PoDatepickerRangeLiterals,
+  PoSelectOption
+} from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-datepicker-range-labs',
@@ -17,6 +22,13 @@ export class SamplePoDatepickerRangeLabsComponent implements OnInit {
   literals: string;
   properties: Array<string>;
   startDate: string | Date;
+  locale: string;
+  poDefaultLanguages: Array<PoSelectOption> = [
+    { label: 'English', value: 'en' },
+    { label: 'Español', value: 'es' },
+    { label: 'Português', value: 'pt' },
+    { label: 'Pусский', value: 'ru' }
+  ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'clean', label: 'Clean' },
@@ -57,6 +69,7 @@ export class SamplePoDatepickerRangeLabsComponent implements OnInit {
     this.literals = undefined;
     this.properties = [];
     this.startDate = undefined;
+    this.locale = undefined;
     setTimeout(() => (this.datepickerRange = undefined));
   }
 }


### PR DESCRIPTION


**PO-DATEPICKER-RANGE**

**#1041**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**

O componente não recebe a propriedade `locale`, referente ao idioma exibido.

**Qual o novo comportamento?**

É possível definir o idioma do componente através da propriedade `locale`

**Simulação**

Simular através do portal