### PR TITLE
docs(table): corrige documentação das colunas para o formato MM

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
@@ -64,7 +64,7 @@ export interface PoDynamicViewField extends PoDynamicField {
    *  [**CurrencyPipe**](https://angular.io/api/common/CurrencyPipe)
    * + Exemplos: 'BRL', 'USD'.
    * - `date`: Aceita valores definidos para a propriedade `format` do [**DatePipe**](https://angular.io/api/common/DatePipe)
-   * e também aceita os caracteres de dia(dd), mês(MM ou mm) e ano (yyyy ou yy),
+   * e também aceita os caracteres de dia(dd), mês(MM) e ano (yyyy ou yy),
    * caso não seja informado um formato o mesmo será 'dd/MM/yyyy'. Exemplos: 'dd/MM/yyyy', 'dd-MM-yy', 'mm/dd/yyyy'.
    * - `time`: Aceita apenas os caracteres de hora(HH), minutos(mm), segundos(ss) e
    *  milisegundos(f-ffffff), os milisegundos são opcionais, caso não seja informado um formato o mesmo será

--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-column.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-column.interface.ts
@@ -20,7 +20,7 @@ export interface PoLookupColumn {
   /**
    * Formato de exibição do valor da coluna:
    * - Formato para moeda (currency). Exemplos: 'BRL', 'USD'.
-   * - Formato para data (date): aceita apenas os caracteres de dia(dd), mês(MM ou mm) e ano (yyyy ou yy),
+   * - Formato para data (date): aceita apenas os caracteres de dia(dd), mês(MM) e ano (yyyy ou yy),
    * valor padrão é 'dd/MM/yyyy'. Exemplos: 'dd/MM/yyyy', 'dd-MM-yy', 'mm/dd/yyyy'.
    */
   format?: string;

--- a/projects/ui/src/lib/components/po-table/interfaces/po-table-column.interface.ts
+++ b/projects/ui/src/lib/components/po-table/interfaces/po-table-column.interface.ts
@@ -98,7 +98,7 @@ export interface PoTableColumn {
   /**
    * Formato de exibição do valor da coluna:
    * - Formato para moeda (currency). Exemplos: 'BRL', 'USD'.
-   * - Formato para data (date): aceita apenas os caracteres de dia(dd), mês(MM ou mm) e ano (yyyy ou yy),
+   * - Formato para data (date): aceita apenas os caracteres de dia(dd), mês(MM) e ano (yyyy ou yy),
    * caso não seja informado um formato o mesmo será 'dd/MM/yyyy'. Exemplos: 'dd/MM/yyyy', 'dd-MM-yy', 'mm/dd/yyyy'.
    * - Formato para horário (time): aceita apenas os caracteres de hora(HH), minutos(mm), segundos(ss) e
    *  milisegundos(f-ffffff), os milisegundos são opcionais, caso não seja informado um formato o mesmo será

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail-column.interface.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail-column.interface.ts
@@ -9,7 +9,7 @@ export interface PoTableDetailColumn {
   /**
    * Formato de exibição do valor da coluna:
    * - Formato para moeda (currency). Exemplos: 'BRL', 'USD'.
-   * - Formato para data (date): aceita apenas os caracteres de dia(dd), mês(MM ou mm) e ano (yyyy ou yy),
+   * - Formato para data (date): aceita apenas os caracteres de dia(dd), mês(MM) e ano (yyyy ou yy),
    * caso não seja informado um formato o mesmo será 'dd/MM/yyyy'. Exemplos: 'dd/MM/yyyy', 'dd-MM-yy', 'mm/dd/yyyy'.
    * - Formato para horário (time): aceita apenas os caracteres de hora(HH), minutos(mm), segundos(ss) e
    *  milisegundos(f-ffffff), os milisegundos são opcionais, caso não seja informado um formato o mesmo será


### PR DESCRIPTION
**Table / Lookup / Dynamic View**

**#1355**

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Documentação incorretamente indicava o uso de `mm` para a formatação de mês.

**Qual o novo comportamento?**
A documentação recomenda apenas o uso de `MM` para o formato de mês.

**Simulação**
Verificar se todas as referencias de `mm` para formato de mês foram removidas da documentação