### PR TITLE
feat(dynamic-table): permite disparar evento de restaurar padrão

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
@@ -1,6 +1,6 @@
-import { Input, Directive } from '@angular/core';
+import { Input, Directive, Output, EventEmitter } from '@angular/core';
 
-import { PoBreadcrumb } from '@po-ui/ng-components';
+import { PoBreadcrumb, PoTableColumnSort } from '@po-ui/ng-components';
 
 import { convertToBoolean } from '../../utils/util';
 
@@ -91,6 +91,42 @@ export class PoPageDynamicListBaseComponent {
 
   /** Título da página. */
   @Input('p-title') title: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao fechar o popover do gerenciador de colunas após alterar as colunas visíveis.
+   *
+   * O componente envia como parâmetro um array de string com as colunas visíveis atualizadas.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   */
+  @Output('p-change-visible-columns') changeVisibleColumns = new EventEmitter<Array<string>>();
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no botão de restaurar padrão no gerenciador de colunas.
+   *
+   * O componente envia como parâmetro um array de string com as colunas configuradas inicialmente.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   */
+  @Output('p-restore-column-manager') columnRestoreManager = new EventEmitter<Array<String>>();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento executado ao ordenar colunas da tabela.
+   *
+   * Recebe um objeto `{ column, type }` onde:
+   *
+   * - column (`PoTableColumn`): objeto da coluna que foi clicada/ordenada.
+   * - type (`PoTableColumnSortType`): tipo da ordenação.
+   */
+  @Output('p-sort-by') sortBy: EventEmitter<PoTableColumnSort> = new EventEmitter<PoTableColumnSort>();
 
   private _autoRouter: boolean = false;
   private _columns: Array<any> = [];

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -22,6 +22,9 @@
     [p-show-more-disabled]="!hasNext"
     (p-show-more)="showMore()"
     (p-sort-by)="onSort($event)"
+    (p-change-visible-columns)="onChangeVisibleColumns($event)"
+    (p-restore-column-manager)="onColumnRestoreManager($event)"
+    (p-sort-by)="onSortBy($event)"
   >
   </po-table>
 </po-page-dynamic-search>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -1993,6 +1993,36 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(component['sortedColumn']).toEqual(expectedValue);
     });
 
+    it('onChangeVisibleColumns: should call `changeVisibleColumns.emit`', () => {
+      spyOn(component.changeVisibleColumns, 'emit');
+      const fakeColumns = ['name', 'age'];
+
+      component.onChangeVisibleColumns(fakeColumns);
+
+      expect(component.changeVisibleColumns.emit).toHaveBeenCalledWith(fakeColumns);
+    });
+
+    it('onColumnRestoreManager: should call `columnRestoreManager.emit`', () => {
+      spyOn(component.columnRestoreManager, 'emit');
+      const fakeColumns = ['name', 'age'];
+
+      component.onColumnRestoreManager(fakeColumns);
+
+      expect(component.columnRestoreManager.emit).toHaveBeenCalledWith(fakeColumns);
+    });
+
+    it('onSortBy: should call `sortBy.emit`', () => {
+      spyOn(component.sortBy, 'emit');
+      const fakeColumns = {
+        column: { property: 'name' },
+        type: PoTableColumnSortType.Ascending
+      };
+
+      component.onSortBy(fakeColumns);
+
+      expect(component.sortBy.emit).toHaveBeenCalledWith(fakeColumns);
+    });
+
     it('onAdvancedSearch: should call `updateFilterValue` with filter if `keepFilters` is true', () => {
       const filter = 'filterValue';
       component.keepFilters = true;

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -440,6 +440,18 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     this.sortedColumn = sortedColumn;
   }
 
+  onChangeVisibleColumns(value) {
+    this.changeVisibleColumns.emit(value);
+  }
+
+  onColumnRestoreManager(value: Array<String>) {
+    this.columnRestoreManager.emit(value);
+  }
+
+  onSortBy(sortedColumn: PoTableColumnSort) {
+    this.sortBy.emit(sortedColumn);
+  }
+
   showMore() {
     this.subscriptions.add(this.loadData({ page: ++this.page, ...this.params }).subscribe());
   }


### PR DESCRIPTION
**DYNAMIC-TABLE**

**DTHFUI-6173**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não era possível utilizar os eventos `p-restore-column-manager`, `p-change-visible-columns` e `p-sort-by` da PoTable através do PoDynamicTable.

**Qual o novo comportamento?**
Agora é possível utilizar os eventos `p-restore-column-manager`, `p-change-visible-columns` e `p-sort-by` da PoTable através do PoDynamicTable.

**Simulação**
Utilizar este [app.zip](https://github.com/po-ui/po-angular/files/9004008/app.zip) e testar no Portal.
 