### PR TITLE
feat(rich-text): adiciona `p-disabled-text-align`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
@@ -31,6 +31,17 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
   @Input('p-auto-focus') @InputBoolean() autoFocus: boolean = false;
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Define se o alinhamento de texto será desabilitado.
+   *
+   * @default `false`
+   */
+  @Input('p-disabled-text-align') @InputBoolean() disabledTextAlign: boolean = false;
+
+  /**
    * @description
    *
    * Mensagem que será apresentada quando a propriedade required estiver habilitada e o campo for limpo após algo ser digitado.

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
@@ -1,9 +1,9 @@
 <div class="po-rich-text-toolbar" #toolbarElement>
-  <div class="po-rich-text-toolbar-button-align">
+  <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="format">
     <po-button-group p-toggle="multiple" [p-small]="true" [p-buttons]="formatButtons"> </po-button-group>
   </div>
 
-  <div *ngIf="!isInternetExplorer" class="po-rich-text-toolbar-button-align">
+  <div *ngIf="!isInternetExplorer" class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="color">
     <div class="po-rich-text-toolbar-color-picker-container">
       <button
         class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
@@ -23,19 +23,19 @@
     </div>
   </div>
 
-  <div class="po-rich-text-toolbar-button-align">
+  <div *ngIf="!disabledTextAlign" class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="align">
     <po-button-group p-toggle="single" [p-small]="true" [p-buttons]="alignButtons"> </po-button-group>
   </div>
 
-  <div class="po-rich-text-toolbar-button-align">
+  <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="list">
     <po-button-group p-toggle="single" [p-small]="true" [p-buttons]="listButtons"> </po-button-group>
   </div>
 
-  <div class="po-rich-text-toolbar-button-align">
+  <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="link">
     <po-button-group [p-small]="true" [p-buttons]="linkButtons"> </po-button-group>
   </div>
 
-  <div class="po-rich-text-toolbar-button-align">
+  <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="media">
     <po-button-group [p-small]="true" [p-buttons]="mediaButtons"> </po-button-group>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.spec.ts
@@ -34,6 +34,26 @@ describe('PoRichTextToolbarComponent:', () => {
   });
 
   describe('Properties:', () => {
+    it('disabledTextAlign: should remove a children element from po-rich-text', () => {
+      component.disabledTextAlign = true;
+
+      fixture.detectChanges();
+
+      const poRichTextToolbarButtonAlign = nativeElement.querySelector('[data-rich-text-toolbar="align"]');
+
+      expect(poRichTextToolbarButtonAlign).toBeNull();
+    });
+
+    it('disabledTextAlign: should keep all children elements inside component po-rich-text', () => {
+      component.disabledTextAlign = false;
+
+      fixture.detectChanges();
+
+      const poRichTextToolbarButtonAlign = nativeElement.querySelector('[data-rich-text-toolbar="align"]');
+
+      expect(poRichTextToolbarButtonAlign).toBeDefined();
+    });
+
     it('readonly: should call toggleDisableButtons', () => {
       spyOn(component, <any>'toggleDisableButtons');
 

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.ts
@@ -109,8 +109,17 @@ export class PoRichTextToolbarComponent implements AfterViewInit {
     }
   ];
 
+  private _disabledTextAlign: boolean;
   private _readonly: boolean;
   private selectedLinkElement;
+
+  @Input('p-disabled-text-align') set disabledTextAlign(value: boolean) {
+    this._disabledTextAlign = value;
+  }
+
+  get disabledTextAlign() {
+    return this._disabledTextAlign;
+  }
 
   @Input('p-readonly') set readonly(value: boolean) {
     this._readonly = value;

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
@@ -18,6 +18,7 @@
     <po-rich-text-toolbar
       #richTextToolbar
       [p-readonly]="readonly"
+      [p-disabled-text-align]="disabledTextAlign"
       (p-link-editing)="richTextBody.linkEditing($event)"
       (p-command)="richTextBody.executeCommand($event)"
     >

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
@@ -1,6 +1,7 @@
 <po-rich-text
   name="richText"
   [(ngModel)]="richText"
+  [p-disabled-text-align]="properties.includes('disabledTextAlign')"
   [p-error-message]="errorMessage"
   [p-height]="height"
   [p-help]="help"

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.ts
@@ -19,7 +19,8 @@ export class SamplePoRichTextLabsComponent implements OnInit {
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'disabledTextAlign', label: 'Disabled Text Align' }
   ];
 
   ngOnInit() {

--- a/projects/ui/src/lib/services/po-notification/po-notification-base.service.spec.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification-base.service.spec.ts
@@ -28,7 +28,8 @@ class PoNotificationService extends PoNotificationBaseService {
       changeDetectorRef: undefined,
       componentType: undefined,
       destroy: function () {},
-      onDestroy: function () {}
+      onDestroy: function () {},
+      setInput: function () {}
     };
     if (toaster.orientation === PoToasterOrientation.Bottom) {
       this.stackBottom.push(componentReference);


### PR DESCRIPTION
**RICH-TEXT**

**DTHFUI-5598**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variáveis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, Firefox, Edge)

**Qual o comportamento atual?**
Componente não permite desativar os botões de alinhamento de texto.

**Qual o novo comportamento?**
Componente permite desativar os botões de alinhamento de texto.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/9145088/app.zip)

**Styles**
https://github.com/po-ui/po-style/pull/327