### PR TITLE
feat(list-view): adiciona po-checkbox no `po-list-view`

### DIFF
--- a/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
@@ -6,18 +6,13 @@
   <div *ngIf="showHeader" class="po-list-view-main-header">
     <div class="po-checkbox-group-item">
       <div class="po-list-view-main-select">
-        <input
-          class="po-input po-checkbox-group-input"
-          type="checkbox"
-          [class.po-checkbox-group-input-checked]="selectAll"
-          [class.po-checkbox-group-input-indeterminate]="selectAll === null"
-        />
-        <label
-          class="po-checkbox-group-label po-list-view-selectable-label po-clickable"
+        <po-checkbox
+          name="selectAll"
+          [(ngModel)]="selectAll"
+          [p-label]="literals.selectAll"
+          (p-change)="selectAllListItems()"
           (click)="selectAllListItems()"
-        >
-          {{ literals.selectAll }}
-        </label>
+        ></po-checkbox>
       </div>
     </div>
   </div>
@@ -35,15 +30,12 @@
           <div class="po-list-view-header">
             <div class="po-list-view-title" [ngSwitch]="checkTitleType(item)">
               <div *ngIf="select" class="po-list-view-select">
-                <input
-                  class="po-input po-checkbox-group-input"
-                  type="checkbox"
-                  [class.po-checkbox-group-input-checked]="item.$selected"
-                />
-                <label
-                  class="po-checkbox-group-label po-list-view-selectable-label po-clickable"
+                <po-checkbox
+                  [(ngModel)]="item.$selected"
+                  name="checkbox"
+                  (p-change)="selectListItem(item)"
                   (click)="selectListItem(item)"
-                ></label>
+                ></po-checkbox>
               </div>
               <a
                 *ngSwitchCase="'externalLink'"

--- a/projects/ui/src/lib/components/po-list-view/po-list-view.component.spec.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.component.spec.ts
@@ -574,42 +574,6 @@ describe('PoListViewComponent:', () => {
       expect(debugElement.querySelector('.po-list-view-select')).toBeNull();
     });
 
-    it('should apply `po-checkbox-group-input-checked` if `showHeader` and `selectAll` are `true`.', () => {
-      component.showHeader = true;
-      component.selectAll = true;
-
-      fixture.detectChanges();
-
-      expect(debugElement.querySelector('.po-checkbox-group-input-checked')).toBeTruthy();
-    });
-
-    it('should apply `po-checkbox-group-input-indeterminate` if `showHeader` is true and `selectAll` is `null`.', () => {
-      component.showHeader = true;
-      component.selectAll = null;
-
-      fixture.detectChanges();
-
-      expect(debugElement.querySelector('.po-checkbox-group-input-indeterminate')).toBeTruthy();
-    });
-
-    it('shouldn`t apply `po-checkbox-group-input-checked` if showHeader is false.', () => {
-      component.showHeader = false;
-      component.selectAll = true;
-
-      fixture.detectChanges();
-
-      expect(debugElement.querySelector('.po-checkbox-group-input-checked')).toBeNull();
-    });
-
-    it('shouldn`t apply `po-checkbox-group-input-indeterminate` if showHeader is false.', () => {
-      component.showHeader = false;
-      component.selectAll = null;
-
-      fixture.detectChanges();
-
-      expect(debugElement.querySelector('.po-checkbox-group-input-indeterminate')).toBeNull();
-    });
-
     it('should contain the attributes `href` and `target` if title is an external link and call getItemTitle with lisItem', () => {
       spyOn(component, 'getItemTitle');
       spyOn(component, 'checkTitleType').and.returnValue('externalLink');

--- a/projects/ui/src/lib/components/po-list-view/po-list-view.module.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.module.ts
@@ -1,9 +1,11 @@
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 import { PoButtonModule } from '../po-button/po-button.module';
 import { PoPopupModule } from '../po-popup/po-popup.module';
+import { PoCheckboxModule } from './../po-field/po-checkbox/po-checkbox.module';
 
 import { PoListViewComponent } from './po-list-view.component';
 import { PoListViewContentTemplateDirective } from './po-list-view-content-template/po-list-view-content-template.directive';
@@ -41,7 +43,7 @@ import { PoListViewDetailTemplateDirective } from './po-list-view-detail-templat
  * ```
  */
 @NgModule({
-  imports: [CommonModule, RouterModule, PoButtonModule, PoPopupModule],
+  imports: [CommonModule, FormsModule, RouterModule, PoButtonModule, PoPopupModule, PoCheckboxModule],
   declarations: [PoListViewComponent, PoListViewContentTemplateDirective, PoListViewDetailTemplateDirective],
   exports: [PoListViewComponent, PoListViewContentTemplateDirective, PoListViewDetailTemplateDirective],
   providers: [],


### PR DESCRIPTION
**LIST-VIEW**

**DTHFUI-6150**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente a PoListView utiliza um checkbox estilizado para selecionar linhas.

**Qual o novo comportamento?**
Agora a PoListView começa a utilizar o PoCheckbox no lugar do checkbox antigo.

**Simulação**
Utilizar o app abaixo e utilizar os Samples do Portal.
`app.component.html`
```html
<po-page-default>
  <po-list-view
    p-property-title="name"
    [p-select]="true"
    [p-items]="[
        { name: 'Registro 1', email: 'register@po-ui.com' },
        { name: 'Registro 2', email: 'register2@po-ui.com' }
    ]"
  >
  <ng-template p-list-view-content-template let-item>
    <div class="po-row">
      <po-info class="po-md-12" p-label="Email" [p-value]="item.email"></po-info>
    </div>
  </ng-template>
</po-list-view>
</po-page-default>
```
