### PR TITLE
feat(table): inclui acessibilidade no gerenciador

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -133,6 +133,7 @@
           >
             <button
               #columnManagerTarget
+              [attr.aria-label]="literals.columnsManager"
               class="po-table-header-column-manager-button po-icon po-icon-settings po-clickable"
               p-tooltip-position="left"
               [p-tooltip]="literals.columnsManager"
@@ -433,6 +434,7 @@
           >
             <button
               #columnManagerTarget
+              [attr.aria-label]="literals.columnsManager"
               class="po-table-header-column-manager-button po-icon po-icon-settings po-clickable"
               p-tooltip-position="left"
               [p-tooltip]="literals.columnsManager"


### PR DESCRIPTION
**TABLE**

**DTHFUI-6088**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O botão do gerenciador de colunas não está acessível para leitores de tela pois não possuí texto, apenas o ícone de uma engrenagem.

**Qual o novo comportamento?**
O botão está acessível pois foi inserido o atributo `aria-label` para que os leitores de tela possam identificar a coluna.

**Simulação**
Executar no app ou no portal.
[app.zip](https://github.com/po-ui/po-angular/files/8863744/app.zip)

