### PR TITLE
refactor(navbar): remove a propriedade p-menu

### DIFF
--- a/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
@@ -37,36 +37,6 @@ export const poNavbarLiteralsDefault = {
  */
 @Directive()
 export abstract class PoNavbarBaseComponent {
-  /**
-   * @deprecated 6.x.x
-   *
-   * @optional
-   *
-   * @description
-   * **Depreciado 6.x.x**
-   *
-   * Caso já possua um menu na aplicação o mesmo deve ser repassado para essa propriedade para que quando entre em modo
-   * responsivo os items do `po-navbar` possam ser adicionados no primeiro item do menu definido.
-   *
-   * > Ao utilizar menu e navbar com logo mantém apenas a logo do navbar.
-   *
-   * Exemplo:
-   *
-   * ```
-   * <po-navbar
-   *  [p-items]="items"
-   *  [p-icon-actions]="iconActions"
-   *  [p-menu]="userMenu">
-   * </po-navbar>
-   * <div class="po-wrapper">
-   *  <po-menu #userMenu
-   *   [p-menus]="[{ label: 'Item 1', link: '/' }]">
-   *  </po-menu>
-   * </div>
-   * ```
-   */
-  @Input('p-menu') menu?: PoMenuComponent;
-
   // Menu que esta sendo exibido na pagina corrente.
   applicationMenu: PoMenuComponent;
 
@@ -74,7 +44,6 @@ export abstract class PoNavbarBaseComponent {
   private _items: Array<PoNavbarItem> = [];
   private _literals: PoNavbarLiterals;
   private _logo: string;
-  private _menu: PoMenuComponent;
   private _shadow: boolean = false;
   private language: string = poLocaleDefault;
 
@@ -187,6 +156,5 @@ export abstract class PoNavbarBaseComponent {
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();
   }
-
   protected abstract validateMenuLogo(): void;
 }


### PR DESCRIPTION
**NAVBAR**

**DTHFUI-5487**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente Navbar possui propriedade ```p-menu```  desnecessária.

**Qual o novo comportamento?**
Componente Navbar deixou de possuiu propriedade ```p-menu```.


**Simulação**
Rodar do portal 