### PR TITLE
fix(schematics): corrige erro no ng add @po-ui/ng-components

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -9,12 +9,12 @@ Para começar a utilizar o **PO UI** é pré-requisito ter o `Node.js` instalado
 
 Instalando com npm:
 ```
-npm i -g @angular/cli@13.1.1
+npm i -g @angular/cli@13
 ```
 
 Caso prefira instalar com o yarn:
 ```
-yarn global add @angular/cli@13.1.1
+yarn global add @angular/cli@13
 ```
 
 ### Passo 1 - Crie o seu primeiro projeto
@@ -53,7 +53,7 @@ Veja abaixo a lista de dependências e as versões compatíveis, elas devem ser 
   },
   "devDependencies": {
     ...
-    "typescript": "~4.4.4"
+    "typescript": "~4.5.2"
   }
 ```
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@angular-eslint/eslint-plugin-template": "13.0.1",
     "@angular-eslint/schematics": "13.0.1",
     "@angular-eslint/template-parser": "13.0.1",
-    "@angular/cli": "^13.0.3",
+    "@angular/cli": "^13.2.2",
     "@angular/compiler-cli": "^13.0.2",
     "@angular/language-service": "^13.0.2",
     "@commitlint/cli": "^12.1.4",
@@ -142,7 +142,7 @@
     "standard-version": "^9.3.0",
     "ts-node": "~10.0.0",
     "typemoq": "^2.1.0",
-    "typescript": "~4.4.4"
+    "typescript": "~4.5.2"
   },
   "standard-version": {
     "skip": {

--- a/projects/app/.browserslistrc
+++ b/projects/app/.browserslistrc
@@ -10,5 +10,3 @@ last 2 versions
 Firefox ESR
 not dead
 IE 9-11 # For IE 9-11 support, remove 'not'.
-not ios_saf 15.2-15.3
-not safari 15.2-15.3

--- a/projects/portal/browserslist
+++ b/projects/portal/browserslist
@@ -10,5 +10,3 @@ last 2 versions
 Firefox ESR
 not dead
 not IE 9-11 # For IE 9-11 support, remove 'not'.
-not ios_saf 15.2-15.3
-not safari 15.2-15.3


### PR DESCRIPTION
**SCHEMATICS**

**DTHFUI-5697**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não era possível executar o comando `ng add @po-ui/ng-components`, por que ocorria um erro durante a execução.

**Qual o novo comportamento?**
Foi corrigido este erro de ngAdd

**Simulação**
Existem duas formas:
1. Remover o `xdescribe` do arquivo `projects/ui/schematics/ng-add/index.spec.ts` e executar `npm run test:schematics`.
2. Seguir o passo a passo do arquivo `projects/ui/schematics/README.md` e seguir o [Primeiros Passos](https://po-ui.io/guides/getting-started) do portal do PO UI.