### PR TITLE
feat(table): adiciona ` p-selectable-entire-line`

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -602,6 +602,28 @@ describe('PoTableBaseComponent:', () => {
       expect(otherRow.$selected).toBeFalsy();
     });
 
+    describe('hasSelectableRow:', () => {
+      it('should return false when selectable is false', () => {
+        component.selectable = false;
+
+        expect(component['hasSelectableRow']()).toBeFalsy();
+      });
+
+      it('should return true when selectable and selectableEntireLine is true', () => {
+        component.selectable = true;
+        component.selectableEntireLine = true;
+
+        expect(component['hasSelectableRow']()).toBeTruthy();
+      });
+
+      it('should return false when selectable is true and selectableEntireLine is false', () => {
+        component.selectable = true;
+        component.selectableEntireLine = false;
+
+        expect(component['hasSelectableRow']()).toBeFalsy();
+      });
+    });
+
     it('selectRow: should set $selected `true` at row and call `configAfterSelectRow` and `emitSelectEvents`', () => {
       const row = { id: 1, $selected: false };
 

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -192,6 +192,17 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   @Input('p-single-select') @InputBoolean() singleSelect?: boolean = false;
 
   /**
+   * @description
+   *
+   * Permite selecionar um item da tabela clicando na linha.
+   *
+   * > Caso haja necessidade de selecionar o item apenas via radio ou checkbox, deve-se definir esta propriedade como `false`.
+   *
+   * @default `true`
+   */
+  @Input('p-selectable-entire-line') @InputBoolean() selectableEntireLine?: boolean = true;
+
+  /**
    * @optional
    *
    * @description
@@ -725,6 +736,10 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     this.emitSelectEvents(row);
 
     this.configAfterSelectRow(this.items, row);
+  }
+
+  hasSelectableRow(): boolean {
+    return this.selectable && this.selectableEntireLine;
   }
 
   selectDetailRow(row: any) {

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -220,7 +220,7 @@
               [class.po-table-column-center]="column.type === 'subtitle'"
               [class.po-table-column-icons]="column.type === 'icon'"
               [ngClass]="getClassColor(row, column)"
-              (click)="selectable ? selectRow(row) : 'javascript:;'"
+              (click)="hasSelectableRow() ? selectRow(row) : 'javascript:;'"
             >
               <div
                 class="po-table-column-cell notranslate"
@@ -507,7 +507,7 @@
             [class.po-table-column-center]="column.type === 'subtitle'"
             [class.po-table-column-icons]="column.type === 'icon'"
             [ngClass]="getClassColor(row, column)"
-            (click)="selectable ? selectRow(row) : 'javascript:;'"
+            (click)="hasSelectableRow() ? selectRow(row) : 'javascript:;'"
           >
             <div
               class="po-table-column-cell notranslate"


### PR DESCRIPTION
**TABLE**

**DTHFUI-5959**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao clicar em qualquer lugar da linha da table, ela é selecionada.

**Qual o novo comportamento?**
Agora é possível habilitar e desabilitar a seleção quando houver clique na linha utilizando a propriedade ` p-selectable-entire-line`.

**Simulação**
Simular no portal e utilizar este [app.zip](https://github.com/po-ui/po-angular/files/9282931/app.zip).
 