### PR TITLE
perf(radio-group): implementa ChangeDetectionStrategy.OnPush

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
@@ -30,8 +30,6 @@ describe('PoRadioGroupComponent:', () => {
     component.help = 'Help de teste';
     component.options = [{ value: '1', label: '1' }];
 
-    fixture.detectChanges();
-
     debugElement = fixture.debugElement.nativeElement;
   });
 
@@ -41,10 +39,12 @@ describe('PoRadioGroupComponent:', () => {
   });
 
   it('should have label', () => {
+    fixture.detectChanges();
     expect(debugElement.innerHTML).toContain('Label de teste');
   });
 
   it('should have help', () => {
+    fixture.detectChanges();
     expect(debugElement.innerHTML).toContain('Help de teste');
   });
 
@@ -61,6 +61,7 @@ describe('PoRadioGroupComponent:', () => {
   });
 
   it('should return input when exists a input with this value', () => {
+    fixture.detectChanges();
     expect(component.getElementByValue('1')).not.toBeNull();
   });
 
@@ -72,11 +73,12 @@ describe('PoRadioGroupComponent:', () => {
     const fakeThis = {
       differ: {
         diff: (opt: any) => false
+      },
+      cd: {
+        markForCheck: () => {}
       }
     };
-
     spyOn(UtilsFunctions, 'removeDuplicatedOptions');
-
     component.ngDoCheck.call(fakeThis);
     expect(removeDuplicatedOptions).not.toHaveBeenCalled();
   });
@@ -228,7 +230,7 @@ describe('PoRadioGroupComponent:', () => {
 
     it('keyup: should call `onKeyUp` when a arrowKey is pressed.', () => {
       spyOn(component, 'onKeyUp');
-
+      fixture.detectChanges();
       const input = debugElement.querySelector('input.po-radio-group-input');
       input.dispatchEvent(eventKeyBoard);
 

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
@@ -1,5 +1,7 @@
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   DoCheck,
   ElementRef,
@@ -47,6 +49,7 @@ import { PoRadioGroupBaseComponent } from './po-radio-group-base.component';
 @Component({
   selector: 'po-radio-group',
   templateUrl: './po-radio-group.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -72,7 +75,7 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
 
   differ: any;
 
-  constructor(differs: IterableDiffers) {
+  constructor(differs: IterableDiffers, private cd: ChangeDetectorRef) {
     super();
     this.differ = differs.find([]).create(null);
   }
@@ -88,6 +91,7 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
     if (change) {
       removeDuplicatedOptions(this.options);
     }
+    this.cd.markForCheck();
   }
 
   eventClick(value: any, disabled: any) {


### PR DESCRIPTION
**radio-group**

**fixes DTHFUI-5519**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente utiliza o ChangeDetectionStrategy.Default

**Qual o novo comportamento?**
Componente utiliza o ChangeDetectionStrategy.OnPush

**Simulação**
Simular portal e app:
[app.zip](https://github.com/po-ui/po-angular/files/7771151/app.zip)

