### PR TITLE
feat(page-dynamic-table): adiciona propriedade `sortable` na interface

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-field.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-field.interface.ts
@@ -23,6 +23,18 @@ export interface PoPageDynamicTableField extends PoDynamicFormField {
   allowColumnsManager?: boolean;
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Controla se a coluna será considerada como "ordenável". Caso seja definido um valor falso, a coluna não será usada para
+   * ordenação.
+   *
+   * @default `true`
+   */
+  sortable?: boolean;
+
+  /**
    * Lista de objetos do tipo `PoTableColumnLabel` que representa as labels disponíveis na coluna do tipo `label`.
    *
    * Exemplo de utilização

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -44,7 +44,7 @@ export class SamplePoPageDynamicTableUsersComponent {
   readonly fields: Array<any> = [
     { property: 'id', key: true, visible: false, filter: true },
     { property: 'name', label: 'Name', filter: true, gridColumns: 6 },
-    { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true },
+    { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true, sortable: false },
     { property: 'search', filter: true, visible: false },
     {
       property: 'birthdate',


### PR DESCRIPTION
**page-dynamic-table**

**DTHFUI-4849**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)


**Simulação**
Portal e app : 

app.html:
```
<po-page-dynamic-table p-service-api="https://po-sample-api.herokuapp.com/v1/people" [p-fields]="fields">
</po-page-dynamic-table>
```

app.ts:

```
readonly fields: Array<any> = [
    { property: 'id', key: true },
    { property: 'name', label: 'Name' },
    { property: 'city', label: 'City', sortable: false }
  ];
```