### PR TITLE
feat(tooltip): remove restrição de caracteres

### DIFF
--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip-base.directive.spec.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip-base.directive.spec.ts
@@ -26,7 +26,7 @@ describe('PoTooltipBaseDirective', () => {
     expectPropertiesValues(component, 'tooltip', '1234567890', '1234567890');
     expectPropertiesValues(component, 'tooltip', null, null);
     expectPropertiesValues(component, 'tooltip', text, text);
-    expectPropertiesValues(component, 'tooltip', text + 'abcd', text);
+    expectPropertiesValues(component, 'tooltip', text + 'abcd', text + 'abcd');
   });
 
   it('should set valid positions', () => {

--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip-base.directive.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip-base.directive.ts
@@ -4,7 +4,6 @@ import { InputBoolean } from '../../decorators';
 
 import { PO_CONTROL_POSITIONS } from './../../services/po-control-position/po-control-position.constants';
 
-const CONTENT_MAX_LENGTH = 140;
 const PO_TOOLTIP_POSITION_DEFAULT = 'bottom';
 
 /**
@@ -43,14 +42,12 @@ export abstract class PoTooltipBaseDirective {
   /**
    * @description
    *
-   * Habilita e atribui um texto ao po-tooltip, com limitação de 140 caracteres.
+   * Habilita e atribui um texto ao po-tooltip.
+   *
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
    */
   @Input('p-tooltip') set tooltip(tooltip: string) {
-    if (tooltip && tooltip.length > CONTENT_MAX_LENGTH) {
-      this._tooltip = tooltip.substring(0, CONTENT_MAX_LENGTH);
-    } else {
-      this._tooltip = tooltip;
-    }
+    this._tooltip = tooltip;
   }
   get tooltip() {
     return this._tooltip;

--- a/projects/ui/src/lib/directives/po-tooltip/samples/sample-po-tooltip-labs/sample-po-tooltip-labs.component.html
+++ b/projects/ui/src/lib/directives/po-tooltip/samples/sample-po-tooltip-labs/sample-po-tooltip-labs.component.html
@@ -8,8 +8,7 @@
 
 <form #f="ngForm">
   <div class="po-row">
-    <po-input class="po-lg-12" name="tooltip" [(ngModel)]="tooltip" p-clean p-label="Tooltip" p-maxlength="140">
-    </po-input>
+    <po-input class="po-lg-12" name="tooltip" [(ngModel)]="tooltip" p-clean p-label="Tooltip"> </po-input>
   </div>
 
   <div class="po-row">


### PR DESCRIPTION
**tooltip**

**DTHFUI-2201**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
componente tem limite de caracteres

**Qual o novo comportamento?**
componente não tem limite de caracteres

**Simulação**
testar portal com o tooltip e componentes que utilizam e app:

html:
```
<po-page-login [p-literals]="customLiterals"></po-page-login>

```

ts:
```
customLiterals: PoPageLoginLiterals = {
  loginHint: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec quisua.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec quisua.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec quisua.`,
  };
```