### PR TITLE
feat(page-dynamic-table): p-page-custom-actions

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-action.interface.ts
@@ -84,4 +84,20 @@ export interface PoPageDynamicTableCustomAction {
    * ```
    */
   icon?: string | TemplateRef<void>;
+
+  /**
+   * @description
+   *
+   * Define se a ação será visível.
+   *
+   * > Caso o valor não seja especificado a ação será visível.
+   *
+   * Opções para tornar a ação visível ou não:
+   *
+   *  - Função que deve retornar um booleano.
+   *
+   *  - Informar diretamente um valor booleano.
+   *
+   */
+  visible?: boolean | Function;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -821,7 +821,8 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
       label: customAction.label,
       action: this.callPageCustomAction.bind(this, customAction),
       disabled: this.isDisablePageCustomAction.bind(this, customAction),
-      ...(customAction.icon && { icon: customAction.icon })
+      ...(customAction.icon && { icon: customAction.icon }),
+      visible: customAction.visible
     }));
   }
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -4,7 +4,7 @@
   p-keep-filters
   p-title="Users"
   [p-actions]="actions"
-  [p-actions-right]="true"
+  [p-actions-right]="actionsRight"
   [p-page-custom-actions]="pageCustomActions"
   [p-table-custom-actions]="tableCustomActions"
   [p-breadcrumb]="breadcrumb"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -20,6 +20,8 @@ export class SamplePoPageDynamicTableUsersComponent {
   @ViewChild('dependentsModal') dependentsModal: PoModalComponent;
 
   readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+
+  actionsRight = false;
   detailedUser;
   dependents;
   quickSearchWidth: number = 3;
@@ -72,6 +74,18 @@ export class SamplePoPageDynamicTableUsersComponent {
   ];
 
   pageCustomActions: Array<PoPageDynamicTableCustomAction> = [
+    {
+      label: 'Actions Right',
+      action: this.onClickActionsSide.bind(this),
+      visible: this.isVisibleActionsRight.bind(this),
+      icon: 'po-icon-arrow-right'
+    },
+    {
+      label: 'Actions Left',
+      action: this.onClickActionsSide.bind(this),
+      visible: this.isVisibleActionsLeft.bind(this),
+      icon: 'po-icon-arrow-left'
+    },
     { label: 'Print', action: this.printPage.bind(this), icon: 'po-icon-print' },
     {
       label: 'Download .csv',
@@ -138,5 +152,16 @@ export class SamplePoPageDynamicTableUsersComponent {
     this.dependents = user.dependents;
 
     this.dependentsModal.open();
+  }
+
+  private onClickActionsSide(value) {
+    this.actionsRight = !this.actionsRight;
+  }
+
+  private isVisibleActionsRight() {
+    return !this.actionsRight;
+  }
+  private isVisibleActionsLeft() {
+    return this.actionsRight;
   }
 }


### PR DESCRIPTION
Adiciona o atributo `visible` na propriedade `p-page-custom-actions`.

Opções para tornar a ação visível ou não:

- Função que retorna um booleano
- Informar diretamente um valor booleano.

Fixes #1158

**Page Dynamic Table**

**1158**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A propriedade `p-page-custom-actions` não tem o atributo `visible`.

**Qual o novo comportamento?**
Foi adicionado o atributo `visible` na propriedade `p-page-custom-actions` para tornar a ação visível ou não. O valor do atributo pode ser atribuído por função que retorna um booleano ou informar diretamente o valor booleano.

**Simulação**
Pode ser realizada no portal.