### PR TITLE
feat(lookup): repassa eventos do po-table

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -500,4 +500,24 @@ export interface PoDynamicFormField extends PoDynamicField {
    * >Essa propriedade será ignorada caso seja utilizada em conjunto com a propriedade `optionsMulti` e `optionsService`.
    */
   forceOptionsComponentType?: ForceOptionComponentEnum;
+
+  /**
+   * Evento disparado ao fechar o popover do gerenciador de colunas após alterar as colunas visíveis.
+   *
+   * O componente envia como parâmetro um array de string com as colunas visíveis atualizadas.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   *
+   * **Componentes compatíveis**: `po-lookup`
+   */
+  changeVisibleColumns?: Function;
+
+  /**
+   * Evento disparado ao clicar no botão de restaurar padrão no gerenciador de colunas.
+   *
+   * O componente envia como parâmetro um array de string com as colunas configuradas inicialmente.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   *
+   * **Componentes compatíveis**: `po-lookup`
+   */
+  columnRestoreManager?: Function;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -252,6 +252,8 @@
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
       [p-advanced-filters]="field.advancedFilters"
+      (p-change-visible-columns)="field.changeVisibleColumns($event)"
+      (p-restore-column-manager)="field.columnRestoreManager($event)"
     >
     </po-lookup>
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -297,6 +297,28 @@ export abstract class PoLookupBaseComponent
    */
   @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao fechar o popover do gerenciador de colunas após alterar as colunas visíveis.
+   *
+   * O componente envia como parâmetro um array de string com as colunas visíveis atualizadas.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   */
+  @Output('p-change-visible-columns') changeVisibleColumns = new EventEmitter<Array<string>>();
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no botão de restaurar padrão no gerenciador de colunas.
+   *
+   * O componente envia como parâmetro um array de string com as colunas configuradas inicialmente.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   */
+  @Output('p-restore-column-manager') columnRestoreManager = new EventEmitter<Array<String>>();
+
   service: any;
 
   protected selectedOptions = [];

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -149,6 +149,28 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
    */
   @Input('p-field-value') fieldValue: string;
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao fechar o popover do gerenciador de colunas após alterar as colunas visíveis.
+   *
+   * O componente envia como parâmetro um array de string com as colunas visíveis atualizadas.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   */
+  @Output('p-change-visible-columns') changeVisibleColumns = new EventEmitter<Array<string>>();
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no botão de restaurar padrão no gerenciador de colunas.
+   *
+   * O componente envia como parâmetro um array de string com as colunas configuradas inicialmente.
+   * Por exemplo: ["idCard", "name", "hireStatus", "age"].
+   */
+  @Output('p-restore-column-manager') columnRestoreManager = new EventEmitter<Array<String>>();
+
   hasNext = true;
   isLoading = false;
   page = 1;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -67,6 +67,8 @@
         (p-all-unselected)="onAllUnselected($event)"
         (p-show-more)="showMoreEvent()"
         (p-sort-by)="sortBy($event)"
+        (p-change-visible-columns)="changeVisibleColumns.emit($event)"
+        (p-restore-column-manager)="columnRestoreManager.emit($event)"
       >
       </po-table>
     </div>

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentRef, Injector } from '@angular/core';
+import { ComponentRef, EventEmitter, Injector } from '@angular/core';
 import { ComponentFixture, inject, TestBed, fakeAsync, tick, flush } from '@angular/core/testing';
 import { Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -960,6 +960,8 @@ describe('PoLookupComponent:', () => {
         component.multiple = false;
         component.fieldLabel = 'label';
         component.fieldValue = 'value';
+        component.changeVisibleColumns = new EventEmitter();
+        component.columnRestoreManager = new EventEmitter();
 
         const {
           advancedFilters,
@@ -970,7 +972,9 @@ describe('PoLookupComponent:', () => {
           infiniteScroll,
           multiple,
           fieldLabel,
-          fieldValue
+          fieldValue,
+          changeVisibleColumns,
+          columnRestoreManager
         } = component;
 
         const selectedItems = undefined;
@@ -986,7 +990,9 @@ describe('PoLookupComponent:', () => {
           multiple,
           selectedItems,
           fieldLabel,
-          fieldValue
+          fieldValue,
+          changeVisibleColumns,
+          columnRestoreManager
         };
 
         spyOn(component['poLookupModalService'], 'openModal');

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -198,7 +198,9 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
         infiniteScroll,
         multiple,
         fieldLabel,
-        fieldValue
+        fieldValue,
+        changeVisibleColumns,
+        columnRestoreManager
       } = this;
 
       const selectedItems = this.checkSelectedItems();
@@ -214,7 +216,9 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
         multiple,
         selectedItems,
         fieldLabel,
-        fieldValue
+        fieldValue,
+        changeVisibleColumns,
+        columnRestoreManager
       });
 
       if (!this.modalSubscription) {

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentRef, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentRef, EventEmitter, NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Routes } from '@angular/router';
 import { TestBed } from '@angular/core/testing';
@@ -43,7 +43,9 @@ describe('PoLookupModalService:', () => {
     multiple: false,
     selectedItems: null,
     fieldValue: 'value',
-    fieldLabel: 'label'
+    fieldLabel: 'label',
+    changeVisibleColumns: new EventEmitter(),
+    columnRestoreManager: new EventEmitter()
   };
 
   beforeEach(() => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
@@ -32,6 +32,8 @@ export class PoLookupModalService {
    * @param selectedItems {any} Valor que está selecionado que será repassado para o modal para apresentar na tabela.
    * @param fieldLabel {string} Valor que será utilizado como descrição do campo.
    * @param fieldValue {string} Valor que será utilizado como valor do campo.
+   * @param changeVisibleColumns {function} Função que será executada quando for alterada a visibilidade das colunas.
+   * @param columnRestoreManager {function} Função que será executada quando for restaurar as colunas padrão.
    */
   openModal(params: {
     advancedFilters: Array<PoDynamicFormField>;
@@ -45,6 +47,8 @@ export class PoLookupModalService {
     selectedItems: Array<any>;
     fieldLabel: string;
     fieldValue: string;
+    changeVisibleColumns: Function;
+    columnRestoreManager: Function;
   }): void {
     const {
       advancedFilters,
@@ -57,7 +61,9 @@ export class PoLookupModalService {
       multiple,
       selectedItems,
       fieldLabel,
-      fieldValue
+      fieldValue,
+      changeVisibleColumns,
+      columnRestoreManager
     } = params;
 
     this.componentRef = this.poComponentInjector.createComponentInApplication(PoLookupModalComponent);
@@ -75,6 +81,8 @@ export class PoLookupModalService {
     this.componentRef.instance.selectedItems = selectedItems;
     this.componentRef.instance.fieldLabel = fieldLabel;
     this.componentRef.instance.fieldValue = fieldValue;
+    this.componentRef.instance.changeVisibleColumns = changeVisibleColumns;
+    this.componentRef.instance.columnRestoreManager = columnRestoreManager;
     this.componentRef.changeDetectorRef.detectChanges();
     this.componentRef.instance.openModal();
   }


### PR DESCRIPTION
**LOOKUP**

**DTHFUI-6214**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não era possível utilizar os eventos `p-restore-column-manager` e `p-change-visible-columns` dentro do Lookup.

**Qual o novo comportamento?**
É possível utilizar os eventos `p-restore-column-manager` e `p-change-visible-columns` dentro do Lookup.

**Simulação**
Utilizar o APP abaixo e testar nos samples do Portal.
`app.component.html`
```html
<po-page-default>
  <po-lookup
  name="lookup"
  p-field-label="label"
  p-field-value="value"
  p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
  p-label="PO Lookup"
  (p-restore-column-manager)="restoreColumnManager($event)"
  (p-change-visible-columns)="changeVisibleColumns($event)"
>
</po-lookup>

<po-dynamic-form [p-fields]="fields"></po-dynamic-form>
</po-page-default>
```
`app.component.ts`
```typescript
import { Component } from '@angular/core';
import { PoDynamicFormField } from '../../../ui/src/lib';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {

  fields: Array<PoDynamicFormField> = [
    {
      property: 'favoriteHero',
      gridColumns: 6,
      gridSmColumns: 12,
      label: 'Favorite hero',
      optional: true,
      searchService: 'https://po-sample-api.herokuapp.com/v1/heroes',
      columns: [
        { property: 'nickname', label: 'Hero' },
        { property: 'label', label: 'Name' }
      ],
      format: ['id', 'nickname'],
      fieldLabel: 'nickname',
      fieldValue: 'email',
      columnRestoreManager: this.restoreColumnManager.bind(this),
      changeVisibleColumns: this.changeVisibleColumns.bind(this)
    }
  ]

  restoreColumnManager(event){
    console.log('restoreColumnManager');
  }
  changeVisibleColumns(event) {
    console.log('changeVisibleColumns');
console.log(event);
  }
}

```