### PR TITLE
feat(datepicker): ativa mudança de estado também no evento `dateSelected`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -680,11 +680,14 @@ describe('PoDatepickerComponent:', () => {
     describe('dateSelected:', () => {
       it('should set `calendar.visible` to false', () => {
         component.visible = true;
+        component['onTouchedModel'] = () => {};
 
+        spyOn(component, <any>'onTouchedModel');
         spyOn(component, <any>'closeCalendar');
 
         component.dateSelected();
 
+        expect(component['onTouchedModel']).toHaveBeenCalled();
         expect(component['closeCalendar']).toHaveBeenCalled();
       });
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -195,6 +195,7 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
   }
 
   dateSelected() {
+    this.onTouchedModel?.();
     if (!this.verifyMobile()) {
       this.inputEl.nativeElement.focus();
     }


### PR DESCRIPTION
A mudança de estado já ocorre no evento `eventOnBlur` e foi incluído também no evento `dateSelected` devido a ordem dos disparos dos eventos no programa `po-dynamic-form-fields.component.ts`:
1. Quando a data é informada manualmente e depois teclado "TAB" o evento `eventOnBlur` ocorre antes do evento `onChangeField`.
2. Quando a data é escolhida através do ícone/calendário e depois teclado "TAB", o evento `eventOnBlur` ocorre depois do
evento `onChangeField`.

Na segunda situação o evento `validate` do componente `page-dynamic-edit` não é disparado, porque a mudança de estado só ocorrerá no evento `eventOnBlur`.

Fixes #1207

**Datepicker**

**1207**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O evento `validate` não é disparado no componente `page-dynamic-edit` quando o `datepicker` é o primeiro componente a ser tocado.

**Qual o novo comportamento?**
A mudança de estado também no evento `dateSelected` no componente, permite que o evento `validate` seja disparado no componente page-dynamic-edit quando o `datepicker` é o primeiro componente a ser tocado.

**Simulação**
Usar o [App](https://github.com/po-ui/po-angular/files/8112450/app.zip) para realizar a simulação.
