### PR TITLE
refactor(event-sourcing): utiliza StatusCodes

### DIFF
--- a/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.ts
+++ b/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.ts
@@ -1,7 +1,7 @@
 import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
-import * as HttpStatus from 'http-status-codes';
+import { StatusCodes } from 'http-status-codes';
 import { Observable, of, Subject } from 'rxjs';
 import { expand, map, reduce } from 'rxjs/operators';
 
@@ -30,14 +30,14 @@ export class PoEventSourcingService {
   static readonly event_sourcing_name: string = 'EventSourcing';
 
   private static readonly VALID_HTTP_STATUS_CODES = [
-    HttpStatus.OK, // 200
-    HttpStatus.CREATED, // 201
-    HttpStatus.ACCEPTED, // 202
-    HttpStatus.NON_AUTHORITATIVE_INFORMATION, // 203
-    HttpStatus.NO_CONTENT, // 204
-    HttpStatus.RESET_CONTENT, // 205
-    HttpStatus.PARTIAL_CONTENT, // 206
-    HttpStatus.MULTI_STATUS // 207
+    StatusCodes.OK, // 200
+    StatusCodes.CREATED, // 201
+    StatusCodes.ACCEPTED, // 202
+    StatusCodes.NON_AUTHORITATIVE_INFORMATION, // 203
+    StatusCodes.NO_CONTENT, // 204
+    StatusCodes.RESET_CONTENT, // 205
+    StatusCodes.PARTIAL_CONTENT, // 206
+    StatusCodes.MULTI_STATUS // 207
   ];
 
   config: PoSyncConfig;


### PR DESCRIPTION
**Event Sourcing (PO Sync)**

**Sem issue**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**

Está exibindo lint de códigos depreciados na esteira do build.

![image](https://user-images.githubusercontent.com/11772148/163245463-c9f820bc-4c0e-4426-a2b2-5d04f19e9815.png)

**Qual o novo comportamento?**

Remover os lints de códigos depreciados.

**Simulação**

Rodar projeto sample usando a lib sync.