### PR TITLE
fix(breadcrumb): ajusta execução de action

### DIFF
--- a/projects/ui/src/lib/components/po-breadcrumb/po-breadcrumb-dropdown/po-breadcrumb-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-breadcrumb/po-breadcrumb-dropdown/po-breadcrumb-dropdown.component.html
@@ -1,5 +1,5 @@
 <ul class="po-breadcrumb-dropdown">
-  <li class="po-breadcrumb-dropdown-item" *ngFor="let item of items" [routerLink]="item.link">
+  <li class="po-breadcrumb-dropdown-item" *ngFor="let item of items" [routerLink]="item.link" (click)="item.action?.()">
     {{ item.label }}
   </li>
 </ul>


### PR DESCRIPTION
**BREADCRUMB**

**DTHFUI-6341, #1325**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A função de Action/link não é executada quando a label é muito longa e a tela é pequena transformando a label em um ícone de '...'

**Qual o novo comportamento?**
A função de Action/link é executada quando a label é muito longa e a tela é pequena transformando a label em um ícone de '...'

**Simulação**

Utilizar o sample do Portal ou este [app.zip](https://github.com/po-ui/po-angular/files/9245795/app.zip).