### PR TITLE
feat(page-dynamic-table): adiciona p-infinite-scroll e p-height

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -17,6 +17,8 @@
     [p-selectable]="enableSelectionTable"
     [p-columns]="columns"
     [p-items]="items"
+    [p-height]="height"
+    [p-infinite-scroll]="infiniteScroll"
     [p-show-more-disabled]="!hasNext"
     (p-show-more)="showMore()"
     (p-sort-by)="onSort($event)"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -50,6 +50,11 @@ describe('PoPageDynamicTableComponent:', () => {
   });
 
   describe('Properties:', () => {
+    const booleanValidTrueValues = [true, 'true', 1, ''];
+    const booleanInvalidValues = [undefined, null, NaN, 2, 'string'];
+    const numberValidValues = [105, 1, 98, 0];
+    const numberInvalidValues = [null, undefined, '', ' ', {}, [], false, true];
+
     it('actions: should set actions to `{}` when pass invalid values', () => {
       const invalidValues = [undefined, null, '', true, false, 0, 1, 'string'];
 
@@ -72,16 +77,37 @@ describe('PoPageDynamicTableComponent:', () => {
       expectPropertiesValues(component, 'actions', validValues, validValues);
     });
 
-    it('p-quick-search-width: should update property p-quick-search-width with valid values.', () => {
-      const validValues = [105, 1, 98, 0];
+    it('p-actions-right: should update property `p-actions-right` with false.', () => {
+      expectPropertiesValues(component, 'actionRight', booleanInvalidValues, false);
+    });
 
-      expectPropertiesValues(component, 'quickSearchWidth', validValues, validValues);
+    it('p-actions-right: should update property `p-actions-right` with true.', () => {
+      expectPropertiesValues(component, 'actionRight', booleanValidTrueValues, true);
+    });
+
+    it('p-quick-search-width: should update property p-quick-search-width with valid values.', () => {
+      expectPropertiesValues(component, 'quickSearchWidth', numberValidValues, numberValidValues);
     });
 
     it('p-quick-search-width: should update property p-quick-search-width with invalid values for undefined.', () => {
-      const invalidValues = [null, undefined, '', ' ', {}, [], false, true];
+      expectPropertiesValues(component, 'quickSearchWidth', numberInvalidValues, undefined);
+    });
 
-      expectPropertiesValues(component, 'quickSearchWidth', invalidValues, undefined);
+    it('p-height: should update property p-height with valid values.', () => {
+      expectPropertiesValues(component, 'height', numberValidValues, numberValidValues);
+    });
+
+    it('p-height: should update property p-height with invalid values for undefined.', () => {
+      expectPropertiesValues(component, 'height', numberInvalidValues, undefined);
+    });
+
+    it('p-infinite-scroll: should update property `p-infinite-scroll` with false.', () => {
+      expectPropertiesValues(component, 'infiniteScroll', booleanInvalidValues, false);
+    });
+
+    it('p-infinite-scroll: should update property `p-infinite-scroll` with true.', () => {
+      component.height = 10;
+      expectPropertiesValues(component, 'infiniteScroll', booleanValidTrueValues, true);
     });
   });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -110,6 +110,11 @@ type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicTableOptions);
  *  <file name="sample-po-page-dynamic-table-basic/sample-po-page-dynamic-table-basic.component.ts"> </file>
  * </example>
  *
+ * <example name="po-page-dynamic-table-people" title="PO Page Dynamic Table - People">
+ *  <file name="sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.html"> </file>
+ *  <file name="sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.ts"> </file>
+ * </example>
+ *
  * <example name="po-page-dynamic-table-users" title="PO Page Dynamic Table - Users">
  *  <file name="sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html"> </file>
  *  <file name="sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts"> </file>
@@ -205,6 +210,23 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   @Input('p-concat-filters')
   concatFilters: boolean = false;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Se verdadeiro, ativa a funcionalidade de scroll infinito para a tabela e o botão "Carregar Mais" deixará de ser exibido. Ao chegar no fim da tabela
+   * executará a função `p-show-more`.
+   *
+   * **Regras de utilização:**
+   *  - O scroll infinito só funciona para tabelas que utilizam a propriedade `p-height` e que possuem o scroll já na carga inicial dos dados.
+   *
+   * @default `false`
+   */
+  @InputBoolean()
+  @Input('p-infinite-scroll')
+  infiniteScroll?: boolean = false;
+
   hasNext = false;
   items = [];
   literals;
@@ -213,6 +235,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
 
   private _actions: PoPageDynamicTableActions = {};
   private _pageCustomActions: Array<PoPageDynamicTableCustomAction> = [];
+  private _height: number;
   private _quickSearchWidth: number;
   private _tableCustomActions: Array<PoPageDynamicTableCustomTableAction> = [];
 
@@ -338,6 +361,21 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
 
   get quickSearchWidth(): number {
     return this._quickSearchWidth;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a altura da tabela em *pixels* e fixa o cabeçalho.
+   */
+  @Input('p-height') set height(value: number) {
+    this._height = util.convertToInt(value);
+  }
+
+  get height(): number {
+    return this._height;
   }
 
   constructor(

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.html
@@ -1,0 +1,11 @@
+<po-page-dynamic-table
+  p-auto-router
+  p-concat-filters
+  p-keep-filters
+  p-title="People"
+  [p-height]="300"
+  [p-infinite-scroll]="true"
+  [p-fields]="fields"
+  [p-service-api]="serviceApi"
+>
+</po-page-dynamic-table>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sample-po-page-dynamic-table-people',
+  templateUrl: './sample-po-page-dynamic-table-people.component.html'
+})
+export class SamplePoPageDynamicTablePeopleComponent {
+  readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+
+  readonly fields: Array<any> = [
+    { property: 'id', key: true, visible: false },
+    { property: 'name', label: 'Name' },
+    { property: 'genre', label: 'Genre', sortable: false },
+    { property: 'city', label: 'City' }
+  ];
+
+  constructor() {}
+}


### PR DESCRIPTION
Adiciona as propriedades p-infinite-scroll e p-height
que serão repassadas para o componente po-table,
onde já são suportadas.

Fixes #1092

** Page Dynamic Table **

** 1192 **
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente não tem as propriedades p-infinite-scroll e p-heigh.

**Qual o novo comportamento?**
Foram adicionadas as propriedades p-infinite-scroll e p-height, que serão repassadas para o componente po-table, onde já são suportadas pelo mesmo.

**Simulação**
Foi criado no portal um exemplo com a funcionalidade ativada.