### PR TITLE
feat(table): cria evento para restaurar padrão

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -310,6 +310,17 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    */
   @Output('p-change-visible-columns') changeVisibleColumns = new EventEmitter<Array<string>>();
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no botão de restaurar padrão no gerenciador de colunas.
+   *
+   * O componente envia como parâmetro um array de string com as colunas configuradas inicialmente.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   */
+  @Output('p-restore-column-manager') columnRestoreManager = new EventEmitter<Array<String>>();
+
   allColumnsWidthPixels: boolean;
   columnMasterDetail: PoTableColumn;
   hasMainColumns: boolean = false;
@@ -320,7 +331,7 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   page = 1;
   pageSize = 10;
   hasService?: boolean = false;
-
+  initialColumns: Array<PoTableColumn>;
   private _actions?: Array<PoTableAction> = [];
   private _columns: Array<PoTableColumn> = [];
   private _container?: string;
@@ -372,6 +383,10 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    *
    */
   @Input('p-columns') set columns(columns: Array<PoTableColumn>) {
+    if (this.initialColumns === undefined) {
+      this.initialColumns = columns;
+    }
+
     this._columns = columns || [];
 
     if (this._columns.length) {

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
@@ -624,11 +624,13 @@ describe('PoTableColumnManagerComponent:', () => {
 
       spyOn(component, <any>'getVisibleColumns').and.returnValue(fakeDefaultVisibleColumns);
       spyOn(component, <any>'checkChanges');
+      spyOn(component.initialColumns, 'emit');
 
       component['restore']();
 
       expect(component['getVisibleColumns']).toHaveBeenCalled();
       expect(component['checkChanges']).toHaveBeenCalledWith(fakeDefaultVisibleColumns, true);
+      expect(component.initialColumns.emit).toHaveBeenCalled();
     });
 
     describe('disableColumnsOptions:', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.ts
@@ -51,6 +51,8 @@ export class PoTableColumnManagerComponent implements OnChanges, OnDestroy {
 
   @Input('p-target') target: ElementRef;
 
+  @Input('p-columns-default') colunsDefault: Array<PoTableColumn>;
+
   @Input('p-last-visible-columns-selected') lastVisibleColumnsSelected: Array<PoTableColumn> = [];
 
   @Output('p-visible-columns-change') visibleColumnsChange = new EventEmitter<Array<PoTableColumn>>();
@@ -58,6 +60,8 @@ export class PoTableColumnManagerComponent implements OnChanges, OnDestroy {
   // Evento disparado ao fechar o popover do gerenciador de colunas após alterar as colunas visíveis.
   // O po-table envia como parâmetro um array de string com as colunas visíveis atualizadas. Por exemplo: ["idCard", "name", "hireStatus", "age"].
   @Output('p-change-visible-columns') changeVisibleColumns = new EventEmitter<Array<string>>();
+
+  @Output('p-initial-columns') initialColumns = new EventEmitter<Array<String>>();
 
   literals;
   columnsOptions: Array<PoCheckboxGroupOption> = [];
@@ -119,7 +123,7 @@ export class PoTableColumnManagerComponent implements OnChanges, OnDestroy {
   restore() {
     this.restoreDefaultEvent = true;
     const defaultColumns = this.getVisibleColumns(this.defaultColumns);
-
+    this.initialColumns.emit(this.getVisibleColumns(this.colunsDefault));
     this.checkChanges(defaultColumns, this.restoreDefaultEvent);
   }
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -699,5 +699,7 @@
   [p-last-visible-columns-selected]="lastVisibleColumnsSelected"
   (p-visible-columns-change)="onVisibleColumnsChange($event)"
   (p-change-visible-columns)="onChangeVisibleColumns($event)"
+  [p-columns-default]="initialColumns"
+  (p-initial-columns)="onColumnRestoreManager($event)"
 >
 </po-table-column-manager>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1659,6 +1659,15 @@ describe('PoTableComponent:', () => {
       expect(component.changeVisibleColumns.emit).toHaveBeenCalledWith(fakeColumns);
     });
 
+    it('onColumnRestoreManager: should call `columnRestoreManager.emit`', () => {
+      spyOn(component.columnRestoreManager, 'emit');
+      const fakeColumns = ['name', 'age'];
+
+      component.onColumnRestoreManager(fakeColumns);
+
+      expect(component.columnRestoreManager.emit).toHaveBeenCalledWith(fakeColumns);
+    });
+
     describe('applyFilters', () => {
       it('should be called when `p-service-api` is used', () => {
         spyOn(component, 'getFilteredItems').and.returnValue(of({ items: [], hasNext: false }));

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -451,6 +451,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.changeVisibleColumns.emit(columns);
   }
 
+  onColumnRestoreManager(value: Array<String>) {
+    this.columnRestoreManager.emit(value);
+  }
+
   onVisibleColumnsChange(columns: Array<PoTableColumn>) {
     this.columns = columns;
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
@@ -17,6 +17,8 @@
   (p-expanded)="onExpandDetail()"
   (p-selected)="sumTotal($event)"
   (p-unselected)="decreaseTotal($event)"
+  (p-change-visible-columns)="changeColumnVisible($event)"
+  (p-restore-column-manager)="restoreColumn($event)"
 >
 </po-table>
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
 
 import {
   PoDialogService,
@@ -16,7 +16,7 @@ import { SamplePoTableAirfareService } from './sample-po-table-airfare.service';
   templateUrl: './sample-po-table-airfare.component.html',
   providers: [SamplePoTableAirfareService, PoDialogService]
 })
-export class SamplePoTableAirfareComponent {
+export class SamplePoTableAirfareComponent implements AfterViewInit {
   @ViewChild(PoModalComponent, { static: true }) poModal: PoModalComponent;
   @ViewChild(PoTableComponent, { static: true }) poTable: PoTableComponent;
 
@@ -41,6 +41,19 @@ export class SamplePoTableAirfareComponent {
     private poNotification: PoNotificationService,
     private poDialog: PoDialogService
   ) {}
+
+  ngAfterViewInit(): void {
+    if (localStorage.getItem('initial-columns')) {
+      const initialColumns = localStorage.getItem('initial-columns').split(',');
+
+      const result = this.columns.map(el => ({
+        ...el,
+        visible: initialColumns.includes(el.property)
+      }));
+
+      this.columns = result;
+    }
+  }
 
   addToCart() {
     const selectedItems = this.poTable.getSelectedRows();
@@ -129,6 +142,18 @@ export class SamplePoTableAirfareComponent {
     if (row.value) {
       this.total += row.value;
     }
+  }
+
+  restoreColumn(event) {
+    const result = this.columns.map(el => ({
+      ...el,
+      visible: event.includes(el.property)
+    }));
+    this.columns = result;
+  }
+
+  changeColumnVisible(event) {
+    localStorage.setItem('initial-columns', event);
   }
 
   private getDescription(item: any) {


### PR DESCRIPTION
**table**

**DTHFUI-4787**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

Cria evento `p-restore-column-manager` para restaurar as colunas configuradas inicialmente no botão de gerenciamento.

**Simulação**
Testar app ou pelo portal:
[app.zip](https://github.com/po-ui/po-angular/files/8475078/app.zip)
 