### PR TITLE
docs(releases): documenta mudança de nomenclatura das versões

### DIFF
--- a/docs/guides/releases.md
+++ b/docs/guides/releases.md
@@ -21,7 +21,7 @@ O número da versão principal é incrementado com base na versão do Angular qu
 ## Caminhos de atualização suportados
 Em alinhamento com o esquema de controle de versão descrito acima, nos comprometemos a oferecer suporte aos seguintes caminhos de atualização:
 - Se você estiver atualizando na **versão principal**, poderá pular todas as versões intermediárias e atualizar diretamente para a versão de destino. Por exemplo, você pode atualizar diretamente da versão 4.0.0 para a 4.17.0.
-- Se você estiver  atualizando de **uma versão principal para outra**, recomendamos que **não ignore as versões principais**. Siga as instruções para atualizar de forma incremental para a próxima versão principal, testando e validando em cada erapa. Por exemplo, se você deseja atualizar da versão 2.xx para a versão 4.xx, recomendamos que vocÊ atualize para a versão 3.xx mais recente primeiro. Depois de atualizar com sucesso para a versão 3.xx, você pode atualizar para a 4.xx.
+- Se você estiver  atualizando de **uma versão principal para outra**, recomendamos que **não ignore as versões principais**. Siga as instruções para atualizar de forma incremental para a próxima versão principal, testando e validando em cada erapa. Por exemplo, se você deseja atualizar da versão 2.xx para a versão 4.xx, recomendamos que você atualize para a versão 3.xx mais recente primeiro. Depois de atualizar com sucesso para a versão 3.xx, você pode atualizar para a 4.xx.
 
 Consulte abaixo nossos guias de migração de versão para obter mais informações sobre como atualizar o PO UI para a versão mais recente nos seus projetos Angular.
 
@@ -72,6 +72,8 @@ Consulte abaixo nossos guias de migração de versão para obter mais informaç�
     </table>
   </div>
 </div>
+
+> Conforme agenda de publicação de novas versões estáveis do Angular, nós atualizaremos nossas versões como de costume e aproveitaremos para fazer uma mudança na nomenclatura das nossas versões. A próxima `v7.x.x` será lançada como **`v14.x.x`**, assim `a versão 14.x.x do PO UI terá compatibilidade com a v14 do Angular` e assim por diante. [Mais informações](https://github.com/po-ui/po-angular/issues/1184).
 
 ## Versões prévias
 

--- a/projects/portal/src/app/app.component.ts
+++ b/projects/portal/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoMenuItem, PoNavbarItem, PoNavbarIconAction } from '@po-ui/ng-components';
+import { PoMenuItem, PoNavbarItem, PoNavbarIconAction, PoNotificationService } from '@po-ui/ng-components';
 
 import { VersionService } from './shared/version.service';
 
@@ -17,7 +17,7 @@ export class AppComponent implements OnInit {
 
   private location;
 
-  constructor(private versionService: VersionService) {}
+  constructor(private versionService: VersionService, private notification: PoNotificationService) {}
 
   async ngOnInit() {
     const version = await this.versionService.getCurrentVersion().toPromise();
@@ -38,9 +38,19 @@ export class AppComponent implements OnInit {
       { icon: 'po-icon-social-twitter', link: 'https://twitter.com/@pouidev', label: 'Twitter' },
       { icon: 'po-icon-social-instagram', link: 'https://www.instagram.com/pouidev/', label: 'Instagram' }
     ];
+
+    setTimeout(this.showVersionNamingChangeNotification.bind(this), 1000);
   }
 
   openExternalLink(url) {
     window.open(url, '_blank');
+  }
+
+  private showVersionNamingChangeNotification() {
+    this.notification.information({
+      message: 'Mudança de nomenclatura das versões a partir da v7.x.x',
+      action: this.openExternalLink.bind(this, 'https://github.com/po-ui/po-angular/issues/1184'),
+      actionLabel: 'Mais informações'
+    });
   }
 }


### PR DESCRIPTION
**Releases**
_____________________________________________________________________________

Conforme agenda de publicação de novas versões estáveis do Angular, nós atualizaremos nossas versões como de costume e aproveitaremos para fazer uma mudança na nomenclatura das nossas versões. A próxima v7.x.x será lançada como v14.x.x, assim a versão 14.x.x do PO UI terá compatibilidade com a v14 do Angular e assim por diante. Mais informações: https://github.com/po-ui/po-angular/issues/1184.

Verificar notification na página inicial do portal e alteração na documentação de releases.