### PR TITLE
feat(page-dynamic-table): p-table-custom-actions

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
@@ -93,4 +93,20 @@ export interface PoPageDynamicTableCustomTableAction {
    * ```
    */
   icon?: string | TemplateRef<void>;
+
+  /**
+   * @description
+   *
+   * Define se a ação será visível.
+   *
+   * > Caso o valor não seja especificado a ação será visível.
+   *
+   * Opções para tornar a ação visível ou não:
+   *
+   *  - Função que deve retornar um booleano.
+   *
+   *  - Informar diretamente um valor booleano.
+   *
+   */
+  visible?: boolean | Function;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -832,7 +832,8 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
       label: tableCustomAction.label,
       icon: tableCustomAction.icon,
       action: this.callTableCustomAction.bind(this, tableCustomAction),
-      disabled: tableCustomAction.disabled
+      disabled: tableCustomAction.disabled,
+      visible: tableCustomAction.visible
     }));
   }
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -18,3 +18,7 @@
 <po-modal #userDetailModal p-title="User Detail">
   <po-dynamic-view [p-fields]="detailFields" [p-value]="detailedUser"> </po-dynamic-view>
 </po-modal>
+
+<po-modal #dependentsModal p-title="Dependents">
+  <po-table [p-items]="dependents"> </po-table>
+</po-modal>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -17,9 +17,11 @@ import { SamplePoPageDynamicTableUsersService } from './sample-po-page-dynamic-t
 })
 export class SamplePoPageDynamicTableUsersComponent {
   @ViewChild('userDetailModal') userDetailModal: PoModalComponent;
+  @ViewChild('dependentsModal') dependentsModal: PoModalComponent;
 
   readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
   detailedUser;
+  dependents;
   quickSearchWidth: number = 3;
 
   readonly actions: PoPageDynamicTableActions = {
@@ -84,6 +86,12 @@ export class SamplePoPageDynamicTableUsersComponent {
       action: this.onClickUserDetail.bind(this),
       disabled: this.isUserInactive.bind(this),
       icon: 'po-icon-user'
+    },
+    {
+      label: 'Dependents',
+      action: this.onClickDependents.bind(this),
+      visible: this.hasDependents.bind(this),
+      icon: 'po-icon-user'
     }
   ];
 
@@ -112,6 +120,10 @@ export class SamplePoPageDynamicTableUsersComponent {
     return person.status === 'inactive';
   }
 
+  hasDependents(person) {
+    return person.dependents.length !== 0;
+  }
+
   printPage() {
     window.print();
   }
@@ -120,5 +132,11 @@ export class SamplePoPageDynamicTableUsersComponent {
     this.detailedUser = user;
 
     this.userDetailModal.open();
+  }
+
+  private onClickDependents(user) {
+    this.dependents = user.dependents;
+
+    this.dependentsModal.open();
   }
 }

--- a/projects/ui/src/lib/components/po-popup/po-popup-action.interface.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup-action.interface.ts
@@ -95,6 +95,13 @@ export interface PoPopupAction {
    * Define se a ação será visível.
    *
    * > Caso o valor não seja especificado a ação será visível.
+   *
+   * Opções para tornar a ação visível ou não:
+   *
+   *  - Função que deve retornar um booleano.
+   *
+   *  - Informar diretamente um valor booleano.
+   *
    */
-  visible?: boolean;
+  visible?: boolean | Function;
 }

--- a/projects/ui/src/lib/components/po-popup/po-popup.component.html
+++ b/projects/ui/src/lib/components/po-popup/po-popup.component.html
@@ -6,7 +6,7 @@
   <div class="po-popup-container">
     <ng-container *ngFor="let action of actions; let actionIndex = index">
       <div
-        *ngIf="action.visible !== false"
+        *ngIf="returnBooleanValue(action, 'visible') !== false"
         [class.po-popup-item-default]="action.type !== 'danger'"
         [class.po-popup-item-danger]="action.type === 'danger'"
         [class.po-popup-item-disabled]="returnBooleanValue(action, 'disabled')"


### PR DESCRIPTION
Adiciona o atributo visible.

Opções para tornar a ação visível ou não:
- Função que retorna um booleano
- Informar diretamente um valor booleano.

Fixes #1156

** Page Dynamic Table **

** 1156 **
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A propriedade p-table-custom-actions não tem o atributo visible.

**Qual o novo comportamento?**
Foi adicionado o atributo visible na propriedade p-table-custom-actions para tornar a ação visível ou não. O valor do atributo pode ser atribuído por função que retorna um booleano ou informar diretamente o valor booleano. 

**Simulação**
Pode ser realizada no portal.