### PR TITLE
feat(button): adiciona a propriedade `p-size` e deprecia a propriedade `p-small`

### DIFF
--- a/projects/portal/src/app/home/home.component.html
+++ b/projects/portal/src/app/home/home.component.html
@@ -77,7 +77,7 @@
                 <p class="po-mb-2">
                   <po-button p-kind="primary" p-label="Primário"></po-button>
                 </p>
-                <p><po-button p-label="Default" p-small></po-button></p>
+                <p><po-button p-label="Default" p-size="large"></po-button></p>
               </div>
             </div>
           </po-widget>

--- a/projects/portal/src/app/tools/tools-dynamic-form/tools-dynamic-form.component.html
+++ b/projects/portal/src/app/tools/tools-dynamic-form/tools-dynamic-form.component.html
@@ -16,7 +16,7 @@
             </po-input>
 
             <button
-              class="po-button po-button-primary po-sm-4 po-md-2 po-mt-4"
+              class="po-button po-button-primary po-sm-4 po-md-2 po-mt-4 po-mb-1"
               type="submit"
               [disabled]="generatorForm.invalid"
             >

--- a/projects/portal/src/app/tools/tools-dynamic-view/tools-dynamic-view.component.html
+++ b/projects/portal/src/app/tools/tools-dynamic-view/tools-dynamic-view.component.html
@@ -16,7 +16,7 @@
             </po-input>
 
             <button
-              class="po-button po-button-primary po-sm-4 po-md-2 po-mt-4"
+              class="po-button po-button-primary po-sm-4 po-md-2 po-mt-4 po-mb-1"
               type="submit"
               [disabled]="generatorForm.invalid"
             >

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.html
@@ -18,7 +18,7 @@
     <po-divider [p-label]="detailFields[0].divider"></po-divider>
 
     <div class="po-row po-mb-2">
-      <po-button [p-label]="literals.detailActionNew" (p-click)="detailActionNew()" p-small></po-button>
+      <po-button [p-label]="literals.detailActionNew" (p-click)="detailActionNew()"></po-button>
     </div>
 
     <po-grid

--- a/projects/ui/src/lib/components/po-button-group/po-button-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group-base.component.ts
@@ -34,9 +34,16 @@ export class PoButtonGroupBaseComponent {
   private _toggle?: string = PO_TOGGLE_TYPE_DEFAULT;
 
   /**
+   * @deprecated 16.x.x
+   *
    * @optional
    *
    * @description
+   *
+   * **Deprecated 16.x.x**.
+   *
+   * > Por regras de acessibilidade o botão não terá mais um tamanho menor do que 44px e por isso a propriedade será depreciada.
+   * > [Saiba mais](https://animaliads.notion.site/Bot-o-fb3a921e8ba54bd38b39758c24613368)
    *
    * Torna o grupo de botões com tamanho minificado.
    *

--- a/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-labs/sample-po-button-group-labs.component.html
+++ b/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-labs/sample-po-button-group-labs.component.html
@@ -1,5 +1,5 @@
 <div class="po-row">
-  <po-button-group class="po-md-12" [p-buttons]="buttons" [p-small]="small" [p-toggle]="toggle"> </po-button-group>
+  <po-button-group class="po-md-12" [p-buttons]="buttons" [p-toggle]="toggle"> </po-button-group>
 </div>
 
 <hr />
@@ -43,8 +43,6 @@
   <div class="po-row">
     <po-select class="po-md-3" name="toggle" [(ngModel)]="toggle" p-label="Toggle" [p-options]="toggleOptions">
     </po-select>
-
-    <po-switch class="po-md-3" name="small" [(ngModel)]="small" p-label="Small"> </po-switch>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-labs/sample-po-button-group-labs.component.ts
+++ b/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-labs/sample-po-button-group-labs.component.ts
@@ -15,7 +15,6 @@ import {
 export class SamplePoButtonGroupLabsComponent implements OnInit {
   button: any;
   buttons: Array<PoButtonGroupItem>;
-  small: boolean;
   toggle: PoButtonGroupToggle;
 
   iconsOptions: Array<PoRadioGroupOption> = [

--- a/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-post/sample-po-button-group-post.component.html
+++ b/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-post/sample-po-button-group-post.component.html
@@ -1,10 +1,10 @@
 <div class="po-font-title po-mb-2">Create New Post</div>
 <po-widget>
   <div class="po-row">
-    <div class="po-md-3 po-lg-2">
+    <div class="po-md-4 po-lg-3">
       <po-button-group p-toggle="multiple" [p-buttons]="fontStyle"> </po-button-group>
     </div>
-    <div class="po-md-3 po-lg-2">
+    <div class="po-md-4 po-lg-3">
       <po-button-group p-toggle="single" [p-buttons]="textAlign"> </po-button-group>
     </div>
     <po-textarea class="po-md-12" name="textArea" [(ngModel)]="textArea" p-maxlength="400"> </po-textarea>

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.spec.ts
@@ -2,6 +2,7 @@ import { PoButtonBaseComponent } from './po-button-base.component';
 
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 import { PoButtonKind } from './po-button-type.enum';
+import { PoButtonSize } from './po-button-size.enum';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 describe('PoButtonBaseComponent', () => {
@@ -28,13 +29,10 @@ describe('PoButtonBaseComponent', () => {
     expectPropertiesValues(component, 'disabled', booleanInvalidValues, false);
   });
 
-  it('should update property `p-small` with valid values', () => {
-    expectPropertiesValues(component, 'small', booleanValidTrueValues, true);
-    expectPropertiesValues(component, 'small', booleanValidFalseValues, false);
-  });
+  it('should set property `p-small` with true if p-size is equal `small`', () => {
+    component.size = 'small';
 
-  it('should update property `p-small` with `false` when invalid values', () => {
-    expectPropertiesValues(component, 'small', booleanInvalidValues, false);
+    expect(component.small).toBeTrue();
   });
 
   it('should update property `p-kind` with valid values', () => {
@@ -60,5 +58,31 @@ describe('PoButtonBaseComponent', () => {
     component.kind = PoButtonKind.primary;
     component.danger = true;
     expect(component.danger).toBe(true);
+  });
+
+  it('should update property `p-size` with valid values', () => {
+    const validValues = ['medium', 'large'];
+
+    expectPropertiesValues(component, 'size', validValues, validValues);
+  });
+
+  it('should update property `p-size` with `medium` when invalid values', () => {
+    const invalidValues = ['extraSmall', 'extraLarge'];
+
+    expectPropertiesValues(component, 'size', invalidValues, 'medium');
+  });
+
+  it('should update property `p-size` with `small` if `p-small` was declared in first', () => {
+    component.small = true;
+    component.size = PoButtonSize.large;
+
+    expect(component.size).toBe('small');
+  });
+
+  it('should ignore property `p-small` if `p-size` was declared in first with value different of `small`', () => {
+    component.size = PoButtonSize.large;
+    component.small = true;
+
+    expect(component.size).toBe('large');
   });
 });

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -94,9 +94,16 @@ export class PoButtonBaseComponent {
   }
 
   /**
+   * @deprecated 16.x.x
+   *
    * @optional
    *
    * @description
+   *
+   * **Deprecated 16.x.x**.
+   *
+   * > Por regras de acessibilidade o botão não terá mais um tamanho menor do que 44px e por isso a propriedade será depreciada.
+   * > [Saiba mais](https://animaliads.notion.site/Bot-o-fb3a921e8ba54bd38b39758c24613368)
    *
    * Deixa o botão menor, com 32px de altura.
    *

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -4,7 +4,7 @@ import { convertToBoolean } from '../../utils/util';
 import { InputBoolean } from '../../decorators';
 
 import { PoButtonKind } from './po-button-type.enum';
-
+import { PoButtonSize } from './po-button-size.enum';
 /**
  * @description
  *
@@ -68,8 +68,11 @@ export class PoButtonBaseComponent {
   private _danger?: boolean = false;
   private _disabled?: boolean = false;
   private _loading?: boolean = false;
-  private _small?: boolean = false;
   private _kind?: string = PoButtonKind.secondary;
+  private _size?: string = PoButtonSize.medium;
+  private _small?: boolean = false;
+
+  protected hasSize?: boolean = false;
 
   /**
    * @optional
@@ -95,13 +98,20 @@ export class PoButtonBaseComponent {
    *
    * @description
    *
-   * Deixa o botão menor.
+   * Deixa o botão menor, com 32px de altura.
    *
    * @default `false`
    */
-  @Input('p-small') set small(value: boolean) {
-    this._small = <any>value === '' ? true : convertToBoolean(value);
+  @Input('p-small')
+  @InputBoolean()
+  set small(value: boolean) {
+    this._small = !this.hasSize ? value : false;
+
+    if (this._small) {
+      this._size = 'small';
+    }
   }
+
   get small(): boolean {
     return this._small;
   }
@@ -128,6 +138,7 @@ export class PoButtonBaseComponent {
   @Input('p-type') set type(value: string) {
     this.kind = value;
   }
+
   get type(): string {
     return this.kind;
   }
@@ -158,9 +169,41 @@ export class PoButtonBaseComponent {
    *
    * @description
    *
+   * Define o tamanho do `po-button`.
+   *
+   * Valores válidos:
+   * - `medium`: o `po-button` fica do tamanho padrão, com 44px de altura.;
+   * - `large`: o `po-button` fica maior, com 56px de altura.;
+   *
+   * @default `medium`
+   *
+   */
+  @HostBinding('attr.p-size')
+  @Input('p-size')
+  set size(value: string) {
+    const size = this.small ? 'small' : value;
+
+    if (size === 'small') {
+      this._size = 'small';
+      this._small = true;
+    } else {
+      this._size = PoButtonSize[size] ? PoButtonSize[size] : PoButtonSize.medium;
+      this.hasSize = true;
+    }
+  }
+
+  get size(): string {
+    return this._size;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Define o estilo do `po-button`.
    *
-   * Valore válidos:
+   * Valores válidos:
    *  - `primary`: deixa o `po-button` com destaque, deve ser usado para ações primárias.
    *  - `secondary`: estilo padrão do `po-button`.
    *  - `tertiary`: o `po-button` é exibido sem cor do fundo, recebendo menos destaque entre as ações.

--- a/projects/ui/src/lib/components/po-button/po-button-size.enum.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-size.enum.ts
@@ -1,0 +1,4 @@
+export enum PoButtonSize {
+  medium = 'medium',
+  large = 'large'
+}

--- a/projects/ui/src/lib/components/po-button/po-button.component.html
+++ b/projects/ui/src/lib/components/po-button/po-button.component.html
@@ -2,6 +2,7 @@
   #button
   class="po-button"
   type="button"
+  [attr.p-size]="size"
   [attr.p-kind]="kind"
   [attr.p-danger]="danger"
   [class.po-button-sm]="small"

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.html
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.html
@@ -6,6 +6,7 @@
     [p-icon]="icon"
     [p-label]="label"
     [p-loading]="properties.includes('loading')"
+    [p-size]="size"
     [p-small]="properties.includes('small')"
     [p-danger]="properties.includes('danger')"
     [p-kind]="kind"
@@ -44,6 +45,16 @@
       [(ngModel)]="kind"
       p-label="Kind"
       [p-options]="kindsOptions"
+      (p-change)="verifyDisabled($event)"
+    >
+    </po-radio-group>
+
+    <po-radio-group
+      class="po-lg-12"
+      name="size"
+      [(ngModel)]="size"
+      p-label="Size"
+      [p-options]="sizesOptions"
       (p-change)="verifyDisabled($event)"
     >
     </po-radio-group>

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.html
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.html
@@ -7,7 +7,6 @@
     [p-label]="label"
     [p-loading]="properties.includes('loading')"
     [p-size]="size"
-    [p-small]="properties.includes('small')"
     [p-danger]="properties.includes('danger')"
     [p-kind]="kind"
     (p-click)="buttonClick()"

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
@@ -16,7 +16,6 @@ export class SamplePoButtonLabsComponent implements OnInit {
   propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'disabled', label: 'Disabled' },
     { value: 'loading', label: 'Loading' },
-    { value: 'small', label: 'Small' },
     { value: 'danger', label: 'Danger' }
   ];
 
@@ -66,10 +65,10 @@ export class SamplePoButtonLabsComponent implements OnInit {
     const value = [...this.propertiesOptions];
 
     if (event === 'tertiary') {
-      value[3] = { value: 'danger', label: 'Danger', disabled: true };
+      value[2] = { value: 'danger', label: 'Danger', disabled: true };
       this.propertiesOptions = value;
     } else {
-      value[3] = { value: 'danger', label: 'Danger', disabled: false };
+      value[2] = { value: 'danger', label: 'Danger', disabled: false };
       this.propertiesOptions = value;
     }
   }

--- a/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
+++ b/projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.ts
@@ -10,6 +10,7 @@ export class SamplePoButtonLabsComponent implements OnInit {
   label: string;
   kind: string;
   icon: string;
+  size: string;
   properties: Array<string>;
 
   propertiesOptions: Array<PoCheckboxGroupOption> = [
@@ -32,6 +33,11 @@ export class SamplePoButtonLabsComponent implements OnInit {
     { label: 'tertiary', value: 'tertiary' }
   ];
 
+  sizesOptions: Array<PoRadioGroupOption> = [
+    { label: 'medium', value: 'medium' },
+    { label: 'large', value: 'large' }
+  ];
+
   constructor(private poDialog: PoDialogService) {}
 
   ngOnInit() {
@@ -44,6 +50,8 @@ export class SamplePoButtonLabsComponent implements OnInit {
 
   propertiesChange(event) {
     this.kindsOptions[2] = { ...this.kindsOptions[2], disabled: false };
+    this.sizesOptions[0] = { ...this.sizesOptions[0], disabled: false };
+    this.sizesOptions[1] = { ...this.sizesOptions[1], disabled: false };
 
     if (event) {
       event.forEach(property => {
@@ -56,6 +64,7 @@ export class SamplePoButtonLabsComponent implements OnInit {
 
   verifyDisabled(event) {
     const value = [...this.propertiesOptions];
+
     if (event === 'tertiary') {
       value[3] = { value: 'danger', label: 'Danger', disabled: true };
       this.propertiesOptions = value;
@@ -67,10 +76,12 @@ export class SamplePoButtonLabsComponent implements OnInit {
 
   restore() {
     this.label = undefined;
-    this.kind = undefined;
+    this.kind = 'secondary';
+    this.size = 'medium';
     this.icon = undefined;
     this.properties = [];
-    this.kindsOptions[0] = { ...this.kindsOptions[0], disabled: false };
     this.kindsOptions[2] = { ...this.kindsOptions[2], disabled: false };
+    this.sizesOptions[0] = { ...this.sizesOptions[0], disabled: false };
+    this.sizesOptions[1] = { ...this.sizesOptions[1], disabled: false };
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
@@ -1,12 +1,12 @@
 <div class="po-rich-text-toolbar" #toolbarElement>
   <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="format">
-    <po-button-group p-toggle="multiple" [p-small]="true" [p-buttons]="formatButtons"> </po-button-group>
+    <po-button-group p-toggle="multiple" [p-buttons]="formatButtons"> </po-button-group>
   </div>
 
   <div *ngIf="!isInternetExplorer" class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="color">
     <div class="po-rich-text-toolbar-color-picker-container">
       <button
-        class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+        class="po-button po-button-default po-rich-text-toolbar-color-picker-button"
         [disabled]="readonly"
         [p-tooltip]="literals.textColor"
         [attr.aria-label]="literals.textColor"
@@ -24,19 +24,19 @@
   </div>
 
   <div *ngIf="!disabledTextAlign" class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="align">
-    <po-button-group p-toggle="single" [p-small]="true" [p-buttons]="alignButtons"> </po-button-group>
+    <po-button-group p-toggle="single" [p-buttons]="alignButtons"> </po-button-group>
   </div>
 
   <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="list">
-    <po-button-group p-toggle="single" [p-small]="true" [p-buttons]="listButtons"> </po-button-group>
+    <po-button-group p-toggle="single" [p-buttons]="listButtons"> </po-button-group>
   </div>
 
   <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="link">
-    <po-button-group [p-small]="true" [p-buttons]="linkButtons"> </po-button-group>
+    <po-button-group [p-buttons]="linkButtons"> </po-button-group>
   </div>
 
   <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="media">
-    <po-button-group [p-small]="true" [p-buttons]="mediaButtons"> </po-button-group>
+    <po-button-group [p-buttons]="mediaButtons"> </po-button-group>
   </div>
 </div>
 

--- a/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
@@ -67,7 +67,6 @@
             <div *ngIf="showButtonsActions" class="po-list-view-actions">
               <po-button
                 *ngFor="let action of visibleActions"
-                p-small="true"
                 [p-disabled]="returnBooleanValue(action, item)"
                 [p-icon]="action.icon"
                 [p-label]="action.label"

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.html
@@ -30,7 +30,6 @@
             (click)="changePosition(option, 'up'); $event.stopPropagation()"
             p-kind="tertiary"
             p-icon="po-icon po-icon-arrow-up"
-            p-small
           >
           </po-button>
           <po-button
@@ -40,7 +39,6 @@
             (click)="changePosition(option, 'down'); $event.stopPropagation()"
             p-kind="tertiary"
             p-icon="po-icon po-icon-arrow-down"
-            p-small
           >
           </po-button>
         </div>
@@ -51,7 +49,6 @@
   <div class="po-table-column-manager-footer">
     <po-button
       class="po-table-column-manager-footer-restore"
-      p-small
       p-kind="tertiary"
       [p-label]="literals.restoreDefault"
       (p-click)="restore()"


### PR DESCRIPTION
**BUTTON**

**DTHFUI-6022**
**DTHFUI-6353**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente `po-button` não possuí uma propriedade para aumentar o tamanho do botão.
O componente possuí a propriedade `p-small` para diminuir o tamanho do botão.

**Qual o novo comportamento?**
Adicionada a propriedade `p-size` para definir o tamanho do botão, permitindo alternar entre os valores `medium` ou `large`.
Deprecia a propriedade `p-small` para seguir com as definições do AnimaliaDS e as regras de acessibilidade.

**Simulação**
app e portal.
[app.zip](https://github.com/po-ui/po-angular/files/9268614/app.zip)

**Style**
https://github.com/po-ui/po-style/pull/331

**Theme Totvs**
https://github.com/totvs/po-theme-totvs/pull/168