### PR TITLE
feat(select): adiciona ` p-field-value` e `p-field-label`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
@@ -10,8 +10,13 @@
     (blur)="onBlur()"
   >
     <option *ngIf="isMobile" disabled hidden selected></option>
-    <option *ngFor="let option of options" [disabled]="readonly" [value]="option.value" (click)="onOptionClick(option)">
-      {{ option?.label }}
+    <option
+      *ngFor="let option of options"
+      [disabled]="readonly"
+      [value]="option?.[this.fieldValue]"
+      (click)="onOptionClick(option)"
+    >
+      {{ option?.[this.fieldLabel] }}
     </option>
   </select>
 
@@ -36,15 +41,15 @@
     <ul #contentList class="po-select-content" [ngClass]="{ 'po-invisible': isMobile }">
       <li
         *ngFor="let option of options"
-        [class.po-select-item-selected]="selectedValue === option.value"
-        [value]="option.value"
+        [class.po-select-item-selected]="selectedValue === option?.[this.fieldLabel]"
+        [value]="option?.[this.fieldValue]"
         (click)="onOptionClick(option)"
       >
         <div class="po-select-item">
           <ng-container *ngIf="selectOptionTemplate; then optionTemplate; else defaultOptionTemplate"></ng-container>
 
           <ng-template #defaultOptionTemplate>
-            <span>{{ option?.label }}</span>
+            <span>{{ option?.[this.fieldLabel] }}</span>
           </ng-template>
 
           <ng-template

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { EventEmitter } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { configureTestSuite, expectPropertiesValues } from './../../../util-test/util-expect.spec';
+import { configureTestSuite, expectPropertiesValues, expectSettersMethod } from './../../../util-test/util-expect.spec';
 import * as UtilsFunctions from '../../../utils/util';
 
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
@@ -469,7 +469,7 @@ describe('PoSelectComponent:', () => {
     });
 
     it('updateValues: should execute updateValues and call onChange', () => {
-      const option = { value: '1', label: '' };
+      const option = { value: undefined, label: '' };
       const fakeThis = {
         selectElement: component.selectElement,
         selectedValue: '',
@@ -482,24 +482,7 @@ describe('PoSelectComponent:', () => {
       component['updateValues'].call(fakeThis, option);
 
       expect(fakeThis.emitChange).toHaveBeenCalledWith(option.value);
-      expect(fakeThis.selectedValue).toBe('1');
-    });
-
-    it('updateValues: shouldn`t execute methods if `selectedValue` is equal `option.value`.', () => {
-      const option = { value: '1', label: 'tst' };
-      const fakeThis = {
-        selectElement: component.selectElement,
-        selectedValue: '1',
-        displayValue: label => {},
-        updateModel: value => {},
-        emitChange: value => {}
-      };
-
-      spyOn(fakeThis, 'emitChange');
-      component['updateValues'].call(fakeThis, option);
-
-      expect(fakeThis.emitChange).not.toHaveBeenCalled();
-      expect(fakeThis.selectedValue).toBe('1');
+      expect(fakeThis.selectedValue).toBe(undefined);
     });
 
     it('onUpdateOptions: should call `onSelectChange` if model is truthy.', () => {
@@ -957,6 +940,18 @@ describe('PoSelectComponent:', () => {
 
       optionsElementOpen = nativeElement.querySelector('.po-select-show');
       expect(optionsElementOpen).toBeTruthy();
+    });
+
+    it('should set p-field-value with `defaultValue` if param is empty', () => {
+      const defaultValue = 'value';
+      expectSettersMethod(component, 'fieldValue', '', 'fieldValue', defaultValue);
+      expect(component.fieldValue).toEqual(defaultValue);
+    });
+
+    it('should set p-field-label with `defaultValue` if param is empty', () => {
+      const defaultLabel = 'label';
+      expectSettersMethod(component, 'fieldLabel', '', 'fieldLabel', defaultLabel);
+      expect(component.fieldLabel).toEqual(defaultLabel);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -1,32 +1,39 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
-  ContentChild,
   Component,
   DoCheck,
   ElementRef,
+  EventEmitter,
   forwardRef,
   HostListener,
-  IterableDiffers,
-  Renderer2,
-  ViewChild,
   Input,
+  IterableDiffers,
   Output,
-  EventEmitter
+  Renderer2,
+  ViewChild
 } from '@angular/core';
-import { NG_VALUE_ACCESSOR, NG_VALIDATORS, AbstractControl } from '@angular/forms';
+import { AbstractControl, NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { isMobile, removeDuplicatedOptions, removeUndefinedAndNullOptions, validValue } from '../../../utils/util';
-import { PoControlPositionService } from './../../../services/po-control-position/po-control-position.service';
+import {
+  isMobile,
+  removeDuplicatedOptions,
+  removeDuplicatedOptionsWithFieldValue,
+  removeUndefinedAndNullOptions,
+  removeUndefinedAndNullOptionsWithFieldValue,
+  validValue
+} from '../../../utils/util';
 import { PoKeyCodeEnum } from './../../../enums/po-key-code.enum';
+import { PoControlPositionService } from './../../../services/po-control-position/po-control-position.service';
 
-import { PoSelectOption } from './po-select-option.interface';
-import { PoFieldValidateModel } from '../po-field-validate.model';
 import { InputBoolean } from '../../../decorators';
+import { PoFieldValidateModel } from '../po-field-validate.model';
+import { PoSelectOption } from './po-select-option.interface';
 
 const poSelectContentOffset = 8;
 const poSelectContentPositionDefault = 'bottom';
+const PO_SELECT_FIELD_LABEL_DEFAULT = 'label';
+const PO_SELECT_FIELD_VALUE_DEFAULT = 'value';
 
 /**
  * @docsExtends PoFieldValidateModel
@@ -49,6 +56,11 @@ const poSelectContentPositionDefault = 'bottom';
  *   <file name="sample-po-select-customer-registration/sample-po-select-customer-registration.service.ts"> </file>
  *   <file name='sample-po-select-customer-registration/sample-po-select-customer-registration.component.e2e-spec.ts'> </file>
  *   <file name='sample-po-select-customer-registration/sample-po-select-customer-registration.component.po.ts'> </file>
+ * </example>
+ *
+ * <example name="po-select-companies" title="PO Select Companies">
+ *   <file name="sample-po-select-companies/sample-po-select-companies.component.html"> </file>
+ *   <file name="sample-po-select-companies/sample-po-select-companies.component.ts"> </file>
  * </example>
  *
  * @description
@@ -135,7 +147,9 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
   onModelTouched: any;
   protected clickoutListener: () => void;
   private differ: any;
-  private _options: Array<PoSelectOption>;
+  private _fieldLabel?: string = PO_SELECT_FIELD_LABEL_DEFAULT;
+  private _fieldValue?: string = PO_SELECT_FIELD_VALUE_DEFAULT;
+  private _options: Array<PoSelectOption> | Array<any>;
 
   /**
    * Nesta propriedade deve ser definido uma coleção de objetos que implementam a interface `PoSelectOption`.
@@ -153,16 +167,63 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
    * this.options.push({ value: 'x', label: 'Nova opção' });
    * ```
    */
-  @Input('p-options') set options(options: Array<PoSelectOption>) {
-    this._options = options;
-    removeDuplicatedOptions(this._options);
-    removeUndefinedAndNullOptions(this._options);
+  @Input('p-options') set options(options: Array<any>) {
+    if (this.fieldLabel && this.fieldValue) {
+      options.map(option => {
+        option.label = option[this.fieldLabel];
+        option.value = option[this.fieldValue];
+      });
+    }
+
+    this.validateOptions([...options]);
     this.onUpdateOptions();
+    this._options = [...options];
   }
 
   get options() {
     return this._options;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   * Deve ser informado o nome da propriedade do objeto que será utilizado para a conversão dos itens apresentados na lista do componente
+   * (`p-options`), esta propriedade será responsável pelo texto de apresentação de cada item da lista.
+   *
+   * @default `label`
+   */
+  @Input('p-field-label') set fieldLabel(value: string) {
+    this._fieldLabel = value || PO_SELECT_FIELD_LABEL_DEFAULT;
+    if (this.options && this.options.length > 0) {
+      this.options = [...this.options];
+    }
+  }
+
+  get fieldLabel() {
+    return this._fieldLabel;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   * Deve ser informado o nome da propriedade do objeto que será utilizado para a conversão dos itens apresentados na lista do componente
+   * (`p-options`), esta propriedade será responsável pelo valor de cada item da lista.
+   *
+   * @default `value`
+   */
+  @Input('p-field-value') set fieldValue(value: string) {
+    this._fieldValue = value || PO_SELECT_FIELD_VALUE_DEFAULT;
+    if (this.options && this.options.length > 0) {
+      this.options = [...this.options];
+    }
+  }
+
+  get fieldValue() {
+    return this._fieldValue;
+  }
+
   /* istanbul ignore next */
   constructor(
     private element: ElementRef,
@@ -214,6 +275,8 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
     if (change) {
       removeDuplicatedOptions(this.options);
       removeUndefinedAndNullOptions(this.options);
+      removeDuplicatedOptionsWithFieldValue(this.options, this.fieldValue);
+      removeUndefinedAndNullOptionsWithFieldValue(this.options, this.fieldValue);
     }
   }
 
@@ -255,7 +318,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
     this.onModelTouched?.();
   }
 
-  onOptionClick(option: PoSelectOption) {
+  onOptionClick(option: any) {
     this.updateValues(option);
     this.toggleButton();
   }
@@ -263,7 +326,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
   // Altera o valor ao selecionar um item.
   onSelectChange(value: any) {
     if (value && this.options && this.options.length) {
-      const optionFound: PoSelectOption = this.findOptionValue(value);
+      const optionFound: any = this.findOptionValue(value);
 
       if (optionFound) {
         this.updateValues(optionFound);
@@ -293,13 +356,13 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
   }
 
   // Atualiza valores
-  updateValues(option: PoSelectOption): void {
-    if (this.selectedValue !== option.value) {
-      this.selectedValue = option.value;
-      this.selectElement.nativeElement.value = option.value;
-      this.updateModel(option.value);
-      this.displayValue = option.label;
-      this.emitChange(option.value);
+  updateValues(option: any): void {
+    if (this.selectedValue !== option[this.fieldValue]) {
+      this.selectedValue = option[this.fieldValue];
+      this.selectElement.nativeElement.value = option[this.fieldValue];
+      this.updateModel(option[this.fieldValue]);
+      this.displayValue = option[this.fieldLabel];
+      this.emitChange(option[this.fieldValue]);
     }
   }
 
@@ -315,13 +378,13 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
 
   // Recebe as alterações do model
   onWriteValue(value: any) {
-    const optionFound: PoSelectOption = this.findOptionValue(value);
+    const optionFound: any = this.findOptionValue(value);
 
     if (optionFound) {
       this.selectElement.nativeElement.value = optionFound.value;
-      this.selectedValue = optionFound.value;
-      this.displayValue = optionFound.label;
-      this.setScrollPosition(optionFound.value);
+      this.selectedValue = optionFound[this.fieldValue];
+      this.displayValue = optionFound[this.fieldLabel];
+      this.setScrollPosition(optionFound[this.fieldValue]);
     } else if (validValue(this.selectedValue)) {
       this.selectElement.nativeElement.value = undefined;
       this.updateModel(undefined);
@@ -411,7 +474,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
     const ulDropdpwn = this.element.nativeElement.querySelector('ul.po-select-content');
 
     if (value && this.options && this.options.length) {
-      const optionFound: PoSelectOption = this.findOptionValue(value);
+      const optionFound: any = this.findOptionValue(value);
 
       if (optionFound) {
         const index = this.options.indexOf(optionFound);
@@ -434,5 +497,12 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
         this.setScrollPosition(this.selectedValue);
       }
     }
+  }
+
+  private validateOptions(options: Array<any>) {
+    removeDuplicatedOptions(options);
+    removeUndefinedAndNullOptions(options);
+    removeDuplicatedOptionsWithFieldValue(options, this.fieldValue);
+    removeUndefinedAndNullOptionsWithFieldValue(options, this.fieldValue);
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-companies/sample-po-select-companies.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-companies/sample-po-select-companies.component.html
@@ -1,0 +1,33 @@
+<po-select
+  name="select"
+  p-label="PO Select"
+  [(ngModel)]="select"
+  [p-field-value]="fieldValue"
+  [p-field-label]="fieldLabel"
+  [p-options]="empresas"
+>
+</po-select>
+
+<po-info p-label="Model" name="selectInfo" [(p-value)]="select"> </po-info>
+
+<div class="po-row">
+  <po-select
+    class="po-md-6"
+    name="fieldLabel"
+    p-label="p-field-label"
+    [p-options]="labels"
+    (p-change)="onChange($event)"
+    [(ngModel)]="fieldLabel"
+  >
+  </po-select>
+
+  <po-select
+    class="po-md-6"
+    name="selectValue"
+    p-label="p-field-value"
+    [p-options]="values"
+    (p-change)="onChange($event)"
+    [(ngModel)]="fieldValue"
+  >
+  </po-select>
+</div>

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-companies/sample-po-select-companies.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-companies/sample-po-select-companies.component.ts
@@ -1,0 +1,70 @@
+import { Component } from '@angular/core';
+
+import { PoSelectOption } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-select-companies',
+  templateUrl: './sample-po-select-companies.component.html'
+})
+export class SamplePoSelectCompaniesComponent {
+  select: Array<string>;
+  fieldLabel = undefined ?? 'nomeFantasia';
+  fieldValue = undefined ?? 'cnpj';
+
+  empresas: Array<any> = [
+    {
+      codigo: '1',
+      nomeFantasia: 'TOTVS SA',
+      razaoSocial: 'TOTVS LTDA',
+      label: 'TOTVS COMPANY',
+      cnpj: '01.234.567/0000-01',
+      value: '100',
+      id: '10',
+      email: 'totvscompany@sample.com',
+      data: '10/03/2015',
+      origem: 'São Paulo'
+    },
+    {
+      codigo: '2',
+      nomeFantasia: 'INSTITUTO TOTVS DE ENSINO SA',
+      razaoSocial: 'INST TOTVS DE ENSINO LTDA',
+      label: 'INST TOTVS',
+      cnpj: '02.345.678/0000-02',
+      value: '200',
+      id: '20',
+      email: 'insttotvs@sample.com',
+      data: '10/10/2020',
+      origem: 'Joinville'
+    },
+    {
+      codigo: '3',
+      nomeFantasia: 'TOTVS ENTERPRISE SA',
+      razaoSocial: 'TOTVS ENTERPRISE LTDA ',
+      label: 'ENT TOTVS',
+      cnpj: '03.456.789/0000-03',
+      value: '300',
+      id: '30',
+      email: 'enttotvs@sample.com',
+      data: '10/01/2022',
+      origem: 'Curitiba'
+    }
+  ];
+
+  readonly labels: Array<PoSelectOption> = [
+    { label: 'nomeFantasia', value: 'nomeFantasia' },
+    { label: 'razaoSocial', value: 'razaoSocial' },
+    { label: 'email', value: 'email' },
+    { label: 'origem', value: 'origem' }
+  ];
+
+  readonly values: Array<PoSelectOption> = [
+    { label: 'codigo', value: 'codigo' },
+    { label: 'cnpj', value: 'cnpj' },
+    { label: 'id', value: 'id' },
+    { label: 'data', value: 'data' }
+  ];
+
+  onChange(event) {
+    this.select = undefined;
+  }
+}

--- a/projects/ui/src/lib/utils/util.spec.ts
+++ b/projects/ui/src/lib/utils/util.spec.ts
@@ -28,7 +28,9 @@ import {
   validateDateRange,
   validateObjectType,
   validValue,
-  valuesFromObject
+  valuesFromObject,
+  removeDuplicatedOptionsWithFieldValue,
+  removeUndefinedAndNullOptionsWithFieldValue
 } from './util';
 
 import * as UtilFunctions from './util';
@@ -507,6 +509,20 @@ describe('Function removeDuplicatedOptions:', () => {
   });
 });
 
+describe('Function removeDuplicatedOptionsWithFieldValue:', () => {
+  it('should return items not duplicated ', () => {
+    const options = [
+      { value: 1, label: 1 },
+      { value: 2, label: 2 },
+      { value: 2, label: 2 },
+      { value: 1, label: 1 },
+      { value: 3, label: 3 }
+    ];
+    removeDuplicatedOptionsWithFieldValue(options, 'value');
+    expect(options.length).toBe(3);
+  });
+});
+
 describe('Function removeUndefinedAndNullOptions:', () => {
   it('should return items not undefined and null ', () => {
     const options = [
@@ -517,6 +533,20 @@ describe('Function removeUndefinedAndNullOptions:', () => {
       { value: 3, label: 3 }
     ];
     removeUndefinedAndNullOptions(options);
+    expect(options.length).toBe(3);
+  });
+});
+
+describe('Function removeUndefinedAndNullOptionsWithFielValue:', () => {
+  it('should return items not undefined and null ', () => {
+    const options = [
+      { value: 1, label: 1 },
+      { value: 2, label: 2 },
+      { value: <any>undefined, label: 'teste' },
+      { value: null, label: 'teste2' },
+      { value: 3, label: 3 }
+    ];
+    removeUndefinedAndNullOptionsWithFieldValue(options, 'value');
     expect(options.length).toBe(3);
   });
 });

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -326,9 +326,31 @@ export function removeDuplicatedOptions(list: Array<any>) {
   }
 }
 
+export function removeDuplicatedOptionsWithFieldValue(list: Array<any>, newValue) {
+  for (let i = 0; i < list.length; i++) {
+    if (i === 0) {
+      continue;
+    }
+
+    if (list.findIndex(op => op[newValue] === list[i][newValue]) !== i) {
+      list.splice(i, 1);
+      i--;
+    }
+  }
+}
+
 export function removeUndefinedAndNullOptions(list: Array<any>) {
   for (let i = 0; i < list.length; i++) {
     if (list[i].value === undefined || list[i].value === null) {
+      list.splice(i, 1);
+      i--;
+    }
+  }
+}
+
+export function removeUndefinedAndNullOptionsWithFieldValue(list: Array<any>, newValue) {
+  for (let i = 0; i < list.length; i++) {
+    if (list[i][newValue] === undefined || list[i][newValue] === null) {
       list.splice(i, 1);
       i--;
     }


### PR DESCRIPTION
**SELECT**

**DTHFUI-6091**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente não possui as propriedades ` p-field-value` e `p-field-label` 

**Qual o novo comportamento?**
Componente passa a ter novas propriedades ` p-field-value` e `p-field-label`

**Simulação**
Rodar build do portal e testar sample `PO Select Companies`