### PR TITLE
fix(dynamic-table): ocorre erro ao tentar filtrar `searchService`

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
@@ -47,6 +47,13 @@ describe('PoPageDynamicSearchBaseComponent:', () => {
       expectPropertiesValues(component, 'filters', validValues, validValues);
     });
 
+    it('should return stringify value with filter without searchService', () => {
+      const columns: Array<any> = [{ property: 'test' }, { searchService: 'service/test' }];
+      const result = '[{"property":"test"},{}]';
+      const filter = component['stringify'](columns);
+      expect(filter).toEqual(result);
+    });
+
     describe('p-literals:', () => {
       it('should be in portuguese if browser is setted with an unsupported language', () => {
         component['language'] = 'zw';

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
@@ -239,7 +239,7 @@ export abstract class PoPageDynamicSearchBaseComponent {
   @Input('p-filters') set filters(filters: Array<PoPageDynamicSearchFilters>) {
     this._filters = Array.isArray(filters) ? [...filters] : [];
 
-    if (JSON.stringify(this._filters) !== JSON.stringify(this.previousFilters)) {
+    if (this.stringify(this._filters) !== this.stringify(this.previousFilters)) {
       this.onChangeFilters(this.filters);
 
       this.previousFilters = [...this._filters];
@@ -277,6 +277,15 @@ export abstract class PoPageDynamicSearchBaseComponent {
       confirmLabel: literals.filterConfirmLabel,
       title: literals.filterTitle
     };
+  }
+
+  private stringify(columns: Array<PoPageDynamicSearchFilters>) {
+    // não faz o stringify da propriedade searchService, pois pode conter objeto complexo e disparar um erro.
+    return JSON.stringify(columns, (key, value) => {
+      if (key !== 'searchService') {
+        return value;
+      }
+    });
   }
 
   abstract onChangeFilters(filters: Array<PoPageDynamicSearchFilters>);

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
@@ -1105,6 +1105,13 @@ describe('PoTableColumnManagerComponent:', () => {
         const filter = component['stringify'](columns);
         expect(filter).toEqual(result);
       });
+
+      it('should return stringify value with filter without searchService', () => {
+        const columns: Array<any> = [{ property: 'test' }, { searchService: 'service/test' }];
+        const result = '[{"property":"test"},{}]';
+        const filter = component['stringify'](columns);
+        expect(filter).toEqual(result);
+      });
     });
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.ts
@@ -320,9 +320,9 @@ export class PoTableColumnManagerComponent implements OnChanges, OnDestroy {
   }
 
   private stringify(columns: Array<PoTableColumn>) {
-    // não faz o stringify da propriedade icon, pois pode conter objeto complexo e disparar um erro.
+    // não faz o stringify da propriedade icon e searchService, pois pode conter objeto complexo e disparar um erro.
     return JSON.stringify(columns, (key, value) => {
-      if (key !== 'icon') {
+      if (key !== 'icon' && key !== 'searchService') {
         return value;
       }
     });


### PR DESCRIPTION
fixes DTHFUI-5621

**Dynamic-Table**

**DTHFUI-5621**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Erro no console ao tentar filtrar coluna searchService

**Qual o novo comportamento?**
Aplica verificação para não filtrar searchService

**Simulação**
- Alterar filtro no gerenciador da tabela
- Abrir busca avançada, selecionar para pesquisar e alterar novamente o gerenciador de filtro.
- Alterar novamente o filtro no gerenciador da tabela.
- Verificar se ocorre erro no console.

Utilizar app: 
[app.zip](https://github.com/po-ui/po-angular/files/7729194/app.zip)

