### PR TITLE
feat(dynamic-form): permite escolher componente a ser renderizado

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-force-component.enum.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-force-component.enum.ts
@@ -1,0 +1,4 @@
+export enum ForceOptionComponentEnum {
+  radioGroup = 'radioGroup',
+  select = 'select'
+}

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -15,6 +15,7 @@ import { PoLookupAdvancedFilter } from '../../po-field/po-lookup/interfaces/po-l
 import { PoLookupColumn } from '../../po-field/po-lookup/interfaces/po-lookup-column.interface';
 import { PoMultiselectOption } from '../../po-field/po-multiselect/po-multiselect-option.interface';
 import { PoSelectOption } from '../../po-field/po-select/po-select-option.interface';
+import { ForceOptionComponentEnum } from '../po-dynamic-field-force-component.enum';
 
 import { PoDynamicField } from '../po-dynamic-field.interface';
 
@@ -489,4 +490,14 @@ export interface PoDynamicFormField extends PoDynamicField {
    * `url + ?page=1&pageSize=20&name=Tony%20Stark,Peter%20Parker,Gohan`
    */
   advancedFilters?: Array<PoLookupAdvancedFilter>;
+  /**
+   * pode ser utilizada em conjunto com a propriedade `options` forçando o componente a renderizar um `po-select` ou `po-radio-group`.
+   *
+   * Valores aceitos:
+   * - ForceOptionComponentEnum.radioGroup
+   * - ForceOptionComponentEnum.select
+   *
+   * >Essa propriedade será ignorada caso seja utilizada em conjunto com a propriedade `optionsMulti` e `optionsService`.
+   */
+  forceOptionsComponentType?: ForceOptionComponentEnum;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -7,6 +7,7 @@ import * as PoDynamicUtil from '../../po-dynamic.util';
 import { PoDynamicFieldType } from '../../po-dynamic-field-type.enum';
 import { PoDynamicFormFieldsBaseComponent } from './po-dynamic-form-fields-base.component';
 import { PoDynamicFormField } from '../po-dynamic-form-field.interface';
+import { ForceOptionComponentEnum } from '../../po-dynamic-field-force-component.enum';
 
 describe('PoDynamicFormFieldsBaseComponent:', () => {
   let component: PoDynamicFormFieldsBaseComponent;
@@ -606,6 +607,65 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         const field = { property: 'code' };
 
         expect(component['getComponentControl'](field)).toBe(expectedValue);
+      });
+
+      it('should return select if `forceOptionsComponentType` is select', () => {
+        const expectedValue = ForceOptionComponentEnum.select;
+        const field: PoDynamicFormField = {
+          property: 'test',
+          forceOptionsComponentType: ForceOptionComponentEnum.select,
+          options: [
+            {
+              label: 'Brasil',
+              value: 'brasil'
+            },
+            {
+              label: 'Chile',
+              value: 'chile'
+            },
+            {
+              label: 'Argentina',
+              value: 'argentina'
+            }
+          ]
+        };
+
+        spyOn(component, <any>'verifyforceOptionComponent').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['verifyforceOptionComponent']).toHaveBeenCalled();
+      });
+
+      it('shouldn`t return select if `forceOptionsComponentType` is select but optionsMulti is true', () => {
+        const expectedValue = 'multiselect';
+        const field: PoDynamicFormField = {
+          property: 'test',
+          forceOptionsComponentType: ForceOptionComponentEnum.select,
+          optionsMulti: true,
+          options: [
+            {
+              label: 'Brasil',
+              value: 'brasil'
+            },
+            {
+              label: 'Chile',
+              value: 'chile'
+            },
+            {
+              label: 'Argentina',
+              value: 'argentina'
+            },
+            {
+              label: 'Paraguai',
+              value: 'paraguai'
+            }
+          ]
+        };
+
+        spyOn(component, <any>'verifyforceOptionComponent').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['verifyforceOptionComponent']).toHaveBeenCalled();
       });
     });
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -148,6 +148,12 @@ export class PoDynamicFormFieldsBaseComponent {
   private getComponentControl(field: PoDynamicFormField = <any>{}) {
     const type = field && field.type ? field.type.toLocaleLowerCase() : 'string';
 
+    const forceOptionComponent = this.verifyforceOptionComponent(field);
+    if (forceOptionComponent) {
+      const { forceOptionsComponentType } = field;
+      return forceOptionsComponentType;
+    }
+
     if (this.isNumberType(field, type)) {
       return 'number';
     } else if (this.isCurrencyType(field, type)) {
@@ -239,6 +245,15 @@ export class PoDynamicFormFieldsBaseComponent {
     const { optionsMulti, options } = field;
 
     return !optionsMulti && !!options && options.length <= 3;
+  }
+
+  private verifyforceOptionComponent(field: PoDynamicFormField) {
+    const { optionsMulti, optionsService, forceOptionsComponentType } = field;
+
+    if (forceOptionsComponentType && !optionsMulti && !optionsService) {
+      return true;
+    }
+    return false;
   }
 
   private isSelect(field: PoDynamicFormField) {


### PR DESCRIPTION
**dynamic-form**

**DTHFUI-6251**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O dynamic-form caso tenha mais de 4 options será um multiselect e se tiver menos será um radio-group

**Qual o novo comportamento?**
Podemos forçar se será um select ou radio-group utilizando a propriedade `forceOptionsComponentType`

**Simulação**
app: [app.zip](https://github.com/po-ui/po-angular/files/9063843/app.zip)
 