### PR TITLE
fix(table): alinha colunas do header

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -78,6 +78,7 @@
 
         <!-- Coluna criada para caso as ações fiquem no lado esquerdo -->
         <th
+          #columnActionLeft
           *ngIf="!actionRight && (visibleActions.length > 1 || isSingleAction)"
           [class.po-table-header-master-detail]="!isSingleAction"
           [class.po-table-header-single-action]="isSingleAction"
@@ -115,7 +116,7 @@
 
         <th
           *ngIf="hasVisibleActions && hideColumnsManager && actionRight"
-          [class.po-table-header-single-action]="isSingleAction"
+          [class.po-table-header-single-action]="isSingleAction && !hideColumnsManager"
           [class.po-table-header-actions]="!isSingleAction"
         ></th>
 
@@ -691,7 +692,13 @@
 
 <!-- Template de ações -->
 <ng-template #ActionsColumnTemplate let-row="row" let-rowIndex="rowIndex">
-  <td *ngIf="isSingleAction" class="po-table-column po-table-column-single-action">
+  <td
+    *ngIf="isSingleAction"
+    class="po-table-column po-table-column-single-action"
+    [style.width.px]="height && actionRight ? getWidthColumnManager() : ''"
+    [style.max-width.px]="height && !actionRight ? getColumnWidthActionsLeft() : ''"
+    [style.width.px]="height && !actionRight ? getColumnWidthActionsLeft() : ''"
+  >
     <div
       *ngIf="firstAction.visible !== false"
       class="po-table-single-action po-clickable"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -2949,6 +2949,62 @@ describe('PoTableComponent:', () => {
     expect(fakeThis.poTableThead.nativeElement.scrollLeft).toEqual(100);
   });
 
+  it('getWidthColumnManager, should return width of column manager', () => {
+    const fakeThis = {
+      columnManager: {
+        nativeElement: {
+          offsetWidth: 120
+        }
+      }
+    };
+
+    fixture.detectChanges();
+
+    component['getWidthColumnManager'].call(fakeThis);
+
+    expect(fakeThis.columnManager.nativeElement.offsetWidth).toEqual(120);
+  });
+
+  it('getWidthColumnManager, should return undefined if not contain column manager', () => {
+    const fakeThis = {
+      columnManager: undefined
+    };
+
+    fixture.detectChanges();
+
+    const valueWidth = component['getWidthColumnManager'].call(fakeThis);
+
+    expect(valueWidth).toEqual(undefined);
+  });
+
+  it('columnActionLeft, should return width of column when action is on the left', () => {
+    const fakeThis = {
+      columnActionLeft: {
+        nativeElement: {
+          offsetWidth: 120
+        }
+      }
+    };
+
+    fixture.detectChanges();
+
+    component['getColumnWidthActionsLeft'].call(fakeThis);
+
+    expect(fakeThis.columnActionLeft.nativeElement.offsetWidth).toEqual(120);
+  });
+
+  it('columnActionLeft, should return undefined if not contain actions on the left', () => {
+    const fakeThis = {
+      columnActionLeft: undefined
+    };
+
+    fixture.detectChanges();
+
+    const valueWidth = component['getColumnWidthActionsLeft'].call(fakeThis);
+
+    expect(valueWidth).toEqual(undefined);
+  });
+
   it('hasInfiniteScroll: should return false if infiniteScroll is false', () => {
     component.infiniteScroll = false;
     component.poTableTbodyVirtual = {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -97,6 +97,8 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   @ViewChild('poTableTbody', { read: ElementRef, static: false }) poTableTbody;
   @ViewChild('poTableThead', { read: ElementRef, static: false }) poTableThead;
   @ViewChild('poTableTbodyVirtual', { read: ElementRef, static: false }) poTableTbodyVirtual;
+  @ViewChild('columnManager', { read: ElementRef, static: false }) columnManager;
+  @ViewChild('columnActionLeft', { read: ElementRef, static: false }) columnActionLeft;
 
   @ViewChildren('actionsIconElement', { read: ElementRef }) actionsIconElement: QueryList<any>;
   @ViewChildren('actionsElement', { read: ElementRef }) actionsElement: QueryList<any>;
@@ -548,6 +550,14 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   public syncronizeHorizontalScroll(): void {
     this.poTableThead.nativeElement.scrollLeft = this.poTableTbodyVirtual.nativeElement.scrollLeft;
+  }
+
+  public getWidthColumnManager() {
+    return this.columnManager?.nativeElement.offsetWidth;
+  }
+
+  public getColumnWidthActionsLeft() {
+    return this.columnActionLeft?.nativeElement.offsetWidth;
   }
 
   protected calculateHeightTableContainer(height) {


### PR DESCRIPTION
Alinha colunas do header quando a tabela possui `p-height`

**Table**

**DTHFUI-6095**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
colunas da tabela estão ficando desalinhada quando possui p-height

**Qual o novo comportamento?**
colunas da tabela estão ficando alinhadas quando possui p-height

**Simulação**
utilizar app e testar samples do portal:
[app.zip](https://github.com/po-ui/po-angular/files/8846442/app.zip)

