### PR TITLE
feat(menu): ajusta sinalização de item ativo

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
@@ -31,6 +31,8 @@ export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
   { path: 'home', component: HomeComponent },
   { path: 'test', component: HomeComponent },
+  { path: 'test/list', component: HomeComponent },
+  { path: 'test2/list', component: HomeComponent },
   { path: 'search', component: SearchComponent }
 ];
 
@@ -105,14 +107,34 @@ describe('PoMenuComponent:', () => {
           { label: 'Level 2.3' }
         ]
       },
-      { label: 'Level 1.2', icon: 'copy' }
+      { label: 'Level 1.2', icon: 'copy' },
+      {
+        label: 'Test',
+        icon: 'home',
+        subItems: [
+          {
+            label: 'list',
+            link: '/test/list'
+          }
+        ]
+      },
+      {
+        label: 'Test2',
+        icon: 'home',
+        subItems: [
+          {
+            label: 'list',
+            link: '/test2/list'
+          }
+        ]
+      }
     ];
-
-    fixture.detectChanges();
 
     fixture.ngZone.run(() => {
       router.initialNavigation();
     });
+
+    fixture.detectChanges();
   });
 
   it('should be created', () => {
@@ -120,7 +142,7 @@ describe('PoMenuComponent:', () => {
   });
 
   it('should create menu items', () => {
-    expect(nativeElement.querySelectorAll('po-menu-item').length).toBe(18); // All itens that are until level 4
+    expect(nativeElement.querySelectorAll('po-menu-item').length).toBe(22); // All itens that are until level 4
   });
 
   it('should toggle overlay of menu mobile', () => {
@@ -383,7 +405,7 @@ describe('PoMenuComponent:', () => {
 
   it('should have icons in all first level items', () => {
     expect(component.allowIcons).toBeTruthy();
-    expect(nativeElement.querySelectorAll('.po-menu-icon-container').length).toBe(7);
+    expect(nativeElement.querySelectorAll('.po-menu-icon-container').length).toBe(9);
   });
 
   it('should not have icons in first level items', () => {
@@ -1448,6 +1470,20 @@ describe('PoMenuComponent:', () => {
           component.activateMenuByUrl(urlPath, component.menus);
           expect(component['activateMenuItem']).toHaveBeenCalled();
           expect(component.linkActive).toBe(urlPath);
+          done();
+        });
+      });
+    });
+
+    it(`activateMenuByUrl: 'linkActive' should be equal to 'urlPath'`, done => {
+      const urlPath = '/test2/list';
+      spyOn(component, <any>'activateMenuItem');
+
+      fixture.ngZone.run(() => {
+        router.navigate(['/test2/list']).then(() => {
+          component.activateMenuByUrl(urlPath, component.menus);
+          expect(component.linkActive).toBe('/test2/list');
+
           done();
         });
       });

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.ts
@@ -213,7 +213,7 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
           formattedMenuLink.lastIndexOf('/')
         )}`;
 
-        if (menuLinkPath === urlPath) {
+        if (menuLinkPath === urlPath && menuLinkPath === formattedMenuLink) {
           this.linkActive = formattedMenuLink;
           this.activateMenuItem(menu);
           return true;


### PR DESCRIPTION
**MENU**

**DTHFUI-5543**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando temos um menu com subitens com o mesmo nome, por exemplo `edit`, e clicamos no último `edit` listado, o menu item selecionado era sempre o primeiro `edit` exibido no menu, sendo exibido de forma equivocada no menu.

**Qual o novo comportamento?**
Quando temos um menu com subitens com o mesmo nome, por exemplo `edit`, e clicamos no ultimo `edit` listado, este aparece selecionado no menu.

**Simulação**
Criar um menu com subitens de mesmo label, ou u tilizar este  [app.zip](https://github.com/po-ui/po-angular/files/7916423/app.zip) para testes.

