### PR TITLE
feat(page-job-scheduler): adiciona a propriedade p-orientation

### DIFF
--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-base.component.spec.ts
@@ -10,6 +10,8 @@ import { PoJobSchedulerInternal } from './interfaces/po-job-scheduler-internal.i
 import { PoPageJobSchedulerBaseComponent } from './po-page-job-scheduler-base.component';
 import { PoPageJobSchedulerInternal } from './po-page-job-scheduler-internal';
 import { PoPageJobSchedulerService } from './po-page-job-scheduler.service';
+import { PoStepperOrientation } from '@po-ui/ng-components';
+import { expectPropertiesValues } from './../../util-test/util-expect.spec';
 
 describe('PoPageJobSchedulerBaseComponent:', () => {
   let serviceJobScheduler: PoPageJobSchedulerService;
@@ -49,6 +51,18 @@ describe('PoPageJobSchedulerBaseComponent:', () => {
 
       expect(component.model).toEqual(returnValue);
     }));
+
+    it('p-orientation: should update property with `undefined` when invalid values', () => {
+      const invalidValues = [undefined, null, '', true, false, 0, 1, 'string', [], {}];
+
+      expectPropertiesValues(component, 'stepperDefaultOrientation', invalidValues, undefined);
+    });
+
+    it('p-orientation: should update property with valid values', () => {
+      const validValues = (<any>Object).values(PoStepperOrientation);
+
+      expectPropertiesValues(component, 'stepperDefaultOrientation', validValues, validValues);
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-base.component.ts
@@ -1,7 +1,7 @@
 import { AbstractControl } from '@angular/forms';
 import { Input, Directive, OnDestroy } from '@angular/core';
 
-import { PoBreadcrumb, PoDynamicFormField } from '@po-ui/ng-components';
+import { PoBreadcrumb, PoDynamicFormField, PoStepperOrientation } from '@po-ui/ng-components';
 
 import { PoJobSchedulerInternal } from './interfaces/po-job-scheduler-internal.interface';
 import { PoPageJobSchedulerInternal } from './po-page-job-scheduler-internal';
@@ -174,9 +174,31 @@ export class PoPageJobSchedulerBaseComponent implements OnDestroy {
     this.model = this.poPageJobSchedulerService.convertToJobSchedulerInternal(value);
   }
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a orientação de exibição do `po-stepper`.
+   *
+   * > Quando não utilizada, segue o comportamento com base nas dimensões da tela.
+   *
+   * > Veja os valores válidos no *enum* [PoStepperOrientation](documentation/po-stepper#stepperOrientation).
+   *
+   */
+
+  @Input('p-orientation') set stepperDefaultOrientation(value: PoStepperOrientation) {
+    this._orientation = (<any>Object).values(PoStepperOrientation).includes(value) ? value : undefined;
+  }
+
+  get stepperDefaultOrientation(): PoStepperOrientation {
+    return this._orientation;
+  }
+
   model: PoJobSchedulerInternal = new PoPageJobSchedulerInternal();
 
   private _subscription = new Subscription();
+  private _orientation;
 
   constructor(protected poPageJobSchedulerService: PoPageJobSchedulerService) {}
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.html
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.html
@@ -1,7 +1,7 @@
 <po-page-default [p-actions]="jobSchedulerActions" [p-breadcrumb]="breadcrumb" [p-title]="title">
   <div class="po-row">
     <po-stepper
-      class="po-lg-3 po-xl-2"
+      [ngClass]="stepperDefaultOrientation === 'horizontal' ? 'po-lg-12 po-xl-12' : 'po-lg-3 po-xl-2'"
       p-sequential="true"
       [p-orientation]="stepperOrientation"
       [p-step]="step"
@@ -10,7 +10,7 @@
     >
     </po-stepper>
 
-    <po-container class="po-lg-8 po-xl-6">
+    <po-container [ngClass]="stepperDefaultOrientation === 'horizontal' ? 'po-lg-12 po-xl-12' : 'po-lg-8 po-xl-6'">
       <form #formScheduler="ngForm">
         <div class="po-row">
           <po-page-job-scheduler-execution

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
@@ -9,6 +9,7 @@ import { getObservable } from '../../util-test/util-expect.spec';
 import { PoJobSchedulerInternal } from './interfaces/po-job-scheduler-internal.interface';
 import { PoPageJobSchedulerComponent } from './po-page-job-scheduler.component';
 import { PoPageJobSchedulerModule } from './po-page-job-scheduler.module';
+import { PoStepperOrientation } from '@po-ui/ng-components';
 
 describe('PoPageJobSchedulerComponent:', () => {
   let component: PoPageJobSchedulerComponent;
@@ -56,6 +57,24 @@ describe('PoPageJobSchedulerComponent:', () => {
         fixture.detectChanges();
 
         expect(component.stepperOrientation).toBe('vertical');
+      });
+
+      it(`should return 'vertical' if 'p-orientation' is 'vertical'`, () => {
+        component.stepperDefaultOrientation = PoStepperOrientation.Vertical;
+        changeBrowserInnerWidth(480);
+
+        fixture.detectChanges();
+
+        expect(component.stepperOrientation).toBe(PoStepperOrientation.Vertical);
+      });
+
+      it(`should return 'horizontal' if 'p-orientation' is 'horizontal'`, () => {
+        component.stepperDefaultOrientation = PoStepperOrientation.Horizontal;
+        changeBrowserInnerWidth(1080);
+
+        fixture.detectChanges();
+
+        expect(component.stepperOrientation).toBe(PoStepperOrientation.Horizontal);
       });
     });
   });

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
@@ -114,7 +114,9 @@ export class PoPageJobSchedulerComponent extends PoPageJobSchedulerBaseComponent
   }
 
   get stepperOrientation(): 'horizontal' | 'vertical' {
-    return window.innerWidth > 481 && window.innerWidth < 960 ? 'horizontal' : 'vertical';
+    return (
+      this.stepperDefaultOrientation || (window.innerWidth > 481 && window.innerWidth < 960 ? 'horizontal' : 'vertical')
+    );
   }
 
   ngOnInit() {


### PR DESCRIPTION
O componente po-page-job-scheduler tem internamente um po-stepper o qual a orientação é definida pela largura da tela. Adiciona a propriedade orientation para que o componente possa receber uma orientação definida e assim aproveitar melhor o espaço em tela para casos específicos.

**po-page-job-scheduler**

**#1418**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente po-page-job-scheduler tem internamente um po-stepper o qual a orientação é definida pela largura da tela. 

**Qual o novo comportamento?**
Com a propriedade p-orientation o componente podereceber uma orientação definida ('horizontal' ou 'vertical') e assim aproveitar melhor o espaço em tela para casos específicos.
