### PR TITLE
fix(build): corrige erro do npm v7+

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,8 +1,6 @@
 [comment]: # (@label Primeiros passos)
 [comment]: # (@link guides/getting-started)
 
-> Instale a versão 6 do NPM antes de iniciar: ```npm i -g npm@6```
-
 ### Pré-requisitos
 
 Para começar a utilizar o **PO UI** é pré-requisito ter o `Node.js` instalado (versão 12.13.0 ou acima) e o seu gerenciador de pacote favorito na versão mais atual. Caso você ainda não tenha instalado o pacote `@angular/cli`, instale-o via `npm` ou `yarn`.
@@ -63,8 +61,6 @@ Instalando com npm:
 ```
 npm install
 ```
-
-> Caso utilizar a versão 7 do npm pode ocorrer erro de versão das dependências, neste caso utilize `npm install --legacy-peer-deps`
 
 Caso prefira instalar com o yarn:
 ```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -36,14 +36,14 @@ Veja abaixo a lista de dependências e as versões compatíveis, elas devem ser 
 
 ```
   "dependencies": {
-    "@angular/animations": "^13.0.2",
-    "@angular/common": "^13.0.2",
-    "@angular/compiler": "^13.0.2",
-    "@angular/core": "^13.0.2",
-    "@angular/forms": "^13.0.2",
-    "@angular/platform-browser": "^13.0.2",
-    "@angular/platform-browser-dynamic": "^13.0.2",
-    "@angular/router": "^13.0.2",
+    "@angular/animations": "~13.3.0",
+    "@angular/common": "~13.3.0",
+    "@angular/compiler": "~13.3.0",
+    "@angular/core": "~13.3.0",
+    "@angular/forms": "~13.3.0",
+    "@angular/platform-browser": "~13.3.0",
+    "@angular/platform-browser-dynamic": "~13.3.0",
+    "@angular/router": "~13.3.0",
     "rxjs": "~7.4.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
@@ -51,7 +51,7 @@ Veja abaixo a lista de dependências e as versões compatíveis, elas devem ser 
   },
   "devDependencies": {
     ...
-    "typescript": "~4.5.2"
+    "typescript": "~4.6.2"
   }
 ```
 

--- a/docs/guides/sync-get-started.md
+++ b/docs/guides/sync-get-started.md
@@ -1,9 +1,7 @@
 [comment]: # (@label Começando com o PO Sync)
 [comment]: # (@link guides/sync-get-started)
 
-> Instale a versão 6 do NPM antes de iniciar: ```npm i -g npm@6```
-
-Esse guia servirá para criar e configurar uma aplicação em [Ionic 5](https://beta.ionicframework.com/docs/) com o uso do PO Sync.
+Esse guia servirá para criar e configurar uma aplicação em [Ionic 6](https://ionicframework.com/docs) com o uso do PO Sync.
 
 Para maiores detalhes sobre os serviços e métodos utilizados neste tutorial, consulte a documentação de
 [Fundamentos do PO Sync](/guides/sync-fundamentals) e a documentação de referência de [API do PO Sync](/documentation/po-sync).
@@ -18,10 +16,6 @@ Para maiores detalhes sobre os serviços e métodos utilizados neste tutorial, c
 - [Ionic](https://ionicframework.com/docs/cli/) (^6.0.0):
   - ```shell
     npm install -g @ionic/cli@6
-    ```
-- [Cordova](https://cordova.apache.org/docs/en/latest/) (10.0.0):
-  - ```shell
-    npm i -g cordova
     ```
 
 
@@ -41,6 +35,8 @@ Caso surja a questão relacionada ao framework desejado, opte por `Angular`.
 
 ### Passo 2 - Instalando as dependências
 
+> É importante verificar se no passo anterior foram criados o arquivo `package-lock.json` e a pasta `node_modules`, caso tenham sido criados vai ser necessário apagar ambos antes de prosseguir.
+
 É necessário realizar alguns ajustes de compatibilidade do PO para o projeto criado.
 
 Navegue até a pasta do aplicativo:
@@ -53,31 +49,32 @@ Antes de executar a instalação, é necessário que todas as dependências do p
 ```typescript
   ...
   "dependencies": {
-    "@angular/animations": "^13.0.2",
-    "@angular/common": "^13.0.2",
-    "@angular/core": "^13.0.2",
-    "@angular/forms": "^13.0.2",
-    "@angular/platform-browser": "^13.0.2",
-    "@angular/platform-browser-dynamic": "^13.0.2",
-    "@angular/router": "^13.0.2",
-    "@angular/service-worker": "^13.0.2",
-    "@ionic-native/core": "^5.0.0",
-    "@ionic-native/splash-screen": "^5.0.0",
-    "@ionic-native/status-bar": "^5.0.0",
-    "@ionic/angular": "^5.5.2",
+    "@angular/animations": "~13.3.0",
+    "@angular/common": "~13.3.0",
+    "@angular/core": "~13.3.0",
+    "@angular/forms": "~13.3.0",
+    "@angular/platform-browser": "~13.3.0",
+    "@angular/platform-browser-dynamic": "~13.3.0",
+    "@angular/router": "~13.3.0",
+    "@angular/service-worker": "~13.3.0",
+    "@ionic/angular": "^6.0.0",
     "rxjs": "~7.4.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
     ...
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^13.0.2",
-    "@angular/cli": "^13.0.2",
-    "@angular/compiler": "^13.0.2",
-    "@angular/compiler-cli": "^13.0.2",
-    "@angular/language-service": "^13.0.2",
-    "@ionic/angular-toolkit": "^4.0.0",
-    "typescript": "~4.4.4"
+    "@angular-devkit/build-angular": "~13.3.0",
+    "@angular-eslint/builder": "~13.2.0",
+    "@angular-eslint/eslint-plugin": "~13.2.0",
+    "@angular-eslint/eslint-plugin-template": "~13.2.0",
+    "@angular-eslint/template-parser": "~13.2.0",
+    "@angular/cli": "~13.3.0",
+    "@angular/compiler": "~13.3.0",
+    "@angular/compiler-cli": "~13.3.0",
+    "@angular/language-service": "~13.3.0",
+    "@ionic/angular-toolkit": "^6.0.0",
+    "typescript": "~4.6.2"
   },
   ...
 ```
@@ -90,7 +87,31 @@ Execute o seguinte comando para instalar as dependências:
 npm install
 ```
 
-### Passo 3 - Instalando o po-sync
+### Passo 3 - Instalando pré-requisitos para uso do po-sync
+
+Antes da instalação do `po-sync`, é necessário instalar os plugins abaixo para que a aplicação realize as sincronizações com sucesso:
+- [cordova-plugin-network-information](https://github.com/apache/cordova-plugin-network-information), utilizado pelo [@awesome-cordova-plugins/network](https://ionicframework.com/docs/native/network/)
+  - ```shell
+  npm install cordova-plugin-network-information @awesome-cordova-plugins/network
+  ```
+- [cordova-plugin-statusbar](https://github.com/apache/cordova-plugin-statusbar), utilizado pelo [@awesome-cordova-plugins/status-bar](https://ionicframework.com/docs/native/status-bar/)
+  - ```shell
+  npm install cordova-plugin-statusbar @awesome-cordova-plugins/status-bar
+  ```
+- [cordova-plugin-splashscreen](https://github.com/apache/cordova-plugin-splashscreen), utilizado pelo [@awesome-cordova-plugins/splash-screen](https://ionicframework.com/docs/native/splash-screen/)
+  - ```shell
+  npm install cordova-plugin-splashscreen @awesome-cordova-plugins/splash-screen
+  ```
+
+Após realizar as instalações, execute o seguinte comando:
+
+```shell
+ionic cap sync
+```
+
+Essas instalações se fazem necessárias por que a instalação inicial do Ionic 6 está usando o [runtime Capacitor no lugar do Cordova](https://ionicframework.com/blog/ionic-isnt-cordova-anymore/), e o PoSync depende desses pacotes atualmente, que está sendo [mantido pela comunidade](https://ionicframework.com/blog/a-new-chapter-for-ionic-native/).
+
+### Passo 4 - Instalando o po-sync
 
 Para instalar o `po-sync` no aplicativo execute o seguinte comando:
 
@@ -98,19 +119,9 @@ Para instalar o `po-sync` no aplicativo execute o seguinte comando:
 ng add @po-ui/ng-sync
 ```
 
-Após a instalação do `po-sync`, é necessário instalar o plugin
-[cordova-plugin-network-information](https://github.com/apache/cordova-plugin-network-information) utilizado pelo [@ionic-native/network](https://ionicframework.com/docs/native/network/), para que a
-aplicação realize as sincronizações com sucesso.
+### Passo 5 - Utilizando o po-sync
 
-Para realizar essa instalação, execute o seguinte comando:
-
-```shell
-ionic cordova plugin add cordova-plugin-network-information
-```
-
-### Passo 4 - Utilizando o po-sync
-
-#### Passo 4.1 - Importando o `po-sync` e o `po-storage`
+#### Passo 5.1 - Importando o `po-sync` e o `po-storage`
 No arquivo `src/app/app.module.ts`, adicione a importação dos módulos do `po-storage` e do `po-sync`: 
 
 > Caso você utilize o comando `ng add`, esse passo será feito automaticamente.
@@ -121,8 +132,8 @@ import { BrowserModule } from '@angular/platform-browser';
 import { RouteReuseStrategy } from '@angular/router';
 
 import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
-import { SplashScreen } from '@ionic-native/splash-screen/ngx';
-import { StatusBar } from '@ionic-native/status-bar/ngx';
+import { SplashScreen } from '@awesome-cordova-plugins/splash-screen/ngx';
+import { StatusBar } from '@awesome-cordova-plugins/status-bar/ngx';
 
 /* Imports adicionados */
 import { PoStorageModule } from '@po-ui/ng-storage';
@@ -150,7 +161,7 @@ import { AppRoutingModule } from './app-routing.module';
 export class AppModule {}
 ```
 
-#### Passo 4.2 - Mapeando seu primeiro *schema*
+#### Passo 5.2 - Mapeando seu primeiro *schema*
 
 O `po-sync` utiliza a definição de `schemas`, onde cada `schema` representa um modelo de dados armazenado no dispositivo.
 
@@ -170,11 +181,11 @@ export const conferenceSchema: PoSyncSchema = {
 };
 ```
 
-### Passo 5 - Configurando o método prepare
+### Passo 6 - Configurando o método prepare
 
 Após ter o seu primeiro *schema* criado, configure o seu aplicativo utilizando o `po-sync` através do método `PoSyncService.prepare()`.
 
-#### Passo 5.1 - Alterando o `src/app/app.component.ts`
+#### Passo 6.1 - Alterando o `src/app/app.component.ts`
 
 Substitua o conteúdo do arquivo pelo conteúdo abaixo:
 
@@ -182,8 +193,8 @@ Substitua o conteúdo do arquivo pelo conteúdo abaixo:
 import { Component } from '@angular/core';
 
 import { Platform } from '@ionic/angular';
-import { SplashScreen } from '@ionic-native/splash-screen/ngx';
-import { StatusBar } from '@ionic-native/status-bar/ngx';
+import { SplashScreen } from '@awesome-cordova-plugins/splash-screen/ngx';
+import { StatusBar } from '@awesome-cordova-plugins/status-bar/ngx';
 import { PoSyncConfig, PoNetworkType, PoSyncService } from '@po-ui/ng-sync';
 
 import { conferenceSchema } from './home/conference-schema.constants';
@@ -228,7 +239,7 @@ export class AppComponent {
 
 Após utilizar o método `PoSyncService.prepare()`, a aplicação estará pronta para sincronizar os dados através do método `PoSyncService.sync()`.
 
-### Passo 6 - Acessando os dados
+### Passo 7 - Acessando os dados
 
 Localize o arquivo `src/app/home/home.page.ts` e faça as seguintes alterações:
 
@@ -263,7 +274,7 @@ export class HomePage {
 
 No construtor, foi realizado uma inscrição no método `PoSyncService.onSync()`, para quando ocorrer uma sincronização, o método `loadHomePage()` busque um registro do *schema* "Conference".
 
-### Passo 7 - Exibindo os dados em tela
+### Passo 8 - Exibindo os dados em tela
 
 No arquivo `src/app/home/home.page.html` crie a seguinte estrutura:
 ```html
@@ -283,13 +294,13 @@ No arquivo `src/app/home/home.page.html` crie a seguinte estrutura:
 </ion-content>
 ```
 
-### Passo 8 - Executando o aplicativo
+### Passo 9 - Executando o aplicativo
 
 Execute o comando `ionic serve` e verifique o funcionamento do aplicativo Ionic com `po-sync`.
 
 > Pode ocorrer o seguinte erro `TS2320: Interface 'HTMLIonIconElement' cannot simultaneously extend types 'IonIcon' and 'HTMLStencilElement'` por conta da versão do TypeScript (4.4.x) conforme esta [issue](https://github.com/ionic-team/ionicons/issues/1011), neste caso adicione no arquivo **tsconfig.json** `"skipLibCheck": true`.
 
-#### Passo 8.1 - Entendendo o funcionamento do `po-sync`
+#### Passo 9.1 - Entendendo o funcionamento do `po-sync`
 
 - O aplicativo sincroniza os dados que estão no servidor através do método `PoSyncService.sync()`;
 

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "format:fix": "pretty-quick --staged",
     "format:check": "prettier --check --loglevel error \"**/*{.ts,.js,.json,.css,.scss,.html}\"",
     "format:all": "prettier --write \"**/*{.ts,.js,.json,.css,.scss,.html}\"",
-    "publish:ui:local": "npm publish dist/ng-components --registry http://localhost:4873",
-    "publish:templates:local": "npm publish dist/ng-templates --registry http://localhost:4873",
-    "publish:sync:local": "npm publish dist/ng-sync --registry http://localhost:4873",
-    "publish:storage:local": "npm publish dist/ng-storage --registry http://localhost:4873",
-    "publish:code-editor:local": "npm publish dist/ng-code-editor --registry http://localhost:4873",
-    "publish:schematics:local": "npm publish dist/ng-schematics --registry http://localhost:4873",
+    "publish:ui:local": "npm publish ./dist/ng-components --registry http://localhost:4873 --ignore-scripts",
+    "publish:templates:local": "npm publish ./dist/ng-templates --registry http://localhost:4873 --ignore-scripts",
+    "publish:sync:local": "npm publish ./dist/ng-sync --registry http://localhost:4873 --ignore-scripts",
+    "publish:storage:local": "npm publish ./dist/ng-storage --registry http://localhost:4873 --ignore-scripts",
+    "publish:code-editor:local": "npm publish ./dist/ng-code-editor --registry http://localhost:4873 --ignore-scripts",
+    "publish:schematics:local": "npm publish ./dist/ng-schematics --registry http://localhost:4873 --ignore-scripts",
     "publish:local": "npm run publish:schematics:local && npm run publish:ui:local && npm run publish:templates:local && npm run publish:code-editor:local && npm run publish:sync:local && npm run publish:storage:local"
   },
   "private": true,
@@ -71,9 +71,9 @@
     "@angular/platform-browser": "^13.0.2",
     "@angular/platform-browser-dynamic": "^13.0.2",
     "@angular/router": "^13.0.2",
-    "@ionic-native/core": "5.33.0",
-    "@ionic-native/network": "5.33.0",
-    "@po-ui/style": "6.11.0",
+    "@awesome-cordova-plugins/core": "^5.41.0",
+    "@awesome-cordova-plugins/network": "^5.41.0",
+    "@po-ui/style": "6.10.0",
     "capitalize": "^2.0.3",
     "colors": "1.4.0",
     "core-js": "3.13.0",
@@ -142,7 +142,7 @@
     "standard-version": "^9.3.0",
     "ts-node": "~10.0.0",
     "typemoq": "^2.1.0",
-    "typescript": "~4.5.2"
+    "typescript": "~4.6.2"
   },
   "standard-version": {
     "skip": {

--- a/projects/sync/ng-package.json
+++ b/projects/sync/ng-package.json
@@ -6,8 +6,8 @@
   },
   "allowedNonPeerDependencies": [
     "@po-ui/ng-storage",
-    "@ionic-native/core",
-    "@ionic-native/network",
+    "@awesome-cordova-plugins/core",
+    "@awesome-cordova-plugins/network",
     "http-status-codes",
     "@po-ui/ng-schematics"
   ]

--- a/projects/sync/package.json
+++ b/projects/sync/package.json
@@ -19,8 +19,8 @@
     ]
   },
   "dependencies": {
-    "@ionic-native/core": "5.33.0",
-    "@ionic-native/network": "5.33.0",
+    "@awesome-cordova-plugins/core": "^5.41.0",
+    "@awesome-cordova-plugins/network": "^5.41.0",
     "@po-ui/ng-storage": "0.0.0-PLACEHOLDER",
     "http-status-codes": "^2.1.4",
     "@po-ui/ng-schematics": "0.0.0-PLACEHOLDER",
@@ -28,8 +28,8 @@
   },
   "peerDependencies": {
     "@angular/core": "^13.0.2",
-    "@ionic-native/core": "5.33.0",
-    "@ionic-native/network": "5.33.0",
+    "@awesome-cordova-plugins/core": "^5.41.0",
+    "@awesome-cordova-plugins/network": "^5.41.0",
     "@po-ui/ng-storage": "0.0.0-PLACEHOLDER",
     "http-status-codes": "^2.1.4",
     "rxjs": "~7.4.0",

--- a/projects/sync/schematics/ng-add/index.spec.ts
+++ b/projects/sync/schematics/ng-add/index.spec.ts
@@ -42,7 +42,7 @@ describe('Schematic: ng-add', () => {
       const packageJson = JSON.parse(getFileContent(tree, '/package.json'));
       const dependencies = packageJson.dependencies;
       const info =
-        'Sync added successfully, please execute the command `ionic cordova plugin add cordova-plugin-network-information`';
+        'Sync added successfully, please execute the commands `npm install cordova-plugin-network-information @awesome-cordova-plugins/network` and `ionic cap sync`';
 
       expect(dependencies['@po-ui/ng-sync']).toBeDefined();
       expect(Object.keys(dependencies)).toEqual(Object.keys(dependencies).sort());

--- a/projects/sync/schematics/ng-add/index.ts
+++ b/projects/sync/schematics/ng-add/index.ts
@@ -30,7 +30,7 @@ function addPoPackageAndInstall(): Rule {
     context.addTask(new NodePackageInstallTask());
     // Log de processamento
     context.logger.info(
-      'Sync added successfully, please execute the command `ionic cordova plugin add cordova-plugin-network-information`'
+      'Sync added successfully, please execute the commands `npm install cordova-plugin-network-information @awesome-cordova-plugins/network` and `ionic cap sync`'
     );
   };
 }

--- a/projects/sync/src/lib/po-sync.module.ts
+++ b/projects/sync/src/lib/po-sync.module.ts
@@ -1,7 +1,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 
-import { Network } from '@ionic-native/network/ngx';
+import { Network } from '@awesome-cordova-plugins/network/ngx';
 
 import { PoEventSourcingService } from './services/po-event-sourcing/po-event-sourcing.service';
 import { PoHttpClientService } from './services/po-http-client/po-http-client.service';

--- a/projects/sync/src/lib/services/po-network/po-network.service.spec.ts
+++ b/projects/sync/src/lib/services/po-network/po-network.service.spec.ts
@@ -1,4 +1,4 @@
-import { Network } from '@ionic-native/network/ngx';
+import { Network } from '@awesome-cordova-plugins/network/ngx';
 
 import { fromEvent, Observable, of, Subject } from 'rxjs';
 import * as rxjs from 'rxjs';

--- a/projects/sync/src/lib/services/po-network/po-network.service.ts
+++ b/projects/sync/src/lib/services/po-network/po-network.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { fromEvent, merge, Observable, Subject } from 'rxjs';
 import { mapTo } from 'rxjs/operators';
 
-import { Network } from '@ionic-native/network/ngx';
+import { Network } from '@awesome-cordova-plugins/network/ngx';
 
 import { PoNetworkStatus } from './../../models';
 


### PR DESCRIPTION
**BUILD**

**DTHFUI-6020**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao utilizar uma versão do npm maior do que a v6 (v7+) ocorre um erro de conflito de dependências do rxjs entre o root e uma peer-dependency do @ionic-native/core e @ionic-native/network

**Qual o novo comportamento?**
Ao realizar o npm i no monorepo com uma versão do npm superior à v6, deve concluir a instalação sem erros.

**Simulação**
1. `npm run build`
2. Usar o [Verdaccio](https://verdaccio.org/docs/installation)
3. publicar os pacotes usando `npm run publish:local`
4. Seguir um dos passos abaixo:
3.1 Seguir o guia [Primeiros Passos](https://po-ui.io/guides/getting-started)
3.2 Apagar `package-lock.json` e `node_modules` no PoAngular e rodar `npm i`
3.3 Utilizar o [po-sample-conference](https://github.com/po-ui/po-sample-conference)
3.4 Seguir o guia [Começando com o PO Sync](https://po-ui.io/guides/sync-get-started)
