### PR TITLE
fix(chart): exibe grafico após a 12 série

### DIFF
--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie.interface.ts
@@ -29,6 +29,9 @@ export interface PoChartSerie {
    *    - <span class="dot po-color-10"></span> `color-10`
    *    - <span class="dot po-color-11"></span> `color-11`
    *    - <span class="dot po-color-12"></span> `color-12`
+   *
+   *
+   * - A partir da 13° série o valor da cor será preta caso não seja enviada uma cor customizada.
    */
   color?: string;
 

--- a/projects/ui/src/lib/services/po-color/po-color.service.spec.ts
+++ b/projects/ui/src/lib/services/po-color/po-color.service.spec.ts
@@ -105,6 +105,27 @@ describe('PoColorService', () => {
 
         expect(service.getColors(data)).toEqual(expectedResult);
       });
+
+      it('the 13th item color should be black if no color is sent', () => {
+        const data = [
+          { label: '1', data: 8 },
+          { label: '2', data: 10 },
+          { label: '3', data: 14 },
+          { label: '4', data: 7 },
+          { label: '5', data: 6 },
+          { label: '6', data: 22 },
+          { label: '7', data: 11 },
+          { label: '8', data: 8 },
+          { label: '9', data: 2 },
+          { label: '10', data: 3 },
+          { label: '11', data: 14 },
+          { label: '12', data: 14 },
+          { label: '13', data: 14 }
+        ];
+        const getColor = service.getColors<any>(data);
+
+        expect(getColor[12].color).toEqual('#000000');
+      });
     });
   });
 });

--- a/projects/ui/src/lib/services/po-color/po-color.service.ts
+++ b/projects/ui/src/lib/services/po-color/po-color.service.ts
@@ -14,6 +14,7 @@ interface PoColorArgs {
 })
 export class PoColorService {
   defaultColors: Array<string> = [];
+  private readonly colorBlack = '#000000';
 
   /**
    * Avalia a propriedade `color` na lista de items passada. Caso sim, trata se é decimal ou string `po-color`. Caso não haja, retorna a cor default.
@@ -30,7 +31,7 @@ export class PoColorService {
         return dataItem;
       }
 
-      const color = this.defaultColors[index];
+      const color = this.defaultColors[index] === undefined ? this.colorBlack : this.defaultColors[index];
       return { ...dataItem, color };
     });
   }


### PR DESCRIPTION
**CHART**

**DTHFUI-5314**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O gráfico desaparece após a 12° caso não envie uma cor customizada

**Qual o novo comportamento?**
O gráfico se mantém após a 12° com a cor preta caso não envie cor customizada

**Simulação**
Testar labs do portal ou app:
[app.zip](https://github.com/po-ui/po-angular/files/8325039/app.zip)
 