### PR TITLE
fix(decimal): atualiza as validações do campo 

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -375,6 +375,20 @@ describe('PoDecimalComponent:', () => {
     expect(component.extraValidation(new FormControl(null))).toBeNull();
   });
 
+  it(`Shouldn't return null in extraValidation if value has separator`, () => {
+    const value = new FormControl(12345678901234.56);
+
+    expect(component.extraValidation(value)).not.toBeNull();
+  });
+
+  it(`Shouldn't return null in extraValidation if thousandMaxlength has value`, () => {
+    component.thousandMaxlength = 5;
+
+    const value = new FormControl(123456);
+
+    expect(component.extraValidation(value)).not.toBeNull();
+  });
+
   it('should have a call getScreenValue method', () => {
     const fakeThis = {
       inputEl: undefined

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -12,7 +12,7 @@ import {
 import { AbstractControl, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
 
-import { minFailed, maxFailed } from '../validators';
+import { minFailed, maxFailed, maxlengpoailed } from '../validators';
 
 import { convertToInt } from '../../../utils/util';
 import { PoInputBaseComponent } from '../po-input/po-input-base.component';
@@ -266,10 +266,13 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
   }
 
   extraValidation(abstractControl: AbstractControl): { [key: string]: any } {
+    const value = abstractControl.value;
+    const thousandValue = Math.trunc(value);
+
     // Verifica se já possui algum error pattern padrão.
     this.errorPattern = this.errorPattern !== 'Valor Inválido' ? this.errorPattern : '';
 
-    if (minFailed(this.min, abstractControl.value)) {
+    if (minFailed(this.min, value)) {
       return {
         min: {
           valid: false
@@ -277,7 +280,19 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
       };
     }
 
-    if (maxFailed(this.max, abstractControl.value)) {
+    if (maxFailed(this.max, value)) {
+      return {
+        max: {
+          valid: false
+        }
+      };
+    }
+
+    if (
+      (maxlengpoailed(this.thousandMaxlength, thousandValue) &&
+        this.thousandMaxlength < poDecimalDefaultThousandMaxlength) ||
+      maxlengpoailed(poDecimalTotalLengthLimit, value)
+    ) {
       return {
         max: {
           valid: false


### PR DESCRIPTION
**DECIMAL**

**DTHFUI-5920**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando copiamos e colamos um valor com mais de 16 caracteres o campo não apresenta uma formatação correta e não invalida o campo.

**Qual o novo comportamento?**
Ao copiar e colar um valor com mais de 16 caracteres o campo será invalidado.

**Simulação**
`app.component.html`
```
<po-page-default p-title="PO page default">
  <div class="po-row">
    <po-decimal
      class="po-md-12"
      name="decimal"
      [(ngModel)]="decimal"
      [p-decimals-length]="decimalsLength"
      p-label="PO decimal"
      p-clean="true"
      [p-thousand-maxlength]="thousandMaxlength"
      [p-max]="max"
      [p-min]="min"
      (p-blur)="changeEvent('p-blur')"
      (p-change)="changeEvent('p-change')"
      (p-change-model)="changeEvent('p-change-model')"
    ></po-decimal>
  </div>

  <hr />

  <div class="po-row">
    <po-info class="po-md-6" p-label="Model" [p-value]="decimal"> </po-info>

    <po-info class="po-md-6" p-label="Event" [p-value]="event"> </po-info>
  </div>

  <hr />

  <form #f="ngForm">
    <div class="po-row">
      <po-number
        class="po-md-6"
        name="decimalsLength"
        [(ngModel)]="decimalsLength"
        p-clean
        p-help="By default is equal 2, check the behavior in doc."
        p-label="Decimals max length"
        p-min="0"
        [p-max]="maxDecimalsLength"
      >
      </po-number>

      <po-number
        class="po-md-6"
        name="thousandMaxlength"
        [(ngModel)]="thousandMaxlength"
        p-clean
        p-help="By default is equal 13, check the behavior in doc."
        p-label="Thousand max length"
        p-min="0"
        [p-max]="maxThousandMaxlength"
      >
      </po-number>
    </div>

    <div class="po-row">
      <po-number class="po-md-6" name="min" [(ngModel)]="min" p-clean p-label="Min"> </po-number>

      <po-number class="po-md-6" name="max" [(ngModel)]="max" p-clean p-label="Max"> </po-number>
    </div>
  </form>
</po-page-default>
```
`app.component.ts`
```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  decimal: number;
  decimalsLength: number;
  event: string;
  thousandMaxlength: number;
  max: number;
  min: number;

  get maxDecimalsLength() {
    return 16 - this.thousandMaxlength || 15;
  }

  get maxThousandMaxlength() {
    return 16 - this.decimalsLength || 13;
  }

 changeEvent(event: string) {
    this.event = event;
  }
}
```
[app.zip](https://github.com/po-ui/po-angular/files/8524170/app.zip)