### PR TITLE
fix(table): corrige ícone de ordenação

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -676,9 +676,13 @@
   </span>
   <span
     *ngIf="sort && column.sortable !== false"
-    [class.po-table-header-icon-unselected]="sortedColumn?.property !== column"
-    [class.po-table-header-icon-descending]="sortedColumn?.property === column && sortedColumn.ascending"
-    [class.po-table-header-icon-ascending]="sortedColumn?.property === column && !sortedColumn.ascending"
+    [class.po-table-header-icon-unselected]="JSON.stringify(sortedColumn?.property) !== JSON.stringify(column)"
+    [class.po-table-header-icon-descending]="
+      JSON.stringify(sortedColumn?.property) === JSON.stringify(column) && sortedColumn.ascending
+    "
+    [class.po-table-header-icon-ascending]="
+      JSON.stringify(sortedColumn?.property) === JSON.stringify(column) && !sortedColumn.ascending
+    "
   >
   </span>
 </ng-template>

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -127,6 +127,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   private clickListener: () => void;
   private resizeListener: () => void;
+  JSON: JSON;
 
   @ViewChild('columnManagerTarget') set columnManagerTarget(value: ElementRef) {
     this._columnManagerTarget = value;
@@ -157,7 +158,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     private defaultService: PoTableService
   ) {
     super(poDate, poLanguageService, defaultService);
-
+    this.JSON = JSON;
     this.differ = differs.find([]).create(null);
 
     // TODO: #5550 ao remover este listener, no portal, quando as colunas forem fixas não sofrem


### PR DESCRIPTION
**Table**

** DTHFUI-6380**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao interagir com o gerenciador de colunas o icone fica com a aparencia de desabilitado mesmo se estiver com ordenador selecionado

**Qual o novo comportamento?**
Ao interagir com o gerenciador de colunas o icone não fica com a aparencia de desabilitado

**Simulação**
Samples do portal