### PR TITLE
fix(combo): permite labels com o mesmo valor

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -1111,7 +1111,7 @@ describe('PoComboBaseComponent:', () => {
       });
     });
 
-    it('hasDuplicatedOption: should return true if contains a duplicated option label', () => {
+    it('hasDuplicatedOption: should return false if contains a duplicated option label', () => {
       const comboOptions = [
         { label: 'labelA', value: 'valueA' },
         { label: 'labelB', value: 'valueB' }
@@ -1119,7 +1119,7 @@ describe('PoComboBaseComponent:', () => {
 
       const expectedValue = component['hasDuplicatedOption'](comboOptions, 'labelA');
 
-      expect(expectedValue).toBeTruthy();
+      expect(expectedValue).toBeFalsy();
     });
 
     it('hasDuplicatedOption: should return false if contains a duplicated option label', () => {
@@ -1205,6 +1205,29 @@ describe('PoComboBaseComponent:', () => {
       expect(spyVerifyIfHasLabel).toHaveBeenCalled();
       expect(spyhasDuplicatedOption).toHaveBeenCalled();
       expect(spyvalidateValue).toHaveBeenCalled();
+    });
+
+    it('verifyComboOptions: Should allow items with the same label`', () => {
+      component.options = [
+        {
+          label: 'Teste',
+          options: [
+            { label: 'Teste1', value: 'Teste1' },
+            { label: 'Teste1.2', value: 'Teste1.2' }
+          ]
+        },
+        {
+          label: 'Teste2',
+          options: [
+            { label: 'Teste1', value: 'value1' },
+            { label: 'Teste2.2', value: 'value2' }
+          ]
+        }
+      ];
+
+      const expectedValue = component['verifyComboOptions'](component.options);
+
+      expect(expectedValue).toEqual(component.options);
     });
 
     it('verifyComboOptions: should verify each option and return a properly options list`', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -460,6 +460,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * - A lista deve seguir as definições descritas nas respectivas interfaces, caso contrário não exibirá a(as) opção(ões) fora dos padrões.
    * - O componente interpretará o formato da lista de acordo com a interface utilizada e só exibirá as opções correspondentes à ela.
    * - Um agrupamento só será exibido se houver pelo menos uma opção válida.
+   * - Aconselha-se utilizar valores distintos no `label` e `value` dos itens.
    */
   @Input('p-options') set options(options: Array<PoComboOption | PoComboOptionGroup>) {
     this._options = Array.isArray(options) ? options : [];
@@ -863,10 +864,11 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     currentOption: string,
     accumulatedGroupOptions?: Array<PoComboGroup>
   ) {
-    return (
-      options.some(option => option.label === currentOption) ||
-      (accumulatedGroupOptions && accumulatedGroupOptions.some(option => option.label === currentOption))
-    );
+    if (accumulatedGroupOptions) {
+      return accumulatedGroupOptions.some(option => option.label === currentOption);
+    } else {
+      return options.some(option => option.value === currentOption);
+    }
   }
 
   private listingComboOptions(comboOptions: Array<PoComboOption | PoComboOptionGroup>) {
@@ -908,7 +910,11 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     return comboOptions.reduce((accumulatedOptions, currentOption) => {
       if (
         !this.verifyIfHasLabel(currentOption) ||
-        this.hasDuplicatedOption(accumulatedOptions, currentOption.label, accumulatedGroupOptions) ||
+        this.hasDuplicatedOption(
+          accumulatedOptions,
+          currentOption['value'] || currentOption['label'],
+          accumulatedGroupOptions
+        ) ||
         !this.validateValue(currentOption, verifyingOptionsGroup)
       ) {
         return accumulatedOptions;


### PR DESCRIPTION
**Combo**

**DTHFUI-5962**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não permite itens com a mesma label

**Qual o novo comportamento?**
Permite itens com a mesma label

**Simulação**
portal 
[app.zip](https://github.com/po-ui/po-angular/files/8557861/app.zip)
