### PR TITLE
feat(table): exibe coluna tipo `array` em linha tipo `detail`

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
@@ -38,14 +38,18 @@
         <strong *ngIf="typeHeaderInline"> {{ getColumnTitleLabel(detail) }}: </strong>
 
         <ng-container [ngSwitch]="detail.type">
-          <span *ngSwitchCase="'currency'">{{ item[detail.property] | currency: detail.format:'symbol':'1.2-2' }}</span>
-          <span *ngSwitchCase="'date'">{{ item[detail.property] | date: detail.format || 'dd/MM/yyyy' }}</span>
-          <span *ngSwitchCase="'time'">{{ item[detail.property] | po_time: detail.format || 'HH:mm:ss.ffffff' }}</span>
+          <span *ngSwitchCase="'currency'">{{
+            getDetailData(item, detail) | currency: detail.format:'symbol':'1.2-2'
+          }}</span>
+          <span *ngSwitchCase="'date'">{{ getDetailData(item, detail) | date: detail.format || 'dd/MM/yyyy' }}</span>
+          <span *ngSwitchCase="'time'">{{
+            getDetailData(item, detail) | po_time: detail.format || 'HH:mm:ss.ffffff'
+          }}</span>
           <span *ngSwitchCase="'dateTime'">
-            {{ item[detail.property] | date: detail.format || 'dd/MM/yyyy HH:mm:ss' }}
+            {{ getDetailData(item, detail) | date: detail.format || 'dd/MM/yyyy HH:mm:ss' }}
           </span>
-          <span *ngSwitchCase="'number'">{{ formatNumberDetail(item[detail.property], detail.format) }}</span>
-          <span *ngSwitchDefault>{{ item[detail.property] }}</span>
+          <span *ngSwitchCase="'number'">{{ formatNumberDetail(getDetailData(item, detail), detail.format) }}</span>
+          <span *ngSwitchDefault>{{ getDetailData(item, detail) }}</span>
         </ng-container>
       </td>
     </tr>

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.spec.ts
@@ -115,6 +115,64 @@ describe('PoTableDetailComponent', () => {
       expect(utilsFunctions.capitalizeFirstLetter).toHaveBeenCalledWith(propertyValue);
     });
 
+    describe('getDetailData:', () => {
+      it('should return the last string in arrayProperty', () => {
+        const detail: any = {
+          property: 'address.street',
+          label: 'Rua'
+        };
+        const item: any = {
+          name: 'teste',
+          address: {
+            street: 'Rua dos Alfeneiros, nº 4'
+          }
+        };
+        const result = component.getDetailData(item, detail);
+        expect(result).toEqual(item.address.street);
+      });
+
+      it('should return property if property is only item in array', () => {
+        const detail: any = {
+          property: 'address',
+          label: 'Rua'
+        };
+        const item: any = {
+          name: 'teste',
+          address: 'Rua dos Alfeneiros, nº 4'
+        };
+        const result = component.getDetailData(item, detail);
+        expect(result).toEqual(item.address);
+      });
+
+      it('should return a empty string when property is `undefined`', () => {
+        const detail: any = {
+          property: 'address.street',
+          label: 'Rua'
+        };
+        const item: any = {
+          name: 'teste',
+          address: {}
+        };
+        const expectedResult = '';
+        const result = component.getDetailData(item, detail);
+        expect(result).toEqual(expectedResult);
+      });
+
+      it('should return property if property value is equal 0', () => {
+        const detail: any = {
+          property: 'status',
+          label: 'Status'
+        };
+        const item: any = {
+          name: 'teste',
+          status: 0
+        };
+        const expectedResult = 0;
+        const result = component.getDetailData(item, detail);
+        expect(result).toEqual(expectedResult);
+      });
+    });
+
     it('onSelectRow: should set `$selected` property of row item to `true` and call `selectRow.emit`', () => {
       const row = { title: 'teste', $selected: false };
       spyOn(component.selectRow, 'emit');

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.ts
@@ -76,6 +76,20 @@ export class PoTableDetailComponent {
     return detail.label || capitalizeFirstLetter(detail.property);
   }
 
+  getDetailData(item: any, detail: PoTableDetailColumn) {
+    const arrayProperty = detail.property.split('.');
+    if (arrayProperty.length > 1) {
+      const nestedProperties = arrayProperty;
+      let value: any = item;
+      for (const property of nestedProperties) {
+        value = value[property] || value[property] === 0 ? value[property] : '';
+      }
+      return value;
+    } else {
+      return item[detail.property];
+    }
+  }
+
   onSelectRow(item) {
     item.$selected = !item.$selected;
     this.selectRow.emit(item);


### PR DESCRIPTION
Quando a propriedade `detail` tem uma coluna do tipo `array`, o conteúdo não é exibido, por exemplo `product.productName`.

Fixes #1328

**Table**

**1328**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando a propriedade `detail` tem uma coluna do tipo `array`, o conteúdo não é exibido, por exemplo `product.productName`.

**Qual o novo comportamento?**
Quando a propriedade `detail` tem uma coluna do tipo `array`, o conteúdo é exibido, por exemplo `product.productName`.

**Simulação**
Pode usar este [App](https://github.com/po-ui/po-angular/files/9192264/app.zip).

