### PR TITLE
feat(datepicker-range): adiciona a propriedade `locale`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -95,6 +95,14 @@ describe('PoDatepickerRangeBaseComponent:', () => {
       expect(component['_minDate'].getFullYear()).toBe(2021);
     });
 
+    it('should be update property p-locale', () => {
+      expectPropertiesValues(component, 'locale', '', 'pt');
+      expectPropertiesValues(component, 'locale', ['pt', 'x'], 'pt');
+      expectPropertiesValues(component, 'locale', 'en', 'en');
+      expectPropertiesValues(component, 'locale', 'es', 'es');
+      expectPropertiesValues(component, 'locale', 'ru', 'ru');
+    });
+
     it('disabled: should update with true value.', () => {
       const booleanValidTrueValues = [true, 'true', 1, ''];
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -126,6 +126,7 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   private _readonly: boolean = false;
   private _required?: boolean = false;
   private _startDate?;
+  private _locale?: string;
 
   private language;
   private onChangeModel: any;
@@ -361,6 +362,27 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
 
   get startDate() {
     return this._startDate;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Idioma que o calendário utilizará para exibir as datas.
+   *
+   * > O locale padrão será recuperado com base no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
+   */
+  @Input('p-locale') set locale(value: string) {
+    if (value) {
+      this._locale = value.length >= 2 ? value : poLocaleDefault;
+    } else {
+      this._locale = this.language;
+    }
+  }
+
+  get locale(): string {
+    return this._locale || this.language;
   }
 
   constructor(protected poDateService: PoDateService, languageService: PoLanguageService) {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
@@ -64,6 +64,7 @@
       [ngModel]="dateRange"
       [p-max-date]="maxDate"
       [p-min-date]="minDate"
+      [p-locale]="locale"
       (ngModelChange)="onCalendarChange($event)"
     ></po-calendar>
   </div>

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
@@ -15,6 +15,7 @@
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
   [p-start-date]="startDate"
+  [p-locale]="locale"
   (p-change)="changeEvent('p-change')"
 >
 </po-datepicker-range>
@@ -78,6 +79,11 @@
       [p-options]="propertiesOptions"
     >
     </po-checkbox-group>
+  </div>
+
+  <div class="po-row">
+    <po-select class="po-lg-6 po-md-12" name="locale" p-label="Locale" [(ngModel)]="locale" [p-options]="localeOptions">
+    </po-select>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
@@ -1,6 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoCheckboxGroupOption, PoDatepickerRange, PoDatepickerRangeLiterals } from '@po-ui/ng-components';
+import {
+  PoCheckboxGroupOption,
+  PoDatepickerRange,
+  PoDatepickerRangeLiterals,
+  PoSelectOption
+} from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-datepicker-range-labs',
@@ -19,6 +24,7 @@ export class SamplePoDatepickerRangeLabsComponent implements OnInit {
   startDate: string | Date;
   maxDate: string | Date;
   minDate: string | Date;
+  locale: string;
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'clean', label: 'Clean' },
@@ -27,6 +33,13 @@ export class SamplePoDatepickerRangeLabsComponent implements OnInit {
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
     { value: 'required', label: 'Required' }
+  ];
+
+  public readonly localeOptions: Array<PoSelectOption> = [
+    { label: 'English', value: 'en' },
+    { label: 'Español', value: 'es' },
+    { label: 'Português', value: 'pt' },
+    { label: 'Pусский', value: 'ru' }
   ];
 
   ngOnInit() {
@@ -61,6 +74,7 @@ export class SamplePoDatepickerRangeLabsComponent implements OnInit {
     this.startDate = undefined;
     this.maxDate = undefined;
     this.minDate = undefined;
+    this.locale = undefined;
     setTimeout(() => (this.datepickerRange = undefined));
   }
 }


### PR DESCRIPTION
Adiciona propriedade `locale` para definir o idioma a ser exibido pelo componente `po-datepicker-range`.

Fixes #1041

**Datepicker**

**1041**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente não recebe a propriedade `locale`, referente ao idioma exibido.

**Qual o novo comportamento?**
É possível definir o idioma do componente através da propriedade `locale`

**Simulação**
Simular através do portal ou pelo [App](https://github.com/po-ui/po-angular/files/9244390/app.zip).
