### PR TITLE
fix(datepicker): corrige data independente do fuso

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -128,8 +128,26 @@ describe('PoDatepickerBaseComponent:', () => {
   });
 
   it('should be update property date', () => {
-    const expectedValue = convertIsoToDate('2021/08/20', false, false);
+    const expectedValue = UtilsFunctions.convertIsoToDateNoTimezone('2021/08/20');
     expectPropertiesValues(component, 'date', '2021/08/20', expectedValue);
+  });
+
+  it('should call `convertIsoToDate` when isExtendedISO is true', () => {
+    spyOn(UtilsFunctions, 'convertIsoToDate');
+    component['isExtendedISO'] = true;
+
+    component.date = '2022-06-07';
+
+    expect(UtilsFunctions.convertIsoToDate).toHaveBeenCalled();
+  });
+
+  it('shouldnt call `convertIsoToDateNoTimezone` when isExtendedISO is false', () => {
+    spyOn(UtilsFunctions, 'convertIsoToDateNoTimezone');
+    component['isExtendedISO'] = false;
+
+    component.date = '2022-06-07';
+
+    expect(UtilsFunctions.convertIsoToDateNoTimezone).toHaveBeenCalled();
   });
 
   it('should transform a String to Date', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -5,9 +5,9 @@ import {
   convertDateToISODate,
   convertDateToISOExtended,
   convertIsoToDate,
+  convertIsoToDateNoTimezone,
   convertToBoolean,
   formatYear,
-  getShortBrowserLanguage,
   isTypeof,
   setYearFrom0To100,
   validateDateRange
@@ -335,7 +335,11 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   }
 
   set date(value: any) {
-    this._date = typeof value === 'string' ? convertIsoToDate(value, false, false) : value;
+    if (this.isExtendedISO) {
+      this._date = typeof value === 'string' ? convertIsoToDate(value, false, false) : value;
+    } else {
+      this._date = typeof value === 'string' ? convertIsoToDateNoTimezone(value) : value;
+    }
   }
 
   get date() {

--- a/projects/ui/src/lib/utils/util.spec.ts
+++ b/projects/ui/src/lib/utils/util.spec.ts
@@ -347,6 +347,17 @@ describe('Function convertIsoToDate:', () => {
   });
 });
 
+describe('Function convertIsoToDateNoTimezone:', () => {
+  it('should be a no value', () => {
+    const date = '';
+    expect(typeof UtilFunctions.convertIsoToDateNoTimezone(date)).toBe('undefined');
+  });
+  it('should transform the value string into data', () => {
+    const date = new Date(2022, 4, 26).toISOString();
+    expect(typeof UtilFunctions.convertIsoToDateNoTimezone(date)).toBe('object');
+  });
+});
+
 describe('Function callFunction:', () => {
   const context = {
     getName: function () {

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -147,6 +147,16 @@ export function convertIsoToDate(value: string, start: boolean, end: boolean) {
   }
 }
 
+export function convertIsoToDateNoTimezone(value: string) {
+  if (value) {
+    const day = parseInt(value.substring(8, 10), 10);
+    const month = parseInt(value.substring(5, 7), 10);
+    const year = parseInt(value.substring(0, 4), 10);
+
+    return new Date(year, month - 1, day);
+  }
+}
+
 export function convertDateToISODate(date: Date) {
   if (date) {
     const getMonth = date.getMonth() + 1;


### PR DESCRIPTION
**Datepicker**

**DTHFUI-5990**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao selecionar uma data através do componente po-datepicker, a data que é aplicada é a do dia anterior ao selecionado.

**Qual o novo comportamento?**
A data selecionada deve ser a mesma data aplicada no model do componente, independente da localização, do fuzo e horário de inverno e verão.

**Simulação**
Alterar Data e Hora do computador local para o fuso de Lisboa.
Importante testar com datas do fuso de inverno da europa, que é o fuso diferente do atual que é o de verão. Exemplo de mês é o fevereiro. Na issue tem a descrição completa dos períodos de inverno e verão.
![image](https://user-images.githubusercontent.com/31509625/170548502-f6638c53-6a2b-4a24-b245-157ef1af4b54.png)

[app.zip](https://github.com/po-ui/po-angular/files/8781019/app.zip)
