### PR TITLE
test(chart): ajusta erro no teste `calculateTooltipPosition`

### DIFF
--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular-path/po-chart-tooltip.directive.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular-path/po-chart-tooltip.directive.spec.ts
@@ -114,7 +114,7 @@ describe('PoChartTooltipDirective', () => {
 
     it('calculateTooltipPosition: should return tooltipPosition', () => {
       const tooltipEvent = { clientX: 300, clientY: 300 };
-      const expectedResult = { left: -77, top: 270 };
+      const expectedResult = { left: -75, top: 270 };
       const result = directive.calculateTooltipPosition(tooltipEvent);
 
       expect(result).toEqual(expectedResult);


### PR DESCRIPTION
O teste estava apresentando o erro abaixo:
`Error: Expected $.left = -75 to equal -77.`

Fixes #1341

**Chart**

**1341**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O teste está apresentando o erro abaixo:
```
        Error: Expected $.left = -75 to equal -77.
            at <Jasmine>
            at UserContext.apply (projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular-path/po-chart-tooltip.directive.spec.ts:120:22)
            at _ZoneDelegate.invoke (node_modules/zone.js/fesm2015/zone.js:372:26)
            at ProxyZoneSpec.onInvoke (node_modules/zone.js/fesm2015/zone-testing.js:287:39)
Chrome Headless 103.0.5060.114 (Windows 10): Executed 3016 of 6485 (1 FAILED) (0 secs / 30.768 secs)
Chrome Headless 103.0.5060.114 (Windows 10) PoChartTooltipDirective Methods:  calculateTooltipPosition: should return tooltipPosition FAILED
        Error: Expected $.left = -75 to equal -77.
            at <Jasmine>
            at UserContext.apply (projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-circular/po-chart-circular-path/po-chart-tooltip.directive.spec.ts:120:22)
            at _ZoneDelegate.invoke (node_modules/zone.js/fesm2015/zone.js:372:26)

```
![image](https://user-images.githubusercontent.com/36740857/179812042-d184e1af-944a-472e-90ae-081530742c63.png)
![image](https://user-images.githubusercontent.com/36740857/179812117-804bfbb4-0a4b-42d7-88f8-9a25354f4ec7.png)

**Qual o novo comportamento?**
O teste não apresenta mais o erro.

![image](https://user-images.githubusercontent.com/36740857/179812945-504c85ff-764b-4756-877e-aeee3c41bdf0.png)


**Simulação**
`npm run test:ui`
