### PR TITLE
docs(page-dynamic-table): ajusta código do componente com opção strict

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -1,7 +1,7 @@
 <po-page-dynamic-table
-  p-auto-router
-  p-concat-filters
-  p-keep-filters
+  [p-auto-router]="true"
+  [p-concat-filters]="true"
+  [p-keep-filters]="true"
   p-title="Users"
   [p-actions]="actions"
   [p-actions-right]="actionsRight"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -16,14 +16,14 @@ import { SamplePoPageDynamicTableUsersService } from './sample-po-page-dynamic-t
   providers: [SamplePoPageDynamicTableUsersService]
 })
 export class SamplePoPageDynamicTableUsersComponent {
-  @ViewChild('userDetailModal') userDetailModal: PoModalComponent;
-  @ViewChild('dependentsModal') dependentsModal: PoModalComponent;
+  @ViewChild('userDetailModal') userDetailModal!: PoModalComponent;
+  @ViewChild('dependentsModal') dependentsModal!: PoModalComponent;
 
   readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
 
   actionsRight = false;
-  detailedUser;
-  dependents;
+  detailedUser: any;
+  dependents: any;
   quickSearchWidth: number = 3;
 
   readonly actions: PoPageDynamicTableActions = {
@@ -130,11 +130,11 @@ export class SamplePoPageDynamicTableUsersComponent {
     };
   }
 
-  isUserInactive(person) {
+  isUserInactive(person: any) {
     return person.status === 'inactive';
   }
 
-  hasDependents(person) {
+  hasDependents(person: any) {
     return person.dependents.length !== 0;
   }
 
@@ -142,19 +142,19 @@ export class SamplePoPageDynamicTableUsersComponent {
     window.print();
   }
 
-  private onClickUserDetail(user) {
+  private onClickUserDetail(user: any) {
     this.detailedUser = user;
 
     this.userDetailModal.open();
   }
 
-  private onClickDependents(user) {
+  private onClickDependents(user: any) {
     this.dependents = user.dependents;
 
     this.dependentsModal.open();
   }
 
-  private onClickActionsSide(value) {
+  private onClickActionsSide(value: any) {
     this.actionsRight = !this.actionsRight;
   }
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.service.ts
@@ -5,8 +5,8 @@ import { HttpClient } from '@angular/common/http';
 export class SamplePoPageDynamicTableUsersService {
   constructor(public http: HttpClient) {}
 
-  downloadCsv(endpoint) {
-    this.http.get(endpoint).subscribe(data => {
+  downloadCsv(endpoint: any) {
+    this.http.get(endpoint).subscribe((data: any) => {
       const csvStr = this.parseJsonToCsv(data['items']);
       const dataUri = 'data:text/csv;charset=utf-8,' + csvStr;
 


### PR DESCRIPTION
A propriedade `stric` e `strictTemplates` já vem configurado como `true` na versão atual do Angular e desta forma o exemplo apresenta erro de compilação.

Fixes #1260

**Page Dynamic Table**

**1260**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O exemplo atual apresenta erro caso o `compilerOptions` estiver com `strict: true` e o `angularCompilerOptions` estiver com `strictTemplates: true` .

**Qual o novo comportamento?**
O código foi alterado e não apresenta mais os erros de compilação.

**Simulação**
Pode ser feita no portal.