### PR TITLE
feat(button): deprecia type danger e adiciona propriedade p-danger

### DIFF
--- a/projects/ui/src/lib/components/po-button/po-button-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.spec.ts
@@ -22,6 +22,11 @@ describe('PoButtonBaseComponent', () => {
     expectPropertiesValues(component, 'disabled', booleanInvalidValues, false);
   });
 
+  it('should set `p-danger` with `value`', () => {
+    component.danger = true;
+    expect(component.danger).toBe(true);
+  });
+
   it('should update property `p-small` with valid values', () => {
     expectPropertiesValues(component, 'small', booleanValidTrueValues, true);
     expectPropertiesValues(component, 'small', booleanValidFalseValues, false);
@@ -32,6 +37,7 @@ describe('PoButtonBaseComponent', () => {
   });
 
   it('should update property `p-kind` with valid values', () => {
+    component.danger = false;
     const validValues = ['primary', 'secondary', 'tertiary', 'danger'];
 
     expectPropertiesValues(component, 'type', validValues, validValues);
@@ -41,5 +47,10 @@ describe('PoButtonBaseComponent', () => {
     const invalidValues = [undefined, null, '', true, false, 0, 1, 'aa', [], {}];
 
     expectPropertiesValues(component, 'type', invalidValues, 'secondary');
+  });
+
+  it('should update property `p-kind` with `secondary` when property `p-danger` is true', () => {
+    component.danger = true;
+    expect(component.kind).toBe('secondary');
   });
 });

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -16,6 +16,7 @@ import { PoButtonKind } from './po-button-type.enum';
  *
  * - Evite `labels` extensos que quebram o layout do `po-button`, use `labels` diretos, curtos e intuitivos.
  * - Utilize apenas um `po-button` configurado como `primary` por página.
+ * - Para ações irreversíveis use sempre a propriedade `p-danger`.
  */
 @Directive()
 export class PoButtonBaseComponent {
@@ -74,6 +75,7 @@ export class PoButtonBaseComponent {
   /** Ação que será executada quando o usuário clicar sobre o `po-button`. */
   @Output('p-click') click = new EventEmitter<null>();
 
+  private _danger?: boolean = false;
   private _disabled?: boolean = false;
   private _loading?: boolean = false;
   private _small?: boolean = false;
@@ -128,7 +130,7 @@ export class PoButtonBaseComponent {
    * Valore válidos:
    *  - `default`: **Deprecated 15.x.x**. Utilizar `p-kind="secondary"`.
    *  - `primary`: deixa o `po-button` com destaque, deve ser usado para ações primárias.
-   *  - `danger`: deve ser usado para ações que o usuário precisa ter cuidado ao executa-lá.
+   *  - `danger`: **Deprecated 15.x.x**. Utilizar `p-danger`.
    *  - `link`: **Deprecated 15.x.x**. Utilizar `p-kind="tertiary"`.
    *
    * @default `secondary`
@@ -138,6 +140,28 @@ export class PoButtonBaseComponent {
   }
   get type(): string {
     return this.kind;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Deve ser usado em ações irreversíveis que o usuário precisa ter cuidado ao executá-la, como a exclusão de um registro.
+   *
+   * > Ao utilizar esta propriedade será atribuído `p-kind="secondary"`.
+   */
+
+  @Input('p-danger') @InputBoolean() set danger(value: boolean) {
+    this._danger = value;
+
+    if (this._danger) {
+      this.kind = PoButtonKind.secondary;
+    }
+  }
+
+  get danger(): boolean {
+    return this._danger;
   }
 
   /**
@@ -155,7 +179,7 @@ export class PoButtonBaseComponent {
    * @default `secondary`
    */
   @Input('p-kind') set kind(value: string) {
-    this._kind = PoButtonKind[value] ? PoButtonKind[value] : PoButtonKind.secondary;
+    this._kind = PoButtonKind[value] && !this.danger ? PoButtonKind[value] : PoButtonKind.secondary;
   }
 
   get kind(): string {

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -10,14 +10,12 @@ import { PoButtonKind } from './po-button-type.enum';
  *
  * O `po-button` permite que o usuário execute ações predefinidas pelo desenvolvedor.
  *
- * Através dos tipos, é possível identificar a importância de cada ação, sendo ela primária (`primary`) ou até mesmo uma
- * ação irreversível (`danger`), como a exclusão de um registro.
+ * Através dos tipos, é possível identificar a importância de cada ação.
  *
  * #### Boas práticas
  *
  * - Evite `labels` extensos que quebram o layout do `po-button`, use `labels` diretos, curtos e intuitivos.
  * - Utilize apenas um `po-button` configurado como `primary` por página.
- * - Para ações irreversíveis use sempre o tipo `danger`.
  */
 @Directive()
 export class PoButtonBaseComponent {
@@ -122,6 +120,7 @@ export class PoButtonBaseComponent {
    * @optional
    *
    * @description
+   *
    * **Deprecated 15.x.x**. Utilizar `p-kind` no lugar.
    *
    * Define o estilo do `po-button`.
@@ -142,7 +141,6 @@ export class PoButtonBaseComponent {
   }
 
   /**
-   *
    * @optional
    *
    * @description
@@ -152,7 +150,6 @@ export class PoButtonBaseComponent {
    * Valore válidos:
    *  - `primary`: deixa o `po-button` com destaque, deve ser usado para ações primárias.
    *  - `secondary`: estilo padrão do `po-button`.
-   *  - `danger`: deve ser usado para ações que o usuário precisa ter cuidado ao executa-lá.
    *  - `tertiary`: o `po-button` é exibido sem cor do fundo, recebendo menos destaque entre as ações.
    *
    * @default `secondary`

--- a/projects/ui/src/lib/components/po-button/po-button.component.html
+++ b/projects/ui/src/lib/components/po-button/po-button.component.html
@@ -3,7 +3,7 @@
   class="po-button"
   type="button"
   [class.po-button-default]="kind === 'secondary'"
-  [class.po-button-danger]="kind === 'danger'"
+  [class.po-button-danger]="kind === 'danger' || danger"
   [class.po-button-link]="kind === 'tertiary'"
   [class.po-button-primary]="kind === 'primary'"
   [class.po-button-sm]="small"

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.html
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.html
@@ -7,6 +7,7 @@
     [p-label]="label"
     [p-loading]="properties.includes('loading')"
     [p-small]="properties.includes('small')"
+    [p-danger]="properties.includes('danger')"
     [p-kind]="kind"
     (p-click)="buttonClick()"
   >
@@ -28,6 +29,7 @@
       [(ngModel)]="properties"
       p-label="Properties"
       [p-options]="propertiesOptions"
+      (p-change)="propertiesChange($event)"
     >
     </po-checkbox-group>
   </div>

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
@@ -15,7 +15,8 @@ export class SamplePoButtonLabsComponent implements OnInit {
   propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'disabled', label: 'Disabled' },
     { value: 'loading', label: 'Loading' },
-    { value: 'small', label: 'Small' }
+    { value: 'small', label: 'Small' },
+    { value: 'danger', label: 'Danger' }
   ];
 
   iconsOptions: Array<PoRadioGroupOption> = [
@@ -28,8 +29,7 @@ export class SamplePoButtonLabsComponent implements OnInit {
   kindsOptions: Array<PoRadioGroupOption> = [
     { label: 'primary', value: 'primary' },
     { label: 'secondary', value: 'secondary' },
-    { label: 'tertiary', value: 'tertiary' },
-    { label: 'danger', value: 'danger' }
+    { label: 'tertiary', value: 'tertiary' }
   ];
 
   constructor(private poDialog: PoDialogService) {}
@@ -42,10 +42,27 @@ export class SamplePoButtonLabsComponent implements OnInit {
     this.poDialog.alert({ title: 'PO Button', message: 'Hello PO World!!!' });
   }
 
+  propertiesChange(event) {
+    this.kindsOptions[0] = { ...this.kindsOptions[0], disabled: false };
+    this.kindsOptions[2] = { ...this.kindsOptions[2], disabled: false };
+
+    if (event) {
+      event.forEach(property => {
+        if (property === 'danger' && this.properties.includes('danger')) {
+          this.kindsOptions[0] = { ...this.kindsOptions[0], disabled: true };
+          this.kindsOptions[2] = { ...this.kindsOptions[2], disabled: true };
+          this.kind = 'secondary';
+        }
+      });
+    }
+  }
+
   restore() {
     this.label = undefined;
     this.kind = undefined;
     this.icon = undefined;
     this.properties = [];
+    this.kindsOptions[0] = { ...this.kindsOptions[0], disabled: false };
+    this.kindsOptions[2] = { ...this.kindsOptions[2], disabled: false };
   }
 }


### PR DESCRIPTION
**BUTTON**

**DTHFUI-6005**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o `PoButton` tem a propriedade `p-kind/p-type` que pode receber o valor `danger` e aplicar um estilo ao botão.

**Qual o novo comportamento?**
A partir de agora será utilizada a propriedade `p-danger` para definir esse estilo e a propriedade `p-kind/p-type` terá o valor `danger` depreciado de sua enumeração.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/8720907/app.zip)