### PR TITLE
feat(modal-footer): cria componente `modal-footer`

### DIFF
--- a/projects/ui/src/lib/components/po-modal/index.ts
+++ b/projects/ui/src/lib/components/po-modal/index.ts
@@ -1,4 +1,5 @@
 export * from './po-modal-action.interface';
 export * from './po-modal.component';
+export * from './po-modal-footer/po-modal-footer.component';
 
 export * from './po-modal.module';

--- a/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
@@ -17,7 +17,8 @@ import { poModalLiterals } from './po-modal.literals';
  * `po-table` e os demais componentes do PO.
  *
  * No rodapé encontram-se os botões de ação primária e secundária, no qual permitem definir uma ação e um rótulo, bem como
- * definir um estado de carregando e / ou desabilitado. Também é possível definir o botão com o tipo *danger*.
+ * definir um estado de carregando e / ou desabilitado e / ou definir o botão com o tipo *danger*. Também é possível utilizar
+ * o componente [`PoModalFooter`](/documentation/po-modal-footer).
  *
  * > É possível fechar a modal através da tecla *ESC*, quando a propriedade `p-hide-close` não estiver habilitada.
  */

--- a/projects/ui/src/lib/components/po-modal/po-modal-footer/po-modal-footer.component.html
+++ b/projects/ui/src/lib/components/po-modal/po-modal-footer/po-modal-footer.component.html
@@ -1,0 +1,3 @@
+<div class="po-modal-footer" [class.po-modal-footer-align-right]="!disabledAlign">
+  <ng-content></ng-content>
+</div>

--- a/projects/ui/src/lib/components/po-modal/po-modal-footer/po-modal-footer.component.spec.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-footer/po-modal-footer.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PoModalFooterComponent } from './po-modal-footer.component';
+
+describe('PoModalFooterComponent', () => {
+  let component: PoModalFooterComponent;
+  let fixture: ComponentFixture<PoModalFooterComponent>;
+  let nativeElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PoModalFooterComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoModalFooterComponent);
+    component = fixture.componentInstance;
+    nativeElement = fixture.debugElement.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should align content on the right by default', () => {
+    component.disabledAlign = true;
+
+    fixture.detectChanges();
+
+    const poModalFooter = nativeElement.querySelector('.po-modal-footer-align-right');
+
+    console.log(poModalFooter);
+
+    expect(poModalFooter).toBeFalsy();
+  });
+
+  it(`shouldn't align content on the right by default`, () => {
+    component.disabledAlign = false;
+
+    fixture.detectChanges();
+
+    const poModalFooter = nativeElement.querySelector('.po-modal-footer-align-right');
+
+    console.log(poModalFooter);
+
+    expect(poModalFooter).toBeTruthy();
+  });
+});

--- a/projects/ui/src/lib/components/po-modal/po-modal-footer/po-modal-footer.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-footer/po-modal-footer.component.ts
@@ -1,0 +1,36 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * @description
+ *
+ * O componente `po-modal-footer` pode ser utilizado para incluir os botões de ações no rodapé da [`PoModal`](/documentation/po-modal), bem como para dar liberdade ao desenvolvedor de incluir outros itens necessários.
+ * > Como boa prática, deve-se observar a utilização de apenas um botão primário.
+ *
+ * ```
+ * <po-modal p-title="Title Modal" #modal>
+ *  <po-modal-footer>
+ *    <po-button p-label="Close" (p-click)="modal.close()"> </po-button>
+ *    <po-button p-label="Clean" (p-click)="clean()"> </po-button>
+ *    <po-button p-label="Confirm" p-type="primary" (p-click)="confirm()"> </po-button>
+ *  </po-modal-footer>
+ * </po-modal>
+ * ```
+ */
+@Component({
+  selector: 'po-modal-footer',
+  templateUrl: './po-modal-footer.component.html'
+})
+export class PoModalFooterComponent {
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Desabilita o alinhamento padrão, à direita, dos botões de ações que ficam no rodapé da [`PoModal`](/documentation/po-modal).
+   *
+   * > Caso a propriedade esteja habilitada, o alinhamento deverá ser a esquerda e pode ser personalizado.
+   *
+   * @default false
+   */
+  @Input('p-disabled-align') disabledAlign?: boolean = false;
+}

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.html
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.html
@@ -17,27 +17,33 @@
             <ng-content></ng-content>
           </div>
 
-          <div class="po-modal-footer">
-            <po-button
-              *ngIf="secondaryAction"
-              [p-disabled]="secondaryAction.disabled"
-              [p-label]="secondaryAction.label"
-              [p-loading]="secondaryAction.loading"
-              [p-type]="getSecondaryActionButtonType()"
-              (p-click)="secondaryAction.action()"
-            >
-            </po-button>
+          <ng-container *ngIf="modalFooter; else defaultModalFooterTemplate">
+            <ng-content select="po-modal-footer"></ng-content>
+          </ng-container>
 
-            <po-button
-              class="po-button-modal-first-action"
-              [p-disabled]="primaryAction.disabled"
-              [p-label]="primaryAction.label"
-              [p-loading]="primaryAction.loading"
-              [p-type]="getPrimaryActionButtonType()"
-              (p-click)="primaryAction.action()"
-            >
-            </po-button>
-          </div>
+          <ng-template #defaultModalFooterTemplate>
+            <po-modal-footer>
+              <po-button
+                *ngIf="secondaryAction"
+                [p-disabled]="secondaryAction.disabled"
+                [p-label]="secondaryAction.label"
+                [p-loading]="secondaryAction.loading"
+                [p-type]="getSecondaryActionButtonType()"
+                (p-click)="secondaryAction.action()"
+              >
+              </po-button>
+
+              <po-button
+                class="po-button-modal-first-action"
+                [p-disabled]="primaryAction.disabled"
+                [p-label]="primaryAction.label"
+                [p-loading]="primaryAction.loading"
+                [p-type]="getPrimaryActionButtonType()"
+                (p-click)="primaryAction.action()"
+              >
+              </po-button>
+            </po-modal-footer>
+          </ng-template>
         </div>
       </div>
     </div>

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
@@ -14,6 +14,7 @@ import { PoInputComponent } from './../po-field/po-input/po-input.component';
 import { PoModalAction } from './po-modal-action.interface';
 import { PoModalBaseComponent } from './po-modal-base.component';
 import { PoModalComponent } from './po-modal.component';
+import { PoModalFooterComponent } from '.';
 
 @Component({
   template: `
@@ -45,6 +46,7 @@ describe('PoModalComponent:', () => {
       imports: [FormsModule, PoButtonModule],
       declarations: [
         PoModalComponent,
+        PoModalFooterComponent,
         PoInputComponent,
         PoCleanComponent,
         PoFieldContainerComponent,
@@ -77,6 +79,7 @@ describe('PoModalComponent:', () => {
   it('should be loaded with just primaryAction', () => {
     component.open();
     fixture.detectChanges();
+
     expect(element.query(By.css('.po-modal-footer')).nativeElement.textContent).toContain('primaryLabel');
   });
 
@@ -562,6 +565,14 @@ describe('PoModalComponent:', () => {
       containerElement.dispatchEvent(new Event('mousedown'));
 
       expect(component.onClickOut).toHaveBeenCalled();
+    });
+
+    it('should not found `.po-button` if `modalFooter` is truthy', () => {
+      component.modalFooter = <any>{};
+      component.open();
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.po-button'))).toBeNull();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.ts
@@ -1,6 +1,7 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ContentChild, ElementRef, ViewChild } from '@angular/core';
 
 import { PoModalBaseComponent } from './po-modal-base.component';
+import { PoModalFooterComponent } from './po-modal-footer/po-modal-footer.component';
 import { uuid } from '../../utils/util';
 
 import { PoActiveOverlayService } from '../../services/po-active-overlay/po-active-overlay.service';
@@ -33,6 +34,7 @@ import { PoLanguageService } from '../../services/po-language/po-language.servic
 })
 export class PoModalComponent extends PoModalBaseComponent {
   @ViewChild('modalContent', { read: ElementRef }) modalContent: ElementRef;
+  @ContentChild(PoModalFooterComponent) modalFooter: PoModalFooterComponent;
 
   private firstElement;
   private focusFunction;

--- a/projects/ui/src/lib/components/po-modal/po-modal.module.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 import { PoButtonModule } from './../po-button/po-button.module';
 import { PoModalComponent } from './po-modal.component';
+import { PoModalFooterComponent } from './po-modal-footer/po-modal-footer.component';
 
 /**
  * @description
@@ -10,7 +11,7 @@ import { PoModalComponent } from './po-modal.component';
  */
 @NgModule({
   imports: [CommonModule, PoButtonModule],
-  declarations: [PoModalComponent],
-  exports: [PoModalComponent]
+  declarations: [PoModalComponent, PoModalFooterComponent],
+  exports: [PoModalComponent, PoModalFooterComponent]
 })
 export class PoModalModule {}

--- a/projects/ui/src/lib/components/po-modal/samples/sample-po-modal-fruits-salad/sample-po-modal-fruits-salad.component.html
+++ b/projects/ui/src/lib/components/po-modal/samples/sample-po-modal-fruits-salad/sample-po-modal-fruits-salad.component.html
@@ -29,6 +29,12 @@
       </po-textarea>
     </div>
   </form>
+
+  <po-modal-footer [p-disabled-align]="false">
+    <po-button p-type="danger" p-label="Close" (p-click)="closeModal()"> </po-button>
+    <po-button p-label="Clear" (p-click)="restore()"> </po-button>
+    <po-button p-type="primary" p-label="Confirm" (p-click)="confirmFruits()"> </po-button>
+  </po-modal-footer>
 </po-modal>
 
 <po-button p-label="Buy fruits salad" (p-click)="openQuestionnaire()"> </po-button>

--- a/projects/ui/src/lib/components/po-modal/samples/sample-po-modal-fruits-salad/sample-po-modal-fruits-salad.component.ts
+++ b/projects/ui/src/lib/components/po-modal/samples/sample-po-modal-fruits-salad/sample-po-modal-fruits-salad.component.ts
@@ -3,8 +3,9 @@ import { NgForm } from '@angular/forms';
 
 import { PoCheckboxGroupOption, PoComboOption } from '@po-ui/ng-components';
 
-import { PoModalAction, PoModalComponent } from '@po-ui/ng-components';
+import { PoModalAction } from '@po-ui/ng-components';
 import { PoNotificationService } from '@po-ui/ng-components';
+import { PoModalComponent } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-modal-fruits-salad',
@@ -52,6 +53,14 @@ export class SamplePoModalFruitsSaladComponent {
   closeModal() {
     this.form.reset();
     this.poModal.close();
+  }
+
+  confirmFruits() {
+    this.proccessOrder();
+  }
+
+  restore() {
+    this.form.reset();
   }
 
   openQuestionnaire() {


### PR DESCRIPTION
MODAL-FOOTER

DTHFUI-4864
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Rodapé do modal possui um alinhamento padrão a direita, para os botões de ações.

**Qual o novo comportamento?**
Da liberdade ao desenvolvedor personalizar o alinhamento e a quantidade de botões de ações. 

**Simulação**
`app.component.html`
```
<div class="po-p-2">
  <po-modal #modal p-title="PO Modal">
    We are TOTVERS!!!
    <po-modal-footer [p-disabled-align]="true">
      <po-button p-label="Tertiary Action"> </po-button>
      <po-button p-label="Secondary Action"> </po-button>
      <po-button p-label="Primary Action"> </po-button>
    </po-modal-footer>
  </po-modal>

  <po-button p-label="Open modal" (p-click)="modal.open()"> </po-button>
</div>
```
Build style
https://github.com/po-ui/po-style/pull/264

Ou rodar pelo portal.