### PR TITLE
feat(page-dynamic-table): adiciona propriedade para fixar filtros

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -50,6 +50,26 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(typeof component.filterSettings.advancedAction).toBe('function');
     });
 
+    it('get filterSettings: should return `filterSettings` with `advancedAction` equal to `onAdvancedAction` if at least one filter is visible', () => {
+      const filters: Array<any> = [
+        { property: 'name', visible: true },
+        { property: 'birthdate', visible: false },
+        { property: 'genre', visible: false }
+      ];
+      component.filters = filters;
+      expect(typeof component.filterSettings.advancedAction).toBe('function');
+    });
+
+    it('get filterSettings: should return `filterSettings` with `advancedAction` equal to `undefined` if filters are not visible', () => {
+      const filters: Array<any> = [
+        { property: 'name', visible: false },
+        { property: 'birthdate', visible: false },
+        { property: 'genre', visible: false }
+      ];
+      component.filters = filters;
+      expect(typeof component.filterSettings.advancedAction).toBe('undefined');
+    });
+
     it('get filterSettings: should apply `quickSearchWidth` value to `filterSettings.width`', () => {
       const filterWidth = 3;
       component.quickSearchWidth = filterWidth;

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -78,7 +78,9 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
   }
 
   get filterSettings() {
-    this._filterSettings.advancedAction = this.filters.length === 0 ? undefined : this.onAdvancedAction.bind(this);
+    const thereAreValidFilters =
+      this.filters.length > 0 && this.filters.some(filter => filter.visible === true || filter.visible === undefined);
+    this._filterSettings.advancedAction = thereAreValidFilters ? this.onAdvancedAction.bind(this) : undefined;
 
     return Object.assign({}, this._filterSettings, {
       placeholder: this.literals.searchPlaceholder,

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-filters.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-filters.interface.ts
@@ -16,4 +16,17 @@ export interface PoPageDynamicTableFilters extends PoPageDynamicTableField {
    * Define um Valor inicial para um filtro de busca avançada.
    */
   initValue?: any;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Controla se o filtro será fixo, ou seja, não poderá ser alterado pelo usuário no filtro avançado.
+   * Caso seja definido um valor true, o filtro não será apresentado na tela de filtro avançado, porém continuará sendo utilizado como filtro.
+   * Por esse motivo deverá ser utilizado em conjunto com as propriedades `filter` e `initValue`.
+   *
+   * @default `false`
+   */
+  fixed?: boolean;
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
@@ -115,6 +115,51 @@ describe('PoPageDynamicListBaseComponent:', () => {
         expect(component.filters).toEqual(filtersResult);
       });
 
+      it('should set `filters` with visible equal false to items that have the `fixed` and `initValue` properties', () => {
+        fields = [
+          { property: 'id', key: true },
+          { property: 'name', label: 'Name', filter: true, visible: true, gridColumns: 6 },
+          { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true, fixed: true },
+          { property: 'birthdate', label: 'Birthdate', type: 'date', gridColumns: 6 },
+          {
+            property: 'city',
+            label: 'City',
+            filter: true,
+            duplicate: true,
+            gridColumns: 12,
+            fixed: true,
+            initValue: 'Joinville'
+          }
+        ];
+
+        const filtersResult = [
+          { property: 'name', label: 'Name', filter: true, visible: true, gridColumns: 6 },
+          {
+            property: 'genre',
+            label: 'Genre',
+            filter: true,
+            gridColumns: 6,
+            visible: true,
+            duplicate: true,
+            fixed: true
+          },
+          {
+            property: 'city',
+            label: 'City',
+            filter: true,
+            duplicate: true,
+            visible: false,
+            gridColumns: 12,
+            fixed: true,
+            initValue: 'Joinville'
+          }
+        ];
+
+        component['setFieldsProperties'](fields);
+
+        expect(component.filters).toEqual(filtersResult);
+      });
+
       it('should set `filters` with [] if no item has the `filter` property', () => {
         const fieldsWithoutFilter = [
           { property: 'id', key: true },

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
@@ -209,9 +209,13 @@ export class PoPageDynamicListBaseComponent {
   }
 
   private setFieldsProperties(fields: Array<any>) {
+    let visibleFilter: boolean;
     this.filters = fields
       .filter(field => field.filter === true)
-      .map(filterField => ({ ...filterField, visible: true }));
+      .map(filterField => {
+        visibleFilter = !(filterField.initValue && filterField.fixed);
+        return { ...filterField, visible: visibleFilter };
+      });
     this.columns = fields.filter(
       field => field.visible === undefined || field.visible === true || field.allowColumnsManager === true
     );

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.html
@@ -1,4 +1,5 @@
 <po-page-dynamic-table
+  #dynamicTable
   [p-auto-router]="true"
   [p-concat-filters]="true"
   [p-keep-filters]="true"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
 
 import { PoBreadcrumb, PoDynamicViewField, PoModalComponent } from '@po-ui/ng-components';
+
 import {
   PoPageDynamicTableActions,
   PoPageDynamicTableCustomAction,
@@ -25,6 +26,7 @@ export class SamplePoPageDynamicTableUsersComponent {
   detailedUser: any;
   dependents: any;
   quickSearchWidth: number = 3;
+  fixedFilter = false;
 
   readonly actions: PoPageDynamicTableActions = {
     new: '/documentation/po-page-dynamic-edit',
@@ -45,7 +47,7 @@ export class SamplePoPageDynamicTableUsersComponent {
     { value: 'Osasco', label: 'Osasco' }
   ];
 
-  readonly fields: Array<any> = [
+  fields: Array<any> = [
     { property: 'id', key: true, visible: false, filter: true },
     { property: 'name', label: 'Name', filter: true, gridColumns: 6 },
     { property: 'genre', label: 'Genre', filter: true, gridColumns: 6, duplicate: true, sortable: false },
@@ -85,6 +87,18 @@ export class SamplePoPageDynamicTableUsersComponent {
       action: this.onClickActionsSide.bind(this),
       visible: this.isVisibleActionsLeft.bind(this),
       icon: 'po-icon-arrow-left'
+    },
+    {
+      label: 'Fixed Filter',
+      action: this.onClickFixedFilter.bind(this),
+      visible: this.isVisibleFixedFilter.bind(this),
+      icon: 'po-icon-lock'
+    },
+    {
+      label: 'Not Fixed Filter',
+      action: this.onClickFixedFilter.bind(this),
+      visible: this.isVisibleNotFixedFilter.bind(this),
+      icon: 'po-icon-lock-off'
     },
     { label: 'Print', action: this.printPage.bind(this), icon: 'po-icon-print' },
     {
@@ -161,7 +175,42 @@ export class SamplePoPageDynamicTableUsersComponent {
   private isVisibleActionsRight() {
     return !this.actionsRight;
   }
+
   private isVisibleActionsLeft() {
     return this.actionsRight;
+  }
+
+  private onClickFixedFilter() {
+    this.fixedFilter = !this.fixedFilter;
+    const fieldsDefault = [...this.fields];
+
+    if (this.fixedFilter) {
+      fieldsDefault
+        .filter(field => field.property === 'search')
+        .map(field => {
+          field.initValue = 'Joinville';
+          field.filter = true;
+          field.fixed = true;
+        });
+
+      this.fields = fieldsDefault;
+    } else {
+      fieldsDefault
+        .filter(field => field.property === 'search')
+        .map(field => {
+          field.initValue = 'São Paulo';
+          field.fixed = false;
+        });
+
+      this.fields = fieldsDefault;
+    }
+  }
+
+  private isVisibleFixedFilter() {
+    return !this.fixedFilter;
+  }
+
+  private isVisibleNotFixedFilter() {
+    return this.fixedFilter;
   }
 }


### PR DESCRIPTION
**po-page-dynamic-table**

**Fixes #1287**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
No template Page Dynamic Table não é possível ocultar filtros no filtro avançado como é possível com o Page Dynamic Search através da propriedade visible. No Page Dynamic Table a propriedade visible é utilizada apenas na table e todos os fields com propriedade filter:true são repassadas para o Page Dynamic Search como visible:true.

**Qual o novo comportamento?**
Foi criada a propriedade fixed na interface PoPageDynamicTableFilters que será usada em conjunto com as propriedades
filter e initValue, com o objetivo de ocultar o filtro na tela de filtro avançado, porém, mantendo o filtro na consulta das informações.

**Simulação**
Pode ser testado no sample PO Page Dynamic Table - Users. Em "Outras ações" há a opção "Fixed Filter" que irá fixar o filtro search com a informação "Joinville". Então o conteúdo será filtrado, porém o filtro não ficará disponível para ser alterado na tela de filtros avançados. Ao clicar em "Not Fixed Filter" a tela retorna para o padrão inicial apresentando o campo search na tela de filtros avançados.
Obs.: Não foi tratado nessa issue a opção de ocultar a opção fechar do disclaimer. Essa implementação foi realizada na issue #1306 e será utilizada outra propriedade para essa tratativa.
