### PR TITLE
feat(calendar): adiciona botão `hoje`

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
@@ -91,4 +91,14 @@
       </div>
     </div>
   </ng-container>
+
+  <ng-container *ngIf="!range">
+    <div class="po-calendar-footer">
+      <div class="po-calendar-footer-today">
+        <button class="po-calendar-footer-today-button" (click)="onSelectDate(today)" [disabled]="isTodayUnavailable()">
+          {{ displayToday }}
+        </button>
+      </div>
+    </div>
+  </ng-container>
 </div>

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.spec.ts
@@ -166,6 +166,75 @@ describe('PoCalendarWrapperComponent', () => {
       expect(component.getForegroundColor(11, 10)).toBe('po-calendar-box-foreground');
     });
 
+    it('isTodayUnavailable: should return `false` if minDate is less than date', () => {
+      const date: string | Date = new Date();
+      const minDate: string | Date = new Date(date);
+
+      minDate.setDate(minDate.getDate() - 1);
+
+      component['today'] = date;
+      component.minDate = minDate;
+
+      expect(minDate.getTime()).toBeLessThan(date.getTime());
+      expect(component.isTodayUnavailable()).toBeFalse();
+    });
+
+    it('isTodayUnavailable: should return `false` if minDate is equal date', () => {
+      const date: string | Date = new Date();
+      const minDate: string | Date = new Date(date);
+
+      component['today'] = date;
+      component.minDate = minDate;
+
+      expect(component.isTodayUnavailable()).toBeFalse();
+    });
+
+    it('isTodayUnavailable: should return `true` if minDate is greater than date', () => {
+      const date: string | Date = new Date();
+      const minDate: string | Date = new Date(date);
+
+      minDate.setDate(minDate.getDate() + 1);
+
+      component['today'] = date;
+      component.minDate = minDate;
+
+      expect(component.isTodayUnavailable()).toBeTrue();
+    });
+
+    it('isTodayUnavailable: should return `false` if maxDate is greater than date', () => {
+      const date: string | Date = new Date();
+      const maxDate: string | Date = new Date(date);
+
+      maxDate.setDate(maxDate.getDate() + 1);
+
+      component['today'] = date;
+      component.maxDate = maxDate;
+
+      expect(component.isTodayUnavailable()).toBeFalse();
+    });
+
+    it('isTodayUnavailable: should return `false` if maxDate is equal date', () => {
+      const date: string | Date = new Date();
+      const maxDate: string | Date = new Date(date);
+
+      component['today'] = date;
+      component.maxDate = maxDate;
+
+      expect(component.isTodayUnavailable()).toBeFalse();
+    });
+
+    it('isTodayUnavailable: should return `true` if maxDate is less than date', () => {
+      const date: string | Date = new Date();
+      const maxDate: string | Date = new Date(date);
+
+      maxDate.setDate(maxDate.getDate() - 1);
+
+      component['today'] = date;
+      component.maxDate = maxDate;
+
+      expect(component.isTodayUnavailable()).toBeTrue();
+    });
+
     it(`monthLabel: should call 'poCalendarLangService.getMonthLabel'`, () => {
       spyOn(component['poCalendarLangService'], 'getMonthLabel').and.callThrough();
 

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.ts
@@ -50,11 +50,12 @@ export class PoCalendarWrapperComponent implements OnInit, OnChanges {
   displayStartDecade: number;
   displayWeekDays: Array<any> = Array();
   displayYear: number;
+  displayToday: string;
+  today: Date = new Date();
 
   protected currentMonthNumber: number;
   protected date: Date;
   protected lastDisplay: string;
-  protected today: Date = new Date();
 
   private _locale: string;
 
@@ -127,6 +128,10 @@ export class PoCalendarWrapperComponent implements OnInit, OnChanges {
 
   getForegroundColor(displayValue: number, propertyValue: number) {
     return displayValue === propertyValue ? 'po-calendar-box-foreground-selected' : 'po-calendar-box-foreground';
+  }
+
+  isTodayUnavailable() {
+    return this.minDate > this.today || this.maxDate < this.today;
   }
 
   onNextMonth() {
@@ -273,6 +278,7 @@ export class PoCalendarWrapperComponent implements OnInit, OnChanges {
     this.displayWeekDays = this.poCalendarLangService.getWeekDaysArray();
     this.displayMonths = this.poCalendarLangService.getMonthsArray();
     this.displayMonth = this.displayMonths[this.displayMonthNumber];
+    this.displayToday = this.poCalendarLangService.getTodayLabel();
   }
 
   private updateDate(value: Date = new Date()) {

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
@@ -106,6 +106,7 @@ export class PoCalendarComponent extends PoCalendarBaseComponent implements OnIn
       }
     } else {
       newValue = selectedDate;
+      this.setActivateDate(selectedDate);
     }
 
     this.value = newValue;

--- a/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.ts
+++ b/projects/ui/src/lib/components/po-calendar/services/po-calendar.lang.service.ts
@@ -142,6 +142,13 @@ export class PoCalendarLangService {
     ru: 'Год'
   };
 
+  private todayLabel = {
+    pt: 'Hoje',
+    en: 'Today',
+    es: 'Hoy',
+    ru: 'Сегодня'
+  };
+
   getMonth(month: number) {
     return this.months[month][this.language];
   }
@@ -173,6 +180,10 @@ export class PoCalendarLangService {
 
   getYearLabel() {
     return this.yearLabel[this.language];
+  }
+
+  getTodayLabel() {
+    return this.todayLabel[this.language];
   }
 
   setLanguage(language: string) {


### PR DESCRIPTION
**CALENDAR**

**DTHFUI-5464**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente `calendar` não tem um botão para selecionar o dia referente a data atual.

**Qual o novo comportamento?**
Adicionado botão no rodapé do `calendar` para que seja possível selecionar o dia referente a data atual mesmo durante a navegação entre meses e anos.

**Simulação**
`app.component.html`
```
<div class="po-p-2">
  <po-calendar [(ngModel)]="calendar" [p-locale]="locale"></po-calendar>
  <po-info p-value={{calendar}}></po-info>
</div>

<div class="po-p-2">
  <po-calendar [(ngModel)]="calendarRange" [p-locale]="locale" [p-mode]="mode"></po-calendar>
</div>

<div class="po-p-2">
  <po-datepicker [(ngModel)]="datepicker"  name="datepicker" p-label="PO Datepicker"></po-datepicker>
  <po-info p-value={{datepicker}}></po-info>
</div>

<div class="po-p-2">
  <po-datepicker-range [(ngModel)]="datepickerRange" name="datepickerRange" p-label="PO Datepicker Range"></po-datepicker-range>
</div>
```

`app.component.ts`
```
import { Component, OnInit } from '@angular/core';
import { PoCalendarMode } from '../../../ui/src/lib';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent implements OnInit {
  calendar;
  calendarRange;
  datepicker;
  datepickerRange;
  locale: string;
  maxDate: string | Date;
  minDate: string | Date;
  mode;

  ngOnInit() {
    this.locale = 'pt';
    this.maxDate = '2021-10-31';
    this.minDate = '2021-10-01';
    this.mode = PoCalendarMode.Range;
  }
}
```

`po-style`
```
https://github.com/po-ui/po-style/pull/262
```