### PR TITLE
docs(gauge): ajusta a propriedade `p-value` com a opção strict

### DIFF
--- a/projects/ui/src/lib/components/po-gauge/samples/sample-po-gauge-basic/sample-po-gauge-basic.component.html
+++ b/projects/ui/src/lib/components/po-gauge/samples/sample-po-gauge-basic/sample-po-gauge-basic.component.html
@@ -1,1 +1,1 @@
-<po-gauge p-value="50"></po-gauge>
+<po-gauge [p-value]="50"></po-gauge>


### PR DESCRIPTION
A propriedade `strictTemplates` já vem configurado
como `true` na versão atual do Angular e desta forma
o exemplo apresenta erro de compilação.

Fixes #1255

**Gauge**

**1255**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O exemplo atual declara o `p-value` da seguinte forma `<po-gauge p-value="50"></po-gauge>` e apresenta erro caso o `angularCompilerOptions` estiver da seguinte forma `strictTemplates: true` .

**Qual o novo comportamento?**
Foi alterado a declaração do p-value para <po-gauge [p-value]="50"></po-gauge> e não apresenta erro caso o angularCompilerOptions estiver da seguinte forma strictTemplates: true .

**Simulação**
Pode ser feita no próprio portal.
