### PR TITLE
fix(dynamic-form): exporta ForceOptionComponentEnum

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/index.ts
+++ b/projects/ui/src/lib/components/po-dynamic/index.ts
@@ -1,4 +1,5 @@
 export * from './po-dynamic-field-type.enum';
+export * from './po-dynamic-field-force-component.enum';
 export * from './po-dynamic-form/po-dynamic-form-field.interface';
 export * from './po-dynamic-form/po-dynamic-form-load/po-dynamic-form-load.interface';
 export * from './po-dynamic-form/po-dynamic-form-validation/po-dynamic-form-field-changed.interface';

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-force-component.enum.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-force-component.enum.ts
@@ -1,4 +1,14 @@
+/**
+ * @usedBy PoDynamicFormComponent
+ *
+ * @description
+ *
+ * Enum para definição do tipo de componente a ser renderizado.
+ */
 export enum ForceOptionComponentEnum {
+  /** Força a renderização de um po-radio-group independente da quantidade do opções */
   radioGroup = 'radioGroup',
+
+  /** Força a renderização de um po-select independente da quantidade do opções */
   select = 'select'
 }


### PR DESCRIPTION
**DYNAMIC-FORM**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ocorre um erro ao importar o enum ForceOptionComponentEnum

**Qual o novo comportamento?**
o Enum foi exportado e o erro não ocorre mais

**Simulação**
Simular em um aplicação apartada.