### PR TITLE
fix(table): corrige o gerenciador de colunas

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -78,23 +78,22 @@
 
         <!-- Coluna criada para caso as ações fiquem no lado esquerdo -->
         <th
-          #columnActionLeft
+          #columnActionLeftFixed
           *ngIf="!actionRight && (visibleActions.length > 1 || isSingleAction)"
           [class.po-table-header-master-detail]="!isSingleAction"
           [class.po-table-header-single-action]="isSingleAction"
         ></th>
 
-        <th *ngIf="!hasMainColumns" #noColumnsHeader class="po-table-header-column po-text-center">
+        <th *ngIf="!hasMainColumns" #noColumnsHeaderFixed class="po-table-header-column po-text-center">
           <ng-container *ngIf="height; then noColumnsWithHeight; else noColumnsWithoutHeight"> </ng-container>
         </th>
 
         <th
           *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
-          #headersTable
           class="po-table-header-ellipsis"
           [style.width]="column.width"
           [style.max-width]="column.width"
-          [style.min-width]="column.width || '50px'"
+          [style.min-width]="column.width"
           [class.po-clickable]="(sort && column.sortable !== false) || hasService"
           [class.po-table-header-subtitle]="column.type === 'subtitle'"
           (click)="sortColumn(column)"
@@ -121,7 +120,7 @@
         ></th>
 
         <th
-          #columnManager
+          #columnManagerFixed
           *ngIf="hasValidColumns && !hideColumnsManager"
           [class.po-table-header-column-manager]="!isSingleAction || !actionRight"
           [class.po-table-header-column-manager-border]="!height && container"
@@ -130,10 +129,10 @@
           <div
             [class.po-table-header-column-manager-border]="height && container"
             [class.po-table-header-column-manager-fixed-inner]="height"
-            [style.width.px]="height && visibleActions.length ? columnManager.offsetWidth : undefined"
+            [style.width.px]="height && visibleActions.length ? columnManagerFixed.offsetWidth : undefined"
           >
             <button
-              #columnManagerTarget
+              #columnManagerTargetFixed
               type="button"
               [attr.aria-label]="literals.columnsManager"
               class="po-table-header-column-manager-button po-icon po-icon-settings po-clickable"
@@ -228,7 +227,7 @@
                 [class.po-table-body-ellipsis]="hideTextOverflow"
                 [ngSwitch]="column.type"
                 [p-tooltip]="tooltipText"
-                [style.width.px]="noColumnsHeader?.nativeElement.parentElement?.offsetWidth"
+                [style.width.px]="noColumnsHeaderFixed?.nativeElement.parentElement?.offsetWidth"
                 (mouseenter)="tooltipMouseEnter($event, column, row)"
                 (mouseleave)="tooltipMouseLeave()"
               >
@@ -393,7 +392,6 @@
 
         <th
           *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
-          #headersTable
           class="po-table-header-ellipsis"
           [style.width]="column.width"
           [style.max-width]="column.width"
@@ -724,7 +722,7 @@
   *ngIf="!hideColumnsManager"
   [p-columns]="columns"
   [p-max-columns]="maxColumns"
-  [p-target]="columnManagerTarget"
+  [p-target]="height ? columnManagerTargetFixed : columnManagerTarget"
   [p-last-visible-columns-selected]="lastVisibleColumnsSelected"
   (p-visible-columns-change)="onVisibleColumnsChange($event)"
   (p-change-visible-columns)="onChangeVisibleColumns($event)"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -3016,6 +3016,23 @@ describe('PoTableComponent:', () => {
     expect(valueWidth).toEqual(undefined);
   });
 
+  it('getWidthColumnManagerFixed, should return width of column manager', () => {
+    const fakeThis = {
+      height: 300,
+      columnManagerFixed: {
+        nativeElement: {
+          offsetWidth: 120
+        }
+      }
+    };
+
+    fixture.detectChanges();
+
+    component['getWidthColumnManager'].call(fakeThis);
+
+    expect(fakeThis.columnManagerFixed.nativeElement.offsetWidth).toEqual(120);
+  });
+
   it('columnActionLeft, should return width of column when action is on the left', () => {
     const fakeThis = {
       columnActionLeft: {
@@ -3042,6 +3059,23 @@ describe('PoTableComponent:', () => {
     const valueWidth = component['getColumnWidthActionsLeft'].call(fakeThis);
 
     expect(valueWidth).toEqual(undefined);
+  });
+
+  it('columnActionLeftFixed, should return width of column when action is on the left', () => {
+    const fakeThis = {
+      height: 300,
+      columnActionLeftFixed: {
+        nativeElement: {
+          offsetWidth: 120
+        }
+      }
+    };
+
+    fixture.detectChanges();
+
+    component['getColumnWidthActionsLeft'].call(fakeThis);
+
+    expect(fakeThis.columnActionLeftFixed.nativeElement.offsetWidth).toEqual(120);
   });
 
   it('hasInfiniteScroll: should return false if infiniteScroll is false', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -91,6 +91,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   @ContentChildren(PoTableColumnTemplateDirective) tableColumnTemplates: QueryList<PoTableColumnTemplateDirective>;
 
   @ViewChild('noColumnsHeader', { read: ElementRef }) noColumnsHeader;
+  @ViewChild('noColumnsHeaderFixed', { read: ElementRef }) noColumnsHeaderFixed;
   @ViewChild('popup') poPopupComponent: PoPopupComponent;
   @ViewChild('tableFooter', { read: ElementRef, static: false }) tableFooterElement;
   @ViewChild('tableWrapper', { read: ElementRef, static: false }) tableWrapperElement;
@@ -98,7 +99,9 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   @ViewChild('poTableThead', { read: ElementRef, static: false }) poTableThead;
   @ViewChild('poTableTbodyVirtual', { read: ElementRef, static: false }) poTableTbodyVirtual;
   @ViewChild('columnManager', { read: ElementRef, static: false }) columnManager;
+  @ViewChild('columnManagerFixed', { read: ElementRef, static: false }) columnManagerFixed;
   @ViewChild('columnActionLeft', { read: ElementRef, static: false }) columnActionLeft;
+  @ViewChild('columnActionLeftFixed', { read: ElementRef, static: false }) columnActionLeftFixed;
 
   @ViewChildren('actionsIconElement', { read: ElementRef }) actionsIconElement: QueryList<any>;
   @ViewChildren('actionsElement', { read: ElementRef }) actionsElement: QueryList<any>;
@@ -112,6 +115,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   lastVisibleColumnsSelected: Array<PoTableColumn>;
 
   private _columnManagerTarget: ElementRef;
+  private _columnManagerTargetFixed: ElementRef;
   private differ;
   private footerHeight;
   private headerHeight;
@@ -131,6 +135,15 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   get columnManagerTarget() {
     return this._columnManagerTarget;
+  }
+
+  @ViewChild('columnManagerTargetFixed') set columnManagerTargetFixed(value: ElementRef) {
+    this._columnManagerTargetFixed = value;
+    this.changeDetector.detectChanges();
+  }
+
+  get columnManagerTargetFixed() {
+    return this._columnManagerTargetFixed;
   }
 
   constructor(
@@ -555,11 +568,15 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   public getWidthColumnManager() {
-    return this.columnManager?.nativeElement.offsetWidth;
+    return this.height
+      ? this.columnManagerFixed?.nativeElement.offsetWidth
+      : this.columnManager?.nativeElement.offsetWidth;
   }
 
   public getColumnWidthActionsLeft() {
-    return this.columnActionLeft?.nativeElement.offsetWidth;
+    return this.height
+      ? this.columnActionLeftFixed?.nativeElement.offsetWidth
+      : this.columnActionLeft?.nativeElement.offsetWidth;
   }
 
   protected calculateHeightTableContainer(height) {


### PR DESCRIPTION
**TABLE**

**DTHFUI-6153**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao utilizar a tabela com uma altura dinamica o gerenciador de colunas para de funcionar após alterar a altura da tabela.

**Qual o novo comportamento?**
Ao utilizar a tabela com uma altura dinamica o gerenciador de colunas permanece funcionando mesmo após alterar a altura da tabela.

**Simulação**
Portal