### PR TITLE
perf(fields): implementa ChangeDetectionStrategy OnPush

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -43,8 +43,6 @@ describe('PoDecimalComponent:', () => {
     component.clean = true;
     inputEl = component.inputEl;
 
-    fixture.detectChanges();
-
     nativeElement = fixture.debugElement.nativeElement;
   });
 
@@ -155,19 +153,23 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should create button clean', () => {
+    fixture.detectChanges();
     expect(nativeElement.querySelector('po-clean')).not.toBeNull();
   });
 
   it('should not create button clean', () => {
+    fixture.detectChanges();
     component.clean = false;
     expect(nativeElement.querySelector('po-clean').length).toBe(undefined);
   });
 
   it('should have a Label', () => {
+    fixture.detectChanges();
     expect(fixture.debugElement.nativeElement.innerHTML).toContain('Label de teste');
   });
 
   it('should have a Help', () => {
+    fixture.detectChanges();
     expect(fixture.debugElement.nativeElement.innerHTML).toContain('Help de teste');
   });
 
@@ -382,6 +384,7 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should have a call replaceCommaToDot method', () => {
+    fixture.detectChanges();
     const valueFormatted = component['replaceCommaToDot']('123,10');
     expect(valueFormatted).toEqual('123.10');
   });
@@ -392,6 +395,7 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should have a call formatValueWithoutThousandSeparator method', () => {
+    fixture.detectChanges();
     const valueFormatted = component['formatValueWithoutThousandSeparator']('12345.10');
     expect(valueFormatted).toEqual('1234510');
   });
@@ -411,6 +415,7 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should return `true` value if call isKeyDecimalSeparator() with event.char `,`', () => {
+    fixture.detectChanges();
     const event = {
       key: '',
       char: ','
@@ -421,6 +426,7 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should have a call containsComma method', () => {
+    fixture.detectChanges();
     const containsComma = component['containsComma']('123456789,10');
     expect(containsComma).toBeTruthy();
   });
@@ -446,6 +452,7 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should have a call addZeroBefore method', () => {
+    fixture.detectChanges();
     const addZeroBefore = component['addZeroBefore'](',');
     expect(addZeroBefore).toEqual('0,');
   });
@@ -561,6 +568,7 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should have a call hasMoreDot method if path', () => {
+    fixture.detectChanges();
     component['oldDotsLength'] = 1;
 
     const hasMoreDot = component['hasMoreDot']('1234.121.100');
@@ -581,11 +589,13 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should have a call formatMask method', () => {
+    fixture.detectChanges();
     const valueFormatted = component['formatMask']('12345');
     expect(valueFormatted).toEqual('12.345');
   });
 
   it('should have a call formatMask method else path', () => {
+    fixture.detectChanges();
     const valueFormatted = component['formatMask']('10123,4');
     expect(valueFormatted).toEqual('10.123,4');
   });
@@ -631,6 +641,7 @@ describe('PoDecimalComponent:', () => {
   }));
 
   it('should have a call formatToViewValue method', () => {
+    fixture.detectChanges();
     component['_decimalsLength'] = 0;
 
     const returnMethod = component['formatToViewValue']('123400');
@@ -639,12 +650,14 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should have a call formatToViewValue method else path', () => {
+    fixture.detectChanges();
     const returnMethod = component['formatToViewValue']('1234');
 
     expect(returnMethod).toBe('1.234,00');
   });
 
   it('should have a call verifyInsertComma method', () => {
+    fixture.detectChanges();
     const fakeEvent = {
       target: {
         value: '123,00'
@@ -657,6 +670,7 @@ describe('PoDecimalComponent:', () => {
   });
 
   it('should have a call verifyValueAfterComma method', () => {
+    fixture.detectChanges();
     const fakeEvent = {
       target: {
         value: '10.245,60',
@@ -1088,6 +1102,7 @@ describe('PoDecimalComponent:', () => {
       });
 
       it('should return true if all validators equal true', () => {
+        fixture.detectChanges();
         spyOn(component, <any>'isKeyDecimalSeparator');
 
         expect(component['validateCursorPositionBeforeSeparator'](fakeEvent)).toBeTruthy();
@@ -1122,6 +1137,7 @@ describe('PoDecimalComponent:', () => {
       });
 
       it('should return false if isKeyDecimalSeparator is true', () => {
+        fixture.detectChanges();
         spyOn(component, <any>'isKeyDecimalSeparator').and.returnValue(true);
 
         expect(component['validateCursorPositionBeforeSeparator'](fakeEvent)).toBeFalsy();
@@ -1143,6 +1159,7 @@ describe('PoDecimalComponent:', () => {
       });
 
       it('should return true if all validators equal true', () => {
+        fixture.detectChanges();
         spyOn(component, <any>'isKeyDecimalSeparator').and.returnValue(false);
         spyOn(component, <any>'isPositionAfterDecimalSeparator').and.returnValue(true);
 
@@ -1158,6 +1175,7 @@ describe('PoDecimalComponent:', () => {
       });
 
       it('should return false if isKeyDecimalSeparator is true', () => {
+        fixture.detectChanges();
         spyOn(component, <any>'isKeyDecimalSeparator').and.returnValue(true);
 
         expect(component['verifyThousandLength'](fakeEvent)).toBeFalsy();
@@ -1178,6 +1196,7 @@ describe('PoDecimalComponent:', () => {
 
     it(`onBlur: should call 'setViewValue' with empty string and 'callOnChange' with undefined if 'target.value'
       contains more than one comma`, () => {
+      fixture.detectChanges();
       const fakeEvent = {
         target: {
           value: '1,200,50'
@@ -1214,6 +1233,7 @@ describe('PoDecimalComponent:', () => {
       });
 
       it('should return `true` if param contains more than one comma', () => {
+        fixture.detectChanges();
         const value = '1.444,200,55';
 
         expect(component['containsMoreThanOneDecimalSeparator'](value)).toBeTruthy();

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -567,6 +567,19 @@ describe('PoDecimalComponent:', () => {
     expect(isLessDot).toBeTruthy();
   });
 
+  it('hasLessDot: should return true', () => {
+    const fakeThis = {
+      regex: {
+        thousand: '.'
+      },
+      oldDotsLength: 2
+    };
+
+    const isLessDot = component['hasLessDot'].call(fakeThis, '12.100');
+
+    expect(isLessDot).toBeTruthy();
+  });
+
   it('should have a call hasMoreDot method if path', () => {
     fixture.detectChanges();
     component['oldDotsLength'] = 1;

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -1,4 +1,14 @@
-import { AfterViewInit, Component, ElementRef, forwardRef, Input, OnInit, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  forwardRef,
+  Input,
+  OnInit,
+  ViewChild
+} from '@angular/core';
 import { AbstractControl, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
@@ -55,6 +65,7 @@ const poDecimalTotalLengthLimit = 16;
 @Component({
   selector: 'po-decimal',
   templateUrl: './po-decimal.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -225,8 +236,8 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
     return this._max;
   }
 
-  constructor(private el: ElementRef, private poLanguageService: PoLanguageService) {
-    super();
+  constructor(private el: ElementRef, private poLanguageService: PoLanguageService, cd: ChangeDetectorRef) {
+    super(cd);
     this.isKeyboardAndroid = !!navigator.userAgent.match(/Android/i);
   }
 

--- a/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.spec.ts
@@ -1,6 +1,6 @@
 import { AbstractControl } from '@angular/forms';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ElementRef } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef } from '@angular/core';
 
 import { configureTestSuite } from './../../../util-test/util-expect.spec';
 
@@ -14,8 +14,8 @@ import { PoNumberBaseComponent } from './po-number-base.component';
   `
 })
 class ContentProjectionComponent extends PoNumberBaseComponent {
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(el: ElementRef, cd: ChangeDetectorRef) {
+    super(el, cd);
   }
 
   extraValidation(c: AbstractControl): { [key: string]: any } {

--- a/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
@@ -1,4 +1,4 @@
-import { ElementRef, Directive } from '@angular/core';
+import { ChangeDetectorRef, ElementRef, Directive } from '@angular/core';
 
 import { PoInputGeneric } from '../po-input-generic/po-input-generic';
 
@@ -9,8 +9,8 @@ export abstract class PoNumberBaseComponent extends PoInputGeneric {
   protected invalidInputValueOnBlur = false;
 
   /* istanbul ignore next */
-  constructor(elementRef: ElementRef) {
-    super(elementRef);
+  constructor(elementRef: ElementRef, cd: ChangeDetectorRef) {
+    super(elementRef, cd);
   }
 
   eventOnInput(e: any) {

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.spec.ts
@@ -26,8 +26,6 @@ describe('PoNumberComponent:', () => {
     component.help = 'Help de teste';
     component.clean = true;
 
-    fixture.detectChanges();
-
     nativeElement = fixture.debugElement.nativeElement;
   });
 
@@ -36,14 +34,17 @@ describe('PoNumberComponent:', () => {
   });
 
   it('should create button clean', () => {
+    fixture.detectChanges();
     expect(nativeElement.querySelector('po-clean')).not.toBeNull();
   });
 
   it('should have a Label', () => {
+    fixture.detectChanges();
     expect(fixture.debugElement.nativeElement.innerHTML).toContain('Label de teste');
   });
 
   it('should have a Help', () => {
+    fixture.detectChanges();
     expect(fixture.debugElement.nativeElement.innerHTML).toContain('Help de teste');
   });
 
@@ -131,6 +132,7 @@ describe('PoNumberComponent:', () => {
       });
 
       it('should return empty string if errorPattern is empty', () => {
+        fixture.detectChanges();
         component.errorPattern = '';
 
         const expectedResult = component.getErrorPatternMessage();

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
@@ -1,5 +1,5 @@
 import { AbstractControl, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
-import { Component, ElementRef, forwardRef, Input } from '@angular/core';
+import { ChangeDetectorRef, ChangeDetectionStrategy, Component, ElementRef, forwardRef, Input } from '@angular/core';
 
 import { minFailed, maxFailed } from '../validators';
 
@@ -34,6 +34,7 @@ import { PoNumberBaseComponent } from './po-number-base.component';
 @Component({
   selector: 'po-number',
   templateUrl: './po-number.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -80,8 +81,8 @@ export class PoNumberComponent extends PoNumberBaseComponent {
   }
 
   /* istanbul ignore next */
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(el: ElementRef, cd: ChangeDetectorRef) {
+    super(el, cd);
   }
 
   extraValidation(abstractControl: AbstractControl): { [key: string]: any } {

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
@@ -12,7 +12,9 @@ class PoTextareaComponent extends PoTextareaBaseComponent {
 }
 
 describe('PoTextareaBase:', () => {
-  const component = new PoTextareaComponent();
+  const cd = <any>{ markForCheck: () => {} };
+
+  const component = new PoTextareaComponent(cd);
 
   it('should be created', () => {
     expect(component instanceof PoTextareaBaseComponent).toBeTruthy();
@@ -73,7 +75,11 @@ describe('PoTextareaBase:', () => {
 
   it('should call writeValueModel', () => {
     spyOn(component, 'writeValueModel');
+    spyOn(component.cd, 'markForCheck');
+
     component.writeValue(1);
+
+    expect(component.cd.markForCheck).toHaveBeenCalled();
     expect(component.writeValueModel).toHaveBeenCalledWith(1);
   });
 
@@ -189,7 +195,12 @@ describe('PoTextareaBase:', () => {
 
       it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
         const expectedValue = true;
+
+        spyOn(component.cd, 'markForCheck');
+
         component.setDisabledState(expectedValue);
+
+        expect(component.cd.markForCheck).toHaveBeenCalled();
         expect(component.disabled).toBe(expectedValue);
       });
 

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -1,5 +1,5 @@
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
-import { EventEmitter, Input, Output, Directive } from '@angular/core';
+import { EventEmitter, Input, Output, Directive, ChangeDetectorRef } from '@angular/core';
 
 import { convertToBoolean, convertToInt } from '../../../utils/util';
 import { maxlengpoailed, minlengpoailed, requiredFailed } from '../validators';
@@ -224,6 +224,8 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
     return this._rows;
   }
 
+  constructor(public cd: ChangeDetectorRef) {}
+
   callOnChange(value: any) {
     // Quando o input não possui um formulário, então esta função não é registrada
     if (this.onChangePropagate) {
@@ -244,6 +246,7 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
   // Usada para interceptar os estados de habilitado via forms api
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
+    this.cd.markForCheck();
   }
 
   // Funções `registerOnChange`, `registerOnTouched` e `registerOnValidatorChange` implementadas referentes ao ControlValueAccessor
@@ -289,6 +292,7 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
   // Função implementada do ControlValueAccessor
   writeValue(value: any) {
     this.writeValueModel(value);
+    this.cd.markForCheck();
   }
 
   protected validateModel() {

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
@@ -20,8 +20,6 @@ describe('PoTextareaComponent:', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PoTextareaComponent);
     component = fixture.componentInstance;
-
-    fixture.detectChanges();
   });
 
   it('should be created', () => {

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
@@ -1,4 +1,12 @@
-import { Component, ElementRef, forwardRef, ViewChild, AfterViewInit } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  ChangeDetectorRef,
+  forwardRef,
+  ViewChild,
+  AfterViewInit,
+  ChangeDetectionStrategy
+} from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { PoTextareaBaseComponent } from './po-textarea-base.component';
@@ -32,6 +40,7 @@ import { PoTextareaBaseComponent } from './po-textarea-base.component';
 @Component({
   selector: 'po-textarea',
   templateUrl: './po-textarea.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -51,8 +60,8 @@ export class PoTextareaComponent extends PoTextareaBaseComponent implements Afte
   valueBeforeChange: any;
   fireChange: boolean = false;
 
-  constructor() {
-    super();
+  constructor(cd: ChangeDetectorRef) {
+    super(cd);
   }
 
   /**


### PR DESCRIPTION
**Number, Decimal e TextArea**

**DTHFUI-5460**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Os componentes utilizam o ChangeDetectionStrategy.Default

**Qual o novo comportamento?**
Os componentes utilizam o ChangeDetectionStrategy.OnPush

**Simulação**
teste dos componentes no portal e app  : 
app.html: 
```
<po-decimal name="decimal" [(ngModel)]="decimal" p-label="PO Decimal"> </po-decimal>
<po-textarea name="textarea" [(ngModel)]="textarea" p-label="PO Textarea"> </po-textarea>
<po-number name="number" [(ngModel)]="number" p-label="PO Number"> </po-number>

```
app.ts: 
```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  decimal;
  textarea;
  number;
}
```