### PR TITLE
feat(table): implementa virtual scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^13.0.2",
+    "@angular/cdk": "^13.3.1",
     "@angular/common": "^13.0.2",
     "@angular/compiler": "^13.0.2",
     "@angular/core": "^13.0.2",

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -428,6 +428,8 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * @description
    *
    * Define a altura da tabela em *pixels* e fixa o cabeçalho.
+   *
+   * Ao utilizar essa propriedade será inserido o `virtual-scroll` na tabela melhorando a performance.
    */
   @Input('p-height') set height(height: number) {
     this._height = height;
@@ -928,9 +930,11 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   }
 
   private sortArray(column: PoTableColumn, ascending: boolean) {
-    this.items.sort((leftSide, rightSide): number =>
+    const itemsList = [...this.items];
+    itemsList.sort((leftSide, rightSide): number =>
       sortValues(leftSide[column.property], rightSide[column.property], ascending)
     );
+    this.items = itemsList;
   }
 
   private unselectOtherRows(rows: Array<any>, row) {

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
@@ -171,6 +171,34 @@ describe('PoTableColumnManagerComponent:', () => {
         expect(component['emitChangesToSelectedColumns']).toHaveBeenCalledWith(fakeEvent);
       });
 
+      it('should call `disabledLastColumn` and `mapTableColumnsToCheckboxOptions` if columns length is 1', () => {
+        spyOn(component, <any>'mapTableColumnsToCheckboxOptions');
+        spyOn(component, <any>'disabledLastColumn');
+
+        const fakeEvent = ['test1'];
+
+        component['verifyToEmitChange'](fakeEvent);
+
+        expect(component['mapTableColumnsToCheckboxOptions']).toHaveBeenCalled();
+        expect(component['disabledLastColumn']).toHaveBeenCalled();
+      });
+
+      it('disabledLastColumn: should disable column that is visible ', () => {
+        const tableColumns = [
+          { property: 'test1', label: 'Code', visible: true },
+          { property: 'test2', label: 'initial', visible: false }
+        ];
+
+        const tableColumnsExpected = [
+          { property: 'test1', label: 'Code', visible: true, disabled: true },
+          { property: 'test2', label: 'initial', visible: false, disabled: false }
+        ];
+
+        const newColumns = component['disabledLastColumn'](tableColumns);
+
+        expect(newColumns).toEqual(tableColumnsExpected);
+      });
+
       it('shouldn`t call `emitChangesToSelectedColumns` if allowsChangeVisibleColumns is false', () => {
         spyOn(component, <any>'allowsChangeVisibleColumns').and.returnValue(false);
         spyOn(component, <any>'emitChangesToSelectedColumns');
@@ -917,20 +945,20 @@ describe('PoTableColumnManagerComponent:', () => {
     describe('mapTableColumnsToCheckboxOptions:', () => {
       it(`mapTableColumnsToCheckboxOptions: should convert table columns to checkbox options and return it without detail columns`, () => {
         const tableColumns = [
-          { property: 'id', label: 'Code', type: 'number' },
-          { property: 'initial', label: 'initial', type: 'detail' },
-          { property: 'name', label: 'Name' },
-          { property: 'total', label: 'Total', type: 'currency', format: 'BRL' },
-          { property: 'atualization', label: 'Atualization', type: 'date' }
+          { property: 'id', label: 'Code', type: 'number', visible: true },
+          { property: 'initial', label: 'initial', type: 'detail', visible: true },
+          { property: 'name', label: 'Name', visible: true },
+          { property: 'total', label: 'Total', type: 'currency', format: 'BRL', visible: true },
+          { property: 'atualization', label: 'Atualization', type: 'date', visible: true }
         ];
 
         spyOn(component, <any>'isDisableColumn').and.returnValues(false, true, true, true);
 
         const checkboxOptions = [
-          { value: 'id', label: 'Code', disabled: false },
-          { value: 'name', label: 'Name', disabled: true },
-          { value: 'total', label: 'Total', disabled: true },
-          { value: 'atualization', label: 'Atualization', disabled: true }
+          { value: 'id', label: 'Code', disabled: false, visible: true },
+          { value: 'name', label: 'Name', disabled: true, visible: true },
+          { value: 'total', label: 'Total', disabled: true, visible: true },
+          { value: 'atualization', label: 'Atualization', disabled: true, visible: true }
         ];
 
         const result = component['mapTableColumnsToCheckboxOptions'](tableColumns);

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -15,12 +15,13 @@
         [class.po-table-header-fixed-columns-pixels]="allColumnsWidthPixels"
         [style.opacity]="tableOpacity"
       >
-        <div *ngIf="height" class="po-table-container" [style.height.px]="heightTableContainer">
+        <div *ngIf="height" class="po-table-container">
           <div #poTableThead class="po-table-header-fixed po-table-header">
             <ng-container *ngTemplateOutlet="tableHeaderTemplate"></ng-container>
           </div>
-          <div #poTableTbody class="po-table-container-fixed-inner" (scroll)="syncronizeHorizontalScroll()">
-            <ng-container *ngTemplateOutlet="tableBodyTemplate"></ng-container>
+
+          <div #poTableTbody class="po-table-container-fixed-inner">
+            <ng-container *ngIf="height; then tableBodyTemplate; else tableTemplate"></ng-container>
           </div>
         </div>
 
@@ -146,198 +147,214 @@
   </table>
 </ng-template>
 
+<!-- só virtual -->
 <ng-template #tableBodyTemplate>
-  <table class="po-table" [class.po-table-striped]="striped" [class.po-table-layout-fixed]="hideTextOverflow">
-    <tbody class="po-table-group-row" *ngIf="!hasItems || !hasMainColumns">
-      <tr class="po-table-row po-table-row-no-data">
-        <td [colSpan]="columnCount" class="po-table-no-data po-text-center">
-          <span> {{ literals.noData }} </span>
-        </td>
-      </tr>
-    </tbody>
-
-    <ng-container *ngIf="hasMainColumns">
-      <tbody class="po-table-group-row" *ngFor="let row of items; let rowIndex = index; trackBy: trackBy">
-        <tr class="po-table-row" [class.po-table-row-active]="row.$selected || (row.$selected === null && selectable)">
-          <td *ngIf="selectable" class="po-table-column-selectable">
-            <ng-container *ngTemplateOutlet="singleSelect ? inputRadio : inputCheckbox; context: { $implicit: row }">
-            </ng-container>
-          </td>
-
-          <!-- Valida se a origem do detail é pelo input do po-table -->
-          <td
-            *ngIf="columnMasterDetail && !hideDetail && !hasRowTemplate"
-            class="po-table-column-detail-toggle"
-            (click)="toggleDetail(row)"
-          >
-            <ng-template
-              [ngTemplateOutlet]="poTableColumnDetail"
-              [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-            >
-            </ng-template>
-          </td>
-
-          <!-- Coluna com as ações na esquerda (padrão)-->
-          <ng-template
-            *ngIf="!actionRight && (visibleActions.length > 1 || isSingleAction)"
-            [ngTemplateOutlet]="ActionsColumnTemplate"
-            [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-          >
-          </ng-template>
-
-          <!-- Valida se a origem do detail é pela diretiva -->
-          <td
-            *ngIf="hasRowTemplate && !hasRowTemplateWithArrowDirectionRight"
-            class="po-table-column-detail-toggle"
-            (click)="toggleDetail(row)"
-          >
-            <ng-template
-              [ngTemplateOutlet]="poTableColumnDetail"
-              [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-            >
-            </ng-template>
-          </td>
-
-          <td
-            *ngFor="let column of mainColumns; let columnIndex = index; trackBy: trackBy"
-            [style.width]="column.width"
-            [style.max-width]="column.width"
-            [style.min-width]="column.width"
-            [class.po-table-column]="column.type !== 'icon'"
-            [class.po-table-column-right]="column.type === 'currency' || column.type === 'number'"
-            [class.po-table-column-center]="column.type === 'subtitle'"
-            [class.po-table-column-icons]="column.type === 'icon'"
-            [ngClass]="getClassColor(row, column)"
-            (click)="selectable ? selectRow(row) : 'javascript:;'"
-          >
-            <div
-              class="po-table-column-cell notranslate"
-              [class.po-table-body-ellipsis]="hideTextOverflow"
-              [ngSwitch]="column.type"
-              [p-tooltip]="tooltipText"
-              [style.width.px]="noColumnsHeader?.nativeElement.parentElement?.offsetWidth"
-              (mouseenter)="tooltipMouseEnter($event, column, row)"
-              (mouseleave)="tooltipMouseLeave()"
-            >
-              <span *ngSwitchCase="'columnTemplate'">
-                <ng-container *ngTemplateOutlet="getTemplate(column); context: { $implicit: getCellData(row, column) }">
-                </ng-container>
-              </span>
-
-              <span *ngSwitchCase="'cellTemplate'">
-                <ng-container *ngTemplateOutlet="tableCellTemplate?.templateRef; context: { row: row, column: column }">
-                </ng-container>
-              </span>
-
-              <span *ngSwitchCase="'boolean'">
-                {{ getBooleanLabel(getCellData(row, column), column) }}
-              </span>
-
-              <span *ngSwitchCase="'currency'">
-                {{ getCellData(row, column) | currency: column.format:'symbol':'1.2-2' }}
-              </span>
-
-              <span *ngSwitchCase="'date'">
-                {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy' }}
-              </span>
-
-              <span *ngSwitchCase="'time'">
-                {{ getCellData(row, column) | po_time: column.format || 'HH:mm:ss.ffffff' }}
-              </span>
-
-              <span *ngSwitchCase="'dateTime'">
-                {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy HH:mm:ss' }}
-              </span>
-
-              <span *ngSwitchCase="'number'">
-                {{ formatNumber(getCellData(row, column), column.format) }}
-              </span>
-
-              <po-table-column-link
-                *ngSwitchCase="'link'"
-                [p-action]="column.action"
-                [p-disabled]="checkDisabled(row, column)"
-                [p-link]="row[column.link]"
-                [p-row]="row"
-                [p-value]="getCellData(row, column)"
-                (click)="onClickLink($event, row, column)"
-              >
-              </po-table-column-link>
-
-              <po-table-column-icon
-                *ngSwitchCase="'icon'"
-                [p-column]="column"
-                [p-icons]="getColumnIcons(row, column)"
-                [p-row]="row"
-              >
-              </po-table-column-icon>
-
-              <span *ngSwitchCase="'subtitle'">
-                <po-table-subtitle-circle [p-subtitle]="getSubtitleColumn(row, column)"></po-table-subtitle-circle>
-              </span>
-              <span *ngSwitchCase="'label'">
-                <po-table-column-label [p-value]="getColumnLabel(row, column)"> </po-table-column-label>
-              </span>
-              <span *ngSwitchDefault>{{ getCellData(row, column) }}</span>
-            </div>
-          </td>
-
-          <td
-            *ngIf="hasRowTemplateWithArrowDirectionRight"
-            class="po-table-column-detail-toggle"
-            (click)="toggleDetail(row)"
-          >
-            <ng-template
-              [ngTemplateOutlet]="poTableColumnDetail"
-              [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-            >
-            </ng-template>
-          </td>
-
-          <!-- Coluna de açoes na direita -->
-          <ng-template
-            *ngIf="actionRight"
-            [ngTemplateOutlet]="ActionsColumnTemplate"
-            [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-          >
-          </ng-template>
-
-          <!-- Coluna para não ficar em branco nas linhas de gerenciamento -->
-          <ng-container *ngIf="!actionRight && (visibleActions.length > 1 || isSingleAction) && !hideColumnsManager">
-            <td class="po-table-column po-table-column-empty"></td>
-          </ng-container>
-
-          <!-- Column Manager -->
-          <td
-            *ngIf="!hasVisibleActions && !hideColumnsManager && !hasRowTemplateWithArrowDirectionRight"
-            class="po-table-column"
-          ></td>
-        </tr>
-
-        <tr *ngIf="hasMainColumns && hasRowTemplate && row.$showDetail && isShowRowTemplate(row, rowIndex)">
-          <td class="po-table-row-template-container" [colSpan]="columnCountForMasterDetail">
-            <ng-template
-              [ngTemplateOutlet]="tableRowTemplate.templateRef"
-              [ngTemplateOutletContext]="{ $implicit: row, rowIndex: rowIndex }"
-            >
-            </ng-template>
-          </td>
-        </tr>
-
-        <tr *ngIf="hasMainColumns && isShowMasterDetail(row)">
-          <td class="po-table-column-detail" [colSpan]="columnCountForMasterDetail">
-            <po-table-detail
-              [p-selectable]="selectable && !detailHideSelect"
-              [p-detail]="columnMasterDetail.detail"
-              [p-items]="row[nameColumnDetail]"
-              (p-select-row)="selectDetailRow($event)"
-            >
-            </po-table-detail>
+  <cdk-virtual-scroll-viewport
+    #poTableTbodyVirtual
+    [itemSize]="itemSize"
+    [style.height.px]="heightTableContainer"
+    [minBufferPx]="height < 100 ? 100 : height"
+    [maxBufferPx]="height < 200 ? 200 : height"
+    (scroll)="syncronizeHorizontalScroll()"
+  >
+    <table class="po-table" [class.po-table-striped]="striped" [class.po-table-layout-fixed]="hideTextOverflow">
+      <tbody class="po-table-group-row" *ngIf="!hasItems || !hasMainColumns">
+        <tr class="po-table-row po-table-row-no-data">
+          <td [colSpan]="columnCount" class="po-table-no-data po-text-center">
+            <span> {{ literals.noData }} </span>
           </td>
         </tr>
       </tbody>
-    </ng-container>
-  </table>
+      <ng-container *ngIf="hasMainColumns">
+        <tbody class="po-table-group-row" *cdkVirtualFor="let row of items; let rowIndex = index; trackBy: trackBy">
+          <tr
+            class="po-table-row"
+            [class.po-table-row-active]="row.$selected || (row.$selected === null && selectable)"
+          >
+            <td *ngIf="selectable" class="po-table-column-selectable">
+              <ng-container *ngTemplateOutlet="singleSelect ? inputRadio : inputCheckbox; context: { $implicit: row }">
+              </ng-container>
+            </td>
+
+            <!-- Valida se a origem do detail é pelo input do po-table -->
+            <td
+              *ngIf="columnMasterDetail && !hideDetail && !hasRowTemplate"
+              class="po-table-column-detail-toggle"
+              (click)="toggleDetail(row)"
+            >
+              <ng-template
+                [ngTemplateOutlet]="poTableColumnDetail"
+                [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+              >
+              </ng-template>
+            </td>
+
+            <!-- Coluna com as ações na esquerda (padrão)-->
+            <ng-template
+              *ngIf="!actionRight && (visibleActions.length > 1 || isSingleAction)"
+              [ngTemplateOutlet]="ActionsColumnTemplate"
+              [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+            >
+            </ng-template>
+
+            <!-- Valida se a origem do detail é pela diretiva -->
+            <td
+              *ngIf="hasRowTemplate && !hasRowTemplateWithArrowDirectionRight"
+              class="po-table-column-detail-toggle"
+              (click)="toggleDetail(row)"
+            >
+              <ng-template
+                [ngTemplateOutlet]="poTableColumnDetail"
+                [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+              >
+              </ng-template>
+            </td>
+
+            <td
+              *ngFor="let column of mainColumns; let columnIndex = index; trackBy: trackBy"
+              [style.width]="column.width"
+              [style.max-width]="column.width"
+              [style.min-width]="column.width"
+              [class.po-table-column]="column.type !== 'icon'"
+              [class.po-table-column-right]="column.type === 'currency' || column.type === 'number'"
+              [class.po-table-column-center]="column.type === 'subtitle'"
+              [class.po-table-column-icons]="column.type === 'icon'"
+              [ngClass]="getClassColor(row, column)"
+              (click)="selectable ? selectRow(row) : 'javascript:;'"
+            >
+              <div
+                class="po-table-column-cell notranslate"
+                [class.po-table-body-ellipsis]="hideTextOverflow"
+                [ngSwitch]="column.type"
+                [p-tooltip]="tooltipText"
+                [style.width.px]="noColumnsHeader?.nativeElement.parentElement?.offsetWidth"
+                (mouseenter)="tooltipMouseEnter($event, column, row)"
+                (mouseleave)="tooltipMouseLeave()"
+              >
+                <span *ngSwitchCase="'columnTemplate'">
+                  <ng-container
+                    *ngTemplateOutlet="getTemplate(column); context: { $implicit: getCellData(row, column) }"
+                  >
+                  </ng-container>
+                </span>
+
+                <span *ngSwitchCase="'cellTemplate'">
+                  <ng-container
+                    *ngTemplateOutlet="tableCellTemplate?.templateRef; context: { row: row, column: column }"
+                  >
+                  </ng-container>
+                </span>
+
+                <span *ngSwitchCase="'boolean'">
+                  {{ getBooleanLabel(getCellData(row, column), column) }}
+                </span>
+
+                <span *ngSwitchCase="'currency'">
+                  {{ getCellData(row, column) | currency: column.format:'symbol':'1.2-2' }}
+                </span>
+
+                <span *ngSwitchCase="'date'">
+                  {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy' }}
+                </span>
+
+                <span *ngSwitchCase="'time'">
+                  {{ getCellData(row, column) | po_time: column.format || 'HH:mm:ss.ffffff' }}
+                </span>
+
+                <span *ngSwitchCase="'dateTime'">
+                  {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy HH:mm:ss' }}
+                </span>
+
+                <span *ngSwitchCase="'number'">
+                  {{ formatNumber(getCellData(row, column), column.format) }}
+                </span>
+
+                <po-table-column-link
+                  *ngSwitchCase="'link'"
+                  [p-action]="column.action"
+                  [p-disabled]="checkDisabled(row, column)"
+                  [p-link]="row[column.link]"
+                  [p-row]="row"
+                  [p-value]="getCellData(row, column)"
+                  (click)="onClickLink($event, row, column)"
+                >
+                </po-table-column-link>
+
+                <po-table-column-icon
+                  *ngSwitchCase="'icon'"
+                  [p-column]="column"
+                  [p-icons]="getColumnIcons(row, column)"
+                  [p-row]="row"
+                >
+                </po-table-column-icon>
+
+                <span *ngSwitchCase="'subtitle'">
+                  <po-table-subtitle-circle [p-subtitle]="getSubtitleColumn(row, column)"></po-table-subtitle-circle>
+                </span>
+                <span *ngSwitchCase="'label'">
+                  <po-table-column-label [p-value]="getColumnLabel(row, column)"> </po-table-column-label>
+                </span>
+                <span *ngSwitchDefault>{{ getCellData(row, column) }}</span>
+              </div>
+            </td>
+
+            <td
+              *ngIf="hasRowTemplateWithArrowDirectionRight"
+              class="po-table-column-detail-toggle"
+              (click)="toggleDetail(row)"
+            >
+              <ng-template
+                [ngTemplateOutlet]="poTableColumnDetail"
+                [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+              >
+              </ng-template>
+            </td>
+
+            <!-- Coluna de açoes na direita -->
+            <ng-template
+              *ngIf="actionRight"
+              [ngTemplateOutlet]="ActionsColumnTemplate"
+              [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+            >
+            </ng-template>
+
+            <!-- Coluna para não ficar em branco nas linhas de gerenciamento -->
+            <ng-container *ngIf="!actionRight && (visibleActions.length > 1 || isSingleAction) && !hideColumnsManager">
+              <td class="po-table-column po-table-column-empty"></td>
+            </ng-container>
+
+            <!-- Column Manager -->
+            <td
+              *ngIf="!hasVisibleActions && !hideColumnsManager && !hasRowTemplateWithArrowDirectionRight"
+              class="po-table-column"
+            ></td>
+          </tr>
+
+          <tr *ngIf="hasMainColumns && hasRowTemplate && row.$showDetail && isShowRowTemplate(row, rowIndex)">
+            <td class="po-table-row-template-container" [colSpan]="columnCountForMasterDetail">
+              <ng-template
+                [ngTemplateOutlet]="tableRowTemplate.templateRef"
+                [ngTemplateOutletContext]="{ $implicit: row, rowIndex: rowIndex }"
+              >
+              </ng-template>
+            </td>
+          </tr>
+
+          <tr *ngIf="hasMainColumns && isShowMasterDetail(row)">
+            <td class="po-table-column-detail" [colSpan]="columnCountForMasterDetail">
+              <po-table-detail
+                [p-selectable]="selectable && !detailHideSelect"
+                [p-detail]="columnMasterDetail.detail"
+                [p-items]="row[nameColumnDetail]"
+                (p-select-row)="selectDetailRow($event)"
+              >
+              </po-table-detail>
+            </td>
+          </tr>
+        </tbody>
+      </ng-container>
+    </table>
+  </cdk-virtual-scroll-viewport>
 </ng-template>
 
 <ng-template #tableTemplate>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -38,6 +38,7 @@ describe('PoTableComponent:', () => {
   let component: PoTableComponent;
   let fixture: ComponentFixture<PoTableComponent>;
   let nativeElement;
+  let tableHeaderElement;
   let tableElement;
   let tableFooterElement;
   let poTableService: PoTableService;
@@ -218,8 +219,9 @@ describe('PoTableComponent:', () => {
 
     nativeElement = fixture.debugElement.nativeElement;
 
-    component.poTableTbody = fixture.debugElement;
+    component.poTableTbodyVirtual = fixture.debugElement;
 
+    tableHeaderElement = nativeElement.querySelector('.po-table-header');
     tableElement = nativeElement.querySelector('.po-table-wrapper');
     tableFooterElement = nativeElement.querySelector('.po-table-footer');
 
@@ -656,7 +658,7 @@ describe('PoTableComponent:', () => {
     component.height = 150;
 
     fixture.detectChanges();
-    expect(tableElement.offsetHeight + tableFooterElement.offsetHeight).toBe(150);
+    expect(tableElement.offsetHeight + tableFooterElement.offsetHeight + tableHeaderElement.offsetHeight).toBe(174);
   });
 
   it('should call calculateWidthHeaders and setTableOpacity in debounceResize', fakeAsync(() => {
@@ -800,6 +802,20 @@ describe('PoTableComponent:', () => {
     spyOn(fakeThisDoCheck, 'debounceResize');
     component.ngDoCheck.call(fakeThisDoCheck);
     expect(fakeThisDoCheck.debounceResize).not.toHaveBeenCalled();
+  });
+
+  it('should set 32 in itemSize if offsetWidth is less than 1366', () => {
+    spyOnProperty(document.body, 'offsetWidth').and.returnValue(1300);
+    component.ngDoCheck();
+
+    expect(component.itemSize).toBe(32);
+  });
+
+  it('should set 44 in itemSize if offsetWidth is greater than 1366', () => {
+    spyOnProperty(document.body, 'offsetWidth').and.returnValue(1500);
+    component.ngDoCheck();
+
+    expect(component.itemSize).toBe(44);
   });
 
   it('should not call debounceResize in ngDoCheck when initialized is false', () => {
@@ -2967,7 +2983,7 @@ describe('PoTableComponent:', () => {
 
   it('syncronizeHorizontalScroll, should syncronize two separated tables during horizontal scroll', () => {
     const fakeThis = {
-      poTableTbody: {
+      poTableTbodyVirtual: {
         nativeElement: {
           scrollLeft: 100
         }
@@ -2988,7 +3004,7 @@ describe('PoTableComponent:', () => {
 
   it('hasInfiniteScroll: should return false if infiniteScroll is false', () => {
     component.infiniteScroll = false;
-    component.poTableTbody = {
+    component.poTableTbodyVirtual = {
       nativeElement: { offsetHeight: 100, scrollTop: 100, scrollHeight: 100 }
     };
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -96,6 +96,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   @ViewChild('tableWrapper', { read: ElementRef, static: false }) tableWrapperElement;
   @ViewChild('poTableTbody', { read: ElementRef, static: false }) poTableTbody;
   @ViewChild('poTableThead', { read: ElementRef, static: false }) poTableThead;
+  @ViewChild('poTableTbodyVirtual', { read: ElementRef, static: false }) poTableTbodyVirtual;
 
   @ViewChildren('actionsIconElement', { read: ElementRef }) actionsIconElement: QueryList<any>;
   @ViewChildren('actionsElement', { read: ElementRef }) actionsElement: QueryList<any>;
@@ -105,6 +106,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   popupTarget;
   tableOpacity: number = 0;
   tooltipText: string;
+  itemSize: number;
   lastVisibleColumnsSelected: Array<PoTableColumn>;
 
   private _columnManagerTarget: ElementRef;
@@ -121,7 +123,6 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   @ViewChild('columnManagerTarget') set columnManagerTarget(value: ElementRef) {
     this._columnManagerTarget = value;
-
     this.changeDetector.detectChanges();
   }
 
@@ -241,6 +242,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
       this.checkInfiniteScroll();
       this.visibleElement = true;
     }
+    document.body.offsetWidth > 1366 ? (this.itemSize = 44) : (this.itemSize = 32);
   }
 
   ngOnDestroy() {
@@ -545,7 +547,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   public syncronizeHorizontalScroll(): void {
-    this.poTableThead.nativeElement.scrollLeft = this.poTableTbody.nativeElement.scrollLeft;
+    this.poTableThead.nativeElement.scrollLeft = this.poTableTbodyVirtual.nativeElement.scrollLeft;
   }
 
   protected calculateHeightTableContainer(height) {
@@ -565,12 +567,13 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
           }
         });
       }
+      this.changeDetector.detectChanges();
     });
   }
 
   protected checkInfiniteScroll(): void {
     if (this.hasInfiniteScroll()) {
-      if (this.poTableTbody.nativeElement.scrollHeight > this.height) {
+      if (this.poTableTbodyVirtual.nativeElement.scrollHeight >= this.height) {
         this.includeInfiniteScroll();
       } else {
         this.infiniteScroll = false;
@@ -627,13 +630,15 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
       this.hasItems &&
       !this.subscriptionScrollEvent &&
       this.height &&
-      this.poTableTbody.nativeElement.scrollHeight
+      this.poTableTbodyVirtual.nativeElement.scrollHeight
     );
   }
 
   private includeInfiniteScroll(): void {
-    this.scrollEvent$ = this.defaultService.scrollListener(this.poTableTbody.nativeElement);
+    this.scrollEvent$ = this.defaultService.scrollListener(this.poTableTbodyVirtual.nativeElement);
     this.subscriptionScrollEvent = this.scrollEvent$.subscribe(event => this.showMoreInfiniteScroll(event));
+
+    this.changeDetector.detectChanges();
   }
 
   private mergeCustomIcons(rowIcons: Array<string>, customIcons: Array<any>) {

--- a/projects/ui/src/lib/components/po-table/po-table.module.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.module.ts
@@ -2,6 +2,7 @@ import { CommonModule, DecimalPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 import { PoButtonModule } from './../po-button/po-button.module';
 import { PoCheckboxGroupModule } from '../po-field/po-checkbox-group/po-checkbox-group.module';
@@ -36,6 +37,7 @@ import { PoTableColumnTemplateDirective } from './po-table-column-template/po-ta
   imports: [
     CommonModule,
     FormsModule,
+    ScrollingModule,
     RouterModule,
     PoButtonModule,
     PoCheckboxGroupModule,

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-basic/sample-po-table-basic.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-basic/sample-po-table-basic.component.html
@@ -1,1 +1,1 @@
-<po-table [p-items]="[{ table: 'PO Table' }]"> </po-table>
+<po-table [p-items]="[{ table: 'PO Table', angular: 'PO-UI' }]"> </po-table>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -103,7 +103,7 @@ export class SamplePoTableLabsComponent implements OnInit {
   }
 
   addItem() {
-    this.items.push(this.samplePoTableLabsService.generateNewItem(this.items.length + 1));
+    this.items = [...this.items, this.samplePoTableLabsService.generateNewItem(this.items.length + 1)];
   }
 
   changeActionOptions() {


### PR DESCRIPTION
**TABLE**

**DTHFUI-5921**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente table não possui cdk-virtual-scroll 

**Qual o novo comportamento?**
Componente table passa a ter cdk-virtual-scroll para melhor desempenho

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/8594506/app.zip),  portal e coloca os samples do portal em um app, dynamic table por exemplo.


po-style: https://github.com/po-ui/po-style/pull/300