### PR TITLE
fix(table): ajusta eventos sendo executados simultaneamente

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -64,9 +64,8 @@
             <po-checkbox
               name="selectAll"
               *ngIf="!hideSelectAll"
-              (click)="selectAllRows()"
               (p-change)="selectAllRows()"
-              [(ngModel)]="selectAll"
+              [p-checkboxValue]="selectAll === null ? 'mixed' : selectAll"
             ></po-checkbox>
           </div>
         </th>
@@ -366,9 +365,8 @@
             <po-checkbox
               name="selectAll"
               *ngIf="!hideSelectAll"
-              (click)="selectAllRows()"
               (p-change)="selectAllRows()"
-              [(ngModel)]="selectAll"
+              [p-checkboxValue]="selectAll === null ? 'mixed' : selectAll"
             ></po-checkbox>
           </div>
         </th>
@@ -659,8 +657,7 @@
   <po-checkbox
     name="checkbox"
     (p-change)="selectable ? selectRow(row) : 'javascript:;'"
-    [(ngModel)]="row.$selected"
-    (click)="selectable ? selectRow(row) : 'javascript:;'"
+    [p-checkboxValue]="row.$selected"
   ></po-checkbox>
 </ng-template>
 


### PR DESCRIPTION
**TABLE**

**DTHFUI-6545**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Os eventos `p-selected` e `p-unselected` estavam sendo chamados simultaneamente.


**Qual o novo comportamento?**
Foi ajustado e agora os eventos `p-selected` e `p-unselected` estão sendo chamados no momento certo.


**Simulação**

Testar o seguinte [App.zip](https://github.com/po-ui/po-angular/files/9657015/app.zip)

