### PR TITLE
feat(checkbox): adiciona propriedade `p-size`

### DIFF
--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -1,4 +1,5 @@
 export * from './po-checkbox/po-checkbox.component';
+export * from './po-checkbox/po-checkbox-size.enum';
 export * from './po-checkbox-group/interfaces/po-checkbox-group-option.interface';
 export * from './po-checkbox-group/po-checkbox-group.component';
 export * from './po-clean/po-clean.component';

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.spec.ts
@@ -3,6 +3,7 @@ import { Directive } from '@angular/core';
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 
 import { PoCheckboxBaseComponent } from './po-checkbox-base.component';
+import { PoCheckboxSize } from './po-checkbox-size.enum';
 
 @Directive()
 class PoCheckboxComponent extends PoCheckboxBaseComponent {
@@ -34,6 +35,18 @@ describe('PoCheckboxBaseComponent:', () => {
       const booleanInvalidValues = [undefined, null, 2, 'string', 0, NaN, false];
 
       expectPropertiesValues(component, 'disabled', booleanInvalidValues, false);
+    });
+
+    it('size: should update with valid values', () => {
+      const validValues = ['medium', 'large', PoCheckboxSize.medium, PoCheckboxSize.large];
+      const expectedValidValues = ['medium', 'large', 'medium', 'large'];
+
+      expectPropertiesValues(component, 'size', validValues, expectedValidValues);
+    });
+    it('size: should update with `medium` when invalid values', () => {
+      const invalidValues = [true, false, 'sm', 'lg'];
+
+      expectPropertiesValues(component, 'size', invalidValues, 'medium');
     });
   });
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -3,6 +3,7 @@ import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
 import { convertToBoolean, uuid } from './../../../utils/util';
 import { InputBoolean } from '../../../decorators';
+import { PoCheckboxSize } from './po-checkbox-size.enum';
 
 /**
  * @description
@@ -80,6 +81,30 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
 
   get disabled(): boolean {
     return this._disabled;
+  }
+
+  private _size?: string = PoCheckboxSize.medium;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o tamanho do *checkbox*
+   *
+   * Valores válidos:
+   * - `medium`: o `po-checkbox` fica do tamanho padrão, com 24px de altura.;
+   * - `large`: o `po-checkbox` fica maior, com 32px de altura.;
+   *
+   * @default `medium`
+   *
+   */
+  @Input('p-size') set size(value: string) {
+    this._size = PoCheckboxSize[value] ? PoCheckboxSize[value] : PoCheckboxSize.medium;
+  }
+
+  get size(): string {
+    return this._size;
   }
 
   changeValue() {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-size.enum.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-size.enum.ts
@@ -1,0 +1,13 @@
+/**
+ * @usedBy PoCheckboxComponent
+ *
+ * @description
+ *
+ * Enum para definir o tamanho do po-checkbox.
+ */
+export enum PoCheckboxSize {
+  /** A caixa de seleção fica do tamanho padrão, com 24px de altura. */
+  medium = 'medium',
+  /** A caixa de seleção fica maior, com 32px de altura. */
+  large = 'large'
+}

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
@@ -4,7 +4,13 @@
   (click)="checkOption(checkboxValue)"
   (keydown)="onKeyDown($event, checkboxValue)"
 >
-  <div role="checkbox" class="po-checkbox-outline" [tabindex]="disabled ? -1 : 0" [attr.aria-checked]="checkboxValue">
+  <div
+    role="checkbox"
+    class="po-checkbox-outline"
+    [attr.p-size]="size"
+    [tabindex]="disabled ? -1 : 0"
+    [attr.aria-checked]="checkboxValue"
+  >
     <span
       [attr.aria-checked]="checkboxValue"
       aria-label=" "

--- a/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.html
@@ -3,6 +3,7 @@
   [(ngModel)]="checkbox"
   [p-disabled]="disabled"
   [p-label]="label"
+  [p-size]="size ? 'large' : 'medium'"
   (p-change)="changeEvent('p-change')"
 >
 </po-checkbox>
@@ -21,7 +22,10 @@
   <div class="po-row">
     <po-input class="po-sm-6" name="label" [(ngModel)]="label" p-label="Label"> </po-input>
 
-    <po-switch class="po-sm-6" name="disabled" [(ngModel)]="disabled" p-label="Disabled"> </po-switch>
+    <po-switch class="po-sm-3" name="disabled" [(ngModel)]="disabled" p-label="Disabled"> </po-switch>
+
+    <po-switch class="po-sm-3" name="size" [(ngModel)]="size" p-label="Size" p-label-off="medium" p-label-on="large">
+    </po-switch>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.ts
@@ -7,6 +7,7 @@ import { Component, OnInit } from '@angular/core';
 export class SamplePoCheckboxLabsComponent implements OnInit {
   checkbox: boolean | null;
   disabled: boolean;
+  size: boolean;
   event: string;
   label: string;
 


### PR DESCRIPTION
**CHECKBOX**

**DTHFUI-6452**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente não possuía propriedade para alterar o size do checkbox.

**Qual o novo comportamento?**
Agora é possível escolher o `p-size` entre os tamanhos `medium` e `large`.


**Simulação**

Testar no Labs do Portal e pelo [App.zip](https://github.com/po-ui/po-angular/files/9599381/app.zip)

https://github.com/po-ui/po-style/pull/343