### PR TITLE
feat(dynamic-table): altera filtro de pesquisa

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-literals.interface.ts
@@ -1,9 +1,9 @@
 /**
- * @usedBy PoPageDynamicSearchComponent
+ * @usedBy PoPageDynamicSearchComponent, PoPageDynamicTableComponent
  *
  * @description
  *
- * Interface para definição das literais usadas no `po-page-dynamic-search`.
+ * Interface para definição das literais usadas no `po-page-dynamic-search` e no `po-page-dynamic-table`.
  */
 export interface PoPageDynamicSearchLiterals {
   /** Título do grupo de *disclaimers* que será exibido após realizar alguma busca. */

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -4,6 +4,7 @@
   [p-hide-close-disclaimers]="hideCloseDisclaimers"
   [p-filters]="filters"
   [p-keep-filters]="keepFilters"
+  [p-literals]="searchLiterals"
   [p-concat-filters]="concatFilters"
   [p-hide-remove-all-disclaimer]="hideRemoveAllDisclaimer"
   [p-quick-search-width]="quickSearchWidth"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -324,13 +324,27 @@ describe('PoPageDynamicTableComponent:', () => {
 
     it('updateDataTable: should be called with the current parameters', () => {
       const expectValue = { page: 1, search: 'test' };
+      component['quickSearchParam'] = null || undefined;
       component['currentPage'] = 1;
+      component['params'] = { [component.quickSearchParam]: 'test' };
+
+      spyOn(component, <any>'loadData').and.returnValue(EMPTY);
+
+      component.updateDataTable();
+
+      expect(component['loadData']).toHaveBeenCalledWith(expectValue);
+    });
+
+    it(`updateDataTable: 'currentPage' should be 1 if it value is undefined`, () => {
+      const expectValue = { page: 1, search: 'test' };
+      component['currentPage'] = undefined;
       component['params'] = { search: 'test' };
 
       spyOn(component, <any>'loadData').and.returnValue(EMPTY);
 
       component.updateDataTable();
 
+      expect(component['currentPage']).toEqual(1);
       expect(component['loadData']).toHaveBeenCalledWith(expectValue);
     });
 
@@ -376,8 +390,8 @@ describe('PoPageDynamicTableComponent:', () => {
 
       component.onQuickSearch(filter);
 
-      expect(component['loadData']).toHaveBeenCalledWith({ page: 1, search: filter });
-      expect(component['params']).toEqual({ search: filter });
+      expect(component['loadData']).toHaveBeenCalledWith({ page: 1, [component.quickSearchParam]: filter });
+      expect(component['params']).toEqual({ [component.quickSearchParam]: filter });
     });
 
     it('onQuickSearch: should call `loadData` with merged filter and quickSearch if concatFilters is true', () => {
@@ -391,7 +405,7 @@ describe('PoPageDynamicTableComponent:', () => {
 
       const expectedParams = {
         ...advancedFiltersParams,
-        search: termTypedInQuickSearch
+        [component.quickSearchParam]: termTypedInQuickSearch
       };
       spyOn(component, <any>'loadData').and.returnValue(EMPTY);
 
@@ -407,6 +421,7 @@ describe('PoPageDynamicTableComponent:', () => {
     });
 
     it('onQuickSearch: should call `loadData` only with quickSearch if concatFilters is false', () => {
+      component.quickSearchParam = 'filter';
       component.concatFilters = false;
       const termTypedInQuickSearch = 'filterValue';
 
@@ -415,7 +430,7 @@ describe('PoPageDynamicTableComponent:', () => {
         name: 'Test'
       };
 
-      const quickSearchParams = { search: termTypedInQuickSearch };
+      const quickSearchParams = { [component.quickSearchParam]: termTypedInQuickSearch };
 
       spyOn(component, <any>'loadData').and.returnValue(EMPTY);
 
@@ -439,6 +454,17 @@ describe('PoPageDynamicTableComponent:', () => {
 
       expect(component['loadData']).toHaveBeenCalledWith(undefined);
       expect(component['params']).toEqual({});
+    });
+
+    it('onQuickSearch: should remove `oldQuickSearchParam` value from object properties if `quickSearchParam` is different.', () => {
+      component.concatFilters = true;
+      component.quickSearchParam = 'search';
+      component.onQuickSearch('search');
+
+      component.quickSearchParam = 'filter';
+
+      component.onQuickSearch('filter');
+      expect(component['params']['search']).not.toBeDefined();
     });
 
     it('showMore: should call `loadData` with next page and `params`', () => {


### PR DESCRIPTION
**PAGE-DYNAMIC_TABLE**
**PAGE-DYNAMIC-SEARCH**

**DTHFUI-5714**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variáveis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, Firefox, Edge)

**Qual o comportamento atual?**
Atualmente ao realizar uma pesquisa, a requisição é feita com o parâmetro 'search'.

**Qual o novo comportamento?**
Ao realizar uma pesquisa, a requisição é feita com o parâmetro 'search' mas pode ser customizada através da propriedade `p-quick-search-param`.
Adicionada a propriedade `p-literals` que permite a customização de textos.

**Simulação**
[app_page-dynamic-table_DTHFUI-5714.zip](https://github.com/po-ui/po-angular/files/9686159/app_page-dynamic-table_DTHFUI-5714.zip)
