### PR TITLE
feat(radio): cria novo componente po-radio

### DIFF
--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -45,6 +45,7 @@ export * from './po-upload/interfaces/po-upload-file-restriction.interface';
 export * from './po-upload/interfaces/po-upload-literals.interface';
 export * from './po-upload/po-upload.component';
 export * from './po-url/po-url.component';
+export * from './po-radio/po-radio.component';
 
 export * from './po-checkbox-group/po-checkbox-group.module';
 export * from './po-datepicker/po-datepicker.module';

--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -55,6 +55,7 @@ import { PoUploadDragDropAreaComponent } from './po-upload/po-upload-drag-drop/p
 import { PoUploadFileRestrictionsComponent } from './po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component';
 import { PoUrlComponent } from './po-url/po-url.component';
 import { PoCheckboxModule } from './po-checkbox/po-checkbox.module';
+import { PoRadioComponent } from './po-radio/po-radio.component';
 
 /**
  * @description
@@ -115,6 +116,7 @@ import { PoCheckboxModule } from './po-checkbox/po-checkbox.module';
     PoTextareaComponent,
     PoUploadComponent,
     PoUrlComponent,
+    PoRadioComponent,
     PoCheckboxModule
   ],
   declarations: [
@@ -149,7 +151,8 @@ import { PoCheckboxModule } from './po-checkbox/po-checkbox.module';
     PoUploadDragDropAreaOverlayComponent,
     PoUploadDragDropAreaComponent,
     PoUploadFileRestrictionsComponent,
-    PoUrlComponent
+    PoUrlComponent,
+    PoRadioComponent
   ],
   providers: []
 })

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio-base.component.spec.ts
@@ -1,0 +1,128 @@
+import { Directive } from '@angular/core';
+
+import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
+import { PoRadioBaseComponent } from './po-radio-base.component';
+
+@Directive()
+class PoRadioComponent extends PoRadioBaseComponent {
+  protected changeModelValue(value: boolean | null) {}
+}
+
+describe('PoRadioBaseComponent:', () => {
+  let component: PoRadioBaseComponent;
+
+  beforeEach(() => {
+    component = new PoRadioComponent();
+    component.propagateChange = (value: any) => {};
+  });
+
+  it('should be created', () => {
+    component.registerOnChange(() => {});
+    component.registerOnTouched(() => {});
+    expect(component instanceof PoRadioBaseComponent).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+    it('disabled: should update with true value', () => {
+      const booleanValidTrueValues = [true, 'true', 1, ''];
+
+      expectPropertiesValues(component, 'disabled', booleanValidTrueValues, true);
+    });
+
+    it('disabled: should update with false value', () => {
+      const booleanInvalidValues = [undefined, null, 2, 'string', 0, NaN, false];
+
+      expectPropertiesValues(component, 'disabled', booleanInvalidValues, false);
+    });
+    it('size: should update with valid values', () => {
+      const validValues = ['medium', 'large'];
+      const expectedValidValues = ['medium', 'large'];
+
+      expectPropertiesValues(component, 'size', validValues, expectedValidValues);
+    });
+    it('size: should update with `medium` when invalid values', () => {
+      const invalidValues = [true, false, 'sm', 'lg'];
+
+      expectPropertiesValues(component, 'size', invalidValues, 'medium');
+    });
+  });
+
+  describe('Methods:', () => {
+    it('changeValue: should call `propagateChange` if it is defined and call `change.emit` with `radioValue`', () => {
+      component.radioValue = true;
+
+      component.propagateChange = () => {};
+
+      spyOn(component, 'propagateChange');
+      spyOn(component.change, 'emit');
+
+      component.changeValue();
+
+      expect(component.propagateChange).toHaveBeenCalledWith(component.radioValue);
+      expect(component.change.emit).toHaveBeenCalledWith(component.radioValue);
+    });
+
+    it('changeValue: should call only `change.emit` with `radioValue` if propagateChange is `null`', () => {
+      component.radioValue = true;
+      component.propagateChange = null;
+
+      spyOn(component.change, 'emit');
+
+      component.changeValue();
+
+      expect(component.change.emit).toHaveBeenCalledWith(component.radioValue);
+    });
+
+    it('checkOption: should call `changeModelValue` and `changeValue` if `disabled` is false.', () => {
+      component.disabled = false;
+      const spyOnChangeValue = spyOn(component, 'changeValue');
+      const spyOnChangeModelValue = spyOn(component, <any>'changeModelValue');
+
+      component.checkOption(true);
+
+      expect(spyOnChangeValue).toHaveBeenCalled();
+      expect(spyOnChangeModelValue).toHaveBeenCalled();
+    });
+
+    it('checkOption: shouldn`t call `changeModelValue` and `changeValue` if `disabled` is true.', () => {
+      component.disabled = true;
+      const spyOnChangeValue = spyOn(component, 'changeValue');
+      const spyOnChangeModelValue = spyOn(component, <any>'changeModelValue');
+
+      component.checkOption(true);
+
+      expect(spyOnChangeValue).not.toHaveBeenCalled();
+      expect(spyOnChangeModelValue).not.toHaveBeenCalled();
+    });
+
+    it('registerOnChange: should set `propagateChange` with value of `fnParam`', () => {
+      const fnParam = () => {};
+
+      component.registerOnChange(fnParam);
+
+      expect(component['propagateChange']).toBe(fnParam);
+    });
+
+    it('writeValue: should call `changeModelValue` if value is different from `radioValue`', () => {
+      const valueParam = true;
+      component.radioValue = undefined;
+
+      spyOn(component, <any>'changeModelValue');
+
+      component.writeValue(valueParam);
+
+      expect(component['changeModelValue']).toHaveBeenCalledWith(valueParam);
+    });
+
+    it('writeValue: shouldn`t call `changeModelValue` if value is same as `radioValue`', () => {
+      const valueParam = undefined;
+      component.radioValue = undefined;
+
+      spyOn(component, <any>'changeModelValue');
+
+      component.writeValue(valueParam);
+
+      expect(component['changeModelValue']).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio-base.component.ts
@@ -1,0 +1,100 @@
+import { Directive, EventEmitter, Input, Output } from '@angular/core';
+
+import { ControlValueAccessor } from '@angular/forms';
+import { InputBoolean } from '../../../decorators';
+import { uuid } from './../../../utils/util';
+import { PoRadioSize } from './po-radio-size.enum';
+
+/**
+ * @docsPrivate
+ *
+ * @description
+ *
+ * O componente `po-radio` é um componente interno e deve ser utilizado em conjunto com o componente `po-radio-group`.
+ */
+
+@Directive()
+export abstract class PoRadioBaseComponent implements ControlValueAccessor {
+  /** Define o nome do *radio*. */
+  @Input('name') name: string;
+
+  /** Texto de exibição do *radio* */
+  @Input('p-label') label?: string;
+
+  /** Define o status do *radio* */
+  @Input('p-checked') radioValue: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o estado do *radio* como desabilitado;
+   *
+   * @default `false`
+   */
+  @Input('p-disabled') @InputBoolean() disabled: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado quando o valor do *radio* for alterado.
+   */
+  @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
+
+  id = uuid();
+  propagateChange: any;
+  onTouched;
+
+  private _size: PoRadioSize = PoRadioSize.medium;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o tamanho do *radio*
+   * @default `medium`
+   */
+  @Input('p-size') set size(value: string) {
+    this._size = PoRadioSize[value] ? PoRadioSize[value] : PoRadioSize.medium;
+  }
+
+  get size() {
+    return this._size;
+  }
+
+  changeValue() {
+    if (this.propagateChange) {
+      this.propagateChange(this.radioValue);
+    }
+
+    this.change.emit(this.radioValue);
+  }
+
+  checkOption(value: boolean) {
+    if (this.disabled) {
+      return;
+    }
+    this.changeModelValue(true);
+    this.changeValue();
+  }
+
+  registerOnChange(fn: any): void {
+    this.propagateChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+
+  writeValue(value: any) {
+    if (value !== this.radioValue) {
+      this.changeModelValue(value);
+    }
+  }
+
+  protected abstract changeModelValue(value: boolean | null);
+}

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio-size.enum.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio-size.enum.ts
@@ -1,0 +1,4 @@
+export enum PoRadioSize {
+  medium = 'medium',
+  large = 'large'
+}

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
@@ -1,0 +1,28 @@
+<div
+  class="po-radio-container"
+  [attr.checked]="radioValue"
+  (click)="checkOption(radioValue)"
+  (keydown)="onKeyDown($event, radioValue)"
+>
+  <input
+    type="radio"
+    [ngClass]="{ 'po-radio-large': size === 'large' }"
+    [attr.aria-checked]="radioValue"
+    [attr.aria-label]="label"
+    [id]="id"
+    class="po-radio"
+    role="radio"
+    [attr.aria-disabled]="disabled"
+    [tabindex]="disabled ? -1 : 0"
+    [disabled]="disabled"
+  />
+  <label
+    #radioLabel
+    [for]="id"
+    class="po-radio-label"
+    [ngClass]="{ 'po-radio-label-disabled': disabled }"
+    tabindex="-1"
+  >
+    {{ label }}
+  </label>
+</div>

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.spec.ts
@@ -1,0 +1,156 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { configureTestSuite } from './../../../util-test/util-expect.spec';
+import { PoRadioComponent } from './po-radio.component';
+
+describe('PoRadioComponent', () => {
+  let changeDetector: any;
+  let component: PoRadioComponent;
+  let fixture: ComponentFixture<PoRadioComponent>;
+  let nativeElement: any;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [PoRadioComponent]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoRadioComponent);
+    component = fixture.componentInstance;
+    nativeElement = fixture.debugElement.nativeElement;
+
+    changeDetector = fixture.componentRef.injector.get(ChangeDetectorRef);
+    fixture.debugElement.injector.get(NG_VALUE_ACCESSOR);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Methods:', () => {
+    it('focus: should call `focus` of radio.', () => {
+      const spyOnFocus = spyOn(component.radioLabel.nativeElement, 'focus');
+      component.focus();
+
+      expect(spyOnFocus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of radio if options is `disabled`.', () => {
+      component.disabled = true;
+      const spyOnFocus = spyOn(component.radioLabel.nativeElement, 'focus');
+      component.focus();
+
+      expect(spyOnFocus).not.toHaveBeenCalled();
+    });
+
+    describe('onKeyDown:', () => {
+      let fakeEvent: any;
+
+      beforeEach(() => {
+        fakeEvent = {
+          which: 32,
+          keyCode: 32,
+          preventDefault: () => {}
+        };
+      });
+
+      it('should call `checkOption` and `preventDefault` if event `which` from spacebar', () => {
+        const spyOnCheckOption = spyOn(component, 'checkOption');
+        const spyOnPreventDefault = spyOn(fakeEvent, 'preventDefault');
+
+        component.onKeyDown(fakeEvent, component.radioValue);
+
+        expect(spyOnCheckOption).toHaveBeenCalledWith(component.radioValue);
+        expect(spyOnPreventDefault).toHaveBeenCalled();
+      });
+
+      it('shouldn`t call `checkOption` and `preventDefault` if event `which` or `keyCode` from tab.', () => {
+        fakeEvent.which = 9;
+        fakeEvent.keyCode = 9;
+
+        const spyOnCheckOption = spyOn(component, 'checkOption');
+        const spyOnPreventDefault = spyOn(fakeEvent, 'preventDefault');
+
+        component.onKeyDown(fakeEvent, component.radioValue);
+
+        expect(spyOnCheckOption).not.toHaveBeenCalled();
+        expect(spyOnPreventDefault).not.toHaveBeenCalled();
+      });
+    });
+
+    it('changeModelValue: should update `changeModelValue` with property values', () => {
+      const items = [
+        { value: true, expectedValue: true },
+        { value: false, expectedValue: false },
+        { value: 'false', expectedValue: false },
+        { value: 'true', expectedValue: false },
+        { value: 'anotherValue', expectedValue: false }
+      ];
+
+      items.forEach(item => {
+        component['changeModelValue'](item.value);
+        expect(component.radioValue).toEqual(item.expectedValue);
+      });
+    });
+
+    it('onBlur: should call `onTouched` on blur', () => {
+      component.onTouched = value => {};
+
+      spyOn(component, 'onTouched');
+      component.onBlur();
+
+      expect(component.onTouched).toHaveBeenCalledWith();
+    });
+
+    it('onBlur: shouldn´t throw error if onTouched is falsy', () => {
+      component['onTouched'] = null;
+
+      const fnError = () => component.onBlur();
+
+      expect(fnError).not.toThrow();
+    });
+  });
+
+  describe('Templates:', () => {
+    it('should have label.', () => {
+      const newLabel = 'PO';
+      component.label = newLabel;
+
+      changeDetector.detectChanges();
+      expect(nativeElement.querySelector('.po-radio-label')).toBeTruthy();
+    });
+
+    it('should set tabindex to -1 when radio is disabled.', () => {
+      changeDetector.detectChanges();
+      expect(nativeElement.querySelector('.po-radio-label[tabindex="-1"]')).toBeTruthy();
+    });
+
+    it('aria-checked should be true if radio is true', () => {
+      component.radioValue = true;
+      changeDetector.detectChanges();
+      const spanRadio = nativeElement.querySelector('.po-radio');
+
+      expect(spanRadio.getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('aria-checked should be null if radio is null', () => {
+      component.radioValue = null;
+      changeDetector.detectChanges();
+      const spanRadio = nativeElement.querySelector('.po-radio');
+
+      expect(spanRadio.getAttribute('aria-checked')).toBeNull();
+    });
+
+    it('aria-checked should be false if radio is false', () => {
+      component.radioValue = false;
+      changeDetector.detectChanges();
+      const spanRadio = nativeElement.querySelector('.po-radio');
+
+      expect(spanRadio.getAttribute('aria-checked')).toBe('false');
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.ts
@@ -1,0 +1,78 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  forwardRef,
+  ViewChild
+} from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { PoKeyCodeEnum } from './../../../enums/po-key-code.enum';
+import { PoRadioBaseComponent } from './po-radio-base.component';
+
+/**
+ * @docsPrivate
+ *
+ * @docsExtends PoRadioBaseComponent
+ */
+@Component({
+  selector: 'po-radio',
+  templateUrl: './po-radio.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => PoRadioComponent),
+      multi: true
+    }
+  ]
+})
+export class PoRadioComponent extends PoRadioBaseComponent {
+  @ViewChild('radioLabel', { static: true }) radioLabel: ElementRef;
+
+  constructor(private changeDetector: ChangeDetectorRef) {
+    super();
+  }
+
+  /**
+   * Função que atribui foco ao *radio*.
+   *
+   * Para utilizá-la é necessário capturar a referência do componente no DOM através do `ViewChild`, como por exemplo:
+   *
+   * ```
+   * import { ViewChild } from '@angular/core';
+   * import { PoRadioComponent } from '@po-ui/ng-components';
+   *
+   * ...
+   *
+   * @ViewChild(PoRadioComponent, { static: true }) radio: PoRadioComponent;
+   *
+   * focusRadio() {
+   * this.radio.focus();
+   * }
+   * ```
+   *
+   */
+  focus(): void {
+    if (this.radioLabel && !this.disabled) {
+      this.radioLabel.nativeElement.focus();
+    }
+  }
+
+  onBlur() {
+    this.onTouched?.();
+  }
+
+  onKeyDown(event: KeyboardEvent, value: boolean) {
+    if (event.which === PoKeyCodeEnum.space || event.keyCode === PoKeyCodeEnum.space) {
+      this.checkOption(value);
+
+      event.preventDefault();
+    }
+  }
+  protected changeModelValue(value: boolean | string) {
+    this.radioValue = typeof value === 'boolean' ? value : false;
+    this.changeDetector.detectChanges();
+  }
+}


### PR DESCRIPTION
**RADIO**

**DTHFUI-6067**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não existe componente interno de input Radio.

**Qual o novo comportamento?**
Cria componente interno input Radio baseado nas definições do AnimaliaDS.

**Simulação**

`app.component.html`
```html
<po-page-default>
  <po-radio p-label="Po Radio" p-disabled="true" [p-checked]="true"></po-radio>
  <po-radio p-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et semper diam. Sed porta nisi id pellentesque lacinia. Pellentesque bibendum tellus quis tortor elementum, id pellentesque erat tincidunt. Morbi ut accumsan libero, sed pellentesque orci. Vivamus sollicitudin pellentesque turpis, id vehicula nisl ornare et. Ut sollicitudin lorem id sodales tincidunt. Sed eu libero id lacus molestie dignissim. Proin ipsum ipsum, sagittis ut euismod eget, blandit non nisi."></po-radio>
  <po-radio p-label="Po Radio Disabled" p-disabled="true"></po-radio>
  <po-radio p-label="Po Radio Large" p-size="large" [p-checked]="true"></po-radio>
  <po-radio p-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et semper diam. Sed porta nisi id pellentesque lacinia. Pellentesque bibendum tellus quis tortor elementum, id pellentesque erat tincidunt. Morbi ut accumsan libero, sed pellentesque orci. Vivamus sollicitudin pellentesque turpis, id vehicula nisl ornare et. Ut sollicitudin lorem id sodales tincidunt. Sed eu libero id lacus molestie dignissim. Proin ipsum ipsum, sagittis ut euismod eget, blandit non nisi." p-size="large"></po-radio>
  <po-radio p-label="Po Radio Large Disabled" p-disabled="true" p-size="large"></po-radio>
</po-page-default>
```
**PRs Adicionais**

**po-style:** https://github.com/po-ui/po-style/pull/313
**po-theme-totvs:** https://github.com/totvs/po-theme-totvs/pull/153