### PR TITLE
Button - deprecia link e default

### DIFF
--- a/projects/ui/src/lib/components/po-button/po-button-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.spec.ts
@@ -32,14 +32,14 @@ describe('PoButtonBaseComponent', () => {
   });
 
   it('should update property `p-type` with valid values', () => {
-    const validValues = ['default', 'primary', 'danger', 'link'];
+    const validValues = ['primary', 'secondary', 'tertiary', 'danger'];
 
     expectPropertiesValues(component, 'type', validValues, validValues);
   });
 
-  it('should update property `p-type` with `default` when invalid values', () => {
+  it('should update property `p-type` with `secondary` when invalid values', () => {
     const invalidValues = [undefined, null, '', true, false, 0, 1, 'aa', [], {}];
 
-    expectPropertiesValues(component, 'type', invalidValues, 'default');
+    expectPropertiesValues(component, 'type', invalidValues, 'secondary');
   });
 });

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -3,8 +3,7 @@ import { EventEmitter, Input, Output, Directive, TemplateRef } from '@angular/co
 import { convertToBoolean } from '../../utils/util';
 import { InputBoolean } from '../../decorators';
 
-const PO_BUTTON_TYPES = ['default', 'primary', 'danger', 'link'];
-const PO_BUTTON_TYPE_DEFAULT = 'default';
+import { PoButtonType } from './po-button-type.enum';
 
 /**
  * @description
@@ -80,7 +79,7 @@ export class PoButtonBaseComponent {
   private _disabled?: boolean = false;
   private _loading?: boolean = false;
   private _small?: boolean = false;
-  private _type?: string = 'default';
+  private _type?: string = PoButtonType.secondary;
 
   /**
    * @optional
@@ -133,7 +132,7 @@ export class PoButtonBaseComponent {
    * @default `default`
    */
   @Input('p-type') set type(value: string) {
-    this._type = PO_BUTTON_TYPES.includes(value) ? value : PO_BUTTON_TYPE_DEFAULT;
+    this._type = PoButtonType[value] ? PoButtonType[value] : PoButtonType.secondary;
   }
   get type(): string {
     return this._type;

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -124,12 +124,14 @@ export class PoButtonBaseComponent {
    * Define o estilo do `po-button`.
    *
    * Valore válidos:
-   *  - `default`: estilo padrão do `po-button`.
+   *  - `default`: **Deprecated 15.x.x**. Utilizar `secondary`.
    *  - `primary`: deixa o `po-button` com destaque, deve ser usado para ações primárias.
+   *  - `secondary`: estilo padrão do `po-button`.
    *  - `danger`: deve ser usado para ações que o usuário precisa ter cuidado ao executa-lá.
-   *  - `link`: o `po-button` recebe o estilo de um link.
+   *  - `link`: **Deprecated 15.x.x**. Utilizar `tertiary`.
+   *  - `tertiary`: o `po-button` é exibido sem cor do fundo, recebendo menos destaque entre as ações.
    *
-   * @default `default`
+   * @default `secondary`
    */
   @Input('p-type') set type(value: string) {
     this._type = PoButtonType[value] ? PoButtonType[value] : PoButtonType.secondary;

--- a/projects/ui/src/lib/components/po-button/po-button-type.enum.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-type.enum.ts
@@ -1,0 +1,8 @@
+export enum PoButtonType {
+  primary = 'primary',
+  default = 'secondary',
+  secondary = 'secondary',
+  link = 'tertiary',
+  tertiary = 'tertiary',
+  danger = 'danger'
+}

--- a/projects/ui/src/lib/components/po-button/po-button.component.html
+++ b/projects/ui/src/lib/components/po-button/po-button.component.html
@@ -2,9 +2,9 @@
   #button
   class="po-button po-text-ellipsis"
   type="button"
-  [class.po-button-default]="type === 'default'"
+  [class.po-button-default]="type === 'secondary'"
   [class.po-button-danger]="type === 'danger'"
-  [class.po-button-link]="type === 'link'"
+  [class.po-button-link]="type === 'tertiary'"
   [class.po-button-primary]="type === 'primary'"
   [class.po-button-sm]="small"
   [class.po-clickable]="type === 'link'"

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
@@ -26,10 +26,10 @@ export class SamplePoButtonLabsComponent implements OnInit {
   ];
 
   typesOptions: Array<PoRadioGroupOption> = [
-    { label: 'default', value: 'default' },
     { label: 'primary', value: 'primary' },
-    { label: 'danger', value: 'danger' },
-    { label: 'link', value: 'link' }
+    { label: 'secondary', value: 'secondary' },
+    { label: 'tertiary', value: 'tertiary' },
+    { label: 'danger', value: 'danger' }
   ];
 
   constructor(private poDialog: PoDialogService) {}

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
@@ -469,20 +469,20 @@ describe('PoModalComponent:', () => {
       expect(component.getSecondaryActionButtonType()).toBe('danger');
     });
 
-    it(`getSecondaryActionButtonType: should return 'default' if 'primaryAction.danger' is 'true'
+    it(`getSecondaryActionButtonType: should return 'secondary' if 'primaryAction.danger' is 'true'
     and 'secondaryAction.danger' is 'false'`, () => {
       component.primaryAction.danger = true;
       component.secondaryAction = { action: () => {}, label: 'primaryLabel', danger: false };
 
-      expect(component.getSecondaryActionButtonType()).toBe('default');
+      expect(component.getSecondaryActionButtonType()).toBe('secondary');
     });
 
-    it(`getSecondaryActionButtonType: should return 'default' if 'primaryAction.danger' is 'true'
+    it(`getSecondaryActionButtonType: should return 'secondary' if 'primaryAction.danger' is 'true'
     and 'secondaryAction.danger' is 'true'`, () => {
       component.primaryAction.danger = true;
       component.secondaryAction = { action: () => {}, label: 'primaryLabel', danger: true };
 
-      expect(component.getSecondaryActionButtonType()).toBe('default');
+      expect(component.getSecondaryActionButtonType()).toBe('secondary');
     });
 
     it(`removeEventListeners: should call 'removeEventListener' with 'focus', 'focusFunction' and 'true' params.`, () => {

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.ts
@@ -71,7 +71,7 @@ export class PoModalComponent extends PoModalBaseComponent {
   }
 
   getSecondaryActionButtonType() {
-    return this.secondaryAction && this.secondaryAction.danger && !this.primaryAction.danger ? 'danger' : 'default';
+    return this.secondaryAction && this.secondaryAction.danger && !this.primaryAction.danger ? 'danger' : 'secondary';
   }
 
   onClickOut(event) {

--- a/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail.component.spec.ts
@@ -98,10 +98,10 @@ describe('PoPageDetailComponent:', () => {
       expect(component.hasEditFn('icon')).toBe('po-icon-delete');
     });
 
-    it(`hasEditFn: should return 'default' if have a edit action and property is 'type'`, () => {
+    it(`hasEditFn: should return 'secondary' if have a edit action and property is 'type'`, () => {
       component.edit.observers.push(<any>of({}));
 
-      expect(component.hasEditFn('type')).toBe('default');
+      expect(component.hasEditFn('type')).toBe('secondary');
     });
 
     it(`hasEditFn: should return 'primary' if does't have a edit action and property is 'type'`, () => {
@@ -144,20 +144,20 @@ describe('PoPageDetailComponent:', () => {
       expect(component.hasEditOrRemoveFn('icon')).toBe('po-icon-arrow-left');
     });
 
-    it(`hasEditOrRemoveFn: should return 'default' if have a edit action, doesn't have remove action
+    it(`hasEditOrRemoveFn: should return 'secondary' if have a edit action, doesn't have remove action
     and property is 'type'`, () => {
       component.edit.observers.push(<any>of({}));
       component.remove.observers.length = 0;
 
-      expect(component.hasEditOrRemoveFn('type')).toBe('default');
+      expect(component.hasEditOrRemoveFn('type')).toBe('secondary');
     });
 
-    it(`hasEditOrRemoveFn: should return 'default' if doesn't have a edit action, have remove action
+    it(`hasEditOrRemoveFn: should return 'secondary' if doesn't have a edit action, have remove action
     and property is 'type'`, () => {
       component.remove.observers.push(<any>of({}));
       component.edit.observers.length = 0;
 
-      expect(component.hasEditOrRemoveFn('type')).toBe('default');
+      expect(component.hasEditOrRemoveFn('type')).toBe('secondary');
     });
 
     it(`hasEditOrRemoveFn: should return 'primary' if doesn't have a edit action and remove action

--- a/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/po-page-detail.component.ts
@@ -35,7 +35,7 @@ export class PoPageDetailComponent extends PoPageDetailBaseComponent {
     if (property === 'icon') {
       return this.hasEvent('edit') ? '' : 'po-icon-delete';
     } else if (property === 'type') {
-      return this.hasEvent('edit') ? 'default' : 'primary';
+      return this.hasEvent('edit') ? 'secondary' : 'primary';
     } else {
       return '';
     }
@@ -45,7 +45,7 @@ export class PoPageDetailComponent extends PoPageDetailBaseComponent {
     if (property === 'icon') {
       return this.hasEvent('edit') || this.hasEvent('remove') ? '' : 'po-icon-arrow-left';
     } else if (property === 'type') {
-      return this.hasEvent('edit') || this.hasEvent('remove') ? 'default' : 'primary';
+      return this.hasEvent('edit') || this.hasEvent('remove') ? 'secondary' : 'primary';
     } else {
       return '';
     }

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.spec.ts
@@ -113,20 +113,20 @@ describe('PoPageEditComponent', () => {
       expect(component.getType('saveNew')).toBe('primary');
     });
 
-    it('getType: should return "default" if type isn`t "saveNew" or "cancel"', () => {
-      expect(component.getType('test')).toBe('default');
+    it('getType: should return "secondary" if type isn`t "saveNew" or "cancel"', () => {
+      expect(component.getType('test')).toBe('secondary');
     });
 
-    it('getType: should return "default" if type is "saveNew" and isn`t primary action', () => {
+    it('getType: should return "secondary" if type is "saveNew" and isn`t primary action', () => {
       spyOn(component, <any>'isPrimaryAction').and.returnValue(false);
 
-      expect(component.getType('saveNew')).toBe('default');
+      expect(component.getType('saveNew')).toBe('secondary');
     });
 
-    it('getType: should return "default" if type is "cancel" and isn`t primary action', () => {
+    it('getType: should return "secondary" if type is "cancel" and isn`t primary action', () => {
       spyOn(component, <any>'isPrimaryAction').and.returnValue(false);
 
-      expect(component.getType('cancel')).toBe('default');
+      expect(component.getType('cancel')).toBe('secondary');
     });
 
     it('hasPageHeader: should return true if has breadcrumb', () => {

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.ts
@@ -43,7 +43,7 @@ export class PoPageEditComponent extends PoPageEditBaseComponent {
     const isCancelPrimaryAction = type === 'cancel' && this.isPrimaryAction('cancel');
     const isSaveNewPrimaryAction = type === 'saveNew' && this.isPrimaryAction('saveNew');
 
-    return isCancelPrimaryAction || isSaveNewPrimaryAction ? 'primary' : 'default';
+    return isCancelPrimaryAction || isSaveNewPrimaryAction ? 'primary' : 'secondary';
   }
 
   hasAnyAction(): boolean {

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.html
@@ -25,7 +25,7 @@
     <po-button
       class="po-table-column-manager-footer-restore"
       p-small
-      p-type="link"
+      p-type="tertiary"
       [p-label]="literals.restoreDefault"
       (p-click)="restore()"
     >


### PR DESCRIPTION
**Button**

**DTHFUI-6000**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

Deprecia `link` e `default` e adiciona `secondary` e `tertiary`


**Simulação**

Testar no portal e app:

```
<po-page-default>
  <po-button  p-label="PO Button" > </po-button>
  <po-button p-type="secondary" p-label="PO Button" > </po-button>
  <po-button p-type="default" p-label="PO Button" > </po-button>

  <br>

  <po-button p-type="link" p-label="PO Button" > </po-button>
  <po-button p-type="tertiary" p-label="PO Button" > </po-button>

  <br>
  <po-button p-type="primary" p-label="PO Button" > </po-button>
  <po-button p-type="danger" p-label="PO Button" > </po-button>
</po-page-default>

```
