### PR TITLE
fix(rich-text): ajustes na toolbar

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.spec.ts
@@ -190,7 +190,7 @@ describe('PoRichTextToolbarComponent:', () => {
 
       component['emitAlignCommand']('justifyleft');
 
-      expect(component.alignButtons[0].selected).toBeFalsy();
+      expect(component.alignButtons[0].selected).toBeTruthy();
     });
 
     it('emitAlignCommand: shouldn`t apply false to alignButtons[index].selected if it`s already false', () => {

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.ts
@@ -176,7 +176,7 @@ export class PoRichTextToolbarComponent implements AfterViewInit {
   private emitAlignCommand(command: string) {
     const index = this.alignButtons.findIndex(btn => btn.command === command);
 
-    if (this.alignButtons[index].selected) {
+    if (!this.alignButtons[index].selected) {
       this.alignButtons[index].selected = false;
     }
 


### PR DESCRIPTION
**RICH-TEXT**

**DTHFUI-6454**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente `po-rich-text` não está aplicando o efeito de botão pressionado nos botões de alinhamento.

**Qual o novo comportamento?**
O componente `po-rich-text` está aplicando o efeito de botão pressionado nos botões de alinhamento.

**Simulação**
[app_rich-text_DTHFUI-6454.zip](https://github.com/po-ui/po-angular/files/9658549/app_rich-text_DTHFUI-6454.zip)

**Style**
[PO-STYLE](https://github.com/po-ui/po-style/pull/346)