### PR TITLE
feat(datepicker-range): inclui propriedade min-date e max-date

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
@@ -43,6 +43,40 @@ describe('PoCalendarComponent:', () => {
       expect(component['setActivateDate']).toHaveBeenCalled();
     });
 
+    it('ngOnChanges: should call `setActivateDate` if `changes` contain minDate', () => {
+      const changes: any = {
+        minDate: '2021-08-08'
+      };
+
+      const spy = spyOn(component, <any>'setActivateDate');
+
+      component.ngOnChanges(changes);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('ngOnChanges: should call `setActivateDate` if `changes` contain maxDate', () => {
+      const changes: any = {
+        maxDate: '2021-08-08'
+      };
+
+      const spy = spyOn(component, <any>'setActivateDate');
+
+      component.ngOnChanges(changes);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it(`ngOnChanges: shouldn't call 'setActivateDate' if 'changes' not contain maxDate ou minDate`, () => {
+      const changes = {};
+
+      const spy = spyOn(component, <any>'setActivateDate');
+
+      component.ngOnChanges(changes);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     it('getActivateDate: should get activateDate if range is true', () => {
       const expectedValue = new Date(2020, 10, 10);
       component.activateDate = { start: expectedValue, end: new Date(2020, 11, 10) };

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/interfaces/po-datepicker-range-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/interfaces/po-datepicker-range-literals.interface.ts
@@ -14,4 +14,7 @@ export interface PoDatepickerRangeLiterals {
 
   /** Data inválida. */
   invalidDate?: string;
+
+  /** Data fora do período. */
+  dateOutOfPeriod?: string;
 }

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -63,6 +63,38 @@ describe('PoDatepickerRangeBaseComponent:', () => {
       expectPropertiesValues(component, 'clean', booleanInvalidValues, false);
     });
 
+    it('max-date: should be update property p-max-date using string', () => {
+      component.maxDate = new Date(2021, 7, 1).toISOString();
+
+      expect(component['_maxDate'].getDate()).toBe(1);
+      expect(component['_maxDate'].getMonth()).toBe(7);
+      expect(component['_maxDate'].getFullYear()).toBe(2021);
+    });
+
+    it('max-date: should be update property p-max-date using Date', () => {
+      component.maxDate = new Date(2021, 7, 1);
+
+      expect(component['_maxDate'].getDate()).toBe(1);
+      expect(component['_maxDate'].getMonth()).toBe(7);
+      expect(component['_maxDate'].getFullYear()).toBe(2021);
+    });
+
+    it('min-date: should be update property p-min-date using string', () => {
+      component.minDate = new Date(2021, 7, 1).toISOString();
+
+      expect(component['_minDate'].getDate()).toBe(1);
+      expect(component['_minDate'].getMonth()).toBe(7);
+      expect(component['_minDate'].getFullYear()).toBe(2021);
+    });
+
+    it('min-date: should be update property p-min-date using Date', () => {
+      component.minDate = new Date(2021, 7, 1);
+
+      expect(component['_minDate'].getDate()).toBe(1);
+      expect(component['_minDate'].getMonth()).toBe(7);
+      expect(component['_minDate'].getFullYear()).toBe(2021);
+    });
+
     it('disabled: should update with true value.', () => {
       const booleanValidTrueValues = [true, 'true', 1, ''];
 
@@ -369,6 +401,46 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         expect(component['dateRangeFormatFailed']).toHaveBeenCalled();
         expect(component['dateRangeFailed']).toHaveBeenCalled();
         expect(validate).toEqual(returnNull);
+      });
+
+      it(`should call 'validateDateInRange' if contain startDate and set 'errorMessage' with 'dateOutOfPeriod'`, () => {
+        component.literals = poDatepickerRangeLiteralsDefault.pt;
+
+        spyOn(component, <any>'requiredDateRangeFailed').and.returnValue(false);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
+        spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(false);
+        spyOn(component, <any>'dateRangeFormatFailed').and.returnValue(false);
+        spyOn(component, <any>'dateRangeFailed').and.returnValue(false);
+        spyOn(component, <any>'validateDateInRange').and.returnValue(false);
+
+        const value = { value: { start: '2021-10-14', end: '' } };
+
+        component.validate(<any>value);
+        const validate = component.validate(<any>value);
+
+        expect(component.errorMessage).toEqual(component.literals.dateOutOfPeriod);
+        expect(component['validateDateInRange']).toHaveBeenCalled();
+        expect(validate).toEqual(invalidDateRangeError);
+      });
+
+      it(`should call 'validateDateInRange' if contain endDate and set 'errorMessage' with 'dateOutOfPeriod'`, () => {
+        component.literals = poDatepickerRangeLiteralsDefault.pt;
+
+        spyOn(component, <any>'requiredDateRangeFailed').and.returnValue(false);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
+        spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(false);
+        spyOn(component, <any>'dateRangeFormatFailed').and.returnValue(false);
+        spyOn(component, <any>'dateRangeFailed').and.returnValue(false);
+        spyOn(component, <any>'validateDateInRange').and.returnValue(false);
+
+        const value = { value: { start: '', end: '2021-10-14' } };
+
+        component.validate(<any>value);
+        const validate = component.validate(<any>value);
+
+        expect(component.errorMessage).toEqual(component.literals.dateOutOfPeriod);
+        expect(component['validateDateInRange']).toHaveBeenCalled();
+        expect(validate).toEqual(invalidDateRangeError);
       });
     });
 
@@ -790,6 +862,22 @@ describe('PoDatepickerRangeBaseComponent:', () => {
 
       expect(component['verifyValidDate']).toHaveBeenCalled();
       expect(component.errorMessage).toEqual(component.literals.invalidDate);
+    });
+
+    it('validateDateInRange: should return false if `date` is out of range', () => {
+      const date = '2021-09-13';
+      component.minDate = new Date(2021, 9, 14);
+      component.maxDate = new Date(2021, 11, 14);
+
+      expect(component['validateDateInRange'](date)).toBeFalsy();
+    });
+
+    it('validateDateInRange: should return true if `date` is inside of range', () => {
+      const date = '2021-10-15';
+      component.minDate = new Date(2021, 9, 14);
+      component.maxDate = new Date(2021, 11, 14);
+
+      expect(component['validateDateInRange'](date)).toBeTruthy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
@@ -59,6 +59,12 @@
 
 <ng-container *ngIf="isCalendarVisible">
   <div #calendarPicker class="po-calendar-range-picker">
-    <po-calendar p-mode="range" [ngModel]="dateRange" (ngModelChange)="onCalendarChange($event)"></po-calendar>
+    <po-calendar
+      p-mode="range"
+      [ngModel]="dateRange"
+      [p-max-date]="maxDate"
+      [p-min-date]="minDate"
+      (ngModelChange)="onCalendarChange($event)"
+    ></po-calendar>
   </div>
 </ng-container>

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
@@ -224,6 +224,40 @@ describe('PoDatepickerRangeComponent:', () => {
       expect(component['poMaskObject']).toEqual(buildMaskReturn);
     });
 
+    it('ngOnChanges: should call `validateModel` if `changes` contain minDate', () => {
+      const changes: any = {
+        minDate: '2021-08-08'
+      };
+
+      const spy = spyOn(component, <any>'validateModel');
+
+      component.ngOnChanges(changes);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('ngOnChanges: should call `validateModel` if `changes` contain maxDate', () => {
+      const changes: any = {
+        maxDate: '2021-08-08'
+      };
+
+      const spy = spyOn(component, <any>'validateModel');
+
+      component.ngOnChanges(changes);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it(`ngOnChanges: shouldn't call 'validateModel' if 'changes' not contain maxDate ou minDate`, () => {
+      const changes = {};
+
+      const spy = spyOn(component, <any>'validateModel');
+
+      component.ngOnChanges(changes);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     it('clear: should call `updateScreenByModel`, `resetDateRangeInputValidation` and `updateModel`', () => {
       spyOn(component, 'updateScreenByModel');
       spyOn(component, <any>'resetDateRangeInputValidation');

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -7,7 +7,9 @@ import {
   ViewChild,
   AfterViewInit,
   Renderer2,
-  OnDestroy
+  OnDestroy,
+  SimpleChanges,
+  OnChanges
 } from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
@@ -77,7 +79,7 @@ const providers = [
 })
 export class PoDatepickerRangeComponent
   extends PoDatepickerRangeBaseComponent
-  implements AfterViewInit, OnInit, OnDestroy {
+  implements AfterViewInit, OnInit, OnDestroy, OnChanges {
   @ViewChild('dateRangeField', { read: ElementRef, static: true }) dateRangeField: ElementRef;
   @ViewChild('endDateInput', { read: ElementRef, static: true }) endDateInput: ElementRef;
   @ViewChild('startDateInput', { read: ElementRef, static: true }) startDateInput: ElementRef;
@@ -166,6 +168,12 @@ export class PoDatepickerRangeComponent
   ngOnInit() {
     // Classe de máscara
     this.poMaskObject = this.buildMask();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.minDate || changes.maxDate) {
+      this.validateModel(this.dateRange);
+    }
   }
 
   ngOnDestroy() {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.literals.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.literals.ts
@@ -4,21 +4,25 @@ export const poDatepickerRangeLiteralsDefault = {
   en: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Date in invalid format',
     startDateGreaterThanEndDate: 'Start date greater than end date',
-    invalidDate: 'Invalid date'
+    invalidDate: 'Invalid date',
+    dateOutOfPeriod: 'Date out of period'
   },
   es: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Fecha en formato no válido',
     startDateGreaterThanEndDate: 'Fecha de inicio mayor que fecha final',
-    invalidDate: 'Fecha invalida'
+    invalidDate: 'Fecha invalida',
+    dateOutOfPeriod: 'Fecha fuera de período'
   },
   pt: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Data no formato inválido',
     startDateGreaterThanEndDate: 'Data inicial maior que data final',
-    invalidDate: 'Data inválida'
+    invalidDate: 'Data inválida',
+    dateOutOfPeriod: 'Data fora do período'
   },
   ru: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Дата в неверном формате',
     startDateGreaterThanEndDate: 'Дата начала больше даты окончания',
-    invalidDate: 'Недействительная дата'
+    invalidDate: 'Недействительная дата',
+    dateOutOfPeriod: 'дата вне периода'
   }
 };

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
@@ -8,6 +8,8 @@
   [p-help]="help"
   [p-label]="label"
   [p-literals]="customLiterals"
+  [p-max-date]="maxDate"
+  [p-min-date]="minDate"
   [p-no-autocomplete]="properties?.includes('noAutocomplete')"
   [p-optional]="properties.includes('optional')"
   [p-readonly]="properties.includes('readonly')"
@@ -32,6 +34,28 @@
     <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
     <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+  </div>
+
+  <div class="po-row">
+    <po-datepicker
+      class="po-md-6"
+      name="minDate"
+      [(ngModel)]="minDate"
+      p-clean
+      p-label="Min date"
+      [p-max-date]="maxDate"
+    >
+    </po-datepicker>
+
+    <po-datepicker
+      class="po-md-6"
+      name="maxDate"
+      [(ngModel)]="maxDate"
+      p-clean
+      p-label="Max date"
+      [p-min-date]="minDate"
+    >
+    </po-datepicker>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
@@ -17,6 +17,8 @@ export class SamplePoDatepickerRangeLabsComponent implements OnInit {
   literals: string;
   properties: Array<string>;
   startDate: string | Date;
+  maxDate: string | Date;
+  minDate: string | Date;
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'clean', label: 'Clean' },
@@ -57,6 +59,8 @@ export class SamplePoDatepickerRangeLabsComponent implements OnInit {
     this.literals = undefined;
     this.properties = [];
     this.startDate = undefined;
+    this.maxDate = undefined;
+    this.minDate = undefined;
     setTimeout(() => (this.datepickerRange = undefined));
   }
 }


### PR DESCRIPTION
**Date-Picker-Range**

**DTHFUI-5395**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente DatePicker-range não tem a propriedade `p-min-date` e `p-max-date`

**Qual o novo comportamento?**
Componente DatePicker-range tem a propriedade `p-min-date` e `p-max-date`

**Simulação**
Simular no labs do Portal e pelo app:

html:
```
<po-datepicker-range  [p-min-date]="minDate" [p-max-date]="maxDate" [(ngModel)]="datepickerRange"></po-datepicker-range>

```
ts:

```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  datepickerRange ;
  minDate: string | Date = new Date(2021, 9, 15);
  maxDate: string | Date = new Date(2021, 10, 15);
}
```