### PR TITLE
feat(combo): adicionado um output para o input search do combo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -230,6 +230,16 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    */
   @Output('ngModelChange') ngModelChange: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Deve ser informada uma função que será disparada quando houver alterações no Search input. A função receberá como argumento o input modificado.
+   *
+   */
+  @Output('p-input-change') inputChange: EventEmitter<string> = new EventEmitter<string>();
+
   cacheOptions: Array<PoComboOption | PoComboGroup> = [];
   defaultService: PoComboFilterService;
   firstInWriteValue: boolean = true;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -304,6 +304,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
           this.shouldMarkLetters = true;
           this.isFiltering = true;
           this.searchForLabel(inputValue, this.comboOptionsList, this.filterMode);
+          this.inputChange.emit(inputValue);
         }
       } else {
         // quando apagar rapido o campo e conter serviço, valor, não disparava o keyup observable


### PR DESCRIPTION
**< COMPONENTE >**
po-combo.component.ts, po-combo-base.component.ts

**< NÚMERO DA ISSUE >**
#1292 
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O valor do input digitado só acessível ao escopo do po-combo

**Qual o novo comportamento?**
O valor do input digitado é emitido através do output "p-input-change"

**Simulação**
Ao ser digitado alguma tecla o valor é emito para o output "p-input-change", somente quando nenhum "p-filter-service" for definido