### PR TITLE
feat(avatar): adiciona a propriedade p-loading

### DIFF
--- a/projects/ui/src/lib/components/po-avatar/po-avatar-base.component.ts
+++ b/projects/ui/src/lib/components/po-avatar/po-avatar-base.component.ts
@@ -20,6 +20,21 @@ export class PoAvatarBaseComponent {
    */
   @Input('p-src') src: string;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Indica como o navegador deve carregar a imagem.
+   *
+   * Valores válidos:
+   *  - `eager` (a imagem é carregada imediatamente, independente de estar visível ou não)
+   *  - `lazy` (a imagem só é carregada quando estiver próxima de ser renderizada)
+   *
+   * @default `eager`
+   */
+  @Input('p-loading') loading: 'eager' | 'lazy' = 'eager';
+
   /** Evento disparado ao clicar na imagem do *avatar*. */
   @Output('p-click') click = new EventEmitter<any>();
 

--- a/projects/ui/src/lib/components/po-avatar/po-avatar.component.html
+++ b/projects/ui/src/lib/components/po-avatar/po-avatar.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <ng-template #sourceImage>
-  <img class="po-avatar-image" [src]="src" alt="" (error)="onError()" />
+  <img class="po-avatar-image" [src]="src" alt="" [attr.loading]="loading" (error)="onError()" />
 </ng-template>
 
 <ng-template #defaultIcon>

--- a/projects/ui/src/lib/components/po-avatar/po-avatar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-avatar/po-avatar.component.spec.ts
@@ -86,4 +86,19 @@ describe('PoAvatarComponent:', () => {
       expect(nativeElement.querySelector('.po-avatar.po-clickable')).toBeNull();
     });
   });
+
+  describe('Loading:', () => {
+    it('should start with eager as default', () => {
+      expect(component.loading).toEqual('eager');
+    });
+
+    it(`should set 'loading' attribute to img tag`, () => {
+      component.src = 'image_path';
+      component.loading = 'lazy';
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('[loading="lazy"]')).toHaveClass('po-avatar-image');
+    });
+  });
 });


### PR DESCRIPTION
Habilita a propriedade experimental `loading` no elemento img do po-avatar, o que permite que as imagens sejam carregadas usando a estratégia de lazy loading.

Fixes #1058

**avatar**

**1058**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente avatar não possui a propriedade loading.

**Qual o novo comportamento?**
A propriedade loading foi adicionada no componente e é utilizada na tag `img`.

**Simulação**

**app.component.html**
```html
<po-avatar
  *ngFor="let item of list"
  p-loading="lazy"
  [p-src]="'https://via.placeholder.com/100x100.png?text=' + item"
></po-avatar>
```

**app.component.ts**
```ts
export class AppComponent {
  list = Array(100)
    .fill(1)
    .map((x, i) => i);
}
```