### PR TITLE
feat(toaster): implementa para pequenas resoluções

### DIFF
--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.html
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.html
@@ -3,22 +3,23 @@
     <po-icon [p-icon]="getIcon()"></po-icon>
   </div>
 
-  <div class="po-toaster-message">{{ message }}</div>
-
   <div class="po-toaster-actions">
-    <po-button
-      *ngIf="action && actionLabel"
-      class="po-toaster-action"
-      (p-click)="poToasterAction($event)"
-      [p-label]="actionLabel"
-      p-type="tertiary"
-    ></po-button>
+    <div class="po-toaster-message">{{ message }}</div>
+    <div class="po-toaster-action">
+      <po-button
+        *ngIf="action && actionLabel"
+        (p-click)="poToasterAction($event)"
+        [p-label]="actionLabel"
+        p-type="tertiary"
+      ></po-button>
+    </div>
+  </div>
 
+  <div class="po-toaster-close">
     <div class="po-toaster-divider"></div>
-
     <po-button
       #buttonClose
-      class="po-toaster-close"
+      class="po-toaster-button-close"
       (p-click)="onButtonClose($event)"
       p-icon="po-icon-close"
       p-type="tertiary"

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.spec.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.spec.ts
@@ -124,7 +124,7 @@ describe('PoToasterComponent', () => {
 
     expect(fixture.debugElement.query(By.css('.po-toaster-error'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-warning'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-action po-button'))).toBeNull();
     expect(fixture.debugElement.query(By.css('.po-toaster-close'))).toBeTruthy();
   });
 
@@ -135,7 +135,9 @@ describe('PoToasterComponent', () => {
 
     expect(fixture.debugElement.query(By.css('.po-toaster-info'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-info'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action')).nativeElement.innerHTML).toContain('Texto Botão');
+    expect(fixture.debugElement.query(By.css('.po-toaster-action po-button')).nativeElement.innerHTML).toContain(
+      'Texto Botão'
+    );
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Success and with action correctly', () => {
@@ -145,7 +147,7 @@ describe('PoToasterComponent', () => {
 
     expect(fixture.debugElement.query(By.css('.po-toaster-success'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-ok'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-action po-button'))).toBeNull();
     expect(fixture.debugElement.query(By.css('.po-toaster-close'))).toBeTruthy();
   });
 
@@ -156,32 +158,32 @@ describe('PoToasterComponent', () => {
 
     expect(fixture.debugElement.query(By.css('.po-toaster-warning'))).not.toBeNull();
     expect(fixture.debugElement.query(By.css('.po-icon-warning'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-action po-button'))).toBeNull();
     expect(fixture.debugElement.query(By.css('.po-toaster-close'))).toBeTruthy();
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Error and without action correctly', () => {
     component.configToaster(toasterErrorWithoutAction);
     fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-action po-button'))).toBeNull();
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Info and without action correctly', () => {
     component.configToaster(toasterInfoWithoutAction);
     fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-action po-button'))).toBeNull();
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Success and without action correctly', () => {
     component.configToaster(toasterSuccessWithoutAction);
     fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-action po-button'))).toBeNull();
   });
 
   it('should be load `component` with all `PoToasterType` with PoToasterType.Warning and without action correctly', () => {
     component.configToaster(toasterWarningWithoutAction);
     fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('.po-toaster-action'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.po-toaster-action po-button'))).toBeNull();
   });
 
   it('should be call the `component.action` method how must call a function correctly', () => {

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
@@ -23,6 +23,7 @@ import { PoButtonComponent } from '../../../components/po-button/po-button.compo
 
 const SPACE_BETWEEN_TOASTERS = 8;
 const TOASTER_HEIGHT_DEFAULT = 62;
+const TOASTER_HEIGHT_ACTION = 88;
 
 /**
  * @docsPrivate
@@ -76,7 +77,8 @@ export class PoToasterComponent extends PoToasterBaseComponent implements AfterV
 
   /* Muda a posição do Toaster na tela*/
   changePosition(position: number): void {
-    this.margin = SPACE_BETWEEN_TOASTERS + TOASTER_HEIGHT_DEFAULT * position + position * SPACE_BETWEEN_TOASTERS;
+    const toasterSize = document.body.offsetWidth < 961 && this.action ? TOASTER_HEIGHT_ACTION : TOASTER_HEIGHT_DEFAULT;
+    this.margin = SPACE_BETWEEN_TOASTERS + toasterSize * position + position * SPACE_BETWEEN_TOASTERS;
 
     if (this.orientation === PoToasterOrientation.Top) {
       this.toaster.nativeElement.style.top = this.margin + 'px';


### PR DESCRIPTION
**Toaster**

**DTHFUI-6203**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O toaster não se ajusta corretamente em pequenas resoluções.

**Qual o novo comportamento?**
O toaster se ajusta conforme definição de UX para pequenas resoluções.

**Simulação**
Testar app no navegador em resolução mobile.
[app.zip](https://github.com/po-ui/po-angular/files/9014787/app.zip)

PR STYLE > https://github.com/po-ui/po-style/pull/320