### PR TITLE
feat(dynamic-form): permite multiselect com serviço

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -41,8 +41,6 @@ export interface PoDynamicFormField extends PoDynamicField {
 
   /**
    * Permite que o usuário faça múltipla seleção dentro da lista de opções.
-   *
-   * > Caso utilizar a propriedade `optionsService` esta propriedade será ignorada.
    */
   optionsMulti?: boolean;
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -815,19 +815,7 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
       expect(component['isMultiselect'](field)).toBe(true);
     });
 
-    it('isMultiselect: should return false if `optionsMulti` is false', () => {
-      const options = [
-        { label: '1', value: 1 },
-        { label: '2', value: 2 },
-        { label: '3', value: 3 },
-        { label: '4', value: 4 }
-      ];
-      const field = { property: 'products', options, optionsMulti: false };
-
-      expect(component['isMultiselect'](field)).toBe(false);
-    });
-
-    it('isMultiselect: should return false if `optionsService` is truthy', () => {
+    it('isMultiselect: should return true if `optionsService` and `optionsMulti` is true', () => {
       const options = [
         { label: '1', value: 1 },
         { label: '2', value: 2 },
@@ -840,6 +828,18 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         optionsMulti: true,
         optionsService: 'http://www.po.com.br/api/customers'
       };
+
+      expect(component['isMultiselect'](field)).toBe(true);
+    });
+
+    it('isMultiselect: should return false if `optionsMulti` is false', () => {
+      const options = [
+        { label: '1', value: 1 },
+        { label: '2', value: 2 },
+        { label: '3', value: 3 },
+        { label: '4', value: 4 }
+      ];
+      const field = { property: 'products', options, optionsMulti: false };
 
       expect(component['isMultiselect'](field)).toBe(false);
     });

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -211,7 +211,7 @@ export class PoDynamicFormFieldsBaseComponent {
   private isMultiselect(field: PoDynamicFormField) {
     const { optionsService, optionsMulti, options } = field;
 
-    return !optionsService && optionsMulti && !!options && options.length > 3;
+    return optionsMulti && (!!optionsService || (!!options && options.length > 3));
   }
 
   private isNumberType(field: PoDynamicFormField, type: string) {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -246,6 +246,9 @@
       [p-required]="field.required"
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
+      [p-field-label]="field.fieldLabel"
+      [p-field-value]="field.fieldValue"
+      [p-filter-service]="field.optionsService"
     >
     </po-multiselect>
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -199,9 +199,11 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    *
    */
   @Input('p-filter-service') set filterService(value: PoMultiselectFilter | string) {
-    this._filterService = value;
-    this.autoHeight = this.autoHeightInitialValue !== undefined ? this.autoHeightInitialValue : true;
-    this.options = [];
+    if (value) {
+      this._filterService = value;
+      this.autoHeight = this.autoHeightInitialValue !== undefined ? this.autoHeightInitialValue : true;
+      this.options = [];
+    }
   }
 
   get filterService() {


### PR DESCRIPTION
**DYNAMIC-FORM**

**DTHFUI-5494**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente `dynamic-form` não aceita o uso de serviço no campo do tipo `multiselect`.

**Qual o novo comportamento?**
Ajuste na condição de uso para o uso de serviço com o campo de `multiselect`.

**Simulação**
`app.component.html`
```
<po-dynamic-form [p-fields]="fields" [p-value]="value"></po-dynamic-form>
```

`app.component.ts`
```
options = ['A', 'B', 'C', 'D', 'E'];
  service = 'https://po-sample-api.herokuapp.com/v1/heroes';
  fields = [
    { property: 'heroes options', options: this.options }, // isSelect
    { property: 'heroes options multi', options: this.options, optionsMulti: true }, // isMultiselect
    { property: 'heroes service combo', optionsService: this.service }, // !!options ? isSelect ? isCombo
    { property: 'heroes service multi', optionsMulti: true, optionsService: this.service, fieldLabel: 'name', fieldValue: 'id' }, // isMultiselect
  ]
  value = {};
```