### PR TITLE
feat(switch): adiciona propriedade `p-format-model`

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -164,6 +164,16 @@ export interface PoDynamicFormField extends PoDynamicField {
   booleanFalse?: string;
 
   /**
+   * Indica se o `model` receberá o valor formatado pelas propriedades `p-label-on` e `p-label-off` ou
+   * apenas o valor puro (sem formatação).
+   *
+   * O valor padrão é: `false`.
+   *
+   * > Esta propriedade está disponivel  apenas para o `swicth`.
+   */
+  formatModel?: boolean;
+
+  /**
    * Valor máximo a ser informado no componente, podendo ser utilizado quando o tipo de dado por *number*, *date* ou *dateTime*.
    *
    * **Componentes compatíveis:** `po-datepicker`, `po-datepicker-range`, `po-number`, `po-decimal`

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -181,6 +181,7 @@
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
       [p-disabled]="isDisabled(field)"
+      [p-format-model]="field.formatModel"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-label-off]="field.booleanFalse"

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -60,6 +60,24 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       errorMessage: 'At least 5 alphabetic and 3 numeric characters are required.',
       placeholder: 'Type your password'
     },
+    {
+      property: 'rememberSecretKey',
+      label: 'Remember Secret Key',
+      gridColumns: 3,
+      type: 'boolean',
+      booleanTrue: 'yes',
+      booleanFalse: 'no',
+      formatModel: true
+    },
+    {
+      property: 'status',
+      label: 'Status',
+      gridColumns: 3,
+      type: 'boolean',
+      booleanTrue: 'Active',
+      booleanFalse: 'Inactive',
+      formatModel: true
+    },
     { property: 'email', divider: 'CONTACTS', gridColumns: 6, icon: 'po-icon-mail' },
     { property: 'phone', mask: '(99) 99999-9999', gridColumns: 6 },
     { property: 'address', gridColumns: 6 },
@@ -178,7 +196,9 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       name: 'Tony Stark',
       birthday: '1970-05-29',
       isJuridicPerson: false,
-      videogame: ['PS4', 'NSW', 'XSSX']
+      videogame: ['PS4', 'NSW', 'XSSX'],
+      rememberSecretKey: 'no',
+      status: 'active'
     };
   }
 

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
@@ -167,6 +167,22 @@ describe('PoSwitchComponent', () => {
       expect(component.change.emit).toHaveBeenCalledWith(false);
     });
 
+    it('changeValue: should call `updateModel` and `change.emit` if switch value is changed with p-model-format is `true`', () => {
+      component.value = true;
+      component.formatModel = true;
+
+      spyOn(component.change, 'emit');
+      spyOn(component, <any>'updateModel');
+
+      component.changeValue(false);
+      expect(component['updateModel']).toHaveBeenCalledWith('false');
+      expect(component.change.emit).toHaveBeenCalledWith(false);
+
+      component.changeValue(true);
+      expect(component['updateModel']).toHaveBeenCalledWith('true');
+      expect(component.change.emit).toHaveBeenCalledWith(true);
+    });
+
     it('onWriteValue: should updated value and call `markForCheck`', () => {
       const expectedValue = false;
 
@@ -176,6 +192,36 @@ describe('PoSwitchComponent', () => {
       spyOn(component['changeDetector'], 'markForCheck');
 
       component.onWriteValue(expectedValue);
+
+      expect(component['changeDetector'].markForCheck).toHaveBeenCalled();
+      expect(component.value).toBe(expectedValue);
+    });
+
+    it('onWriteValue: should updated value on first time and call `markForCheck` with p-model-format is `true`', () => {
+      const expectedValue = false;
+
+      component.value = false;
+      component.formatModel = true;
+
+      component['changeDetector'] = <any>{ markForCheck: () => {} };
+      spyOn(component['changeDetector'], 'markForCheck');
+
+      component.onWriteValue(null);
+
+      expect(component['changeDetector'].markForCheck).toHaveBeenCalled();
+      expect(component.value).toBe(expectedValue);
+    });
+
+    it('onWriteValue: should updated value and call `markForCheck` with p-model-format is `true`', () => {
+      const expectedValue = true;
+
+      component.value = false;
+      component.formatModel = true;
+
+      component['changeDetector'] = <any>{ markForCheck: () => {} };
+      spyOn(component['changeDetector'], 'markForCheck');
+
+      component.onWriteValue('true');
 
       expect(component['changeDetector'].markForCheck).toHaveBeenCalled();
       expect(component.value).toBe(expectedValue);

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
@@ -8,6 +8,7 @@ import {
   ViewChild
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { InputBoolean } from '../../../decorators';
 
 import { uuid } from '../../../utils/util';
 
@@ -77,7 +78,7 @@ import { PoSwitchLabelPosition } from './po-switch-label-position.enum';
     }
   ]
 })
-export class PoSwitchComponent extends PoFieldModel<boolean> {
+export class PoSwitchComponent extends PoFieldModel<any> {
   @ViewChild('switchContainer', { static: true }) switchContainer: ElementRef;
 
   id = `po-switch[${uuid()}]`;
@@ -86,6 +87,28 @@ export class PoSwitchComponent extends PoFieldModel<boolean> {
   private _labelOff: string = 'false';
   private _labelOn: string = 'true';
   private _labelPosition: PoSwitchLabelPosition = PoSwitchLabelPosition.Right;
+  private _formatModel: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Indica se o `model` receberá o valor formatado pelas propriedades `p-label-on` e `p-label-off` ou
+   * apenas o valor puro (sem formatação).
+   *
+   * > Por padrão será atribuído `false`.
+   * @default `false`
+   */
+  @Input('p-format-model')
+  @InputBoolean()
+  set formatModel(format: boolean) {
+    this._formatModel = format || false;
+  }
+
+  get formatModel() {
+    return this._formatModel;
+  }
 
   /**
    * @optional
@@ -182,7 +205,15 @@ export class PoSwitchComponent extends PoFieldModel<boolean> {
   changeValue(value: any) {
     if (this.value !== value) {
       this.value = value;
-      this.updateModel(value);
+      if (this.formatModel) {
+        if (this.value) {
+          this.updateModel(this.labelOn);
+        } else {
+          this.updateModel(this.labelOff);
+        }
+      } else {
+        this.updateModel(value);
+      }
       this.emitChange(this.value);
     }
   }
@@ -195,8 +226,11 @@ export class PoSwitchComponent extends PoFieldModel<boolean> {
 
   onWriteValue(value: any): void {
     if (value !== this.value) {
-      this.value = !!value;
-
+      if (this.formatModel && !!value) {
+        this.value = value.toLowerCase() === this.labelOn.toLowerCase();
+      } else {
+        this.value = !!value;
+      }
       this.changeDetector.markForCheck();
     }
   }

--- a/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.html
@@ -7,6 +7,7 @@
   [p-label-off]="labelOff"
   [p-label-on]="labelOn"
   [p-label-position]="labelPosition"
+  [p-format-model]="properties.includes('formatModel')"
   (p-change)="changeEvent('p-change')"
 >
 </po-switch>

--- a/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.ts
@@ -21,7 +21,10 @@ export class SamplePoSwitchLabsComponent implements OnInit {
     { label: 'Right', value: PoSwitchLabelPosition.Right }
   ];
 
-  public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [{ value: 'disabled', label: 'Disabled' }];
+  public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
+    { value: 'disabled', label: 'Disabled' },
+    { value: 'formatModel', label: 'Format Model' }
+  ];
 
   ngOnInit() {
     this.restore();


### PR DESCRIPTION
Indica se o `model` receberá o valor formatado pelas propriedades `p-label-on` e `p-label-off` ou apenas o valor puro (sem formatação).

Fixes #1423, DTHFUI-1887

**Switch**

**1423**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente não permitir customizar os valores do model (true/false)

**Qual o novo comportamento?**
O componente permitir customizar os valores do model (true/false)

**Simulação**
Para simulação pelo portal ou pode ser usado o [App.zip](https://github.com/po-ui/po-angular/files/9981695/app.zip).
