### PR TITLE
fix(multiselect): corrige emissão de evento pela listagem

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -567,14 +567,14 @@ describe('PoMultiselectBaseComponent:', () => {
       expect(component.updateVisibleItems).toHaveBeenCalled();
     });
 
-    it('updateSelectedOptions: should set `0` for `lastLengthModel` if `newOptions.lenght` is `0`', () => {
+    it('updateSelectedOptions: should set `undefined` for `lastLengthModel` if `newOptions.lenght` is `0`', () => {
       spyOn(component, 'updateVisibleItems');
       const params = [];
       const options = [];
       component.filterService = poMultiselectFilterServiceStub;
       component['updateSelectedOptions'](params, options);
       expect(component.selectedOptions).toEqual([]);
-      expect(component.lastLengthModel).toBe(0);
+      expect(component.lastLengthModel).toBeUndefined();
       expect(component.updateVisibleItems).toHaveBeenCalled();
     });
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -615,7 +615,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
     this.selectedOptions = [];
 
     if (newOptions.length === 0) {
-      this.lastLengthModel = 0;
+      this.lastLengthModel = undefined;
     }
 
     if (this.filterService) {


### PR DESCRIPTION
**MULTISELECT**

**DTHFUI-6424**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente não emite o change quando removemos a ultima seleção ativa dos itens na lista, impactando a emissão do validate no DynamicFormField.

**Qual o novo comportamento?**
Foi ajustado a emissão do change sempre que removermos qualquer seleção ativa dos itens na lista, ajustando o problema de emitir o validate usando o DynamicFormField

**Simulação**
Utilizar o seguinte [App.zip](https://github.com/po-ui/po-angular/files/9560713/app.zip) e os Samples do Portal
