### PR TITLE
fix(combo): corrige retorno `undefined` do `p-filter-service`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -597,7 +597,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     }
 
     if (isUpdateModel) {
-      const optionValue = (option && option.value) || undefined;
+      const optionValue = option?.value !== undefined ? option.value : undefined;
 
       this.updateModel(optionValue);
     }


### PR DESCRIPTION
Quando o `value` é do tipo `number` e igual a zero o retorno do `value` do `p-filter-service` é `undefined`

Fixes #1183

**Combo**

**1183**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando o `value` é do tipo `number` e igual a zero o retorno do `value` do `p-filter-service` é `undefined`

**Qual o novo comportamento?**
Na situação relatada acima, agora o retorno é zero como esperado.



**Simulação**
A simulação pode ser feita neste [App](https://github.com/po-ui/po-angular/files/8069114/app.zip).