### PR TITLE
fix(datepicker): corrige funcionamento com fuso

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -128,26 +128,8 @@ describe('PoDatepickerBaseComponent:', () => {
   });
 
   it('should be update property date', () => {
-    const expectedValue = UtilsFunctions.convertIsoToDateNoTimezone('2021/08/20');
+    const expectedValue = convertIsoToDate('2021/08/20', false, false);
     expectPropertiesValues(component, 'date', '2021/08/20', expectedValue);
-  });
-
-  it('should call `convertIsoToDate` when isExtendedISO is true', () => {
-    spyOn(UtilsFunctions, 'convertIsoToDate');
-    component['isExtendedISO'] = true;
-
-    component.date = '2022-06-07';
-
-    expect(UtilsFunctions.convertIsoToDate).toHaveBeenCalled();
-  });
-
-  it('shouldnt call `convertIsoToDateNoTimezone` when isExtendedISO is false', () => {
-    spyOn(UtilsFunctions, 'convertIsoToDateNoTimezone');
-    component['isExtendedISO'] = false;
-
-    component.date = '2022-06-07';
-
-    expect(UtilsFunctions.convertIsoToDateNoTimezone).toHaveBeenCalled();
   });
 
   it('should transform a String to Date', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -5,7 +5,6 @@ import {
   convertDateToISODate,
   convertDateToISOExtended,
   convertIsoToDate,
-  convertIsoToDateNoTimezone,
   convertToBoolean,
   formatYear,
   isTypeof,
@@ -335,11 +334,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   }
 
   set date(value: any) {
-    if (this.isExtendedISO) {
-      this._date = typeof value === 'string' ? convertIsoToDate(value, false, false) : value;
-    } else {
-      this._date = typeof value === 'string' ? convertIsoToDateNoTimezone(value) : value;
-    }
+    this._date = typeof value === 'string' ? convertIsoToDate(value, false, false) : value;
   }
 
   get date() {

--- a/projects/ui/src/lib/utils/util.spec.ts
+++ b/projects/ui/src/lib/utils/util.spec.ts
@@ -347,17 +347,6 @@ describe('Function convertIsoToDate:', () => {
   });
 });
 
-describe('Function convertIsoToDateNoTimezone:', () => {
-  it('should be a no value', () => {
-    const date = '';
-    expect(typeof UtilFunctions.convertIsoToDateNoTimezone(date)).toBe('undefined');
-  });
-  it('should transform the value string into data', () => {
-    const date = new Date(2022, 4, 26).toISOString();
-    expect(typeof UtilFunctions.convertIsoToDateNoTimezone(date)).toBe('object');
-  });
-});
-
 describe('Function callFunction:', () => {
   const context = {
     getName: function () {

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -127,6 +127,7 @@ export function convertIsoToDate(value: string, start: boolean, end: boolean) {
     const day = parseInt(value.substring(8, 10), 10);
     const month = parseInt(value.substring(5, 7), 10);
     const year = parseInt(value.substring(0, 4), 10);
+
     if (start) {
       const date = new Date(year, month - 1, day, 0, 0, 0);
 
@@ -140,20 +141,8 @@ export function convertIsoToDate(value: string, start: boolean, end: boolean) {
 
       return date;
     } else {
-      const milliseconds = Date.parse(value);
-      const timezone = new Date().getTimezoneOffset() * 60000;
-      return new Date(milliseconds + timezone);
+      return new Date(year, month - 1, day);
     }
-  }
-}
-
-export function convertIsoToDateNoTimezone(value: string) {
-  if (value) {
-    const day = parseInt(value.substring(8, 10), 10);
-    const month = parseInt(value.substring(5, 7), 10);
-    const year = parseInt(value.substring(0, 4), 10);
-
-    return new Date(year, month - 1, day);
   }
 }
 
@@ -222,6 +211,7 @@ export function formatYear(year: number) {
     return `000${year}`;
   }
 }
+
 // Verifica se o navegador em que está sendo usado é Internet Explorer ou Edge
 export function isIEOrEdge() {
   const userAgent = window.navigator.userAgent;


### PR DESCRIPTION
**DATEPICKER**

**DTHFUI-6215**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variáveis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, Firefox, Edge)

**Qual o comportamento atual?**
Atualmente o componente apresenta uma falha ao ser utilizado em países com horário de verão e fuso diferente.
Ao selecionar uma data fora do horário de verão, a data era convertida para o dia anterior a data selecionada.
Ex:
Data selecionada: 22/02/2022
Data registrada: 21/02/2022

**Qual o novo comportamento?**
O componente passou a verificar se a data selecionada esta dentro do horário de verão, convertendo corretamente.

**Simulação**
app e portal
[app.zip](https://github.com/po-ui/po-angular/files/9170288/app.zip)

