### PR TITLE
fix(multiselect): corrige chamada de api

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -401,9 +401,29 @@ describe('PoMultiselectComponent:', () => {
       expect(fnDestroy).not.toThrow();
     });
 
-    it('Should call `setService` if a change occurs', () => {
+    it('Should call `setService` if a change occurs in `filterService` and contain `filterService`', () => {
       const changes = { filterService: 'filterServiceURL' };
+      component.filterService = 'http://localhost:4200/test';
+      spyOn(component, <any>'setService');
 
+      component.ngOnChanges(<any>changes);
+
+      expect(component['setService']).toHaveBeenCalledWith(component.filterService);
+    });
+
+    it('Should call `setService` if a change occurs in `fieldValue` and contain `filterService`', () => {
+      const changes = { fieldValue: 'valueTest' };
+      component.filterService = 'http://localhost:4200/test';
+      spyOn(component, <any>'setService');
+
+      component.ngOnChanges(<any>changes);
+
+      expect(component['setService']).toHaveBeenCalledWith(component.filterService);
+    });
+
+    it('Should call `setService` if a change occurs in `fieldLabel` and contain `filterService`', () => {
+      const changes = { fieldLabel: 'labelTest' };
+      component.filterService = 'http://localhost:4200/test';
       spyOn(component, <any>'setService');
 
       component.ngOnChanges(<any>changes);

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -122,7 +122,7 @@ export class PoMultiselectComponent
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.filterService || changes.fieldValue || changes.fieldLabel) {
+    if (this.filterService && (changes.filterService || changes.fieldValue || changes.fieldLabel)) {
       this.setService(this.filterService);
     }
   }


### PR DESCRIPTION
**multiselect**

**DTHFUI-6085**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
multiselect faz requisição desnecessária quando utilizado em um dynamic-form

**Qual o novo comportamento?**
multiselect não faz requisição desnecessária quando utilizado em um dynamic-form


**Simulação**
app:
[app.zip](https://github.com/po-ui/po-angular/files/9242566/app.zip)
 