### PR TITLE
build(lint): ajusta regras após atualização de pacote

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -115,8 +115,64 @@
         "@typescript-eslint/semi": ["off", null],
         "@typescript-eslint/type-annotation-spacing": "off",
         "camelcase": "off",
-        "@typescript-eslint/naming-convention": "off",
-        "@typescript-eslint/member-ordering": "off",
+        "@typescript-eslint/naming-convention": [
+          "error",
+          {
+            "selector": "default",
+            "format": ["camelCase"]
+          },
+          {
+            "selector": "variable",
+            "format": ["camelCase", "UPPER_CASE", "snake_case", "PascalCase"],
+            "leadingUnderscore": "allow"
+          },
+          {
+            "selector": "classProperty",
+            "format": ["camelCase", "UPPER_CASE", "snake_case", "PascalCase"],
+            "leadingUnderscore": "allow"
+          },
+          {
+            "selector": "parameter",
+            "format": ["camelCase"],
+            "leadingUnderscore": "allow"
+          },
+          {
+            "selector": "memberLike",
+            "modifiers": ["private"],
+            "format": ["camelCase"],
+            "leadingUnderscore": "allow"
+          },
+          {
+            "selector": "typeLike",
+            "format": ["PascalCase", "camelCase"]
+          },
+          {
+            "selector": "enumMember",
+            "format": ["UPPER_CASE", "camelCase", "PascalCase"],
+            "leadingUnderscore": "allow"
+          },
+          {
+            "selector": ["objectLiteralMethod"],
+            "format": ["PascalCase", "camelCase", "snake_case", "UPPER_CASE"],
+            "leadingUnderscore": "allow"
+          },
+          {
+            "selector": ["objectLiteralProperty"],
+            "format": null,
+            "leadingUnderscore": "allow"
+          },
+          {
+            "selector": "function",
+            "format": ["PascalCase", "camelCase"],
+            "leadingUnderscore": "allow"
+          }
+        ],
+        "@typescript-eslint/member-ordering": [
+          "error",
+          {
+            "default": ["signature", "field", "constructor", "method"]
+          }
+        ],
         "arrow-parens": ["off", "always"],
         "arrow-body-style": ["error", "as-needed"],
         "brace-style": ["off", "off"],
@@ -153,7 +209,12 @@
         "no-shadow": "off",
         "no-trailing-spaces": "off",
         "no-underscore-dangle": "off",
-        "no-unused-expressions": ["error", { "allowTernary": true }],
+        "no-unused-expressions": [
+          "error",
+          {
+            "allowTernary": true
+          }
+        ],
         "no-use-before-define": "off",
         "object-shorthand": "off",
         "padded-blocks": [


### PR DESCRIPTION
**LINT**

**DTHFUI-6274**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Com a atualização dos pacotes do projeto, acabou quebrando as regras de lint, por mudança no comportamento dos mesmos.

**Qual o novo comportamento?**
Foi ajustada a configuração para que o lint continue funcionando como funcionava antes da atualização.

**Simulação**
Executar `npm run lint`