### PR TITLE
feat(rich-text): adiciona atributo aria-label

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
@@ -9,6 +9,7 @@
         class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button"
         [disabled]="readonly"
         [p-tooltip]="literals.textColor"
+        [attr.aria-label]="literals.textColor"
       >
         <input
           #colorPickerInput
@@ -16,6 +17,7 @@
           type="color"
           [disabled]="readonly"
           (change)="changeTextColor($event.target.value)"
+          [attr.aria-label]="literals.textColor"
         />
       </button>
     </div>

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.spec.ts
@@ -276,5 +276,13 @@ describe('PoRichTextToolbarComponent:', () => {
 
       expect(colorPickerInput).toBeTruthy();
     });
+
+    it('aria-label: check if ari-label has value ', () => {
+      const inputColorPicker = nativeElement.querySelector('.po-rich-text-toolbar-color-picker-input');
+      const buttonColorPicker = nativeElement.querySelector('.po-rich-text-toolbar-color-picker-button');
+
+      expect(inputColorPicker.getAttribute('aria-label')).toBe(component.literals.textColor);
+      expect(buttonColorPicker.getAttribute('aria-label')).toBe(component.literals.textColor);
+    });
   });
 });


### PR DESCRIPTION
RICH-TEXT

DTHFUI-5847
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não possui atributo aria-label no input do color picker, impossibilitando o (NVDA) de fazer a leitura.

**Qual o novo comportamento?**
Ao utilizar leitor de tela (NVDA) no input do color picker o mesmo passa ler corretamente o atributo aria-label definido.

**Simulação**

`app.component.html`

```
<!DOCTYPE html>
<html lang="pt">
<head>
    <meta charset="UTF-8">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Document</title>
</head>
<body>
    <po-rich-text></po-rich-text>
</body>
</html>
 ```

Utiliza o leito de tela (NVDA) no color picker.