### PR TITLE
fix(lookup): campo não atualizado ao alterar o model

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -318,6 +318,14 @@ describe('PoLookupBaseComponent:', () => {
   });
 
   describe('Methods:', () => {
+    it('cleanViewValue: should call `setDisclaimers` when execute the method `cleanViewValue`.', () => {
+      spyOn(component, <any>'setDisclaimers');
+
+      component['cleanViewValue']();
+
+      expect(component['setDisclaimers']).toHaveBeenCalled();
+    });
+
     it('cleanViewValue: should call `setViewValue` when execute the method `cleanViewValue`.', () => {
       spyOn(component, <any>'setViewValue');
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -581,6 +581,7 @@ export abstract class PoLookupBaseComponent
   }
 
   protected cleanViewValue() {
+    this.setDisclaimers([]);
     this.setViewValue('', {});
     this.oldValue = '';
     this.valueToModel = null;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -10,7 +10,7 @@ import {
   Renderer2,
   ViewChild
 } from '@angular/core';
-import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { NgControl, NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
 import { PoLookupBaseComponent } from './po-lookup-base.component';
@@ -32,6 +32,11 @@ const providers = [
     // eslint-disable-next-line
     useExisting: forwardRef(() => PoLookupComponent),
     multi: true
+  },
+  {
+    provide: NgControl,
+    useExisting: forwardRef(() => PoLookupComponent),
+    multi: false
   }
 ];
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-sw-films/sample-po-lookup-sw-films.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-sw-films/sample-po-lookup-sw-films.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-
 import { PoRadioGroupOption } from '@po-ui/ng-components';
-
 import { SamplePoLookupSwFilmsService } from './sample-po-lookup-sw-films.service';
 
 @Component({
@@ -68,7 +66,12 @@ export class SamplePoLookupSwFilmsComponent implements OnInit {
   }
 
   onSelected(entity) {
-    this.filmItemsFiltered = this.filmItems.filter(film => entity.films.includes(film.url));
+    this.filterService.getObjectByValue(entity, this.filterParams).subscribe(
+      result => {
+        this.filmItemsFiltered = this.filmItems.filter(film => result?.films.includes(film.url));
+      },
+      err => console.error(err)
+    );
   }
 
   private getEntityColumns(entity) {


### PR DESCRIPTION
**LOOKUP**

**DTHFUI-5512**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente `lookup` não atualiza o campo de disclaimers ao realizar a limpeza do model.

**Qual o novo comportamento?**
O método `setDisclaimers` foi adicionado ao método `cleanViewValue` para executar a limpeza do campo de disclaimers.

**Simulação**
`app.compenent.html`
```
<div class="po-p-2">
  <po-lookup
    name="lookup"
    [(ngModel)]="lookup"
    p-field-label="label"
    p-field-value="value"
    p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
    p-label="PO Lookup"
    [p-multiple]="true"
  ></po-lookup>
  {{ lookup }}
  <button (click)="onclick()">LIMPA</button>
</div>
```

`app.component.ts`
```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  lookup;

  onclick() {
    this.lookup = null;
  }
}
```
