### PR TITLE
fix(language): adiciona limpeza das variáveis do `localStorage`

### DIFF
--- a/projects/ui/src/lib/services/po-language/po-language.service.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.ts
@@ -8,6 +8,9 @@ import {
   poLocaleThousandSeparatorList
 } from './po-language.constant';
 
+localStorage.removeItem('PO_DEFAULT_LANGUAGE');
+localStorage.removeItem('PO_USER_LOCALE');
+
 const poDefaultLanguage = 'PO_DEFAULT_LANGUAGE';
 const poLocaleKey = 'PO_USER_LOCALE';
 


### PR DESCRIPTION
Foi adicionado a limpeza das variáveis do `localStorage`:
- `PO_DEFAULT_LANGUAGE`
- `PO_USER_LOCALE`

Estas variáveis são populadas pelas funções:
- `languageDefault`.
- `setLanguage`.

A limpeza é necessária quando se deixa de usar as funções acima, evitando uso de valores indevidos.

Fixes #1331

**Language**

**1331**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O serviço não está carregando o idioma correto, quando se usa as funções `languageDefault` e ou `setLanguage` e depois deixa  de usar, assim os valores ficam gravados indevidamente na `localStorage`, impedindo a verificação do idioma do navegador

**Qual o novo comportamento?**
O serviço esta carregando o idioma do navegados, quando as funções de atribuição de idiomas deixa de ser usadas.

**Simulação**
Utilize o [App](https://github.com/po-ui/po-angular/files/9144186/app.zip), descomente e comente as linhas abaixo para a simulação:
- `app.module.ts`:
```
  //  language: 'pt-BR',
  //  language: 'en-US',
```
- `app.component.ts`:
```
  //  this.poI18nService.setLanguage('pt-BR');
  //  this.poI18nService.setLanguage('en-US');
```