### PR TITLE
feat(page-dynamic-table): adiciona o `refresh` na `p-actions`

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-actions.interface.ts
@@ -111,6 +111,16 @@ export interface PoPageDynamicTableActions {
    */
   new?: string | Function;
 
+  /**
+   * @description
+   *
+   * Habilita a ação que dipara uma requisição para atualização do recusos exibidos na pagina.
+   *
+   * > A requição será feita com a quantidade de recursos já estão exibidas na pagina.
+   *
+   */
+  refresh?: boolean;
+
   /** Habilita a ação de exclusão na tabela. */
   remove?: boolean | ((id: string, resource: any) => boolean);
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-literals.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table-literals.ts
@@ -1,6 +1,7 @@
 export const poPageDynamicTableLiteralsDefault = {
   en: {
     pageAction: 'New',
+    pageActionRefresh: 'Refresh',
     pageActionRemoveAll: 'Delete',
     tableActionView: 'View',
     tableActionEdit: 'Edit',
@@ -16,6 +17,7 @@ export const poPageDynamicTableLiteralsDefault = {
   },
   es: {
     pageAction: 'Nuevo',
+    pageActionRefresh: 'Atualizar',
     pageActionRemoveAll: 'Borrar',
     tableActionView: 'Visualizar',
     tableActionEdit: 'Editar',
@@ -31,6 +33,7 @@ export const poPageDynamicTableLiteralsDefault = {
   },
   pt: {
     pageAction: 'Novo',
+    pageActionRefresh: 'Atualizar',
     pageActionRemoveAll: 'Excluir',
     tableActionView: 'Visualizar',
     tableActionEdit: 'Editar',
@@ -47,6 +50,7 @@ export const poPageDynamicTableLiteralsDefault = {
   },
   ru: {
     pageAction: 'Новый',
+    pageActionRefresh: 'Обновить',
     pageActionRemoveAll: 'Удалить',
     tableActionView: 'Просмотр',
     tableActionEdit: 'Редактировать',

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -368,6 +368,17 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(component['loadData']).toHaveBeenCalledWith(<any>{ 0: 'paramValue', page: 2 });
     });
 
+    it('refresh: should call `loadData` with next page and `params`', () => {
+      component['page'] = 2;
+      component['params'] = ['paramValue'];
+
+      spyOn(component, <any>'loadData').and.returnValue(EMPTY);
+
+      component['refresh']();
+
+      expect(component['loadData']).toHaveBeenCalledWith(<any>{ 0: 'paramValue', page: 1, pageSize: 20 });
+    });
+
     it('confirmRemove: should call `poDialogService.confirm`', () => {
       const path = '/people/:id';
 
@@ -1725,6 +1736,49 @@ describe('PoPageDynamicTableComponent:', () => {
       const pageAction = [
         {
           label: component.literals.pageAction,
+          action: jasmine.any(Function)
+        }
+      ];
+
+      expect(component.pageActions).toEqual(pageAction);
+    });
+
+    it('setRefreshAction: shouldn`t set `refresh` page action if haven`t `actions.refresh`', () => {
+      component['_refreshAction'] = [];
+
+      const actions = undefined;
+      component['setRefreshAction'](actions);
+
+      expect(component.pageActions).toEqual([]);
+    });
+
+    it('setRefreshAction: shouldn`t set `refresh` page action if haven`t `actions.refresh`', () => {
+      component['_refreshAction'] = [];
+
+      const actions = { refresh: undefined };
+      component['setRefreshAction'](actions);
+
+      expect(component.pageActions).toEqual([]);
+    });
+
+    it('setRefreshAction: shouldn`t set `refresh` page action if haven`t `actions.refresh`', () => {
+      component['_refreshAction'] = [];
+
+      const actions = { refresh: false };
+      component['setRefreshAction'](actions);
+
+      expect(component.pageActions).toEqual([]);
+    });
+
+    it('setRefreshAction: should set `refresh` page action if have `actions.refresh`', () => {
+      component['_refreshAction'] = [];
+
+      const actions = { refresh: true };
+      component['setRefreshAction'](actions);
+
+      const pageAction = [
+        {
+          label: component.literals.pageActionRefresh,
           action: jasmine.any(Function)
         }
       ];


### PR DESCRIPTION
O botão `refresh` permite a atualização dos recursos na pagina.

Fixes #1106, DTHFUI-5713

**Page Dynamic Table**

**1106 DTHFUI-5713**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente não permite a atualização dos recursos na pagina, assim é necessário forçar uma atualização usando o filtro de busca com e sem conteúdo. 

**Qual o novo comportamento?**
O botão de atualização permite a recarga dos recursos da pagina, facilitando a verificação de qualquer alteração no repositório.

**Simulação**
A simulação pode ser feita [App](https://github.com/po-ui/po-angular/files/8228609/app.zip).
