### PR TITLE
feat(dynamic): repasse de propriedades, permite uso de Array<any> no options e personalização de cores do `po-tag`

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -57,7 +57,12 @@ export interface PoDynamicFormField extends PoDynamicField {
    *
    * **Componentes compatíveis:** `po-select`, `po-radio-group`, `po-checkbox-group`, `po-multiselect`.
    * */
-  options?: Array<string> | Array<PoSelectOption> | Array<PoMultiselectOption> | Array<PoCheckboxGroupOption>;
+  options?:
+    | Array<string>
+    | Array<PoSelectOption>
+    | Array<PoMultiselectOption>
+    | Array<PoCheckboxGroupOption>
+    | Array<any>;
 
   /**
    * Permite que o usuário faça múltipla seleção dentro da lista de opções.
@@ -262,7 +267,7 @@ export interface PoDynamicFormField extends PoDynamicField {
    *
    * O valor padrão é: `label`.
    *
-   * > Esta propriedade pode ser utilizada em conjunto com: `optionsService` e `searchService`.
+   * > Esta propriedade pode ser utilizada em conjunto com: `options`, `optionsService` e `searchService`.
    */
   fieldLabel?: string;
 
@@ -271,7 +276,7 @@ export interface PoDynamicFormField extends PoDynamicField {
    *
    * O valor padrão é: `value`.
    *
-   * > Esta propriedade pode ser utilizada em conjunto com: `optionsService` e `searchService`.
+   * > Esta propriedade pode ser utilizada em conjunto com: `options`, `optionsService` e `searchService`.
    */
   fieldValue?: string;
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -142,6 +142,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [p-field-label]="field.fieldLabel"
+      [p-field-value]="field.fieldValue"
       [p-disabled]="isDisabled(field)"
       [p-help]="field.help"
       [p-label]="field.label"

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -75,13 +75,15 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       property: 'state',
       gridColumns: 6,
       options: [
-        { label: 'Santa Catarina', value: 1 },
-        { label: 'São Paulo', value: 2 },
-        { label: 'Rio de Janeiro', value: 3 },
-        { label: 'Minas Gerais', value: 4 }
-      ]
+        { state: 'Santa Catarina', code: 1 },
+        { state: 'São Paulo', code: 2 },
+        { state: 'Rio de Janeiro', code: 3 },
+        { state: 'Minas Gerais', code: 4 }
+      ],
+      fieldLabel: 'state',
+      fieldValue: 'code'
     },
-    { property: 'city', disabled: true, gridColumns: 6 },
+    { property: 'city', disabled: true, gridColumns: 6, fieldValue: 'code', fieldLabel: 'city' },
     {
       property: 'vacation',
       type: 'date',
@@ -130,6 +132,33 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       format: ['id', 'nickname'],
       fieldLabel: 'nickname',
       fieldValue: 'email'
+    },
+    {
+      property: 'partner',
+      gridColumns: 6,
+      gridSmColumns: 12,
+      optionsService: 'https://po-sample-api.herokuapp.com/v1/people',
+      fieldLabel: 'name',
+      fieldValue: 'id',
+      optional: true
+    },
+    {
+      property: 'videogame',
+      gridColumns: 6,
+      gridSmColumns: 12,
+      label: 'Video game console',
+      optional: true,
+      fieldValue: 'code',
+      fieldLabel: 'console',
+      options: [
+        { console: 'Nintendo Wii U', code: 'NWU' },
+        { console: 'Playstation 4', code: 'PS4' },
+        { console: 'Xbox One', code: 'XONE' },
+        { console: 'Nintendo Switch', code: 'NSW' },
+        { console: 'Playstation 5', code: 'PS5' },
+        { console: 'Xbox Series S|X', code: 'XSSX' }
+      ],
+      optionsMulti: true
     }
   ];
 
@@ -139,7 +168,8 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
     this.person = {
       name: 'Tony Stark',
       birthday: '1970-05-29',
-      isJuridicPerson: false
+      isJuridicPerson: false,
+      videogame: ['PS4', 'NSW', 'XSSX']
     };
   }
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.service.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.service.ts
@@ -6,34 +6,34 @@ export class PoDynamicFormRegisterService {
     switch (state) {
       case 1: {
         return [
-          { label: 'Palhoça', value: 5 },
-          { label: 'Lages', value: 6 },
-          { label: 'Balneário Camboriú', value: 7 },
-          { label: 'Brusque', value: 8 }
+          { city: 'Palhoça', code: 5 },
+          { city: 'Lages', code: 6 },
+          { city: 'Balneário Camboriú', code: 7 },
+          { city: 'Brusque', code: 8 }
         ];
       }
       case 2: {
         return [
-          { label: 'São Paulo', value: 9 },
-          { label: 'Guarulhos', value: 10 },
-          { label: 'Campinas', value: 11 },
-          { label: 'São Bernardo do Campo', value: 12 }
+          { city: 'São Paulo', code: 9 },
+          { city: 'Guarulhos', code: 10 },
+          { city: 'Campinas', code: 11 },
+          { city: 'São Bernardo do Campo', code: 12 }
         ];
       }
       case 3: {
         return [
-          { label: 'Rio de Janeiro', value: 13 },
-          { label: 'São Gonçalo', value: 14 },
-          { label: 'Duque de Caxias', value: 15 },
-          { label: 'Nova Iguaçu', value: 16 }
+          { city: 'Rio de Janeiro', code: 13 },
+          { city: 'São Gonçalo', code: 14 },
+          { city: 'Duque de Caxias', code: 15 },
+          { city: 'Nova Iguaçu', code: 16 }
         ];
       }
       case 4: {
         return [
-          { label: 'Belo Horizonte', value: 17 },
-          { label: 'Uberlândia', value: 18 },
-          { label: 'Contagem', value: 19 },
-          { label: 'Juiz de Fora', value: 20 }
+          { city: 'Belo Horizonte', code: 17 },
+          { city: 'Uberlândia', code: 18 },
+          { city: 'Contagem', code: 19 },
+          { city: 'Juiz de Fora', code: 20 }
         ];
       }
     }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
@@ -18,9 +18,12 @@ export interface PoDynamicViewField extends PoDynamicField {
   tag?: boolean;
 
   /**
-   * Define uma cor para o campo do tipo *tag*.
-   *
-   * Valores válidos:
+   * Determina a cor da tag. As maneiras de customizar as cores são:
+   * - Hexadeximal, por exemplo `#c64840`;
+   * - RGB, como `rgb(0, 0, 165)`;
+   * - O nome da cor, por exemplo `blue`;
+   * - Usando uma das cores do tema do PO:
+   * - Valores válidos:
    *  - <span class="dot po-color-01"></span> `color-01`
    *  - <span class="dot po-color-02"></span> `color-02`
    *  - <span class="dot po-color-03"></span> `color-03`

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.ts
@@ -19,7 +19,7 @@ export class SamplePoDynamicViewEmployeeComponent {
     { property: 'admissionDate', label: 'Admission date', type: 'date' },
     { property: 'hoursPerDay', label: 'Hours per day', type: 'time' },
     { property: 'wage', label: 'Wage', type: 'currency' },
-    { property: 'availability', tag: true, color: 'color-11', icon: 'po-icon-ok' },
+    { property: 'availability', tag: true, color: '#4B0082', icon: 'po-icon-ok' },
     { property: 'city', label: 'City', divider: 'Address' },
     { property: 'addressStreet', label: 'Street' },
     { property: 'addressNumber', label: 'Number' },


### PR DESCRIPTION
**DYNAMIC-FORM**, **DYNAMIC-VIEW**

**DTHFUI-6453**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Dynamic-view: não é possível personalizar as cores do componente `po-tag`.
Dynamic-form: não é possível que componentes `po-combo`, `po-select` e `po-multiselect` utilizem um Array<any> como opções para serem exibidas, bem como utilizar as propriedades fieldLabel e fieldValue.

**Qual o novo comportamento?**
Dynamic-view: agora é permitido personalizar as cores do componente `po-tag`.
Dynamic-form: agora os componentes `po-combo`, `po-select` e `po-multiselect` podem utilizar um Array<any> como opções para serem exibidas, bem como utilizar as propriedades fieldLabel e fieldValue.

**Simulação**
Testar nos Samples do Portal e utilizar este  [App.zip](https://github.com/po-ui/po-angular/files/9667543/App.zip)