### PR TITLE
feat(page-dynamic-edit): adiciona parâmetro `p-literals`

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
@@ -1,5 +1,6 @@
 export * from './po-page-dynamic-edit.component';
 export * from './interfaces/po-page-dynamic-edit-actions.interface';
+export * from './interfaces/po-page-dynamic-edit-literals.interface';
 export * from './interfaces/po-page-dynamic-edit-field.interface';
 export * from './interfaces/po-page-dynamic-edit-before-cancel.interface';
 export * from './interfaces/po-page-dynamic-edit-before-save.interface';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-literals.interface.ts
@@ -1,0 +1,71 @@
+/**
+ * @usedBy PoPageDynamicEditComponent
+ *
+ * @description
+ *
+ * Interface para definição das literais usadas no `po-page-dynamic-edit`.
+ */
+export interface PoPageDynamicEditLiterals {
+  /**
+   * @description
+   *
+   * Texto exibido na mensagem de cancelamento da inclusão/edição.
+   */
+  cancelConfirmMessage?: string;
+
+  /**
+   * @description
+   *
+   * Rótulo exibido no botão `Novo`.
+   */
+  detailActionNew?: string;
+
+  /**
+   * @description
+   *
+   * Rótulo exibido no botão `Cancelar`.
+   */
+  pageActionCancel?: string;
+
+  /**
+   * @description
+   *
+   * Rótulo exibido no botão `Salvar`.
+   */
+  pageActionSave?: string;
+
+  /**
+   * @description
+   *
+   * Rótulo exibido no botão `Salvar e novo`.
+   */
+  pageActionSaveNew?: string;
+
+  /**
+   * @description
+   *
+   * Texto exibido para resgistro não encontrado.
+   */
+  registerNotFound?: string;
+
+  /**
+   * @description
+   *
+   * Texto exibido para recurso salvo com sucesso.
+   */
+  saveNotificationSuccessSave?: string;
+
+  /**
+   * @description
+   *
+   * Texto exibido para recurso atualizado com sucesso.
+   */
+  saveNotificationSuccessUpdate?: string;
+
+  /**
+   * @description
+   *
+   * Texto exibido para adivertência de formulário preenchido de forma incorreta.
+   */
+  saveNotificationWarning?: string;
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -11,7 +11,9 @@ import { PoDialogModule } from '@po-ui/ng-components';
 import * as util from './../../utils/util';
 import { expectPropertiesValues } from './../../util-test/util-expect.spec';
 
-import { PoPageDynamicEditComponent } from './po-page-dynamic-edit.component';
+import { poLocaleDefault } from './../../../../../ui/src/lib/services/po-language/po-language.constant';
+
+import { PoPageDynamicEditComponent, poPageDynamicEditLiteralsDefault } from './po-page-dynamic-edit.component';
 import { PoPageDynamicEditActions } from './interfaces/po-page-dynamic-edit-actions.interface';
 import { PoDynamicFormStubComponent } from './test/po-dynamic-form-stub-component';
 import { PoPageDynamicEditBeforeSave } from './interfaces/po-page-dynamic-edit-before-save.interface';
@@ -107,6 +109,75 @@ describe('PoPageDynamicEditComponent: ', () => {
       const invalidValues = ['teste', undefined, null, NaN, 0, 'false', false];
 
       expectPropertiesValues(component, 'autoRouter', invalidValues, false);
+    });
+
+    describe('p-literals:', () => {
+      it('should be in portuguese if browser is setted with an unsupported language', () => {
+        component['language'] = 'zw';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicEditLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should be in portuguese if browser is setted with `pt`', () => {
+        component['language'] = 'pt';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicEditLiteralsDefault.pt);
+      });
+
+      it('should be in english if browser is setted with `en`', () => {
+        component['language'] = 'en';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicEditLiteralsDefault.en);
+      });
+
+      it('should be in spanish if browser is setted with `es`', () => {
+        component['language'] = 'es';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicEditLiteralsDefault.es);
+      });
+
+      it('should be in russian if browser is setted with `ru`', () => {
+        component['language'] = 'ru';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicEditLiteralsDefault.ru);
+      });
+
+      it('should accept custom literals', () => {
+        component['language'] = poLocaleDefault;
+
+        const customLiterals = Object.assign({}, poPageDynamicEditLiteralsDefault[poLocaleDefault]);
+
+        customLiterals.pageActionSave = 'Salvar';
+        customLiterals.pageActionSaveNew = 'Salvar e novo';
+
+        component.literals = customLiterals;
+
+        expect(component.literals).toEqual(customLiterals);
+      });
+
+      it('should update property with default literals if is setted with invalid values', () => {
+        const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
+
+        component['language'] = poLocaleDefault;
+
+        expectPropertiesValues(component, 'literals', invalidValues, poPageDynamicEditLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should get literals directly from poPageDynamicEditLiteralsDefault if it not initialized', () => {
+        component['language'] = 'pt';
+
+        expect(component.literals).toEqual(poPageDynamicEditLiteralsDefault['pt']);
+      });
     });
 
     it('duplicates: get duplicates', () => {
@@ -1069,7 +1140,7 @@ describe('PoPageDynamicEditComponent: ', () => {
     it('executeSaveNew: should call `saveOperation`, `poNotification.success` and reset dynamicForm ', fakeAsync(() => {
       const saveNewRedirectPath = 'people';
 
-      const message = component.literals.saveNotificationSuccess;
+      const message = component.literals.saveNotificationSuccessSave;
       const activatedRoute: any = {
         snapshot: {
           params: { id: undefined }
@@ -1085,7 +1156,9 @@ describe('PoPageDynamicEditComponent: ', () => {
       spyOn(component, <any>'navigateTo');
 
       component['executeSaveNew'](saveNewRedirectPath).subscribe(() => {
-        expect(component['poNotification'].success).toHaveBeenCalledWith(component.literals.saveNotificationSuccess);
+        expect(component['poNotification'].success).toHaveBeenCalledWith(
+          component.literals.saveNotificationSuccessSave
+        );
         expect(component.model).toEqual({});
         expect(component.dynamicForm.form.reset).toHaveBeenCalled();
 

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -27,12 +27,13 @@ import { PoPageDynamicEditMetadata } from './interfaces/po-page-dynamic-edit-met
 import { PoPageDynamicOptionsSchema } from '../../services/po-page-customization/po-page-dynamic-options.interface';
 import { PoPageDynamicEditActionsService } from './po-page-dynamic-edit-actions.service';
 import { PoPageDynamicEditBeforeCancel } from './interfaces/po-page-dynamic-edit-before-cancel.interface';
+import { PoPageDynamicEditLiterals } from './interfaces/po-page-dynamic-edit-literals.interface';
 
 type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicEditOptions);
 type SaveAction = PoPageDynamicEditActions['save'] | PoPageDynamicEditActions['saveNew'];
 
 export const poPageDynamicEditLiteralsDefault = {
-  en: {
+  en: <PoPageDynamicEditLiterals>{
     cancelConfirmMessage: 'Are you sure you want to cancel this operation?',
     detailActionNew: 'New',
     pageActionCancel: 'Cancel',
@@ -43,7 +44,7 @@ export const poPageDynamicEditLiteralsDefault = {
     saveNotificationSuccessUpdate: 'Resource successfully updated.',
     saveNotificationWarning: 'Form must be filled out correctly.'
   },
-  es: {
+  es: <PoPageDynamicEditLiterals>{
     cancelConfirmMessage: 'Está seguro de que desea cancelar esta operación?',
     detailActionNew: 'Nuevo',
     pageActionCancel: 'Cancelar',
@@ -54,7 +55,7 @@ export const poPageDynamicEditLiteralsDefault = {
     saveNotificationSuccessUpdate: 'Recurso actualizado con éxito.',
     saveNotificationWarning: 'El formulario debe llenarse correctamente.'
   },
-  pt: {
+  pt: <PoPageDynamicEditLiterals>{
     cancelConfirmMessage: 'Tem certeza que deseja cancelar esta operação?',
     detailActionNew: 'Novo',
     pageActionCancel: 'Cancelar',
@@ -65,7 +66,7 @@ export const poPageDynamicEditLiteralsDefault = {
     saveNotificationSuccessUpdate: 'Recurso atualizado com sucesso.',
     saveNotificationWarning: 'Formulário precisa ser preenchido corretamente.'
   },
-  ru: {
+  ru: <PoPageDynamicEditLiterals>{
     cancelConfirmMessage: 'Вы уверены, что хотите отменить эту операцию?',
     detailActionNew: 'Новый',
     pageActionCancel: 'Отменить',
@@ -279,7 +280,6 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
    */
   @Input('p-load') onLoad: string | (() => PoPageDynamicEditOptions);
 
-  literals;
   model: any = {};
 
   // beforeSave: return boolean
@@ -289,8 +289,10 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
   // beforeInsert: : return boolean
   readonly detailActions: PoGridRowActions = {};
 
+  private language: string;
   private subscriptions: Array<Subscription> = [];
   private _actions: PoPageDynamicEditActions = {};
+  private _literals: PoPageDynamicEditLiterals;
   private _autoRouter: boolean = false;
   private _controlFields: Array<any> = [];
   private _detailFields: Array<any> = [];
@@ -314,6 +316,53 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
 
   get actions() {
     return { ...this._actions };
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Objeto com as literais usadas no `po-page-dynamic-edit`.
+   *
+   * É possivel customizar passando um objeto com todas as literais disponíveis
+   * ou passando apenas as literais que deseja customizar
+   *
+   * ```
+   *  const customLiterals: PoPageDynamicSearchLiterals = {
+   *    detailActionNew: 'Incluir',
+   *    pageActionCancel: 'Descartar',
+   *    pageActionSave: 'Gravar',
+   *    pageActionSaveNew: 'Gravar e incluir',
+   *  };
+   * ```
+   *
+   * E para carregar as literais customizadas, basta apenas passar o objeto para o componente.
+   *
+   * ```
+   * <po-page-dynamic-search
+   *   [p-literals]="customLiterals">
+   * </po-page-dynamic-search>
+   * ```
+   *
+   * > O valor padrão será traduzido de acordo com o idioma configurado no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
+   */
+  @Input('p-literals') set literals(value: PoPageDynamicEditLiterals) {
+    if (value instanceof Object && !(value instanceof Array)) {
+      this._literals = {
+        ...poPageDynamicEditLiteralsDefault[poLocaleDefault],
+        ...poPageDynamicEditLiteralsDefault[this.language],
+        ...value
+      };
+    } else {
+      this._literals = poPageDynamicEditLiteralsDefault[this.language];
+    }
+
+    this._pageActions = this.getPageActions(this._actions);
+  }
+
+  get literals() {
+    return this._literals || poPageDynamicEditLiteralsDefault[this.language];
   }
 
   /**
@@ -363,12 +412,7 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
     private poPageDynamicEditActionsService: PoPageDynamicEditActionsService,
     languageService: PoLanguageService
   ) {
-    const language = languageService.getShortLanguage();
-
-    this.literals = {
-      ...poPageDynamicEditLiteralsDefault[poLocaleDefault],
-      ...poPageDynamicEditLiteralsDefault[language]
-    };
+    this.language = languageService.getShortLanguage();
   }
 
   ngOnInit(): void {

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.html
@@ -4,6 +4,7 @@
   [p-actions]="actions"
   [p-breadcrumb]="breadcrumb"
   [p-fields]="fields"
+  [p-literals]="literals"
   [p-service-api]="serviceApi"
 >
 </po-page-dynamic-edit>

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 import { PoBreadcrumb, PoDynamicFormField } from '@po-ui/ng-components';
 
-import { PoPageDynamicEditActions } from '@po-ui/ng-templates';
+import { PoPageDynamicEditActions, PoPageDynamicEditLiterals } from '@po-ui/ng-templates';
 
 @Component({
   selector: 'sample-po-page-dynamic-edit-user',
@@ -14,6 +14,12 @@ export class SamplePoPageDynamicEditUserComponent {
   public readonly actions: PoPageDynamicEditActions = {
     save: '/documentation/po-page-dynamic-detail',
     saveNew: '/documentation/po-page-dynamic-edit'
+  };
+
+  public readonly literals: PoPageDynamicEditLiterals = {
+    pageActionCancel: 'Descartar',
+    pageActionSave: 'Gravar',
+    pageActionSaveNew: 'Gravar e novo'
   };
 
   public readonly breadcrumb: PoBreadcrumb = {


### PR DESCRIPTION
Foi adicionado o parâmetro `p-literals` para customizar o rótulo dos botões de ação e o texto das mensagens.

Fixes #1321

**Page Dynamic Edit**

**1321**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não é possível renomear os botões de ação do componente.

**Qual o novo comportamento?**
É possível renomear os botões de ação do componente.

**Simulação**
Pode ser feita através do portal ou pelo [App](https://github.com/po-ui/po-angular/files/9660128/app.zip).
