### PR TITLE
fix(build): adiciona a dependencia do cdk

### DIFF
--- a/projects/ui/ng-package.json
+++ b/projects/ui/ng-package.json
@@ -4,5 +4,5 @@
   "lib": {
     "entryFile": "./src/public-api.ts"
   },
-  "allowedNonPeerDependencies": ["@po-ui/style", "@po-ui/ng-schematics"]
+  "allowedNonPeerDependencies": ["@angular/cdk", "@po-ui/style", "@po-ui/ng-schematics"]
 }

--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -21,12 +21,14 @@
     ]
   },
   "dependencies": {
+    "@angular/cdk": "^13.3.1",
     "@po-ui/style": "0.0.0-PLACEHOLDER",
     "@po-ui/ng-schematics": "0.0.0-PLACEHOLDER",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/animations": "^13.0.2",
+    "@angular/cdk": "^13.3.1",
     "@angular/common": "^13.0.2",
     "@angular/compiler": "^13.0.2",
     "@angular/core": "^13.0.2",


### PR DESCRIPTION
**BUILD**

**DTHFUI-6180**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao iniciar um novo projeto em angular e adicionar a biblioteca de componentes do Po-UI, é apresentado um erro na execução por falta da dependência @angular/cdk/scrolling.

**Qual o novo comportamento?**
Dependência foi incluída no projeto do UI.

**Simulação**
Criar um novo projeto angular seguindo os primeiros passos no portal.
Primeiros passos: https://po-ui.io/guides/getting-started
