### PR TITLE
feat(page-dynamic-table): permite url externa e implementa `concatKey`

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
@@ -43,6 +43,14 @@ export interface PoPageDynamicTableCustomTableAction {
    * > Ao utilizar a propriedade `url` e a `action`, somente a `action` será executada.
    */
   url?: string;
+  /**
+   * Permite concatenar o valor de propriedades definidas como keys na url via path parameter.
+   *
+   * Caso exista a necessidade de se utiizar mais de uma key, a concatenação entre as keys será separado por vírgulas, conforme exemplo: `/cidade/2,Joinville`
+   *
+   * > Poderá ser utilizada somente em conjunto com a propriedade PoPageDynamicTableCustomTableAction.url, tanto para URL interna quanto url externa.
+   */
+  concatKeys?: boolean;
 
   /**
    * @description

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -2229,6 +2229,32 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(component['router'].navigate).toHaveBeenCalledWith(['test/'], { queryParams: undefined });
     });
 
+    it('should navigate to `test/1` if action of tableCustomAction is undefined and url is defined and concatKeys is true', () => {
+      component.actions = {
+        detail: '/detail',
+        edit: '/edit'
+      };
+      const selectedItemKey = { id: '1' };
+
+      component.items = [
+        { id: '1', name: 'angular', $selected: true },
+        { id: '2', name: 'react' },
+        { id: '3', name: 'vue' }
+      ];
+      component.fields = [{ property: 'id', key: true }];
+
+      const tableCustomAction = { label: 'Table Custom Action 1', url: 'test', concatKeys: true };
+
+      component.tableCustomActions = [tableCustomAction];
+
+      spyOn(component['router'], 'navigate').and.callThrough();
+
+      const tableActions = visibleTableActions();
+      tableActions[2].action(selectedItemKey, tableCustomAction);
+
+      expect(component['router'].navigate).toHaveBeenCalledWith(['test/1'], { queryParams: undefined });
+    });
+
     it('shouldn`t navigate and call action from tableActions if action and url are undefined', () => {
       component.actions = {
         detail: '/detail',
@@ -2247,6 +2273,72 @@ describe('PoPageDynamicTableComponent:', () => {
 
       expect(routerNavigateSpy).not.toHaveBeenCalled();
       expect(customActionServiceSpy).not.toHaveBeenCalled();
+    });
+
+    it('should open an external url', () => {
+      const tableCustomAction = { label: 'External', url: 'https://fakeUrl.com' };
+      component.actions = {};
+      component.tableCustomActions = [tableCustomAction];
+
+      const openExternalLink = spyOn(utilsFunctions, 'openExternalLink');
+      const createConcatenatedUrlSpy = spyOn(component, <any>'createConcatenatedUrl').and.callThrough();
+
+      const tableActions = visibleTableActions();
+      tableActions[0].action(tableCustomAction);
+
+      expect(createConcatenatedUrlSpy).toHaveBeenCalled();
+      expect(openExternalLink).toHaveBeenCalledWith('https://fakeUrl.com');
+    });
+
+    it('should open an external url with concatenated key and has a unique key', () => {
+      const tableCustomAction = { label: 'External', url: 'https://fakeUrl.com', concatKeys: true };
+
+      const selectedItemKey = { id: '1' };
+
+      component.items = [
+        { id: '1', name: 'angular', $selected: true },
+        { id: '2', name: 'react' },
+        { id: '3', name: 'vue' }
+      ];
+      component.fields = [{ property: 'id', key: true }];
+
+      component.tableCustomActions = [tableCustomAction];
+
+      const openExternalLink = spyOn(utilsFunctions, 'openExternalLink');
+      const createConcatenatedUrlSpy = spyOn(component, <any>'createConcatenatedUrl').and.callThrough();
+
+      const tableActions = visibleTableActions();
+      tableActions[0].action(selectedItemKey, tableCustomAction);
+
+      expect(createConcatenatedUrlSpy).toHaveBeenCalled();
+      expect(openExternalLink).toHaveBeenCalledWith('https://fakeUrl.com/1');
+    });
+
+    it('should open an external url with a concatenated key and has multiple keys', () => {
+      const tableCustomAction = { label: 'External', url: 'https://fakeUrl.com', concatKeys: true };
+
+      const selectedItemKey = { id: '1', name: 'angular' };
+
+      component.items = [
+        { id: '1', name: 'angular', $selected: true },
+        { id: '2', name: 'react' },
+        { id: '3', name: 'vue' }
+      ];
+      component.fields = [
+        { property: 'id', key: true },
+        { property: 'name', key: true }
+      ];
+
+      component.tableCustomActions = [tableCustomAction];
+
+      const openExternalLink = spyOn(utilsFunctions, 'openExternalLink');
+      const createConcatenatedUrlSpy = spyOn(component, <any>'createConcatenatedUrl').and.callThrough();
+
+      const tableActions = visibleTableActions();
+      tableActions[0].action(selectedItemKey, tableCustomAction);
+
+      expect(createConcatenatedUrlSpy).toHaveBeenCalled();
+      expect(openExternalLink).toHaveBeenCalledWith('https://fakeUrl.com/1,angular');
     });
 
     it('should call action from tableActions and call modifyUITableItem if return an object', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -38,6 +38,7 @@ import { PoPageDynamicTableBeforeDuplicate } from './interfaces/po-page-dynamic-
 import { PoPageDynamicTableBeforeRemoveAll } from './interfaces/po-page-dynamic-table-before-remove-all.interface';
 import { PoPageDynamicTableCustomAction } from './interfaces/po-page-dynamic-table-custom-action.interface';
 import { PoPageDynamicTableCustomTableAction } from './interfaces/po-page-dynamic-table-custom-table-action.interface';
+import { isExternalLink, openExternalLink } from '../../utils/util';
 
 type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicTableOptions);
 
@@ -507,6 +508,11 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     });
   }
 
+  private createConcatenatedUrl(concatKeys: boolean, url: string, selectedItem): string {
+    const keys = this.keys.map(key => encodeURIComponent(selectedItem[key])).join();
+    return concatKeys ? `${url}/${keys}` : url;
+  }
+
   private openDetail(action: PoPageDynamicTableActions['detail'], item) {
     const id = this.formatUniqueKey(item);
     this.subscriptions.add(
@@ -847,7 +853,13 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
 
       this.subscriptions.add(sendCustomActionSubscription);
     } else if (customAction.url) {
-      this.navigateTo({ path: customAction.url });
+      if (isExternalLink(customAction.url)) {
+        openExternalLink(this.createConcatenatedUrl(customAction.concatKeys, customAction.url, selectedItem));
+      } else {
+        this.navigateTo({
+          path: this.createConcatenatedUrl(customAction.concatKeys, customAction.url, selectedItem)
+        });
+      }
     }
   }
 


### PR DESCRIPTION
**PAGE-DYNAMIC-TABLE**

**DTHFUI-5648**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente não é permitido a utilização de URL Externa, nem concatenar o ID do item da tabela com a URL digitada.

**Qual o novo comportamento?**
Agora é possível utilizar URL Externa, bem como concatenar o ID à URL adicionada, através da propriedade `concatKey`

**Simulação**

Utilizar este [APP](https://github.com/po-ui/po-angular/files/7953859/app.zip)

