### PR TITLE
feat(table): adiciona po-checkbox na po-table

### DIFF
--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -48,6 +48,7 @@ export * from './po-url/po-url.component';
 
 export * from './po-checkbox-group/po-checkbox-group.module';
 export * from './po-datepicker/po-datepicker.module';
+export * from './po-checkbox/po-checkbox.module';
 
 export * from './po-field.module';
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.module.ts
@@ -1,0 +1,12 @@
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { PoCheckboxComponent } from './po-checkbox.component';
+
+@NgModule({
+  declarations: [PoCheckboxComponent],
+  imports: [CommonModule, FormsModule],
+  exports: [PoCheckboxComponent]
+})
+export class PoCheckboxModule {}

--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -21,7 +21,6 @@ import { PoTableModule } from '../po-table/po-table.module';
 import { PoTooltipModule } from './../../directives/po-tooltip/po-tooltip.module';
 import { PoIconModule } from '../po-icon/po-icon.module';
 
-import { PoCheckboxComponent } from './po-checkbox/po-checkbox.component';
 import { PoComboComponent } from './po-combo/po-combo.component';
 import { PoComboOptionTemplateDirective } from './po-combo/po-combo-option-template/po-combo-option-template.directive';
 import { PoDatepickerComponent } from './po-datepicker/po-datepicker.component';
@@ -55,6 +54,7 @@ import { PoUploadDragDropAreaOverlayComponent } from './po-upload/po-upload-drag
 import { PoUploadDragDropAreaComponent } from './po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component';
 import { PoUploadFileRestrictionsComponent } from './po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component';
 import { PoUrlComponent } from './po-url/po-url.component';
+import { PoCheckboxModule } from './po-checkbox/po-checkbox.module';
 
 /**
  * @description
@@ -87,13 +87,13 @@ import { PoUrlComponent } from './po-url/po-url.component';
     PoServicesModule,
     PoTableModule,
     PoTooltipModule,
-    PoIconModule
+    PoIconModule,
+    PoCheckboxModule
   ],
   exports: [
     PoCheckboxGroupModule,
     PoCleanModule,
     PoDatepickerModule,
-    PoCheckboxComponent,
     PoComboComponent,
     PoComboOptionTemplateDirective,
     PoDecimalComponent,
@@ -114,10 +114,10 @@ import { PoUrlComponent } from './po-url/po-url.component';
     PoSwitchComponent,
     PoTextareaComponent,
     PoUploadComponent,
-    PoUrlComponent
+    PoUrlComponent,
+    PoCheckboxModule
   ],
   declarations: [
-    PoCheckboxComponent,
     PoComboComponent,
     PoComboOptionTemplateDirective,
     PoDecimalComponent,

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
@@ -17,8 +17,12 @@
       <ng-container *ngIf="isSelectable; else masterDetailSpace">
         <td class="po-table-column-master-detail-space-checkbox"></td>
         <td class="po-table-column po-table-column-selectable">
-          <input class="po-table-checkbox" type="checkbox" [class.po-table-checkbox-checked]="item.$selected" />
-          <label class="po-table-checkbox-label po-clickable" (click)="onSelectRow(item)"> </label>
+          <po-checkbox
+            name="checkbox"
+            (click)="onSelectRow(item)"
+            (p-change)="onSelectRow(item)"
+            [(ngModel)]="item.$selected"
+          ></po-checkbox>
         </td>
       </ng-container>
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -60,15 +60,13 @@
       <tr [class.po-table-header]="!height">
         <th *ngIf="hasSelectableColumn" class="po-table-column-selectable">
           <div [class.po-table-header-fixed-inner]="height">
-            <input
+            <po-checkbox
+              name="selectAll"
               *ngIf="!hideSelectAll"
-              type="checkbox"
-              class="po-table-checkbox"
-              [class.po-table-checkbox-checked]="selectAll"
-              [class.po-table-checkbox-indeterminate]="selectAll === null"
-            />
-            <label *ngIf="!hideSelectAll" class="po-table-checkbox-label po-clickable" (click)="selectAllRows()">
-            </label>
+              (click)="selectAllRows()"
+              (p-change)="selectAllRows()"
+              [(ngModel)]="selectAll"
+            ></po-checkbox>
           </div>
         </th>
 
@@ -346,15 +344,13 @@
       <tr [class.po-table-header]="!height">
         <th *ngIf="hasSelectableColumn" class="po-table-column-selectable">
           <div [class.po-table-header-fixed-inner]="height">
-            <input
+            <po-checkbox
+              name="selectAll"
               *ngIf="!hideSelectAll"
-              type="checkbox"
-              class="po-table-checkbox"
-              [class.po-table-checkbox-checked]="selectAll"
-              [class.po-table-checkbox-indeterminate]="selectAll === null"
-            />
-            <label *ngIf="!hideSelectAll" class="po-table-checkbox-label po-clickable" (click)="selectAllRows()">
-            </label>
+              (click)="selectAllRows()"
+              (p-change)="selectAllRows()"
+              [(ngModel)]="selectAll"
+            ></po-checkbox>
           </div>
         </th>
 
@@ -639,8 +635,12 @@
 </ng-template>
 
 <ng-template #inputCheckbox let-row>
-  <input type="checkbox" class="po-table-checkbox" [class.po-table-checkbox-checked]="row.$selected" />
-  <label class="po-table-checkbox-label po-clickable" (click)="selectable ? selectRow(row) : 'javascript:;'"></label>
+  <po-checkbox
+    name="checkbox"
+    (p-change)="selectable ? selectRow(row) : 'javascript:;'"
+    [(ngModel)]="row.$selected"
+    (click)="selectable ? selectRow(row) : 'javascript:;'"
+  ></po-checkbox>
 </ng-template>
 
 <ng-template #contentHeaderTemplate let-column>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -322,49 +322,6 @@ describe('PoTableComponent:', () => {
     expect(selectableHeader).toBeFalsy();
   });
 
-  it('should allow multiple row selection', () => {
-    component.selectable = true;
-    component.singleSelect = false;
-    component.selectRow(component.items[0]);
-    component.selectRow(component.items[1]);
-
-    fixture.detectChanges();
-
-    const checkedColumns = tableElement.querySelectorAll('.po-table-checkbox-checked');
-    expect(checkedColumns.length).toBe(2);
-  });
-
-  it('should show indeterminate selectable', () => {
-    component.selectable = true;
-    fixture.detectChanges();
-
-    let selectableHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox-indeterminate');
-    expect(selectableHeader).toBeFalsy();
-
-    component.selectRow(component.items[0]);
-    component.selectRow(component.items[1]);
-    fixture.detectChanges();
-
-    selectableHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox-indeterminate');
-    expect(selectableHeader).toBeTruthy();
-  });
-
-  it('should select one row', () => {
-    const itemSelected = component.items[0];
-    component.selectable = true;
-    component.hideDetail = true;
-    component.columns = columnsWithDetail;
-    component.selectRow(itemSelected);
-
-    fixture.detectChanges();
-
-    const rowSelected = tableElement.querySelectorAll('.po-table-row-active');
-
-    expect(rowSelected).toBeTruthy();
-    expect(rowSelected[0].querySelector('.po-table-checkbox-checked')).toBeTruthy();
-    expect(rowSelected[0].innerHTML).toContain(itemSelected.id);
-  });
-
   it('should select all rows', () => {
     component.selectable = true;
     component.selectAllRows();
@@ -385,16 +342,6 @@ describe('PoTableComponent:', () => {
 
     const selectableColumnHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox');
     expect(selectableColumnHeader).toBeFalsy();
-  });
-
-  it('should show the option to select all', () => {
-    component.selectable = true;
-    component.hideSelectAll = false;
-
-    fixture.detectChanges();
-
-    const selectableColumnHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox');
-    expect(selectableColumnHeader).toBeTruthy();
   });
 
   it('shouldn`t show more button', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.module.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.module.ts
@@ -13,6 +13,7 @@ import { PoPopupModule } from './../po-popup/po-popup.module';
 import { PoTimeModule } from '../../pipes/po-time/index';
 import { PoTooltipModule } from '../../directives/po-tooltip/index';
 import { PoIconModule } from './../po-icon/po-icon.module';
+import { PoCheckboxModule } from './../po-field/po-checkbox/po-checkbox.module';
 
 import { PoTableColumnIconComponent } from './po-table-column-icon/po-table-column-icon.component';
 import { PoTableColumnLabelComponent } from './po-table-column-label/po-table-column-label.component';
@@ -46,7 +47,8 @@ import { PoTableColumnTemplateDirective } from './po-table-column-template/po-ta
     PoPopupModule,
     PoTimeModule,
     PoTooltipModule,
-    PoIconModule
+    PoIconModule,
+    PoCheckboxModule
   ],
   declarations: [
     PoTableComponent,


### PR DESCRIPTION
**TABLE**

**DTHFUI-6066**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente a PoTable utiliza um checkbox estilizado para selecionar linhas.

**Qual o novo comportamento?**
Agora a PoTable começa a utilizar o PoCheckbox no lugar do checkbox antigo.

**Simulação**
Utilizar este [app.zip](https://github.com/po-ui/po-angular/files/8764026/app.zip) e utilizar os Samples do Portal.

**PO-STYLE**: https://github.com/po-ui/po-style/pull/308