### PR TITLE
docs(page-dynamic-detail): ajusta propriedade p-auto-router com strict

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/samples/sample-po-page-dynamic-detail-user/sample-po-page-dynamic-detail-user.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/samples/sample-po-page-dynamic-detail-user/sample-po-page-dynamic-detail-user.component.html
@@ -1,5 +1,5 @@
 <po-page-dynamic-detail
-  p-auto-router
+  [p-auto-router]="true"
   p-title="Detail"
   [p-actions]="actions"
   [p-breadcrumb]="breadcrumb"


### PR DESCRIPTION
A propriedade `strictTemplates` já vem configurado como `true` na versão atual do Angular e desta forma o exemplo apresenta erro de compilação.

Fixes #1257

**Page Dynamic Detail**

**1257**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O exemplo está informando desta forma:

```
<po-page-dynamic-detail
  p-auto-router
  p-title="Detail"
  [p-actions]="actions"
  [p-breadcrumb]="breadcrumb"
  [p-fields]="fields"
  [p-service-api]="serviceApi"
>
</po-page-dynamic-detail>
```

**Qual o novo comportamento?**
Deve ser informado desta forma:

```
<po-page-dynamic-detail
  [p-auto-router]="true"
  p-title="Detail"
  [p-actions]="actions"
  [p-breadcrumb]="breadcrumb"
  [p-fields]="fields"
  [p-service-api]="serviceApi"
>
</po-page-dynamic-detail>
```

**Simulação**
Pode ser feito no próprio portal.