### PR TITLE
fix(calendar): corrige focus quando pressionada a tecla ENTER

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
@@ -95,7 +95,12 @@
   <ng-container *ngIf="!range">
     <div class="po-calendar-footer">
       <div class="po-calendar-footer-today">
-        <button class="po-calendar-footer-today-button" (click)="onSelectDate(today)" [disabled]="isTodayUnavailable()">
+        <button
+          type="button"
+          class="po-calendar-footer-today-button"
+          (click)="onSelectDate(today)"
+          [disabled]="isTodayUnavailable()"
+        >
           {{ displayToday }}
         </button>
       </div>


### PR DESCRIPTION
**Calendar**

**DTHFUI-5688**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao selecionar um input e apertar ENTER o componente datepicker é preenchido e recebe foco

**Qual o novo comportamento?**
Ao selecionar um input e apertar ENTER o componente datepicker não é preenchido e não recebe foco

**Simulação**
Selecionar Input e apertar enter

html:

```
<form>
    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>

    <po-input class="po-md-6" name="label2" [(ngModel)]="label2" p-clean p-label="Label2"> </po-input>

    <po-datepicker
    class="po-sm-12"
    name="datepicker"
    [(ngModel)]="datepicker"
  >
  </po-datepicker>
</form>
```

app.ts:
```
  datepicker;
  label;
  label2;
```