### PR TITLE
fix(page-dynamic-search): ajusta o GET request com atributo `range`

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -186,7 +186,8 @@ export class PoPageDynamicSearchComponent
   }
 
   onAdvancedSearch(filteredItems, isAdvancedSearch?) {
-    const { filter, optionsService } = filteredItems;
+    const { optionsService } = filteredItems;
+    let { filter } = filteredItems;
 
     const visibleFilters =
       this.visibleFixedFilters === false
@@ -196,6 +197,8 @@ export class PoPageDynamicSearchComponent
     this._disclaimerGroup.disclaimers = this.setDisclaimers(filter, optionsService, visibleFilters);
 
     this.setFilters(filter);
+
+    filter = this.addComplexFilter(filter);
 
     this.advancedSearch.emit(filter);
 
@@ -292,7 +295,7 @@ export class PoPageDynamicSearchComponent
       return this.formatValueToCurrency(field, value);
     }
 
-    if (field.type === PoDynamicFieldType.Date) {
+    if (field.type === PoDynamicFieldType.Date || field.type?.toLowerCase() === PoDynamicFieldType.DateTime) {
       return field.range ? this.formatDate(value.start) + ' - ' + this.formatDate(value.end) : this.formatDate(value);
     }
 
@@ -432,5 +435,27 @@ export class PoPageDynamicSearchComponent
     };
 
     return this.poPageCustomizationService.getCustomOptions(onLoad, originalOption, pageOptionSchema);
+  }
+
+  private addComplexFilter(filter: object): object {
+    let complexFilter;
+
+    Object.keys(filter).forEach(property => {
+      if (filter[property].start && filter[property].end) {
+        if (!complexFilter) {
+          complexFilter = '';
+        } else {
+          complexFilter += ' and ';
+        }
+        complexFilter += `${property} ge '${filter[property].start}' and ${property} le '${filter[property].end}'`;
+        delete filter[property];
+      }
+    });
+
+    if (complexFilter) {
+      filter = Object.assign(filter, { $filter: complexFilter });
+    }
+
+    return filter;
   }
 }


### PR DESCRIPTION
Foi incluído o `$filter` para filtros complexos no GET Request quando o atributo `range` está com `true`

Fixes #1211

**Page Dynamic Table**

**1211**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando é usado o atributo `range` a URL da requisição está sendo gerada com um objeto e não funciona conforme esperado.

**Qual o novo comportamento?**
Quando é usado o atributo `range` a URL da requisição está sendo gerado o atributo `$filter` para filtro complexo conforme o  [Guia de APIs da Totvs - Filtros complexos](https://tdn.totvs.com/pages/viewpage.action?pageId=484701395#Guiadeimplementa%C3%A7%C3%A3odeAPIV2.0-Filtroscomplexos(opcional))

**Simulação**

A simulação pode ser feita no [App](https://github.com/po-ui/po-angular/files/8179197/app.zip).

- Para uso completo do App, será necessário configurar o proxy ou copiar a requisição e colar no navegador.
- Será necessário logar no Datasul e o usuário se senha esta descrito em [TDN](https://tdn.totvs.com/display/public/EN/Ambientes+DATASUL+-+Desenvolvimento+e+Testes), use a senha que tem a letra 'z'.

Exemplo de requisição: [GET](http://138.219.88.181:8080/api/pdp/v1/ordersPublic?page=1&pageSize=10&customerCode=90000035&$filter=implantationDate%20ge%202014-01-01%20and%20implantationDate%20le%202014-01-05%20and%20deliveryDate%20ge%202014-01-01%20and%20deliveryDate%20le%202014-01-02)

![payload](https://user-images.githubusercontent.com/36740857/156602607-0dbde0e5-656b-4484-8919-b84a7512b056.png)

![view](https://user-images.githubusercontent.com/36740857/156602085-1403593e-3fbf-41ba-8910-5a9e3d713b62.png)

