### PR TITLE
fix(select): ajusta o `OnTouched` do campo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -235,6 +235,14 @@ describe('PoSelectComponent:', () => {
 
       expect(expectedValue).toEqual(component.options[0]);
     });
+
+    it('registerOnTouched: should set `onModelTouched` with value of the `fnTouched`', () => {
+      const fnTouched = () => {};
+
+      component.registerOnTouched(fnTouched);
+
+      expect(component['onModelTouched']).toBe(fnTouched);
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -124,7 +124,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
   displayValue;
   modelValue: any;
   selectedValue: any;
-  onModelTouched: any;
+  protected onModelTouched: any;
 
   private differ: any;
   private _fieldLabel?: string = PO_SELECT_FIELD_LABEL_DEFAULT;
@@ -247,6 +247,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
 
   // Altera o valor ao selecionar um item.
   onSelectChange(value: any) {
+    this.onModelTouched?.();
     if (value && this.options && this.options.length) {
       const optionFound: any = this.findOptionValue(value);
 
@@ -294,6 +295,10 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements DoCh
 
   extraValidation(c: AbstractControl): { [key: string]: any } {
     return null;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onModelTouched = fn;
   }
 
   private isEqual(value: any, inputValue: any): boolean {


### PR DESCRIPTION
Foi ajustado o `OnTouched` para que o evento `change` seja disparado corretamente, pois o mesmo só é disparado após o campo ser tocado.

Fixes #1378, DTHFUI-6477

**Dynamic Form**

**1378**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O evento `change` não dispara quando o combo é o primeiro campo a ser tocado e alterado

**Qual o novo comportamento?**
O evento `change` dispara quando o combo for tocado e alterado independente da ordem de alteração dos campos.

**Simulação**
Pode ser feita pelo portal ou pelo [APP](https://github.com/po-ui/po-angular/files/9427473/app.zip).
