### PR TITLE
feat(accordion-item): adding outputs to expand and collapse events

### DIFF
--- a/projects/ui/src/lib/components/po-accordion/po-accordion-item/po-accordion-item.component.spec.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-item/po-accordion-item.component.spec.ts
@@ -29,22 +29,22 @@ describe('PoAccordionItemComponent:', () => {
   });
 
   describe('Methods:', () => {
-    it('collapse: should set `expanded` to `false` and call `accordionService.sendToParentAccordionItemClicked`', () => {
-      spyOn(component['accordionService'], 'sendToParentAccordionItemClicked');
+    it('collapse: should set `expanded` to `false` and emits `p-collapse` event', () => {
+      spyOn(component.collapseEvent, 'emit');
 
       component.collapse();
 
       expect(component.expanded).toBe(false);
-      expect(component['accordionService'].sendToParentAccordionItemClicked).toHaveBeenCalled();
+      expect(component.collapseEvent.emit).toHaveBeenCalled();
     });
 
-    it('expand: should set `expanded` to `true` and call `accordionService.sendToParentAccordionItemClicked`', () => {
-      spyOn(component['accordionService'], 'sendToParentAccordionItemClicked');
+    it('expand: should set `expanded` to `true` and emits `p-expand` event', () => {
+      spyOn(component.expandEvent, 'emit');
 
       component.expand();
 
       expect(component.expanded).toBe(true);
-      expect(component['accordionService'].sendToParentAccordionItemClicked).toHaveBeenCalled();
+      expect(component.expandEvent.emit).toHaveBeenCalled();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-item/po-accordion-item.component.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-item/po-accordion-item.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, Output, TemplateRef, ViewChild } from '@angular/core';
+import { filter, Subscription } from 'rxjs';
 
 import { PoAccordionService } from '../services/po-accordion.service';
 
@@ -37,15 +38,43 @@ import { PoAccordionService } from '../services/po-accordion.service';
   selector: 'po-accordion-item',
   templateUrl: 'po-accordion-item.component.html'
 })
-export class PoAccordionItemComponent {
+export class PoAccordionItemComponent implements OnDestroy {
   /** Título do item. */
   @Input('p-label') label: string;
+
+  /** Evento disparado ao expandir o item, seja manualmente ou programaticamente. */
+  @Output('p-expand') expandEvent = new EventEmitter<void>();
+
+  /** Evento disparado ao retrair o item, seja manualmente ou programaticamente. */
+  @Output('p-collapse') collapseEvent = new EventEmitter<void>();
 
   @ViewChild(TemplateRef, { static: true }) templateRef: TemplateRef<any>;
 
   expanded: boolean;
 
-  constructor(private accordionService: PoAccordionService) {}
+  private expandSubscription: Subscription;
+  private collapseSubscription: Subscription;
+
+  constructor(private accordionService: PoAccordionService) {
+    this.expandSubscription = this.accordionService
+      .receiveFromChildAccordionClicked()
+      .pipe(filter(poAccordionItem => poAccordionItem === this && poAccordionItem.expanded))
+      .subscribe(() => {
+        this.expandEvent.emit();
+      });
+
+    this.collapseSubscription = this.accordionService
+      .receiveFromChildAccordionClicked()
+      .pipe(filter(poAccordionItem => poAccordionItem === this && !poAccordionItem.expanded))
+      .subscribe(() => {
+        this.collapseEvent.emit();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.expandSubscription.unsubscribe();
+    this.collapseSubscription.unsubscribe();
+  }
 
   /**
    * Método para colapsar o `po-accordion-item`.

--- a/projects/ui/src/lib/components/po-accordion/po-accordion.component.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion.component.ts
@@ -51,7 +51,7 @@ export class PoAccordionComponent extends PoAccordionBaseComponent implements On
   headerToggle(event: boolean, poAccordionItem: PoAccordionItemComponent) {
     poAccordionItem.expanded = event;
 
-    this.toggle(poAccordionItem);
+    this.accordionService.sendToParentAccordionItemClicked(poAccordionItem);
   }
 
   private receiveFromChildAccordionSubscription() {

--- a/projects/ui/src/lib/components/po-accordion/services/po-accordion.service.spec.ts
+++ b/projects/ui/src/lib/components/po-accordion/services/po-accordion.service.spec.ts
@@ -22,9 +22,9 @@ describe('PoAccordionService:', () => {
   describe('Methods:', () => {
     it('should call subjectChild.next with accordionItem in sendToParentAccordionItemClicked', () => {
       spyOn(accordionService['subjectChild'], 'next');
-      accordionService.sendToParentAccordionItemClicked(accordionItem);
+      accordionService.sendToParentAccordionItemClicked(accordionItem as any);
 
-      expect(accordionService['subjectChild'].next).toHaveBeenCalledWith(accordionItem);
+      expect(accordionService['subjectChild'].next).toHaveBeenCalledWith(accordionItem as any);
     });
 
     it('should call subjectChild.asObservable in receiveFromChildAccordionClicked', () => {

--- a/projects/ui/src/lib/components/po-accordion/services/po-accordion.service.ts
+++ b/projects/ui/src/lib/components/po-accordion/services/po-accordion.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 
 import { Subject } from 'rxjs';
 
+import { PoAccordionItemComponent } from '../po-accordion-item/po-accordion-item.component';
+
 /**
  * @docsPrivate
  *
@@ -12,7 +14,7 @@ import { Subject } from 'rxjs';
  */
 @Injectable()
 export class PoAccordionService {
-  private subjectChild = new Subject<any>();
+  private subjectChild = new Subject<PoAccordionItemComponent>();
 
   // Recebe o accordionItem
   receiveFromChildAccordionClicked() {
@@ -20,7 +22,7 @@ export class PoAccordionService {
   }
 
   // Envia accordionItem colapsado/expadido do accordion
-  sendToParentAccordionItemClicked(accordionItem: object) {
+  sendToParentAccordionItemClicked(accordionItem: PoAccordionItemComponent) {
     this.subjectChild.next(accordionItem);
   }
 }


### PR DESCRIPTION
Closes #DTHFUI-6432.

**PoAccordionItem**

**DTHFUI-6432**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
PoAccordionItem não possui eventos de alteração de estado expand/collapse.

**Qual o novo comportamento?**
Possível adicionar listeners aos eventos de expand e collapse.

**Simulação**
```html
<po-accordion>
  <po-accordion-item
    p-label="xyz"
    (p-expand)="handleXyzExpand()"
    (p-collapse)="handleXyzCollapse()"
  >
    po-accordion works
  </po-accordion-item>

  <po-accordion-item
    p-label="abc"
    (p-expand)="handleAbcExpand()"
    (p-collapse)="handleAbcCollapse()"
  >
    po-accordion works
  </po-accordion-item>
</po-accordion>
```

```ts
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  handleXyzExpand() {
    console.log('expand xyz');
  }
  handleXyzCollapse() {
    console.log('collapse xyz');
  }

  handleAbcExpand() {
    console.log('expand abc')
  }
  handleAbcCollapse() {
    console.log('collapse abc');
  }
}
```

![PoAccordion - Events](https://user-images.githubusercontent.com/6165501/185621518-3b79e096-a015-401c-a714-61c2c45db2ac.gif)

**Detalhes da Implementação**

A estrutura atual do componente PoAccordion e PoAccordionItem não possui um fluxo único de estado. Por isso, foi necessário alterar a relação dos componentes com o PoAccordionService, para que ele realize o gerenciamento do estado de maneira central, podendo emitir os eventos tanto em interações manuais quanto programáticas (ex: invocar o método expand/collapse de um PoAccordionItem).