### PR TITLE
feat(combo): permite usar o `p-options` com `any`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -968,6 +968,27 @@ describe('PoComboBaseComponent:', () => {
       expect(spyUpdateModel).not.toHaveBeenCalled();
     });
 
+    describe('VisibleOptions:', () => {
+      beforeEach(() => {
+        component = new PoComboTest();
+
+        component.filterService = null;
+        component.defaultService = null;
+      });
+
+      it(`should set 'visibleOptions' with 'options' with 'value' and 'label' dynamic`, () => {
+        component.fieldLabel = 'labelDynamic';
+        component.fieldValue = 'valueDynamic';
+        component.options = [
+          { labelDynamic: '1', valueDynamic: '1' },
+          { labelDynamic: '2', valueDynamic: '2' }
+        ];
+
+        component.updateComboList();
+        expect(component.visibleOptions).toEqual(component.options);
+      });
+    });
+
     describe('updateComboList:', () => {
       it(`should set 'visibleOptions' with 'component.comboOptionsList' if 'options param' and 'selectedValue' are falsy`, () => {
         component.options = [{ label: '1', value: '1' }];
@@ -1066,11 +1087,17 @@ describe('PoComboBaseComponent:', () => {
     });
 
     it('compareOptions: should compare received param options', () => {
-      expect(component['compareOptions']({ label: 'a' }, { label: 'b' })).toBe(-1);
-      expect(component['compareOptions']({ label: 'c' }, { label: 'b' })).toBe(1);
-      expect(component['compareOptions']({ label: 'c' }, { label: 'c' })).toBe(0);
-      expect(component['compareOptions']({ label: 'A' }, { label: 'b' })).toBe(-1);
-      expect(component['compareOptions']({ label: 'a' }, { label: 'C' })).toBe(-1);
+      const arrayA = [{ label: 'a' }, { label: 'b' }].sort(component['compareOptions']('label'));
+      const arrayB = [{ label: 'c' }, { label: 'b' }].sort(component['compareOptions']('label'));
+      const arrayC = [{ label: 'c' }, { label: 'c' }].sort(component['compareOptions']('label'));
+      const arrayD = [{ label: 'A' }, { label: 'b' }].sort(component['compareOptions']('label'));
+      const arrayE = [{ label: 'a' }, { label: 'C' }].sort(component['compareOptions']('label'));
+
+      expect(arrayA).toEqual([{ label: 'a' }, { label: 'b' }]);
+      expect(arrayB).toEqual([{ label: 'b' }, { label: 'c' }]);
+      expect(arrayC).toEqual([{ label: 'c' }, { label: 'c' }]);
+      expect(arrayD).toEqual([{ label: 'A' }, { label: 'b' }]);
+      expect(arrayE).toEqual([{ label: 'a' }, { label: 'C' }]);
     });
 
     describe('ValidateValue', () => {
@@ -1408,6 +1435,46 @@ describe('PoComboBaseComponent:', () => {
       expect(component.updateComboList).toHaveBeenCalled();
       expect(component.initInputObservable).toHaveBeenCalled();
       expect(component.selectedValue).toEqual(undefined);
+    });
+
+    it(`checkIfService: should return 'label' if contain service and param is 'label'`, () => {
+      const urlService = 'https://po-ui.io/sample/api/new/heros';
+      component.setService(urlService);
+      component.fieldLabel = 'labelTest';
+
+      const expectLabel = component['checkIfService']('label');
+
+      expect(expectLabel).toEqual('label');
+    });
+
+    it(`checkIfService: should return 'fieldLabel' if not contain service and param is 'label'`, () => {
+      component.setService(undefined);
+      component.filterService = undefined;
+      component.fieldLabel = 'labelTest';
+
+      const expectLabel = component['checkIfService']('label');
+
+      expect(expectLabel).toEqual('labelTest');
+    });
+
+    it(`checkIfService: should return 'value' if contain service and param is 'value'`, () => {
+      const urlService = 'https://po-ui.io/sample/api/new/heros';
+      component.setService(urlService);
+      component.fieldValue = 'valueTest';
+
+      const expectLabel = component['checkIfService']('value');
+
+      expect(expectLabel).toEqual('value');
+    });
+
+    it(`checkIfService: should return 'fieldValue' if not contain service and param is 'value'`, () => {
+      component.setService(undefined);
+      component.filterService = undefined;
+      component.fieldValue = 'valueTest';
+
+      const expectLabel = component['checkIfService']('value');
+
+      expect(expectLabel).toEqual('valueTest');
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -63,10 +63,12 @@
       <ng-container *ngIf="comboOptionTemplate; then optionTemplate; else defaultOptionTemplate"></ng-container>
 
       <ng-template #defaultOptionTemplate>
-        <label *ngIf="option?.options; else optionLink" class="po-combo-item-title">{{ option.label }}</label>
+        <label *ngIf="option?.options; else optionLink" class="po-combo-item-title">{{
+          option[this.dynamicLabel]
+        }}</label>
         <ng-template #optionLink>
           <a class="po-combo-item">
-            <span style="pointer-events: none" [innerHTML]="getLabelFormatted(option?.label)"></span>
+            <span style="pointer-events: none" [innerHTML]="getLabelFormatted(option?.[this.dynamicLabel])"></span>
           </a>
         </ng-template>
       </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -355,7 +355,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   controlApplyFilter(value) {
-    if (!this.isProcessingValueByTab && (!this.selectedOption || value !== this.selectedOption.label)) {
+    if (!this.isProcessingValueByTab && (!this.selectedOption || value !== this.selectedOption[this.dynamicLabel])) {
       this.defaultService.hasNext = true;
       this.page = this.setPage();
       this.options = [];
@@ -400,7 +400,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   getObjectByValue(value) {
-    if (this.selectedValue !== value && this.selectedOption?.label !== value) {
+    if (this.selectedValue !== value && this.selectedOption?.[this.dynamicLabel] !== value) {
       this.isProcessingValueByTab = true;
 
       this.getSubscription = this.service.getObjectByValue(value, this.filterParams).subscribe(
@@ -424,32 +424,44 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   selectPreviousOption() {
-    const currentViewValue = this.selectedView && this.selectedView.value;
+    const currentViewValue = this.selectedView && this.selectedView[this.dynamicValue];
 
     if (currentViewValue) {
       const nextOption = this.getNextOption(currentViewValue, this.visibleOptions, true);
 
-      this.updateSelectedValue(nextOption, nextOption && nextOption.value !== currentViewValue && !this.changeOnEnter);
+      this.updateSelectedValue(
+        nextOption,
+        nextOption && nextOption[this.dynamicValue] !== currentViewValue && !this.changeOnEnter
+      );
     } else if (this.visibleOptions.length) {
       const visibleOption = this.visibleOptions[this.visibleOptions.length - 1];
 
-      this.updateSelectedValue(visibleOption, visibleOption.value !== currentViewValue && !this.changeOnEnter);
+      this.updateSelectedValue(
+        visibleOption,
+        visibleOption[this.dynamicValue] !== currentViewValue && !this.changeOnEnter
+      );
     }
   }
 
   selectNextOption() {
-    const currentViewValue = this.selectedView && this.selectedView.value;
+    const currentViewValue = this.selectedView && this.selectedView[this.dynamicValue];
 
     if (currentViewValue) {
       const nextOption = this.getNextOption(currentViewValue, this.visibleOptions);
 
-      this.updateSelectedValue(nextOption, nextOption && nextOption.value !== currentViewValue && !this.changeOnEnter);
+      this.updateSelectedValue(
+        nextOption,
+        nextOption && nextOption[this.dynamicValue] !== currentViewValue && !this.changeOnEnter
+      );
     } else if (this.visibleOptions.length) {
       const index = this.changeOnEnter ? 1 : 0;
 
       const visibleOption = this.visibleOptions[index];
 
-      this.updateSelectedValue(visibleOption, visibleOption.value !== currentViewValue && !this.changeOnEnter);
+      this.updateSelectedValue(
+        visibleOption,
+        visibleOption[this.dynamicValue] !== currentViewValue && !this.changeOnEnter
+      );
     }
   }
 
@@ -480,7 +492,8 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   onOptionClick(option: PoComboOption | PoComboGroup, event?: any) {
     const inputValue = this.getInputValue();
     const isUpdateModel =
-      option.value !== this.selectedValue || !!(this.selectedView && inputValue !== this.selectedView.label);
+      option[this.dynamicValue] !== this.selectedValue ||
+      !!(this.selectedView && inputValue !== this.selectedView[this.dynamicLabel]);
 
     if (event) {
       event.stopPropagation();
@@ -492,7 +505,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
       this.updateComboList([...this.cacheStaticOptions]);
     }
 
-    this.previousSearchValue = this.selectedView.label;
+    this.previousSearchValue = this.selectedView[this.dynamicLabel];
   }
 
   scrollTo(index) {

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-scheduling/sample-po-combo-scheduling.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-scheduling/sample-po-combo-scheduling.component.html
@@ -99,6 +99,8 @@
       p-required
       p-sort
       [p-options]="medicalSpecialtyOptions"
+      p-field-label="specialty"
+      p-field-value="specialtyValue"
     >
     </po-combo>
   </div>

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-scheduling/sample-po-combo-scheduling.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-scheduling/sample-po-combo-scheduling.component.ts
@@ -18,7 +18,7 @@ export class SamplePoComboSchedulingComponent implements OnInit {
   email: string;
   informations: string;
   medicalSpecialty: string;
-  medicalSpecialtyOptions: Array<PoComboOption>;
+  medicalSpecialtyOptions: Array<any>;
   name: string;
   phone: string;
   typeScheduling: string;

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-scheduling/sample-po-combo-scheduling.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-scheduling/sample-po-combo-scheduling.service.ts
@@ -34,15 +34,15 @@ export class SamplePoComboSchedulingService {
 
   getMedicalSpecialty() {
     return [
-      { label: 'Allergist', value: 'allergist' },
-      { label: 'Cardiologist', value: 'cardiologist' },
-      { label: 'General practitioner', value: 'generalPractitioner' },
-      { label: 'Dermatologist', value: 'dermatologist' },
-      { label: 'Gynecologist', value: 'gynecologist' },
-      { label: 'Nutritionist', value: 'nutritionist' },
-      { label: 'Pediatrist', value: 'pediatrist' },
-      { label: 'Psychiatrist', value: 'psychiatrist' },
-      { label: 'Orthopaedist', value: 'orthopaedist' }
+      { specialty: 'Allergist', specialtyValue: 'allergist' },
+      { specialty: 'Cardiologist', specialtyValue: 'cardiologist' },
+      { specialty: 'General practitioner', specialtyValue: 'generalPractitioner' },
+      { specialty: 'Dermatologist', specialtyValue: 'dermatologist' },
+      { specialty: 'Gynecologist', specialtyValue: 'gynecologist' },
+      { specialty: 'Nutritionist', specialtyValue: 'nutritionist' },
+      { specialty: 'Pediatrist', specialtyValue: 'pediatrist' },
+      { specialty: 'Psychiatrist', specialtyValue: 'psychiatrist' },
+      { specialty: 'Orthopaedist', specialtyValue: 'orthopaedist' }
     ];
   }
 }


### PR DESCRIPTION
**Combo**

**DTHFUI-6127**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
não permite usar o `p-options` com `any` com `p-field-value` e `p-field-label`

**Qual o novo comportamento?**
permite usar o `p-options` com `any` com `p-field-value` e `p-field-label`

**Simulação**
app:
[app.zip](https://github.com/po-ui/po-angular/files/9309160/app.zip)
  e samples do portal