### PR TITLE
feat(multiselect): permite usar o `p-options` com `any`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -5,7 +5,11 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { Observable, of } from 'rxjs';
 
 import { expectPropertiesValues, expectSettersMethod } from '../../../util-test/util-expect.spec';
-import { removeDuplicatedOptions, removeUndefinedAndNullOptions, sortOptionsByProperty } from '../../../utils/util';
+import {
+  removeDuplicatedOptionsWithFieldValue,
+  removeUndefinedAndNullOptionsWithFieldValue,
+  sortOptionsByProperty
+} from '../../../utils/util';
 import * as UtilsFunctions from '../../../utils/util';
 
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
@@ -125,10 +129,8 @@ describe('PoMultiselectBaseComponent:', () => {
   });
 
   it('should set options', () => {
-    spyOn(component, 'validAndSortOptions');
     component.options = [{ label: '1', value: '1' }];
     expect(component.options.length).toBe(1);
-    expect(component.validAndSortOptions).toHaveBeenCalled();
   });
 
   it('should set p-sort', () => {
@@ -205,13 +207,13 @@ describe('PoMultiselectBaseComponent:', () => {
     component.options = [{ label: '1', value: 1 }];
     component.sort = true;
 
-    spyOn(UtilsFunctions, 'removeUndefinedAndNullOptions');
-    spyOn(UtilsFunctions, 'removeDuplicatedOptions');
+    spyOn(UtilsFunctions, 'removeUndefinedAndNullOptionsWithFieldValue');
+    spyOn(UtilsFunctions, 'removeDuplicatedOptionsWithFieldValue');
     spyOn(component, 'setUndefinedLabels');
     spyOn(UtilsFunctions, 'sortOptionsByProperty');
     component.validAndSortOptions();
-    expect(removeUndefinedAndNullOptions).toHaveBeenCalled();
-    expect(removeDuplicatedOptions).toHaveBeenCalled();
+    expect(removeUndefinedAndNullOptionsWithFieldValue).toHaveBeenCalled();
+    expect(removeDuplicatedOptionsWithFieldValue).toHaveBeenCalled();
     expect(component.setUndefinedLabels).toHaveBeenCalled();
     expect(sortOptionsByProperty).toHaveBeenCalled();
   });
@@ -220,13 +222,13 @@ describe('PoMultiselectBaseComponent:', () => {
     component.options = [{ label: '1', value: 1 }];
     component.sort = false;
 
-    spyOn(UtilsFunctions, 'removeUndefinedAndNullOptions');
-    spyOn(UtilsFunctions, 'removeDuplicatedOptions');
+    spyOn(UtilsFunctions, 'removeUndefinedAndNullOptionsWithFieldValue');
+    spyOn(UtilsFunctions, 'removeDuplicatedOptionsWithFieldValue');
     spyOn(component, 'setUndefinedLabels');
     spyOn(UtilsFunctions, 'sortOptionsByProperty');
     component.validAndSortOptions();
-    expect(removeUndefinedAndNullOptions).toHaveBeenCalled();
-    expect(removeDuplicatedOptions).toHaveBeenCalled();
+    expect(removeUndefinedAndNullOptionsWithFieldValue).toHaveBeenCalled();
+    expect(removeDuplicatedOptionsWithFieldValue).toHaveBeenCalled();
     expect(component.setUndefinedLabels).toHaveBeenCalled();
     expect(sortOptionsByProperty).not.toHaveBeenCalled();
   });
@@ -235,13 +237,13 @@ describe('PoMultiselectBaseComponent:', () => {
     component.options = [];
     component.sort = false;
 
-    spyOn(UtilsFunctions, 'removeUndefinedAndNullOptions');
-    spyOn(UtilsFunctions, 'removeDuplicatedOptions');
+    spyOn(UtilsFunctions, 'removeUndefinedAndNullOptionsWithFieldValue');
+    spyOn(UtilsFunctions, 'removeDuplicatedOptionsWithFieldValue');
     spyOn(component, 'setUndefinedLabels');
     spyOn(UtilsFunctions, 'sortOptionsByProperty');
     component.validAndSortOptions();
-    expect(removeUndefinedAndNullOptions).not.toHaveBeenCalled();
-    expect(removeDuplicatedOptions).not.toHaveBeenCalled();
+    expect(removeUndefinedAndNullOptionsWithFieldValue).not.toHaveBeenCalled();
+    expect(removeDuplicatedOptionsWithFieldValue).not.toHaveBeenCalled();
     expect(component.setUndefinedLabels).not.toHaveBeenCalled();
     expect(sortOptionsByProperty).not.toHaveBeenCalled();
   });

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -7,8 +7,8 @@ import { debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs/operato
 import {
   convertToBoolean,
   isTypeof,
-  removeDuplicatedOptions,
-  removeUndefinedAndNullOptions,
+  removeDuplicatedOptionsWithFieldValue,
+  removeUndefinedAndNullOptionsWithFieldValue,
   sortOptionsByProperty
 } from '../../../utils/util';
 import { requiredFailed } from './../validators';
@@ -136,8 +136,8 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    */
   @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
-  selectedOptions: Array<PoMultiselectOption> = [];
-  visibleOptionsDropdown: Array<PoMultiselectOption> = [];
+  selectedOptions: Array<PoMultiselectOption | any> = [];
+  visibleOptionsDropdown: Array<PoMultiselectOption | any> = [];
   visibleDisclaimers = [];
   isServerSearching = false;
   isFirstFilter: boolean = true;
@@ -158,7 +158,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   private _filterMode?: PoMultiselectFilterMode = PoMultiselectFilterMode.startsWith;
   private _hideSearch?: boolean = false;
   private _literals: PoMultiselectLiterals;
-  private _options: Array<PoMultiselectOption>;
+  private _options: Array<PoMultiselectOption | any>;
   private _required?: boolean = false;
   private _sort?: boolean = false;
   private _autoHeight: boolean = false;
@@ -359,7 +359,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   /**
    * @description
    *
-   * Nesta propriedade deve ser definida uma lista de objetos que implementam a interface PoMultiselectOption.
+   * Nesta propriedade deve ser definida uma lista de objetos que será exibida no multiselect.
    * Esta lista deve conter os valores e os labels que serão apresentados na tela.
    *
    * > Essa propriedade é imutável, ou seja, sempre que quiser atualizar a lista de opções disponíveis
@@ -372,14 +372,23 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * // evite, pois não atualiza a referência do objeto podendo gerar atrasos na atualização do template
    * this.options.push({ value: 'x', label: 'Nova opção' });
    * ```
+   * > A lista pode ser definida utilizando um array com o valor representando `value` e `label` das seguintes formas:
+   *
+   * ```
+   * <po-multiselect name="multiselect" p-label="PO Multiselect" [p-options]="[{value: 1, label: 'One'}, {value: 2, label: 'two'}]"> </po-multiselect>
+   * ```
+   *
+   * ```
+   * <po-multiselect name="multiselect" p-label="PO Multiselect" [p-options]="[{name: 'Roger', age: 28}, {name: 'Anne', age: 35}]" p-field-label="name" p-field-value="age"> </po-multiselect>
+   * ```
+   *
+   * - Aconselha-se utilizar valores distintos no `label` e `value` dos itens.
    */
-  @Input('p-options') set options(options: Array<PoMultiselectOption>) {
+  @Input('p-options') set options(options: Array<PoMultiselectOption | any>) {
     this._options = options;
-
-    this.validAndSortOptions();
   }
 
-  get options() {
+  get options(): Array<PoMultiselectOption | any> {
     return this._options;
   }
 
@@ -445,7 +454,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * @default `label`
    */
   @Input('p-field-label') set fieldLabel(value: string) {
-    this._fieldLabel = value || PO_MULTISELECT_FIELD_LABEL_DEFAULT;
+    this._fieldLabel = value ? value : PO_MULTISELECT_FIELD_LABEL_DEFAULT;
 
     if (isTypeof(this.filterService, 'string') && this.service) {
       this.service.fieldLabel = this._fieldLabel;
@@ -469,7 +478,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * @default `value`
    */
   @Input('p-field-value') set fieldValue(value: string) {
-    this._fieldValue = value || PO_MULTISELECT_FIELD_VALUE_DEFAULT;
+    this._fieldValue = value ? value : PO_MULTISELECT_FIELD_VALUE_DEFAULT;
 
     if (isTypeof(this.filterService, 'string') && this.service) {
       this.service.fieldValue = this._fieldValue;
@@ -499,6 +508,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
       )
       .subscribe();
 
+    this.validAndSortOptions();
     this.updateList(this.options);
   }
 
@@ -515,31 +525,31 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
 
   validAndSortOptions() {
     if (this.options && this.options.length) {
-      removeUndefinedAndNullOptions(this.options);
-      removeDuplicatedOptions(this.options);
+      removeUndefinedAndNullOptionsWithFieldValue(this.options, this.fieldValue);
+      removeDuplicatedOptionsWithFieldValue(this.options, this.fieldValue);
       this.setUndefinedLabels(this.options);
 
       if (this.sort) {
-        sortOptionsByProperty(this.options, 'label');
+        sortOptionsByProperty(this.options, this.fieldLabel);
       }
     }
   }
 
   setUndefinedLabels(options) {
     options.forEach(option => {
-      if (!option['label']) {
-        option.label = option.value;
+      if (!option[this.fieldLabel]) {
+        option[this.fieldLabel] = option[this.fieldValue];
       }
     });
   }
 
-  updateList(options: Array<PoMultiselectOption>) {
+  updateList(options: Array<PoMultiselectOption | any>) {
     if (options) {
       this.visibleOptionsDropdown = options;
     }
   }
 
-  callOnChange(selectedOptions: Array<PoMultiselectOption>) {
+  callOnChange(selectedOptions: Array<PoMultiselectOption | any>) {
     if (this.onModelChange) {
       this.onModelChange(this.getValuesFromOptions(selectedOptions));
       this.eventChange(selectedOptions);
@@ -553,20 +563,20 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
     this.lastLengthModel = selectedOptions ? selectedOptions.length : null;
   }
 
-  getValuesFromOptions(selectedOptions: Array<PoMultiselectOption>) {
-    return selectedOptions && selectedOptions.length ? selectedOptions.map(option => option.value) : [];
+  getValuesFromOptions(selectedOptions: Array<PoMultiselectOption | any>) {
+    return selectedOptions && selectedOptions.length ? selectedOptions.map(option => option[this.fieldValue]) : [];
   }
 
   getLabelByValue(value) {
-    const index = this.options.findIndex(option => option.value === value);
+    const index = this.options.findIndex(option => option[this.fieldValue] === value);
     return this.options[index].label;
   }
 
-  searchByLabel(search: string, options: Array<PoMultiselectOption>, filterMode: PoMultiselectFilterMode) {
+  searchByLabel(search: string, options: Array<PoMultiselectOption | any>, filterMode: PoMultiselectFilterMode) {
     if (search && options && options.length) {
-      const newOptions: Array<PoMultiselectOption> = [];
+      const newOptions: Array<PoMultiselectOption | any> = [];
       options.forEach(option => {
-        if (option.label && this.compareMethod(search, option, filterMode)) {
+        if (option[this.fieldLabel] && this.compareMethod(search, option, filterMode)) {
           newOptions.push(option);
         }
       });
@@ -588,15 +598,15 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   }
 
   startsWith(search: string, option: PoMultiselectOption) {
-    return option.label.toLowerCase().startsWith(search.toLowerCase());
+    return option[this.fieldLabel].toLowerCase().startsWith(search.toLowerCase());
   }
 
   contains(search: string, option: PoMultiselectOption) {
-    return option.label.toLowerCase().indexOf(search.toLowerCase()) > -1;
+    return option[this.fieldLabel].toLowerCase().indexOf(search.toLowerCase()) > -1;
   }
 
   endsWith(search: string, option: PoMultiselectOption) {
-    return option.label.toLowerCase().endsWith(search.toLowerCase());
+    return option[this.fieldLabel].toLowerCase().endsWith(search.toLowerCase());
   }
 
   validate(c: AbstractControl): { [key: string]: any } {
@@ -623,7 +633,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
     } else {
       newOptions.forEach(newOption => {
         options.forEach(option => {
-          if (option.value === newOption.value) {
+          if (option[this.fieldValue] === newOption[this.fieldValue]) {
             this.selectedOptions.push(option);
           }
         });
@@ -643,7 +653,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
       });
     } else {
       // Validar se todos os items existem entre os options, senão atualizar o model
-      this.updateSelectedOptions(values.map(value => ({ value })));
+      this.updateSelectedOptions(values.map(value => ({ [this.fieldValue]: value })));
 
       if (this.selectedOptions && this.selectedOptions.length < values.length) {
         this.callOnChange(this.selectedOptions);
@@ -675,6 +685,6 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
     }
   }
 
-  abstract applyFilter(value?: string): Observable<Array<PoMultiselectOption>>;
+  abstract applyFilter(value?: string): Observable<Array<PoMultiselectOption | any>>;
   abstract updateVisibleItems(): void;
 }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
@@ -3,6 +3,7 @@
     #searchElement
     *ngIf="!hideSearch"
     [p-literals]="literals"
+    [p-field-value]="fieldValue"
     [p-placeholder]="placeholderSearch"
     (p-change)="callChangeSearch($event)"
   >
@@ -28,7 +29,7 @@
 
       <po-multiselect-item
         *ngFor="let option of visibleOptions"
-        [p-label]="option.label"
+        [p-label]="option[fieldLabel]"
         [p-selected]="isSelectedItem(option)"
         (p-change)="clickItem($event, option)"
       >

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.spec.ts
@@ -28,6 +28,9 @@ describe('PoMultiselectDropdownComponent:', () => {
       { label: 'label1', value: 'value1' },
       { label: 'label2', value: 'value2' }
     ];
+
+    component.fieldLabel = 'label';
+    component.fieldValue = 'value';
   });
 
   it('should be created', () => {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
@@ -43,13 +43,17 @@ export class PoMultiselectDropdownComponent {
   @Input('p-selected-options') selectedOptions: Array<any> = [];
 
   /** Propriedade que recebe a lista com todas as opções. */
-  @Input('p-options') options: Array<PoMultiselectOption> = [];
+  @Input('p-options') options: Array<PoMultiselectOption | any> = [];
 
   /** Propriedade que recebe a lista de opções que deverão ser criadas no dropdown. */
-  @Input('p-visible-options') visibleOptions: Array<PoMultiselectOption> = [];
+  @Input('p-visible-options') visibleOptions: Array<PoMultiselectOption | any> = [];
 
   /** Propriedade que indica se o campo "Selecionar todos" deverá ser escondido. */
   @Input('p-hide-select-all') hideSelectAll?: boolean = false;
+
+  @Input('p-field-value') fieldValue: string;
+
+  @Input('p-field-label') fieldLabel: string;
 
   /** Evento disparado a cada tecla digitada na pesquisa. */
   @Output('p-change-search') changeSearch = new EventEmitter();
@@ -90,7 +94,7 @@ export class PoMultiselectDropdownComponent {
   }
 
   isSelectedItem(option: PoMultiselectOption) {
-    return this.selectedOptions.some(selectedItem => selectedItem.value === option.value);
+    return this.selectedOptions.some(selectedItem => selectedItem[this.fieldValue] === option[this.fieldValue]);
   }
 
   clickItem(check, option) {
@@ -102,7 +106,7 @@ export class PoMultiselectDropdownComponent {
   }
 
   onClickSelectAll() {
-    const selectedValues = this.selectedOptions.map(({ value }) => value);
+    const selectedValues = this.selectedOptions.map(({ [this.fieldValue]: value }) => value);
 
     if (this.everyVisibleOptionsSelected(selectedValues)) {
       this.selectedOptions = [];
@@ -116,21 +120,23 @@ export class PoMultiselectDropdownComponent {
     if (checked) {
       this.selectedOptions.push(option);
     } else {
-      this.selectedOptions = this.selectedOptions.filter(selectedOption => selectedOption.value !== option.value);
+      this.selectedOptions = this.selectedOptions.filter(
+        selectedOption => selectedOption[this.fieldValue] !== option[this.fieldValue]
+      );
     }
     this.change.emit(this.selectedOptions);
   }
 
   everyVisibleOptionsSelected(selectedValues) {
-    return this.visibleOptions.every(visibleOption => selectedValues.includes(visibleOption.value));
+    return this.visibleOptions.every(visibleOption => selectedValues.includes(visibleOption[this.fieldValue]));
   }
 
   someVisibleOptionsSelected(selectedValues) {
-    return this.visibleOptions.some(visibleOption => selectedValues.includes(visibleOption.value));
+    return this.visibleOptions.some(visibleOption => selectedValues.includes(visibleOption[this.fieldValue]));
   }
 
   getStateSelectAll() {
-    const selectedValues = this.selectedOptions.map(({ value }) => value);
+    const selectedValues = this.selectedOptions.map(({ [this.fieldValue]: value }) => value);
 
     if (this.everyVisibleOptionsSelected(selectedValues)) {
       return true;
@@ -161,7 +167,7 @@ export class PoMultiselectDropdownComponent {
     const newSelectedOptions = [...this.selectedOptions];
 
     for (const visibleOption of this.visibleOptions) {
-      if (!selectedValues.includes(visibleOption.value)) {
+      if (!selectedValues.includes(visibleOption[this.fieldValue])) {
         newSelectedOptions.push(visibleOption);
       }
     }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.interface.ts
@@ -16,7 +16,7 @@ export interface PoMultiselectFilter {
    *
    * @param {{ property: string, value: string }} params Objeto contendo a propriedade e o valor responsável por realizar o filtro.
    */
-  getFilteredData(params: { property: string; value: string }): Observable<Array<PoMultiselectOption>>;
+  getFilteredData(params: { property: string; value: string }): Observable<Array<PoMultiselectOption | any>>;
 
   /**
    * Método que será chamado ao iniciar o componente com valor, deve retornar um Observable que contém apenas os objetos filtrados que
@@ -24,5 +24,5 @@ export interface PoMultiselectFilter {
    *
    * @param {Array<string | number>} values Array com os valores a serem buscados.
    */
-  getObjectsByValues(values: Array<string | number>): Observable<Array<PoMultiselectOption>>;
+  getObjectsByValues(values: Array<string | number>): Observable<Array<PoMultiselectOption | any>>;
 }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-filter.service.ts
@@ -20,7 +20,7 @@ export class PoMultiselectFilterService implements PoMultiselectFilter {
 
   constructor(private http: HttpClient) {}
 
-  getFilteredData({ value }: any): Observable<Array<PoMultiselectOption>> {
+  getFilteredData({ value }: any): Observable<Array<PoMultiselectOption | any>> {
     const params = value ? { filter: value } : {};
     return this.http
       .get(this.url, {
@@ -29,7 +29,7 @@ export class PoMultiselectFilterService implements PoMultiselectFilter {
       .pipe(map(response => this.parseToArrayMultiselectOptions(response['items'])));
   }
 
-  getObjectsByValues(value: Array<string | number>): Observable<Array<PoMultiselectOption>> {
+  getObjectsByValues(value: Array<string | number>): Observable<Array<PoMultiselectOption | any>> {
     return this.http
       .get(`${this.url}?${this.fieldValue}=${value.toString()}`)
       .pipe(map(response => this.parseToArrayMultiselectOptions(response['items'])));
@@ -41,7 +41,7 @@ export class PoMultiselectFilterService implements PoMultiselectFilter {
     this.fieldValue = fieldValue;
   }
 
-  private parseToArrayMultiselectOptions(items: Array<any>): Array<PoMultiselectOption> {
+  private parseToArrayMultiselectOptions(items: Array<any>): Array<PoMultiselectOption | any> {
     if (items && items.length > 0) {
       return items.map(item => this.parseToMultiselectOption(item));
     }
@@ -49,10 +49,10 @@ export class PoMultiselectFilterService implements PoMultiselectFilter {
     return [];
   }
 
-  private parseToMultiselectOption(item: any): PoMultiselectOption {
+  private parseToMultiselectOption(item: any): PoMultiselectOption | any {
     const label = item[this.fieldLabel];
     const value = item[this.fieldValue];
 
-    return { label, value };
+    return { [this.fieldLabel]: label, [this.fieldValue]: value };
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-search/po-multiselect-search.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-search/po-multiselect-search.component.ts
@@ -31,6 +31,8 @@ export class PoMultiselectSearchComponent {
   /** Propriedade que recebe as literais definidas no `po-multiselect`. */
   @Input('p-literals') literals?: PoMultiselectLiterals;
 
+  @Input('p-field-value') fieldValue: string;
+
   /** Evento que será disparado a cada tecla digitada no campo de busca. */
   @Output('p-change') change = new EventEmitter();
 
@@ -62,7 +64,7 @@ export class PoMultiselectSearchComponent {
   }
 
   onChange(event) {
-    this.change.emit({ event: event, value: this.inputElement.nativeElement.value });
+    this.change.emit({ event: event, [this.fieldValue]: this.inputElement.nativeElement.value });
   }
 
   setFocus() {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -19,12 +19,12 @@
       <po-disclaimer
         *ngFor="let disclaimer of visibleDisclaimers"
         class="po-multiselect-input-disclaimer"
-        [p-label]="disclaimer.label"
-        [p-value]="disclaimer.value"
-        [p-hide-close]="disclaimer.value === '' || disabled"
-        [class.po-clickable]="disclaimer.value === '' && !disabled"
-        (click)="openDropdown(disclaimer.value === '')"
-        (p-close-action)="closeDisclaimer(disclaimer.value)"
+        [p-label]="disclaimer[fieldLabel]"
+        [p-value]="disclaimer[fieldValue]"
+        [p-hide-close]="disclaimer[fieldValue] === '' || disabled"
+        [class.po-clickable]="disclaimer[fieldValue] === '' && !disabled"
+        (click)="openDropdown(disclaimer[fieldValue] === '')"
+        (p-close-action)="closeDisclaimer(disclaimer[fieldValue])"
       >
       </po-disclaimer>
 
@@ -49,6 +49,8 @@
     [p-visible-options]="visibleOptionsDropdown"
     [p-selected-options]="selectedOptions"
     [p-placeholder-search]="placeholderSearch"
+    [p-field-value]="fieldValue"
+    [p-field-label]="fieldLabel"
     (p-change)="changeItems($event)"
     (p-change-search)="changeSearch($event)"
     (p-close-dropdown)="controlDropdownVisibility(false)"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -111,7 +111,9 @@ describe('PoMultiselectComponent:', () => {
       },
       visibleDisclaimers: [],
       selectedOptions: selectedOptions,
-      isCalculateVisibleItems: true
+      isCalculateVisibleItems: true,
+      fieldValue: 'value',
+      fieldLabel: 'label'
     };
 
     component.calculateVisibleItems.call(fakeThis);
@@ -546,7 +548,9 @@ describe('PoMultiselectComponent:', () => {
         },
         visibleDisclaimers: [],
         selectedOptions: selectedOptions,
-        isCalculateVisibleItems: true
+        isCalculateVisibleItems: true,
+        fieldLabel: 'label',
+        fieldValue: 'value'
       };
 
       component.calculateVisibleItems.call(fakeThis);

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -77,6 +77,12 @@ const providers = [
  *   <file name="sample-po-multiselect-heroes/sample-po-multiselect-heroes.component.ts"> </file>
  *   <file name="sample-po-multiselect-heroes/sample-po-multiselect-heroes.service.ts"> </file>
  * </example>
+ *
+ * <example name="po-multiselect-any-array" title="PO Multiselect - Array Any">
+ *   <file name="sample-po-multiselect-any-array/sample-po-multiselect-any-array.component.html"> </file>
+ *   <file name="sample-po-multiselect-any-array/sample-po-multiselect-any-array.component.ts"> </file>
+ * </example>
+ *
  */
 @Component({
   selector: 'po-multiselect',
@@ -101,7 +107,7 @@ export class PoMultiselectComponent
   visibleElement = false;
 
   private isCalculateVisibleItems: boolean = true;
-  private cacheOptions: Array<PoMultiselectOption>;
+  private cacheOptions: Array<PoMultiselectOption | any>;
 
   constructor(
     private renderer: Renderer2,
@@ -206,11 +212,11 @@ export class PoMultiselectComponent
         if (sum + extraDisclaimerSize > inputWidth) {
           this.visibleDisclaimers.splice(-2, 2);
           const label = '+' + (this.selectedOptions.length + 1 - i).toString();
-          this.visibleDisclaimers.push({ value: '', label: label });
+          this.visibleDisclaimers.push({ [this.fieldValue]: '', [this.fieldLabel]: label });
         } else {
           this.visibleDisclaimers.splice(-1, 1);
           const label = '+' + (this.selectedOptions.length - i).toString();
-          this.visibleDisclaimers.push({ value: '', label: label });
+          this.visibleDisclaimers.push({ [this.fieldValue]: '', [this.fieldLabel]: label });
         }
       }
     }
@@ -290,7 +296,9 @@ export class PoMultiselectComponent
 
   scrollToSelectedOptions() {
     if (this.selectedOptions && this.selectedOptions.length) {
-      const index = this.options.findIndex(option => option.value === this.selectedOptions[0].value);
+      const index = this.options.findIndex(
+        option => option[this.fieldValue] === this.selectedOptions[0][this.fieldValue]
+      );
       this.dropdown.scrollTo(index);
     }
   }
@@ -301,11 +309,11 @@ export class PoMultiselectComponent
   }
 
   changeSearch(event) {
-    if (event && event.value !== undefined) {
+    if (event && event[this.fieldValue] !== undefined) {
       if (this.filterService) {
-        this.filterSubject.next(event.value);
+        this.filterSubject.next(event[this.fieldValue]);
       } else {
-        this.searchByLabel(event.value, this.options, this.filterMode);
+        this.searchByLabel(event[this.fieldValue], this.options, this.filterMode);
       }
     } else {
       this.setVisibleOptionsDropdown(this.options);
@@ -316,7 +324,7 @@ export class PoMultiselectComponent
   }
 
   closeDisclaimer(value) {
-    const index = this.selectedOptions.findIndex(option => option.value === value);
+    const index = this.selectedOptions.findIndex(option => option[this.fieldValue] === value);
     this.selectedOptions.splice(index, 1);
 
     this.updateVisibleItems();
@@ -334,14 +342,14 @@ export class PoMultiselectComponent
     }
   }
 
-  applyFilter(value: string = ''): Observable<Array<PoMultiselectOption>> {
-    const param = { property: 'label', value: value };
+  applyFilter(value: string = ''): Observable<Array<PoMultiselectOption | any>> {
+    const param = { property: this.fieldLabel, value: value };
     return this.service.getFilteredData(param).pipe(
       catchError(err => {
         this.isServerSearching = false;
         return of([]);
       }),
-      tap((options: Array<PoMultiselectOption>) => {
+      tap((options: Array<PoMultiselectOption | any>) => {
         this.setOptionsByApplyFilter(options);
       })
     );
@@ -360,7 +368,7 @@ export class PoMultiselectComponent
     }
   }
 
-  private setOptionsByApplyFilter(items: Array<PoMultiselectOption>) {
+  private setOptionsByApplyFilter(items: Array<PoMultiselectOption | any>) {
     if (this.isFirstFilter) {
       this.cacheOptions = [...items];
       this.isFirstFilter = false;

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-any-array/sample-po-multiselect-any-array.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-any-array/sample-po-multiselect-any-array.component.html
@@ -1,0 +1,37 @@
+<div class="po-row">
+  <div class="po-md-6">
+    <po-select
+      name="label"
+      p-label="Select Field Label"
+      [p-options]="optionsSelect"
+      [(ngModel)]="fieldLabel"
+      (p-change)="onChange($event)"
+    >
+    </po-select>
+    <po-select
+      name="label"
+      p-label="Select Field Value"
+      [p-options]="optionsSelect"
+      [(ngModel)]="fieldValue"
+      (p-change)="onChange($event)"
+    >
+    </po-select>
+  </div>
+  <div class="po-md-6">
+    <div class="po-row">
+      <po-multiselect
+        class="po-md-12"
+        name="multiselect"
+        p-label="Select your Company"
+        [p-options]="options"
+        [p-field-value]="fieldValue"
+        [p-field-label]="fieldLabel"
+        [(ngModel)]="company"
+      >
+      </po-multiselect>
+    </div>
+    <div class="po-row">
+      <po-info class="po-md-12" p-label="Model" [p-value]="company"> </po-info>
+    </div>
+  </div>
+</div>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-any-array/sample-po-multiselect-any-array.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-any-array/sample-po-multiselect-any-array.component.ts
@@ -1,0 +1,69 @@
+import { Component, OnInit } from '@angular/core';
+
+import { PoSelectOption } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-multiselect-any-array',
+  templateUrl: './sample-po-multiselect-any-array.component.html'
+})
+export class SamplePoMultiselectAnyArrayComponent {
+  company;
+  fieldLabel = 'razaoSocial';
+  fieldValue = 'cnpj';
+
+  public readonly options: Array<any> = [
+    {
+      codigo: '1',
+      nomeFantasia: 'TOTVS SA',
+      razaoSocial: 'TOTVS LTDA',
+      label: 'TOTVS COMPANY',
+      cnpj: '01.234.567/0000-01',
+      value: '100',
+      id: '10',
+      email: 'totvscompany@sample.com',
+      data: '10/03/2015',
+      origem: 'São Paulo'
+    },
+    {
+      codigo: '2',
+      nomeFantasia: 'INSTITUTO TOTVS DE ENSINO SA',
+      razaoSocial: 'INST TOTVS DE ENSINO LTDA',
+      label: 'INST TOTVS',
+      cnpj: '02.345.678/0000-02',
+      value: '200',
+      id: '20',
+      email: 'insttotvs@sample.com',
+      data: '10/10/2020',
+      origem: 'Joinville'
+    },
+    {
+      codigo: '3',
+      nomeFantasia: 'TOTVS ENTERPRISE SA',
+      razaoSocial: 'TOTVS ENTERPRISE LTDA ',
+      label: 'ENT TOTVS',
+      cnpj: '03.456.789/0000-03',
+      value: '300',
+      id: '30',
+      email: 'enttotvs@sample.com',
+      data: '10/01/2022',
+      origem: 'Curitiba'
+    }
+  ];
+
+  public readonly optionsSelect: Array<PoSelectOption> = [
+    { label: 'codigo', value: 'codigo' },
+    { label: 'nomeFantasia', value: 'nomeFantasia' },
+    { label: 'razaoSocial', value: 'razaoSocial' },
+    { label: 'label', value: 'label' },
+    { label: 'cnpj', value: 'cnpj' },
+    { label: 'value', value: 'value' },
+    { label: 'id', value: 'id' },
+    { label: 'email', value: 'email' },
+    { label: 'data', value: 'data' },
+    { label: 'origem', value: 'origem' }
+  ];
+
+  onChange(event) {
+    this.company = undefined;
+  }
+}


### PR DESCRIPTION
**MULTISELECT**

**DTHFUI-6128**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não permite usar o `p-options` com `any` com `p-field-value` e `p-field-label`

**Qual o novo comportamento?**
Permite usar o `p-options` com `any` com `p-field-value` e `p-field-label`

**Simulação**
Utilizar este  [app.zip](https://github.com/po-ui/po-angular/files/9492109/app.zip)  e o Sample no Portal.
