### PR TITLE
feat(table): move coluna de ações para esquerda

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -196,6 +196,17 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    *
    * @description
    *
+   * Define que a coluna de ações ficará no lado direito da tabela.
+   *
+   * @default `false`
+   */
+  @Input('p-actions-right') @InputBoolean() actionRight?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Define uma quantidade máxima de colunas que serão exibidas na tabela.
    *
    * Quando chegar no valor informado, as colunas que não estiverem selecionadas ficarão

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -75,6 +75,13 @@
           class="po-table-header-column po-table-header-master-detail"
         ></th>
 
+        <!-- Coluna criada para caso as ações fiquem no lado esquerdo -->
+        <th
+          *ngIf="!actionRight && (visibleActions.length > 1 || isSingleAction)"
+          [class.po-table-header-master-detail]="!isSingleAction"
+          [class.po-table-header-single-action]="isSingleAction"
+        ></th>
+
         <th *ngIf="!hasMainColumns" #noColumnsHeader class="po-table-header-column po-text-center">
           <ng-container *ngIf="height; then noColumnsWithHeight; else noColumnsWithoutHeight"> </ng-container>
         </th>
@@ -106,7 +113,7 @@
         ></th>
 
         <th
-          *ngIf="hasVisibleActions && hideColumnsManager"
+          *ngIf="hasVisibleActions && hideColumnsManager && actionRight"
           [class.po-table-header-single-action]="isSingleAction"
           [class.po-table-header-actions]="!isSingleAction"
         ></th>
@@ -114,9 +121,9 @@
         <th
           #columnManager
           *ngIf="hasValidColumns && !hideColumnsManager"
-          [class.po-table-header-column-manager]="!isSingleAction"
+          [class.po-table-header-column-manager]="!isSingleAction || !actionRight"
           [class.po-table-header-column-manager-border]="!height && container"
-          [class.po-table-header-single-action]="isSingleAction"
+          [class.po-table-header-single-action]="isSingleAction && actionRight"
         >
           <div
             [class.po-table-header-column-manager-border]="height && container"
@@ -163,6 +170,14 @@
             >
             </ng-template>
           </td>
+
+          <!-- Coluna com as ações na esquerda (padrão)-->
+          <ng-template
+            *ngIf="!actionRight && (visibleActions.length > 1 || isSingleAction)"
+            [ngTemplateOutlet]="ActionsColumnTemplate"
+            [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+          >
+          </ng-template>
 
           <!-- Valida se a origem do detail é pela diretiva -->
           <td
@@ -272,25 +287,19 @@
             </ng-template>
           </td>
 
-          <td *ngIf="isSingleAction" class="po-table-column po-table-column-single-action">
-            <div
-              *ngIf="firstAction.visible !== false"
-              class="po-table-single-action po-clickable"
-              [class.po-table-action-disabled]="firstAction.disabled ? validateTableAction(row, firstAction) : false"
-              (click)="executeTableAction(row, firstAction)"
-            >
-              <po-icon
-                *ngIf="firstAction.icon"
-                class="po-table-single-action-content"
-                [p-icon]="firstAction.icon"
-              ></po-icon>
-              {{ firstAction.label }}
-            </div>
-          </td>
+          <!-- Coluna de açoes na direita -->
+          <ng-template
+            *ngIf="actionRight"
+            [ngTemplateOutlet]="ActionsColumnTemplate"
+            [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+          >
+          </ng-template>
 
-          <td *ngIf="visibleActions.length > 1" class="po-table-column-actions">
-            <span #popupTarget class="po-icon po-icon-more po-clickable" (click)="togglePopup(row, popupTarget)"></span>
-          </td>
+          <!-- Coluna para não ficar em branco nas linhas de gerenciamento -->
+          <ng-container *ngIf="!actionRight && (visibleActions.length > 1 || isSingleAction) && !hideColumnsManager">
+            <td class="po-table-column"></td>
+          </ng-container>
+
           <!-- Column Manager -->
           <td
             *ngIf="!hasVisibleActions && !hideColumnsManager && !hasRowTemplateWithArrowDirectionRight"
@@ -373,6 +382,25 @@
 
 <ng-template #noColumnsWithoutHeight>
   {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
+</ng-template>
+
+<!-- Template de ações -->
+<ng-template #ActionsColumnTemplate let-row="row" let-rowIndex="rowIndex">
+  <td *ngIf="isSingleAction" class="po-table-column po-table-column-single-action">
+    <div
+      *ngIf="firstAction.visible !== false"
+      class="po-table-single-action po-clickable"
+      [class.po-table-action-disabled]="firstAction.disabled ? validateTableAction(row, firstAction) : false"
+      (click)="executeTableAction(row, firstAction)"
+    >
+      <po-icon *ngIf="firstAction.icon" class="po-table-single-action-content" [p-icon]="firstAction.icon"></po-icon>
+      {{ firstAction.label }}
+    </div>
+  </td>
+
+  <td *ngIf="visibleActions.length > 1" class="po-table-column-actions">
+    <span #popupTarget class="po-icon po-icon-more po-clickable" (click)="togglePopup(row, popupTarget)"></span>
+  </td>
 </ng-template>
 
 <po-table-column-manager

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -756,6 +756,7 @@ describe('PoTableComponent:', () => {
     component.actions = actions;
     component.hideDetail = false;
     component.columns = columnsWithDetail;
+    component.actionRight = true;
 
     fixture.detectChanges();
 
@@ -775,6 +776,22 @@ describe('PoTableComponent:', () => {
 
     const singleActionColumn = nativeElement.querySelector('.po-table-header-single-action');
     expect(singleActionColumn).toBeNull();
+  });
+
+  it('should contain more than 1 "header-master-detail" if actionRight is false and "isSingleAction" is false', () => {
+    component.selectable = true;
+    component.actions = [
+      { label: 'PO1', visible: true },
+      { label: 'PO2', visible: true }
+    ];
+    component.hideDetail = false;
+    component.columns = columnsWithDetail;
+
+    fixture.detectChanges();
+
+    const masterDetails = nativeElement.querySelectorAll('.po-table-header-master-detail');
+
+    expect(masterDetails.length).toBe(2);
   });
 
   it('should not call debounceResize in ngDoCheck when visibleElement is true', () => {
@@ -2281,6 +2298,7 @@ describe('PoTableComponent:', () => {
       component.columns = [{ property: 'name' }, { property: 'age' }];
       component.actions = [{ label: 'First Action', action: () => {} }];
       component.hideColumnsManager = false;
+      component.actionRight = true;
 
       component.tableRowTemplate = {
         ...mockTableDetailDiretive,

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -1,5 +1,6 @@
 <po-table
   [p-actions]="actions"
+  [p-actions-right]="properties.includes('actionsRight')"
   [p-columns]="columns"
   [p-container]="container"
   [p-height]="height"

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -86,7 +86,8 @@ export class SamplePoTableLabsComponent implements OnInit {
     { label: 'Hide detail', value: 'hideDetail' },
     { label: 'Loading', value: 'loading' },
     { label: 'Auto collapse', value: 'autoCollapse' },
-    { label: 'Hide columns manager', value: 'hideColumnsManager' }
+    { label: 'Hide columns manager', value: 'hideColumnsManager' },
+    { label: 'Actions Right', value: 'actionsRight' }
   ];
 
   public readonly typeHeaderOptions: Array<PoRadioGroupOption> = [


### PR DESCRIPTION
**Table**

**DTHFUI-5488**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
As ações ficam do lado direito da tabela como padrão

**Qual o novo comportamento?**
As ações ficam do lado esquerdo da tabela como padrão, porém mantém a possibilidade de manter a coluna de ações na direita utilizando a propriedade `p-actions-right`

**Simulação**
Testar o componente table, portal e samples.

app.html:

```
<sample-po-table-airfare></sample-po-table-airfare>

<!-- <po-table [p-items]="[{ table: 'PO Table' }]"> </po-table> -->

<!-- <sample-po-table-transport></sample-po-table-transport> -->

<!-- <sample-po-table-components></sample-po-table-components> -->

``` 
