### PR TITLE
docs(page-dynamic-edit): ajusta propriedade p-auto-router com strict

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.html
@@ -1,5 +1,5 @@
 <po-page-dynamic-edit
-  p-auto-router
+  [p-auto-router]="true"
   p-title="User edit"
   [p-actions]="actions"
   [p-breadcrumb]="breadcrumb"


### PR DESCRIPTION
A propriedade `strictTemplates` já vem configurado como `true`  na versão atual do Angular e desta forma o exemplo apresenta erro de compilação.

Fixes #1262

**Page Dynamic Edit**

**1262**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O exemplo está informando desta forma:
```
<po-page-dynamic-edit
  p-auto-router
  p-title="User edit"
  [p-actions]="actions"
  [p-breadcrumb]="breadcrumb"
  [p-fields]="fields"
  [p-service-api]="serviceApi"
>
</po-page-dynamic-edit>
```

**Qual o novo comportamento?**
Deve ser informado desta forma:
```
<po-page-dynamic-edit
  [p-auto-router]="true"
  p-title="User edit"
  [p-actions]="actions"
  [p-breadcrumb]="breadcrumb"
  [p-fields]="fields"
  [p-service-api]="serviceApi"
>
</po-page-dynamic-edit>
```
**Simulação**
Pode ser feita no portal.