### PR TITLE
feat(upload): adiciona o parâmetro `extraFormData` no evento `p-upload`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -235,11 +235,18 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * Função que será executada no momento de realizar o envio do arquivo,
    * onde será possível adicionar informações ao parâmetro que será enviado na requisição.
-   * É passado por parâmetro um objeto com o arquivo e a propriedade data nesta propriedade pode ser informado algum dado,
-   * que será enviado em conjunto com o arquivo na requisição, por exemplo:
+   * É passado por parâmetro um objeto com o arquivo e as propriedades data e extraFormData,
+   * que serão enviadas em conjunto com o arquivo na requisição, por exemplo:
    *
+   * > data, nesta propriedade pode ser informado algum dado
    * ```
    *   event.data = {id: 'id do usuário'};
+   * ```
+   * > extraFormData, nesta propriedade pode ser informado algum dado solicitado pela API
+   * > que não possa estar no objeto `data`, assim o conteúdo sará extraído do objeto e
+   * > enviado como parâmetro
+   * ```
+   *   event.extraFormData = {id: 'id do usuário'};
    * ```
    */
   @Output('p-upload') onUpload: EventEmitter<any> = new EventEmitter<any>();

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.service.spec.ts
@@ -87,6 +87,43 @@ describe('PoUploadBaseService:', () => {
     expect(service.sendFile).toHaveBeenCalled();
   }));
 
+  it('should call formData.append with correct parameters', inject(
+    [PoUploadBaseService],
+    (service: PoUploadBaseService) => {
+      const fakeFile = new Blob([]);
+      fakeFile['lastModified'] = 1504558774471;
+      fakeFile['lastModifiedDate'] = new Date();
+      fakeFile['name'] = 'Teste';
+      fakeFile['webkitRelativePath'] = '';
+      const files = [new PoUploadFile(<File>fakeFile)];
+      const headers = { Authorization: '145236' };
+      const tOnUpload = new EventEmitter<any>();
+      const callback = (file: PoUploadFile, event: any) => '';
+
+      const formData = new FormData();
+      spyOn(window, 'FormData').and.returnValue(formData);
+      spyOn(formData, 'append');
+
+      const uploadEvent = {
+        extraFormData: { param1: 'value1', param2: 'value2' },
+        data: { key: 'value' },
+        url: 'http://example.com/upload',
+        headers: { 'Content-Type': 'application/json' }
+      };
+
+      spyOn(tOnUpload, 'emit').and.callFake(event => {
+        event.extraFormData = uploadEvent.extraFormData;
+        event.data = uploadEvent.data;
+        event.url = uploadEvent.url;
+        event.headers = uploadEvent.headers;
+      });
+
+      service.upload('', files, headers, tOnUpload, callback, callback, callback);
+
+      expect(formData.append).toHaveBeenCalled();
+    }
+  ));
+
   it('should execute uploadCallback function', inject([PoUploadBaseService], (service: PoUploadBaseService) => {
     const methods = returnMethodsCallback();
     const fakeThis = {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.service.ts
@@ -41,6 +41,7 @@ export class PoUploadBaseService {
     const filesLength = files.length;
     const uploadEvent: any = {
       data: {},
+      extraFormData: {},
       file: null,
       url: url,
       headers: headers
@@ -57,6 +58,10 @@ export class PoUploadBaseService {
       if (tOnUpload) {
         uploadEvent['file'] = file;
         tOnUpload.emit(uploadEvent);
+
+        Object.keys(uploadEvent.extraFormData).forEach(key => {
+          formData.append(key, uploadEvent.extraFormData[key]);
+        });
 
         formData.append('data', JSON.stringify(uploadEvent.data));
         url = uploadEvent.url;


### PR DESCRIPTION
Adiciona a propriedade `extraFormData` no evento `p-upload` e  nesta propriedade pode ser informado algum dado solicitado pela API que não possa estar no objeto `data`, assim o conteúdo será extraído do objeto e enviado como parâmetro.

Fixes #1395

**Upload**

**1395**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não é possível enviar um parâmetro para a API fora do objeto `data`, ou seja, o atributo precisa estar diretamente no `body`.

**Qual o novo comportamento?**
Agora é possível inserir alguns dados no objeto `extraFormData`, que serão extraídos e enviados como parâmetro para API diretamente no `body`.

**Simulação**

Pode ser feito pelo portal ou pelo [APP](https://github.com/user-attachments/files/16396466/app.zip).

**Teste realizado com o Render:**
![image](https://github.com/user-attachments/assets/77d5243f-0cdc-4c10-815e-83217a1e96f1)
![image](https://github.com/user-attachments/assets/d71d3199-9ff2-463b-a847-6184e0616f7a)

**Teste realizado com o ambiente de homologação do TAE:**
![image](https://github.com/user-attachments/assets/12e5897b-9166-44c5-8d78-ec325fcdd321)
![image](https://github.com/user-attachments/assets/8ef63b1e-de11-4c77-b4e9-4f3a4f1a6ea7)
