### PR TITLE
perf(fields): implementando ChangeDetectionStrategy OnPush

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-email/po-email.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-email/po-email.component.spec.ts
@@ -26,8 +26,6 @@ describe('PoEmailComponent:', () => {
     component.label = 'Label de teste';
     component.help = 'Help de teste';
     component.clean = true;
-
-    fixture.detectChanges();
   });
 
   it('should be created', () => {
@@ -35,6 +33,7 @@ describe('PoEmailComponent:', () => {
   });
 
   it('should return null in extraValidation()', () => {
+    fixture.detectChanges();
     expect(component.extraValidation(null)).toBeNull();
   });
 
@@ -107,6 +106,7 @@ describe('PoEmailComponent:', () => {
     const eventKeyup = new KeyboardEvent('keyup', { 'key': 'a' });
 
     it('should have `mail` icon', () => {
+      fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.querySelector('.po-icon-mail')).toBeTruthy();
     });
 

--- a/projects/ui/src/lib/components/po-field/po-email/po-email.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-email/po-email.component.ts
@@ -1,4 +1,12 @@
-import { AfterViewInit, Component, ElementRef, forwardRef, OnDestroy } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  forwardRef,
+  OnDestroy
+} from '@angular/core';
 import { AbstractControl, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
 
 import { PoInputGeneric } from '../po-input-generic/po-input-generic';
@@ -48,6 +56,7 @@ const providers = [
 @Component({
   selector: 'po-email',
   templateUrl: '../po-input/po-input.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers
 })
 export class PoEmailComponent extends PoInputGeneric implements AfterViewInit, OnDestroy {
@@ -82,8 +91,8 @@ export class PoEmailComponent extends PoInputGeneric implements AfterViewInit, O
   private listener = this.validateClassesForPattern.bind(this);
 
   /* istanbul ignore next */
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(el: ElementRef, cd: ChangeDetectorRef) {
+    super(el, cd);
     this.maxlength = 254;
   }
 

--- a/projects/ui/src/lib/components/po-field/po-login/po-login.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-login/po-login.component.spec.ts
@@ -22,8 +22,6 @@ describe('PoLoginComponent:', () => {
     component = fixture.componentInstance;
     component.clean = true;
     component.type = 'text';
-
-    fixture.detectChanges();
   });
 
   it('should be created', () => {
@@ -31,10 +29,12 @@ describe('PoLoginComponent:', () => {
   });
 
   it('should return null in extraValidation()', () => {
+    fixture.detectChanges();
     expect(component.extraValidation(null)).toBeNull();
   });
 
   it('should be type text', () => {
+    fixture.detectChanges();
     expect(component.type === 'text').toBeTruthy();
   });
 

--- a/projects/ui/src/lib/components/po-field/po-login/po-login.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-login/po-login.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, forwardRef } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef } from '@angular/core';
 import { AbstractControl, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
 
 import { PoInputGeneric } from '../po-input-generic/po-input-generic';
@@ -46,14 +46,15 @@ const providers = [
 @Component({
   selector: 'po-login',
   templateUrl: './po-login.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers
 })
 export class PoLoginComponent extends PoInputGeneric {
   type = 'text';
 
   /* istanbul ignore next */
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(el: ElementRef, cd: ChangeDetectorRef) {
+    super(el, cd);
   }
 
   extraValidation(c: AbstractControl): { [key: string]: any } {

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.spec.ts
@@ -23,19 +23,21 @@ describe('PoNumberComponent:', () => {
     component = fixture.componentInstance;
     component.clean = true;
     component.type = 'password';
-    fixture.detectChanges();
     nativeElement = fixture.debugElement.nativeElement;
   });
 
   it('should be created', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should return null in extraValidation()', () => {
+    fixture.detectChanges();
     expect(component.extraValidation(null)).toBeNull();
   });
 
   it('should be type password', () => {
+    fixture.detectChanges();
     expect(component.type === 'password').toBeTruthy();
   });
 

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.ts
@@ -1,5 +1,5 @@
 import { AbstractControl, NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { Component, ElementRef, forwardRef, Input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef, Input } from '@angular/core';
 
 import { convertToBoolean } from '../../../utils/util';
 import { PoInputGeneric } from '../po-input-generic/po-input-generic';
@@ -30,6 +30,7 @@ import { PoInputGeneric } from '../po-input-generic/po-input-generic';
 @Component({
   selector: 'po-password',
   templateUrl: './po-password.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -75,8 +76,8 @@ export class PoPasswordComponent extends PoInputGeneric {
   }
 
   /* istanbul ignore next */
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(el: ElementRef, cd: ChangeDetectorRef) {
+    super(el, cd);
   }
 
   extraValidation(c: AbstractControl): { [key: string]: any } {

--- a/projects/ui/src/lib/components/po-field/po-url/po-url.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-url/po-url.component.spec.ts
@@ -25,8 +25,6 @@ describe('PoUrlComponent:', () => {
     component.label = 'Label de teste';
     component.help = 'Help de teste';
     component.clean = true;
-
-    fixture.detectChanges();
   });
 
   it('should be created', () => {
@@ -34,6 +32,7 @@ describe('PoUrlComponent:', () => {
   });
 
   it('should return null in extraValidation()', () => {
+    fixture.detectChanges();
     expect(component.extraValidation(null)).toBeNull();
   });
 
@@ -190,6 +189,7 @@ describe('PoUrlComponent:', () => {
     const eventKeyup = new KeyboardEvent('keyup', { 'key': 'a' });
 
     it('should have `world` icon', () => {
+      fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.querySelector('.po-icon-world')).toBeTruthy();
     });
 

--- a/projects/ui/src/lib/components/po-field/po-url/po-url.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-url/po-url.component.ts
@@ -1,4 +1,12 @@
-import { AfterViewInit, Component, ElementRef, forwardRef, OnDestroy } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  forwardRef,
+  OnDestroy
+} from '@angular/core';
 import { AbstractControl, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
 
 import { PoInputGeneric } from '../po-input-generic/po-input-generic';
@@ -31,6 +39,7 @@ import { PoInputGeneric } from '../po-input-generic/po-input-generic';
 @Component({
   selector: 'po-url',
   templateUrl: '../po-input/po-input.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -62,8 +71,8 @@ export class PoUrlComponent extends PoInputGeneric implements AfterViewInit, OnD
   private listener = this.validateClassesForPattern.bind(this);
 
   /* istanbul ignore next */
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(el: ElementRef, cd: ChangeDetectorRef) {
+    super(el, cd);
     this.maxlength = 254;
   }
 


### PR DESCRIPTION
** PoEmail, PoUrl, PoPassword e PoLogin;**

**<DTHFUI-5354 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Os componentes utilizam o ChangeDetectionStrategy.Default

**Qual o novo comportamento?**
Os componentes utilizam o ChangeDetectionStrategy.OnPush

**Simulação**

**app.component.html**
```
<po-email name="email" [(ngModel)]="email" p-label="PO Email" (p-change)="changeInput($event)"> </po-email>
<po-login name="login" [(ngModel)]="login" p-label="PO Login" (p-change)="changeInput($event)"> </po-login>
<po-password name="password" [(ngModel)]="password" p-label="PO Password" (p-change)="changeInput($event)"> </po-password>
<po-url name="url" [(ngModel)]="url" p-label="PO URL" (p-change)="changeInput($event)"> </po-url>

<ul>
  <li> {{ email }}</li>
  <li> {{ login }}</li>
  <li> {{ password }}</li>
  <li> {{ url }}</li>
</ul>
```
**app.component.ts**
```
email;
  login;
  password;
  url;

  changeInput(event) {
    console.log(event);
  }
```