### PR TITLE
fix(table): ajusta o calculo de altura da tabela

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -15,7 +15,7 @@
         [class.po-table-header-fixed-columns-pixels]="allColumnsWidthPixels"
         [style.opacity]="tableOpacity"
       >
-        <div *ngIf="height" class="po-table-container">
+        <div *ngIf="height" class="po-table-container" [style.height.px]="heightTableContainer">
           <div #poTableThead class="po-table-header-fixed po-table-header">
             <ng-container *ngTemplateOutlet="tableHeaderTemplate"></ng-container>
           </div>
@@ -152,7 +152,7 @@
   <cdk-virtual-scroll-viewport
     #poTableTbodyVirtual
     [itemSize]="itemSize"
-    [style.height.px]="heightTableContainer"
+    [style.height.px]="heightTableVirtual"
     [minBufferPx]="height < 100 ? 100 : height"
     [maxBufferPx]="height < 200 ? 200 : height"
     (scroll)="syncronizeHorizontalScroll()"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -605,7 +605,7 @@ describe('PoTableComponent:', () => {
     component.height = 150;
 
     fixture.detectChanges();
-    expect(tableElement.offsetHeight + tableFooterElement.offsetHeight + tableHeaderElement.offsetHeight).toBe(174);
+    expect(tableElement.offsetHeight + tableFooterElement.offsetHeight + tableHeaderElement.offsetHeight).toBe(150);
   });
 
   it('should call calculateWidthHeaders and setTableOpacity in debounceResize', fakeAsync(() => {
@@ -622,6 +622,7 @@ describe('PoTableComponent:', () => {
   it('should calculate when height is a number in function calculateHeightTableContainer', () => {
     const fakeThis = {
       getHeightTableFooter: () => 0,
+      getHeightTableHeader: () => 0,
       heightTableContainer: 0,
       setTableOpacity: () => {},
       changeDetector: {
@@ -826,6 +827,24 @@ describe('PoTableComponent:', () => {
       tableFooterElement: undefined
     };
     expect(component['getHeightTableFooter'].call(fakeThis)).toBe(0);
+  });
+
+  it('should return height table header', () => {
+    const fakeThis = {
+      poTableThead: {
+        nativeElement: {
+          offsetHeight: 100
+        }
+      }
+    };
+    expect(component['getHeightTableHeader'].call(fakeThis)).toBe(100);
+  });
+
+  it('should return the header table height equal to 0', () => {
+    const fakeThis = {
+      poTableThead: undefined
+    };
+    expect(component['getHeightTableHeader'].call(fakeThis)).toBe(0);
   });
 
   it('should set tableOpacity property with method setTableOpacity', () => {
@@ -1379,7 +1398,8 @@ describe('PoTableComponent:', () => {
         changeDetector: {
           detectChanges: () => {}
         },
-        getHeightTableFooter: () => {}
+        getHeightTableFooter: () => {},
+        getHeightTableHeader: () => {}
       };
 
       spyOn(fakeThis.changeDetector, 'detectChanges');

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -105,6 +105,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   @ViewChildren('headersTable') headersTable: QueryList<any>;
 
   heightTableContainer: number;
+  heightTableVirtual: number;
   popupTarget;
   tableOpacity: number = 0;
   tooltipText: string;
@@ -563,6 +564,9 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   protected calculateHeightTableContainer(height) {
     const value = parseFloat(height);
     this.heightTableContainer = value ? value - this.getHeightTableFooter() : undefined;
+    this.heightTableVirtual = this.heightTableContainer
+      ? this.heightTableContainer - this.getHeightTableHeader()
+      : undefined;
     this.setTableOpacity(1);
     this.changeDetector.detectChanges();
   }
@@ -632,6 +636,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   private getHeightTableFooter() {
     return this.tableFooterElement ? this.tableFooterElement.nativeElement.offsetHeight : 0;
+  }
+
+  private getHeightTableHeader() {
+    return this.poTableThead ? this.poTableThead.nativeElement.offsetHeight : 0;
   }
 
   private hasInfiniteScroll(): boolean {


### PR DESCRIPTION
**TABLE**

**DTHFUI-6170**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O botão "Carregar mais resultados" está sendo cortado utilizando o PoLookup.

**Qual o novo comportamento?**
O botão "Carregar mais resultados" está sendo exibido corretamente.

**Simulação**
Testar o App abaixo e no Portal.
`app.component.html`
```html
<po-page-default>
  <po-lookup
  name="lookup"
  p-field-label="label"
  p-field-value="value"
  p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
  p-label="PO Lookup"
  [p-multiple]="true"
>
</po-lookup>

<po-table p-service-api="https://po-sample-api.herokuapp.com/v1/heroes" p-height="300"> </po-table>

<po-lookup
  name="lookup"
  p-field-label="label"
  p-field-value="value"
  p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
  p-label="PO Lookup"
  [p-infinite-scroll]="true"
  [p-multiple]="true"
>
</po-lookup>

<po-table p-service-api="https://po-sample-api.herokuapp.com/v1/heroes" p-height="300" [p-infinite-scroll]="true"> </po-table>
</po-page-default>
```