### PR TITLE
fix(button-group): ajusta `selected` para ocorrer antes de `action`

### DIFF
--- a/projects/ui/src/lib/components/po-button-group/po-button-group.component.html
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group.component.html
@@ -10,7 +10,7 @@
     [p-label]="button.label"
     [p-small]="small"
     [p-tooltip]="!button.disabled ? button.tooltip : undefined"
-    (p-click)="button.action(button); onButtonClick(button, i)"
+    (p-click)="onButtonClick(button, i); button.action(button)"
   >
   </po-button>
 </div>


### PR DESCRIPTION
Foi realizado um ajuste para que o valor da propriedade `selected` seja atribuído antes da chamada da propriedade `action`.

Fixes #1234

**Button Group**

**1234**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A ação atribuída ao botão está sendo executada antes das alterações na propriedade `selected`, fazendo com que o valor esteja sempre um passo atrás do que será exibido na tela.

**Qual o novo comportamento?**
A ação atribuída ao botão é executada após as alterações na propriedade `selected`, para que, ao acessar esta propriedade, os valores estejam condizentes com o que aparecerá na tela.

**Simulação**
Segue o [App](https://github.com/po-ui/po-angular/files/8587124/app.zip) para a simulação.

