### PR TITLE
docs(guia de migração do PO-UI): corrige o nome da dependência

### DIFF
--- a/docs/guides/migration-poui.md
+++ b/docs/guides/migration-poui.md
@@ -61,7 +61,7 @@ O `ng update` ajudará nas alterações necessárias para seu projeto seguir atu
   - Caso houver *breaking changes*, serão realizados as alterações possíveis, mas fique atento ao
   [CHANGELOG](https://github.com/po-ui/po-angular/blob/master/CHANGELOG.md);
   - Atualizar as versões dos pacotes:
-    - `@po-ui/ng-componentes`;
+    - `@po-ui/ng-components`;
     - `@po-ui/ng-templates`;
     - `@po-ui/ng-code-editor`;
     - `@po-ui/ng-storage`;


### PR DESCRIPTION
no Guia Migração do PO UI o pacote @po-ui/ng-components está escrito
com grafia errada, possuindo a letra "e" a mais gerando erro na instalação.

**Guia Migração do PO UI**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
No Guia Migração do PO UI o pacote @po-ui/ng-components está escrito com grafia errada, possuindo a letra "e" o que gera erro na instalação.

**Qual o novo comportamento?**
Corrigida a grafia no nome do pacote.

**Simulação**
