### PR TITLE
docs(button-group): corrige enum na documentação

### DIFF
--- a/projects/ui/src/lib/components/po-button-group/po-button-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group-base.component.ts
@@ -64,7 +64,7 @@ export class PoButtonGroupBaseComponent {
    *
    * Define o modo de seleção de botões.
    *
-   * > Veja os valores válidos no *enum* `PoMultiselectFilterMode`.
+   * > Veja os valores válidos no *enum* `PoButtonGroupToggle`.
    *
    * @default `none`
    */


### PR DESCRIPTION
**BUTTON-GROUP**

**N/A**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Na documentação do button-group estava informando que deveria ser utilizado os valores do enum `PoMultiselectFilterMode`, porém o componente espera que sejam utilizados os valores do enum `PoButtonGroupToggle`


**Qual o novo comportamento?**
Foi ajustada a documentação informando utilizar os valores do enum `PoButtonGroupToggle`.

**Simulação**
Verificar documentação no Portal