### PR TITLE
feat(page-dynamic-table): adiciona a propriedade p-actions-right

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -13,6 +13,7 @@
   <po-table
     [p-sort]="true"
     [p-actions]="tableActions"
+    [p-actions-right]="actionRight"
     [p-selectable]="enableSelectionTable"
     [p-columns]="columns"
     [p-items]="items"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -170,6 +170,19 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
    *
    * @description
    *
+   * Define que a coluna de ações ficará no lado direito da tabela.
+   *
+   * @default `false`
+   */
+  @InputBoolean()
+  @Input('p-actions-right')
+  actionRight?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Permite a utilização da pesquisa rápida junto com a pesquisa avançada.
    *
    * Desta forma, ao ter uma pesquisa avançada estabelecida e ser

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -4,6 +4,7 @@
   p-keep-filters
   p-title="Users"
   [p-actions]="actions"
+  [p-actions-right]="true"
   [p-page-custom-actions]="pageCustomActions"
   [p-table-custom-actions]="tableCustomActions"
   [p-breadcrumb]="breadcrumb"


### PR DESCRIPTION
adiciona propriedade p-actions-right que permite manter as ações na direita da tabela.

Feat#1160

**page-dynamic-table**

**1160**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Houve uma mudança no componente table, onde o lado padrão das ações foi movido para a esquerda e no componente page-dynamic-table não existe a possibilidade de colocar no lado direito como no table.  

**Qual o novo comportamento?**
Foi adiciona propriedade p-actions-right que permite manter as ações na direita da tabela.

**Simulação**
npm run build:portal && ng serve portal

No exemplo "PO Page Dynamic Table - Users" foi adicionado a propriedade [p-actions-right]="true" que posiciona as acções do lado direito.