### PR TITLE
feat(page-login): adiciona `loading` automático com `p-authentication-url`

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -968,6 +968,7 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
     }
 
     if (this.authenticationUrl) {
+      this.loading = true;
       this.loginSubscription = this.loginService
         .onLogin(this.authenticationUrl, this.authenticationType, loginForm)
         .subscribe(
@@ -975,12 +976,14 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
             this.setValuesToProperties();
             sessionStorage.setItem('PO_USER_LOGIN', JSON.stringify(data));
             this.openInternalLink('/');
+            this.loading = false;
           },
           error => {
             if (error.error.code === '400' || error.error.code === '401') {
               this.setValuesToProperties(error);
               this.redirectBlockedUrl(this.exceededAttemptsWarning, this.blockedUrl);
             }
+            this.loading = false;
           }
         );
     } else {


### PR DESCRIPTION
Quando a propriedade `p-authentication-url` está ativada, não existe `loading` automático durante a autenticação pela API do backend.

Fixes #1350

**Page Login**

**1350**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando a propriedade `p-authentication-url` está ativada, não existe `loading` automático durante a autenticação pela API do backend e se houver um pequena demora o usuário fica sem saber se a autenticação está sendo realizada ou não.

**Qual o novo comportamento?**
Quando a propriedade `p-authentication-url` está ativada, existe `loading` automático durante a autenticação pela API do backend e se houver um pequena demora o usuário fica sabendo que e a autenticação está sendo realizada.

**Simulação**
Pode ser feita pelo portal ou pelo [App](https://github.com/po-ui/po-angular/files/9189961/app.zip).
 