### PR TITLE
feat(textarea): aplica estilo e acessibilidade definidos pelo DS

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -22,6 +22,16 @@ import { InputBoolean } from '../../../decorators';
  *   [ngModelOptions]="{standalone: true}">
  * </po-textarea>
  * ```
+ *
+ * #### Acessibilidade tratada no componente
+ * Algumas diretrizes de acessibilidade já são tratadas no componente, internamente, e não podem ser alteradas. São elas:
+ *
+ * - O Text area foi desenvolvido com uso de controles padrões HTML, o que permite a identificação do mesmo na interface por tecnologias
+ * assistivas. [WCAG 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+ * - O foco é visível e possui uma espessura superior a 2 pixels CSS, não ficando escondido por outros
+ * elementos da tela. [WCAG 2.4.12: Focus Appearance)](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-enhanced)
+ * - A identificação do erro acontece também através da mudança de cor do campo, mas também de um ícone
+ * junto da mensagem. [WGAG 1.4.1: Use of Color, 3.2.4: Consistent Identification](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color)
  */
 @Directive()
 export abstract class PoTextareaBaseComponent implements ControlValueAccessor, Validator {

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.html
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.html
@@ -7,13 +7,13 @@
       (focus)="eventOnFocus()"
       (input)="eventOnInput($event)"
       [attr.name]="name"
+      [attr.aria-label]="label"
       [disabled]="disabled"
-      [placeholder]="placeholder"
+      [placeholder]="disabled ? '' : placeholder"
       [readonly]="readonly"
       [required]="required"
       [rows]="rows"
-    >
-    </textarea>
+    ></textarea>
   </div>
 
   <po-field-container-bottom></po-field-container-bottom>


### PR DESCRIPTION
**TEXTAREA**

**DTHFUI-6442**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente não apresenta o estilo definido pelo design system e não segue as regras de acessibilidade.

**Qual o novo comportamento?**
O componente apresenta novo estilo definido pelo design system e segue as regras de acessibilidade.

**Simulação**
Simular no [app.zip](https://github.com/po-ui/po-angular/files/9538860/app.zip) e no portal.


https://github.com/po-ui/po-style/pull/340

https://github.com/totvs/po-theme-totvs/pull/176

Varíaveis customizadas
```css
po-textarea {
    --font-family: "Comic Sans MS", "Comic Sans", cursive;
    --font-size: .5 rem;
    --text-color-placeholder: red;
    --color:navy;
    --background: green;
    --text-color: yellow;
    --color-hover: tomato;
    --background-hover: orange;
    --color-focused: gold;
    --outline-color-focused: silver;
    --color-disabled: brown;
    --background-disabled: gray;
    --text-color-disabled: white;
}
```