### PR TITLE
feat(radio-group): ativado o estado `onTouched` no componente

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.spec.ts
@@ -73,6 +73,14 @@ describe('PoRadioGroupBase: ', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('should register function registerOnTouched', () => {
+    component['onTouched'] = undefined;
+    const func = () => true;
+
+    component.registerOnTouched(func);
+    expect(component['onTouched']).toBe(func);
+  });
+
   describe('Methods: ', () => {
     const onChangePropagate: any = 'onChangePropagate';
 

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
@@ -67,6 +67,8 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
   mdColumns: number = poRadioGroupColumnsDefaultLength;
   value: any;
 
+  protected onTouched: any = null;
+
   private _columns: number = poRadioGroupColumnsDefaultLength;
   private _disabled?: boolean = false;
   private _options: Array<PoRadioGroupOption>;
@@ -174,7 +176,9 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
     this.onChangePropagate = fn;
   }
 
-  registerOnTouched(fn: any) {}
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
 
   registerOnValidatorChange(fn: any) {
     this.validatorChange = fn;

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
@@ -49,15 +49,41 @@ describe('PoRadioGroupComponent:', () => {
   });
 
   it('should call changeValue when clicked and enabled', () => {
+    component['onTouched'] = value => {};
+    spyOn(component, <any>'onTouched');
     spyOn(component, 'changeValue');
+
     component.eventClick('valor', false);
+
     expect(component.changeValue).toHaveBeenCalledWith('valor');
+    expect(component['onTouched']).toHaveBeenCalledWith();
   });
 
   it('shouldn`t call changeValue when clicked and disabled', () => {
+    component['onTouched'] = value => {};
+    spyOn(component, <any>'onTouched');
     spyOn(component, 'changeValue');
+
     component.eventClick('valor', true);
+
     expect(component.changeValue).not.toHaveBeenCalledWith('valor');
+    expect(component['onTouched']).not.toHaveBeenCalledWith();
+  });
+
+  it('eventClick: shouldn´t throw error if onTouched is falsy when clicked and enabled', () => {
+    component['onTouched'] = null;
+
+    const fnError = () => component.eventClick('valor', false);
+
+    expect(fnError).not.toThrow();
+  });
+
+  it('eventClick: shouldn´t throw error if onTouched is falsy when clicked and disabled', () => {
+    component['onTouched'] = null;
+
+    const fnError = () => component.eventClick('valor', true);
+
+    expect(fnError).not.toThrow();
   });
 
   it('should return input when exists a input with this value', () => {

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
@@ -96,6 +96,7 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
 
   eventClick(value: any, disabled: any) {
     if (!disabled) {
+      this.onTouched?.();
       this.changeValue(value);
     }
   }


### PR DESCRIPTION
A ativação do `onTouched` no componente permite que o evento `validate` seja disparado no componente `page-dynamic-edit` quando o `radio-group` é o primeiro componente a ser tocado.

Fixes #1202

**Radio Group**

**1202**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
 O evento `validate` não é disparado no componente `page-dynamic-edit` quando o `radio-group` é o primeiro componente a ser tocado.

**Qual o novo comportamento?**
A ativação do `onTouched` no componente permite que o evento `validate` seja disparado no componente `page-dynamic-edit`
quando o `radio-group` é o primeiro componente a ser tocado.

**Simulação**
Usar o [App](https://github.com/po-ui/po-angular/files/8100859/app.zip) para realizar a simulação.
