### PR TITLE
fix(datepicker-range): corrige para permitir apenas datas válidas

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/interfaces/po-datepicker-range-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/interfaces/po-datepicker-range-literals.interface.ts
@@ -11,4 +11,7 @@ export interface PoDatepickerRangeLiterals {
 
   /** Data inicial maior que data final. */
   startDateGreaterThanEndDate?: string;
+
+  /** Data inválida. */
+  invalidDate?: string;
 }

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -269,6 +269,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
 
         spyOn(component, <any>'convertPatternDateFormat');
         spyOn(component, <any>'requiredDateRangeFailed');
+        spyOn(component, <any>'verifyValidDate');
         spyOn(component, <any>'dateRangeFormatFailed');
         spyOn(component, <any>'dateRangeFailed');
 
@@ -301,12 +302,13 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         expect(component.disabled).toBe(expectedValue);
       });
 
-      it(`should call 'dateRangeObjectFailed', set 'errorMessage' as 'literals.invalidFormat'
+      it(`should call 'dateRangeFormatFailed', set 'errorMessage' as 'literals.invalidFormat'
         and return 'invalidDateRangeError'.`, () => {
         component.literals = poDatepickerRangeLiteralsDefault.pt;
 
         spyOn(component, <any>'dateRangeFormatFailed').and.returnValue(true);
         spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(false);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
         spyOn(component, <any>'requiredDateRangeFailed');
         spyOn(component, <any>'dateRangeFailed');
 
@@ -321,7 +323,9 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         and return 'invalidDateRangeError'.`, () => {
         component.literals = poDatepickerRangeLiteralsDefault.pt;
 
+        spyOn(component, <any>'dateRangeFormatFailed').and.returnValue(false);
         spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(true);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
         spyOn(component, <any>'requiredDateRangeFailed');
         spyOn(component, <any>'dateRangeFailed');
 
@@ -338,6 +342,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
 
         spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(false);
         spyOn(component, <any>'dateRangeFailed').and.returnValue(true);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
         spyOn(component, <any>'requiredDateRangeFailed');
         spyOn(component, <any>'dateRangeFormatFailed');
 
@@ -354,6 +359,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         const returnNull = null;
 
         spyOn(component, <any>'requiredDateRangeFailed').and.returnValue(spyOnReturns);
+        spyOn(component, <any>'verifyValidDate').and.returnValue(true);
         spyOn(component, <any>'dateRangeFormatFailed').and.returnValue(spyOnReturns);
         spyOn(component, <any>'dateRangeFailed').and.returnValue(spyOnReturns);
 
@@ -699,6 +705,99 @@ describe('PoDatepickerRangeBaseComponent:', () => {
       const date = '2018-10-25';
 
       expect(component['convertPatternDateFormat'](date)).toBe(date);
+    });
+
+    it(`should call 'verifyValidDate with startDate valid and return true`, () => {
+      const date = '2021-10-04';
+
+      expect(component['verifyValidDate'](date, '')).toBeTruthy();
+    });
+    it(`should call 'verifyValidDate with startDate invalid and return false`, () => {
+      const date = '2021-02-29';
+
+      expect(component['verifyValidDate'](date, '')).toBeFalsy();
+    });
+    it(`should call 'verifyValidDate with endDate valid and return true`, () => {
+      const date = '2021-10-04';
+
+      expect(component['verifyValidDate']('', date)).toBeTruthy();
+    });
+    it(`should call 'verifyValidDate with endDate invalid and return false`, () => {
+      const date = '2021-02-29';
+
+      expect(component['verifyValidDate']('', date)).toBeFalsy();
+    });
+    it(`should call 'verifyValidDate with startDate e endDate valid and return false`, () => {
+      const startDate = '2021-02-27';
+      const endDate = '2021-02-28';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeTruthy();
+    });
+    it(`should call 'verifyValidDate with startDate e endDate invalid and return false`, () => {
+      const startDate = '2021-02-29';
+      const endDate = '2021-03-32';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeFalsy();
+    });
+    it('should call dateIsValid with a date that is with a month that is 31 days', () => {
+      const startDate = '2021-02-28';
+      const endDate = '2021-03-31';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeTruthy();
+    });
+    it('should call dateIsValid with a date that is with a month that is 30 days', () => {
+      const startDate = '2021-02-28';
+      const endDate = '2021-09-30';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeTruthy();
+    });
+    it('should call dateIsValid with a date with leap year date', () => {
+      const startDate = '2020-02-29';
+      const endDate = '2021-03-31';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeTruthy();
+    });
+    it('should call dateIsValid with a date without a leap year date', () => {
+      const startDate = '2021-02-28';
+      const endDate = '2021-03-31';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeTruthy();
+    });
+
+    it('should call dateIsValid with a invalid date that is with a month that is 31 days', () => {
+      const startDate = '2021-02-28';
+      const endDate = '2021-03-32';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeFalsy();
+    });
+    it('should call dateIsValid with a invalid date that is with a month that is 30 days', () => {
+      const startDate = '2021-02-28';
+      const endDate = '2021-09-31';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeFalsy();
+    });
+    it('should call dateIsValid with a invalid date with leap year date', () => {
+      const startDate = '2020-02-30';
+      const endDate = '2021-03-31';
+
+      expect(component['verifyValidDate'](startDate, endDate)).toBeFalsy();
+    });
+
+    it(`should call 'verifyValidDate', set 'errorMessage' as 'literals.invalidFormat'`, () => {
+      component.literals = poDatepickerRangeLiteralsDefault.pt;
+
+      spyOn(component, <any>'dateRangeObjectFailed').and.returnValue(false);
+      spyOn(component, <any>'dateRangeFailed').and.returnValue(false);
+      spyOn(component, <any>'verifyValidDate').and.returnValue(false);
+      spyOn(component, <any>'requiredDateRangeFailed');
+      spyOn(component, <any>'dateRangeFormatFailed');
+
+      const value = { value: { start: '2021-02-29', end: '' } };
+
+      component.validate(<any>value);
+
+      expect(component['verifyValidDate']).toHaveBeenCalled();
+      expect(component.errorMessage).toEqual(component.literals.invalidDate);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -1,15 +1,13 @@
+import { Directive, EventEmitter, Input, Output } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, ValidationErrors, Validator } from '@angular/forms';
-import { EventEmitter, Input, Output, Directive } from '@angular/core';
-
-import { convertToBoolean } from './../../../utils/util';
-import { requiredFailed } from '../validators';
 import { InputBoolean } from '../../../decorators';
-import { PoDateService } from './../../../services/po-date/po-date.service';
-import { PoLanguageService } from '../../../services/po-language/po-language.service';
 import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
-
-import { PoDatepickerRange } from './interfaces/po-datepicker-range.interface';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { requiredFailed } from '../validators';
+import { PoDateService } from './../../../services/po-date/po-date.service';
+import { convertToBoolean } from './../../../utils/util';
 import { PoDatepickerRangeLiterals } from './interfaces/po-datepicker-range-literals.interface';
+import { PoDatepickerRange } from './interfaces/po-datepicker-range.interface';
 import { poDatepickerRangeLiteralsDefault } from './po-datepicker-range.literals';
 
 /**
@@ -356,6 +354,15 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
       };
     }
 
+    if (!this.verifyValidDate(startDate, endDate)) {
+      this.errorMessage = this.literals.invalidDate;
+      return {
+        date: {
+          valid: false
+        }
+      };
+    }
+
     if (this.dateRangeObjectFailed(control.value) || this.dateRangeFormatFailed(startDate, endDate)) {
       this.errorMessage = this.literals.invalidFormat;
 
@@ -375,7 +382,6 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
         }
       };
     }
-
     return null;
   }
 
@@ -456,6 +462,34 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
       requiredFailed(this.required, this.disabled, startDate) &&
       requiredFailed(this.required, this.disabled, endDate)
     );
+  }
+
+  private verifyValidDate(startDate: string, endDate: string) {
+    if (startDate !== '' && endDate !== '') {
+      return this.dateIsValid(startDate) && this.dateIsValid(endDate);
+    } else if (startDate !== '') {
+      return this.dateIsValid(startDate);
+    } else {
+      return this.dateIsValid(endDate);
+    }
+  }
+
+  private dateIsValid(date) {
+    const [year, month, day] = date.split('-');
+    //verificação dos meses com 31 dias
+    if (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12) {
+      return day < 1 || day > 31 ? false : true;
+    } else if (month == 4 || month == 6 || month == 9 || month == 11) {
+      //verificação dos meses com 30 dias
+      return day < 1 || day > 30 ? false : true;
+    } else {
+      //verificacao de ano bissexto para verificar até qual dia irá o mês de fevereiro
+      if ((year % 4 == 0 && year % 100 != 0) || year % 400 == 0) {
+        return day < 1 || day > 29 ? false : true;
+      } else {
+        return day < 1 || day > 28 ? false : true;
+      }
+    }
   }
 
   protected abstract resetDateRangeInputValidation(): void;

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.literals.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.literals.ts
@@ -3,18 +3,22 @@ import { PoDatepickerRangeLiterals } from './interfaces/po-datepicker-range-lite
 export const poDatepickerRangeLiteralsDefault = {
   en: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Date in invalid format',
-    startDateGreaterThanEndDate: 'Start date greater than end date'
+    startDateGreaterThanEndDate: 'Start date greater than end date',
+    invalidDate: 'Invalid date'
   },
   es: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Fecha en formato no válido',
-    startDateGreaterThanEndDate: 'Fecha de inicio mayor que fecha final'
+    startDateGreaterThanEndDate: 'Fecha de inicio mayor que fecha final',
+    invalidDate: 'Fecha invalida'
   },
   pt: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Data no formato inválido',
-    startDateGreaterThanEndDate: 'Data inicial maior que data final'
+    startDateGreaterThanEndDate: 'Data inicial maior que data final',
+    invalidDate: 'Data inválida'
   },
   ru: <PoDatepickerRangeLiterals>{
     invalidFormat: 'Дата в неверном формате',
-    startDateGreaterThanEndDate: 'Дата начала больше даты окончания'
+    startDateGreaterThanEndDate: 'Дата начала больше даты окончания',
+    invalidDate: 'Недействительная дата'
   }
 };


### PR DESCRIPTION

O componente estava permitindo inserir valores inválidos via digitação,
como exemplo 31/02/2021, sendo que Fevereiro é até dia 28.

Fixes DTHFUI-5127

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
