### PR TITLE
fix(lookup): `p-selected`  não retorna objeto completo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -156,17 +156,42 @@ describe('PoLookupBaseComponent:', () => {
     expect(component['keysDescription'].length).toBe(1);
   });
 
-  it('selectValue: should call `callOnChange` with `valueToModel` and call `selected.emit` with objectSelected', () => {
+  it('selectValue: should call `callOnChange` with `valueToModel.fieldvalue` and call `selected.emit` with objectSelected', () => {
     const objectSelected = { value: 123, label: 'test label' };
     component.fieldValue = 'value';
 
     spyOn(component.selected, 'emit');
     spyOn(component, 'callOnChange');
 
-    component.selectValue(objectSelected[component.fieldValue]);
+    component.selectValue(objectSelected);
 
-    expect(component.callOnChange).toHaveBeenCalledWith(123);
-    expect(component.selected.emit).toHaveBeenCalledWith(objectSelected[component.fieldValue]);
+    expect(component.callOnChange).toHaveBeenCalledWith(objectSelected[component.fieldValue]);
+    expect(component.selected.emit).toHaveBeenCalledWith(objectSelected);
+  });
+
+  it('selectValue: should call `callOnChange` with `valueToModel` and call `selected.emit` with objectSelected if is multiple', () => {
+    const objectSelected = { value: 123, label: 'test label' };
+    component.fieldValue = 'value';
+    component.multiple = true;
+
+    spyOn(component.selected, 'emit');
+    spyOn(component, 'callOnChange');
+
+    component.selectValue(objectSelected);
+
+    expect(component.callOnChange).toHaveBeenCalledWith({ value: 123, label: 'test label' });
+    expect(component.selected.emit).toHaveBeenCalledWith(objectSelected);
+  });
+
+  it('selectValue: should call `callOnChange` with `undefined` if not contain `valueSelected`', () => {
+    component.fieldValue = 'value';
+    component.multiple = false;
+
+    spyOn(component, 'callOnChange');
+
+    component.selectValue(undefined);
+
+    expect(component.callOnChange).toHaveBeenCalledWith(undefined);
   });
 
   it('should be called the onChangePropated event', () => {
@@ -213,7 +238,7 @@ describe('PoLookupBaseComponent:', () => {
 
     spyOn(component.change, 'emit');
 
-    component.selectValue(objectSelected[component.fieldValue]);
+    component.selectValue(objectSelected);
     expect(component.change.emit).toHaveBeenCalledWith(1495832652942);
   });
 
@@ -700,13 +725,11 @@ describe('PoLookupBaseComponent:', () => {
 
       component.fieldValue = 'value';
 
-      const newModel = 1;
-
       spyOn(component, 'selectValue');
 
       component['selectModel'](options);
 
-      expect(component.selectValue).toHaveBeenCalledWith(newModel);
+      expect(component.selectValue).toHaveBeenCalledWith({ label: 'John', value: 1 });
     });
 
     it('selectModel: should set oldValue and call setViewValue if options.length is equal to 1', () => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -491,7 +491,11 @@ export abstract class PoLookupBaseComponent
   // Seleciona o valor do model.
   selectValue(valueSelected: any) {
     this.valueToModel = valueSelected;
-    this.callOnChange(this.valueToModel);
+    this.multiple
+      ? this.callOnChange(this.valueToModel)
+      : this.valueToModel
+      ? this.callOnChange(this.valueToModel[this.fieldValue])
+      : this.callOnChange(undefined);
     this.selected.emit(valueSelected);
   }
 
@@ -502,7 +506,7 @@ export abstract class PoLookupBaseComponent
     }
 
     if (this.oldValueToModel !== this.valueToModel) {
-      this.change.emit(this.valueToModel);
+      this.change.emit(value);
     }
 
     // Armazenar o valor antigo do model
@@ -597,7 +601,7 @@ export abstract class PoLookupBaseComponent
     if (options.length) {
       this.selectedOptions = [...options];
 
-      const newModel = this.multiple ? options.map(option => option[this.fieldValue]) : options[0][this.fieldValue];
+      const newModel = this.multiple ? options.map(option => option[this.fieldValue]) : options[0];
       this.selectValue(newModel);
 
       if (options.length === 1) {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
@@ -351,6 +351,16 @@ describe('PoLookupModalBaseComponent:', () => {
       expect(spySelectRowItem).toHaveBeenCalled();
     });
 
+    it('setSelectedItems: should call `selectRowItem` if is multiple', () => {
+      component.selecteds = [{ value: 1495832652942 }, { value: 1495832596999 }];
+      component.multiple = true;
+      const spySelectRowItem = spyOn(component.poTable, 'selectRowItem').and.callThrough();
+
+      component.setSelectedItems();
+
+      expect(spySelectRowItem).toHaveBeenCalled();
+    });
+
     it('setTableLiterals: should set table literals.', () => {
       component.literals = {
         'modalTableLoadMoreData': 'moreData',
@@ -514,8 +524,18 @@ describe('PoLookupModalBaseComponent:', () => {
     });
 
     it('setDisclaimersItems: should set selecteds with component.selectedItems if component.selectedItems is array', () => {
-      const expectSelecteds = [{ value: 123, label: '123' }];
+      const expectSelecteds = { value: 123, label: '123' };
+      component.multiple = false;
+      component.selectedItems = expectSelecteds;
 
+      component.setDisclaimersItems();
+
+      expect(component.selecteds[0]).toEqual(expectSelecteds);
+    });
+
+    it('setDisclaimersItems: should set selecteds with component.selectedItems if component.selectedItems is array and is multiple', () => {
+      const expectSelecteds = [{ value: 123, label: '123' }];
+      component.multiple = true;
       component.selectedItems = [...expectSelecteds];
 
       component.setDisclaimersItems();
@@ -525,7 +545,7 @@ describe('PoLookupModalBaseComponent:', () => {
 
     it('setDisclaimersItems: should set selecteds with [{ value: component.selectedItems }] if selectedItems isnt array', () => {
       const expectSelecteds = [{ value: 123456789 }];
-
+      component.multiple = true;
       component.selectedItems = 123456789;
 
       component.setDisclaimersItems();

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -342,15 +342,19 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
 
   //Método responsável por selecionar as linhas quando abre o modal.
   setSelectedItems() {
-    this.selecteds.forEach(selectedItem =>
-      this.poTable.selectRowItem(item => item[this.fieldValue] === selectedItem.value)
-    );
+    this.selecteds.forEach(selectedItem => {
+      if (this.multiple) {
+        this.poTable.selectRowItem(item => item[this.fieldValue] === selectedItem.value);
+      } else {
+        this.poTable.selectRowItem(item => item[this.fieldValue] === selectedItem[this.fieldValue]);
+      }
+    });
   }
 
   //Método responsável por criar os disclaimers quando abre o modal.
   setDisclaimersItems() {
     if (this.selectedItems && !Array.isArray(this.selectedItems)) {
-      this.selecteds = [{ value: this.selectedItems }];
+      this.multiple ? (this.selecteds = [{ value: this.selectedItems }]) : (this.selecteds = [this.selectedItems]);
       return;
     }
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-sw-films/sample-po-lookup-sw-films.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-sw-films/sample-po-lookup-sw-films.component.ts
@@ -66,7 +66,7 @@ export class SamplePoLookupSwFilmsComponent implements OnInit {
   }
 
   onSelected(entity) {
-    this.filterService.getObjectByValue(entity, this.filterParams).subscribe(
+    this.filterService.getObjectByValue(entity.name, this.filterParams).subscribe(
       result => {
         this.filmItemsFiltered = this.filmItems.filter(film => result?.films.includes(film.url));
       },


### PR DESCRIPTION
**Lookup**

**DTHFUI-5695**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando o componente não é multiplo o `p-selected` retorna apenas o id do item selecionado

**Qual o novo comportamento?**
Quando o componente não é multiplo o `p-selected` retorna o objeto completo

**Simulação**
html:

```
<po-lookup
  [(ngModel)]="lookup"
  name="lookup"
  p-field-label="label"
  p-field-value="value"
  p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
  p-label="PO Lookup"
  (p-selected)="teste($event)"
>
</po-lookup>
```

app.ts:

```
teste(value) {
    console.log(value)
  }
```