### PR TITLE
feat(menu): inclui propriedade p-logo-alt

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
@@ -398,6 +398,24 @@ describe('PoMenuBaseComponent:', () => {
 
       expect(result).toEqual(parentExpected);
     });
+
+    it('maxLenght: should set value according to max allowed', () => {
+      const largeValue =
+        'Lorem ipsum dolor sit amet consectetur adipisicing elit. Sit incidunt aliquam asperiores maxime, nulla fugit exercitationem. Abratione, quisquam.';
+      const maxLenght = component['maxLength'](largeValue);
+      const expectedValue =
+        'Lorem ipsum dolor sit amet consectetur adipisicing elit. Sit incidunt aliquam asperiores maxime, nulla fugit exercitationem. ';
+
+      expect(maxLenght).toBe(expectedValue);
+    });
+
+    it('maxLenght: should set exact value if value is less than max allowed', () => {
+      const smallValue =
+        'Lorem ipsum dolor sit amet consectetur adipisicing elit. Sit incidunt aliquam asperiores maxime, nulla fugit exercitationem.';
+      const maxLenght = component['maxLength'](smallValue);
+
+      expect(maxLenght).toBe(smallValue);
+    });
   });
 
   describe('Properties:', () => {
@@ -446,6 +464,19 @@ describe('PoMenuBaseComponent:', () => {
       const validValues = ['https://po-ui.io/logo', 'https://other.com/images/logo'];
 
       expectPropertiesValues(component, 'logo', validValues, validValues);
+    });
+
+    it('logoAlt: should set property with `default value` if invalid value', () => {
+      const invalidValues = ['', ' ', null, undefined, 0, false, true];
+      const expectedValue = 'Logomarca home';
+
+      expectPropertiesValues(component, 'logoAlt', invalidValues, expectedValue);
+    });
+
+    it('logoAlt: should set property with valid value', () => {
+      const validValues = ['Po-UI Logo', 'Other image logo'];
+
+      expectPropertiesValues(component, 'logoAlt', validValues, validValues);
     });
 
     it('shortLogo: should set property with `undefined` if invalid values', () => {

--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
@@ -18,11 +18,29 @@ import { PoLanguageService } from '../../services/po-language/po-language.servic
 import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 
 export const poMenuLiteralsDefault = {
-  en: { itemNotFound: 'Item not found.', emptyLabelError: 'Attribute PoMenuItem.label can not be empty.' },
-  es: { itemNotFound: 'Elemento no encontrado.', emptyLabelError: 'El atributo PoMenuItem.label no puede ser vacío.' },
-  pt: { itemNotFound: 'Item não encontrado.', emptyLabelError: 'O atributo PoMenuItem.label não pode ser vazio.' },
-  ru: { itemNotFound: 'Предмет не найден.', emptyLabelError: 'Атрибут PoMenuItem.label не может быть пустым.' }
+  en: {
+    itemNotFound: 'Item not found.',
+    emptyLabelError: 'Attribute PoMenuItem.label can not be empty.',
+    logomarcaHome: 'Home logo'
+  },
+  es: {
+    itemNotFound: 'Elemento no encontrado.',
+    emptyLabelError: 'El atributo PoMenuItem.label no puede ser vacío.',
+    logomarcaHome: 'Logomarca inicio'
+  },
+  pt: {
+    itemNotFound: 'Item não encontrado.',
+    emptyLabelError: 'O atributo PoMenuItem.label não pode ser vazio.',
+    logomarcaHome: 'Logomarca home'
+  },
+  ru: {
+    itemNotFound: 'Предмет не найден.',
+    emptyLabelError: 'Атрибут PoMenuItem.label не может быть пустым.',
+    logomarcaHome: 'Дом Логомарка'
+  }
 };
+
+export const MAX_LENGHT: number = 125;
 
 /**
  * @description
@@ -49,6 +67,7 @@ export abstract class PoMenuBaseComponent {
   private _filter = false;
   private _level;
   private _logo: string;
+  private _logoAlt: string = this.literals.logomarcaHome;
   private _maxLevel = 4;
   private _menus = [];
   private _params: any;
@@ -214,6 +233,24 @@ export abstract class PoMenuBaseComponent {
    *
    * @description
    *
+   * Texto alternativo para o logo.
+   *
+   * > Caso esta propriedade seja indefinida ou inválida o texto padrão será "Logomarca home".
+   */
+  @Input('p-logo-alt') set logoAlt(value: string) {
+    const alt = isTypeof(value, 'string') && value.trim() ? this.maxLength(value) : undefined;
+    this._logoAlt = alt ?? this._logoAlt;
+  }
+
+  get logoAlt() {
+    return this._logoAlt;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Caminho para a logomarca, que será exibida quando o componente estiver colapsado, localizada na parte superior.
    *
    * > **Importante:**
@@ -343,6 +380,10 @@ export abstract class PoMenuBaseComponent {
         this.validateMenu(subItem);
       });
     }
+  }
+
+  private maxLength(value: string) {
+    return value.length > MAX_LENGHT ? value.toString().substring(0, MAX_LENGHT) : value;
   }
 
   protected abstract checkActiveMenuByUrl(urlRouter);

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.html
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.html
@@ -11,6 +11,7 @@
           <img
             [ngClass]="enableCollapse ? 'po-menu-short-logo' : 'po-menu-logo'"
             [src]="enableCollapse ? shortLogo || logo : logo"
+            [alt]="logoAlt"
           />
         </a>
       </div>


### PR DESCRIPTION
**MENU**

**DTHFUI-6004**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o logo do menu não possuí a propriedade `alt`.

**Qual o novo comportamento?**
Adicionado a propriedade `p-logo-alt` para inclusão de texto alternativo e realizado os tratamentos necessários para controle de caracteres.

**Simulação**
`app.component.html`
```
<po-menu
  p-logo="https://po-ui.io/assets/po-logos/po_color.svg"
  p-logo-alt="Po-UI Logo"
  [p-menus]="[{ label: 'PO UI - Angular Framework', link: '/' }]"
>
</po-menu>
```