### PR TITLE
fix(multiselect): componente não dispara evento de `change`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -567,6 +567,17 @@ describe('PoMultiselectBaseComponent:', () => {
       expect(component.updateVisibleItems).toHaveBeenCalled();
     });
 
+    it('updateSelectedOptions: should set `0` for `lastLengthModel` if `newOptions.lenght` is `0`', () => {
+      spyOn(component, 'updateVisibleItems');
+      const params = [];
+      const options = [];
+      component.filterService = poMultiselectFilterServiceStub;
+      component['updateSelectedOptions'](params, options);
+      expect(component.selectedOptions).toEqual([]);
+      expect(component.lastLengthModel).toBe(0);
+      expect(component.updateVisibleItems).toHaveBeenCalled();
+    });
+
     it('searchByLabel: should set visibleOptionsDropdown with component.options if search is empty', () => {
       component.options = [
         { label: 'Label 1', value: 'Value 1' },

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -614,6 +614,10 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   updateSelectedOptions(newOptions: Array<any>, options = this.options) {
     this.selectedOptions = [];
 
+    if (newOptions.length === 0) {
+      this.lastLengthModel = 0;
+    }
+
     if (this.filterService) {
       this.selectedOptions = newOptions;
     } else {


### PR DESCRIPTION
**MULTISELECT**

**DTHFUI-5503**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente não dispara evento de `change` caso a quantidade de seleções atuais seja igual à anterior após a limpeza do campo.

**Qual o novo comportamento?**
Incluída condicional que valida a quantidade de seleções e corrige o valor do `model` anterior.

**Simulação**
`app.component.html`
```
<div class="po-row">
  <po-multiselect
    class="po-md-12"
    name="multiselect"
    [(ngModel)]="multiselect"
    p-label="Multiselect service"
    [p-options]="options"
    p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
    (p-change)="changeEvent('p-change')"
  ></po-multiselect>
</div>

<div class="po-row">
  <po-info class="po-md-6" p-label="Model" [p-value]="multiselect"> </po-info>
  <po-info class="po-md-6" p-label="Events" [p-value]="event"> </po-info>
</div>

<div class="po-row">
  <po-button class="po-md-3" p-label="Clear" (p-click)="clear()"> </po-button>
</div>
```

`app.component.ts`
```
event: string;
multiselect: any;
options: Array<any> = [
  { value: 'poMultiselect1', label: 'PO Multiselect 1' },
  { value: 'poMultiselect2', label: 'PO Multiselect 2' },
  { value: 'poMultiselect3', label: 'PO Multiselect 3' },
  { value: 'poMultiselect4', label: 'PO Multiselect 4' }
];

changeEvent(event: string) {
  this.event = event;
}

clear() {
  this.event = '';
  this.multiselect = []
}
```