### PR TITLE
docs(po-sample-api): atualiza url base das API's

### DIFF
--- a/projects/portal/src/app/tools/tools-dynamic-form/tools-dynamic-form.component.ts
+++ b/projects/portal/src/app/tools/tools-dynamic-form/tools-dynamic-form.component.ts
@@ -99,7 +99,7 @@ export class ToolsDynamicFormComponent {
   readonly serviceFields: Array<PoDynamicFormField> = [
     {
       property: 'searchService',
-      help: 'https://po-sample-api.herokuapp.com/v1/heroes',
+      help: 'https://po-sample-api.fly.dev/v1/heroes',
       label: 'SearchService',
       gridColumns: 12,
       gridLgColumns: 6,
@@ -107,7 +107,7 @@ export class ToolsDynamicFormComponent {
     },
     {
       property: 'optionsService',
-      help: 'https://po-sample-api.herokuapp.com/v1/heroes',
+      help: 'https://po-sample-api.fly.dev/v1/heroes',
       label: 'OptionsService',
       gridColumns: 12,
       gridLgColumns: 6,

--- a/projects/templates/src/lib/components/po-modal-password-recovery/samples/sample-po-modal-password-recovery-request/sample-po-modal-password-recovery-request.component.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/samples/sample-po-modal-password-recovery-request/sample-po-modal-password-recovery-request.component.ts
@@ -10,7 +10,7 @@ export class SamplePoModalPasswordRecoveryRequestComponent {
   @ViewChild(PoModalPasswordRecoveryComponent) poModalPasswordRecovery: PoModalPasswordRecoveryComponent;
 
   type: PoModalPasswordRecoveryType = PoModalPasswordRecoveryType.All;
-  urlRecovery: string = 'https://po-sample-api.herokuapp.com/v1/users';
+  urlRecovery: string = 'https://po-sample-api.fly.dev/v1/users';
 
   openPasswordRecoveryModal() {
     this.poModalPasswordRecovery.open();

--- a/projects/templates/src/lib/components/po-page-change-password/samples/sample-po-page-change-password-request/sample-po-page-change-password-request.component.html
+++ b/projects/templates/src/lib/components/po-page-change-password/samples/sample-po-page-change-password-request/sample-po-page-change-password-request.component.html
@@ -11,6 +11,6 @@
   p-secondary-logo="https://via.placeholder.com/80x24?text=SECONDARY+LOGO"
   p-token="rzDsQiSYoq"
   p-url-new-password="https://thf.totvs.com.br/sample/api/new-password"
-  [p-recovery]="{ url: 'https://po-sample-api.herokuapp.com/v1/users', type: 'all', contactMail: 'support@mail.com' }"
+  [p-recovery]="{ url: 'https://po-sample-api.fly.dev/v1/users', type: 'all', contactMail: 'support@mail.com' }"
 >
 </po-page-change-password>

--- a/projects/templates/src/lib/components/po-page-dynamic-detail/samples/sample-po-page-dynamic-detail-user/sample-po-page-dynamic-detail-user.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/samples/sample-po-page-dynamic-detail-user/sample-po-page-dynamic-detail-user.component.ts
@@ -8,7 +8,7 @@ import { PoPageDynamicDetailActions, PoPageDynamicDetailField } from '@po-ui/ng-
   templateUrl: './sample-po-page-dynamic-detail-user.component.html'
 })
 export class SamplePoPageDynamicDetailUserComponent {
-  public readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+  public readonly serviceApi = 'https://po-sample-api.fly.dev/v1/people';
 
   public readonly actions: PoPageDynamicDetailActions = {
     back: '/documentation/po-page-dynamic-table'

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-basic/sample-po-page-dynamic-edit-basic.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-basic/sample-po-page-dynamic-edit-basic.component.html
@@ -1,6 +1,6 @@
 <po-page-dynamic-edit
   p-title="Po Page Dynamic Edit"
   [p-fields]="[{ property: 'id', label: 'User ID' }]"
-  p-service-api="https://po-sample-api.herokuapp.com/v1/people"
+  p-service-api="https://po-sample-api.fly.dev/v1/people"
 >
 </po-page-dynamic-edit>

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.ts
@@ -9,7 +9,7 @@ import { PoPageDynamicEditActions } from '@po-ui/ng-templates';
   templateUrl: './sample-po-page-dynamic-edit-user.component.html'
 })
 export class SamplePoPageDynamicEditUserComponent {
-  public readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+  public readonly serviceApi = 'https://po-sample-api.fly.dev/v1/people';
 
   public readonly actions: PoPageDynamicEditActions = {
     save: '/documentation/po-page-dynamic-detail',
@@ -57,7 +57,7 @@ export class SamplePoPageDynamicEditUserComponent {
     },
     {
       property: 'city',
-      optionsService: 'https://po-sample-api.herokuapp.com/v1/cities?transform=true',
+      optionsService: 'https://po-sample-api.fly.dev/v1/cities?transform=true',
       offsetColumns: 4,
       gridColumns: 4
     }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-basic/sample-po-page-dynamic-table-basic.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-basic/sample-po-page-dynamic-table-basic.component.html
@@ -1,2 +1,2 @@
-<po-page-dynamic-table p-title="Po Page Dynamic Table" p-service-api="https://po-sample-api.herokuapp.com/v1/people">
+<po-page-dynamic-table p-title="Po Page Dynamic Table" p-service-api="https://po-sample-api.fly.dev/v1/people">
 </po-page-dynamic-table>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.ts
@@ -14,7 +14,7 @@ import {
 export class SamplePoPageDynamicTableHotelsComponent {
   @ViewChild('hotelDetailModal') hotelDetailModal!: PoModalComponent;
 
-  readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/hotels';
+  readonly serviceApi = 'https://po-sample-api.fly.dev/v1/hotels';
 
   actionsRight = true;
   detailedHotel: any;

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   templateUrl: './sample-po-page-dynamic-table-people.component.html'
 })
 export class SamplePoPageDynamicTablePeopleComponent {
-  readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+  readonly serviceApi = 'https://po-sample-api.fly.dev/v1/people';
 
   readonly fields: Array<any> = [
     { property: 'id', key: true, visible: false },

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -20,7 +20,7 @@ export class SamplePoPageDynamicTableUsersComponent {
   @ViewChild('userDetailModal') userDetailModal!: PoModalComponent;
   @ViewChild('dependentsModal') dependentsModal!: PoModalComponent;
 
-  readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+  readonly serviceApi = 'https://po-sample-api.fly.dev/v1/people';
 
   actionsRight = false;
   detailedUser: any;

--- a/projects/templates/src/lib/components/po-page-job-scheduler/samples/sample-po-page-job-scheduler-background-process/sample-po-page-job-scheduler-background-process.component.html
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/samples/sample-po-page-job-scheduler-background-process/sample-po-page-job-scheduler-background-process.component.html
@@ -1,5 +1,5 @@
 <po-page-job-scheduler
-  p-service-api="https://po-sample-api.herokuapp.com/v1/scheduler"
+  p-service-api="https://po-sample-api.fly.dev/v1/scheduler"
   p-title="Background Process Scheduler"
   [p-breadcrumb]="breadcrumb"
 >

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-automatic-service/sample-po-page-login-automatic-service.component.html
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-automatic-service/sample-po-page-login-automatic-service.component.html
@@ -5,7 +5,7 @@
   </div>
 </po-container>
 <po-page-login
-  p-authentication-url="https://po-sample-api.herokuapp.com/v1/users/authentication"
+  p-authentication-url="https://po-sample-api.fly.dev/v1/users/authentication"
   p-blocked-url="/documentation/po-page-blocked-user"
   p-authentication-type="Bearer"
   p-logo="https://via.placeholder.com/160x64?text=MAIN+LOGO"

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-human-resources/sample-po-page-login-human-resources.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-human-resources/sample-po-page-login-human-resources.component.ts
@@ -29,7 +29,7 @@ export class SamplePoPageLoginHumanResourcesComponent implements OnDestroy, OnIn
   passwordErrors = [];
   params: PoPageBlockedUserReasonParams = { attempts: 3, hours: 24 };
   passwordRecovery: PoPageLoginRecovery = {
-    url: 'https://po-sample-api.herokuapp.com/v1/users',
+    url: 'https://po-sample-api.fly.dev/v1/users',
     type: PoModalPasswordRecoveryType.All,
     contactMail: 'support@mail.com'
   };

--- a/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-labs/sample-po-page-login-labs.component.html
+++ b/projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-labs/sample-po-page-login-labs.component.html
@@ -201,7 +201,7 @@
       name="customFieldComboUrl"
       [(ngModel)]="customField.url"
       p-clean
-      p-help="Ex.: https://po-sample-api.herokuapp.com/v1/heroes"
+      p-help="Ex.: https://po-sample-api.fly.dev/v1/heroes"
       p-label="Custom Field URL"
       (p-change-model)="onChangeCustomProperties()"
     >

--- a/projects/ui/src/lib/components/po-breadcrumb/samples/sample-po-breadcrumb-labs/sample-po-breadcrumb-labs.component.html
+++ b/projects/ui/src/lib/components/po-breadcrumb/samples/sample-po-breadcrumb-labs/sample-po-breadcrumb-labs.component.html
@@ -41,7 +41,7 @@
       name="favoriteService"
       [(ngModel)]="favoriteService"
       p-clean
-      p-help="Ex.: https://po-sample-api.herokuapp.com/v1/favorite"
+      p-help="Ex.: https://po-sample-api.fly.dev/v1/favorite"
       p-label="Favorite service"
       [p-disabled]="!breadcrumbItems?.length"
     >

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -124,7 +124,7 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       gridSmColumns: 12,
       label: 'Favorite hero',
       optional: true,
-      searchService: 'https://po-sample-api.herokuapp.com/v1/heroes',
+      searchService: 'https://po-sample-api.fly.dev/v1/heroes',
       columns: [
         { property: 'nickname', label: 'Hero' },
         { property: 'label', label: 'Name' }
@@ -137,7 +137,7 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       property: 'partner',
       gridColumns: 6,
       gridSmColumns: 12,
-      optionsService: 'https://po-sample-api.herokuapp.com/v1/people',
+      optionsService: 'https://po-sample-api.fly.dev/v1/people',
       fieldLabel: 'name',
       fieldValue: 'id',
       optional: true

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes-reactive-form/sample-po-combo-heroes-reactive-form.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes-reactive-form/sample-po-combo-heroes-reactive-form.component.html
@@ -6,7 +6,7 @@
         formControlName="hero"
         p-field-label="nickname"
         p-field-value="name"
-        p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
+        p-filter-service="https://po-sample-api.fly.dev/v1/heroes"
         p-label="Search a Hero"
         p-sort
         (p-change)="onChangeHero($event)"

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes-reactive-form/sample-po-combo-heroes-reactive-form.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes-reactive-form/sample-po-combo-heroes-reactive-form.component.ts
@@ -35,6 +35,6 @@ export class SamplePoComboHeroesReactiveFormComponent implements OnInit {
   }
 
   private getHero(heroName: string) {
-    return this.http.get(`https://po-sample-api.herokuapp.com/v1/heroes/${heroName}`);
+    return this.http.get(`https://po-sample-api.fly.dev/v1/heroes/${heroName}`);
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes/sample-po-combo-heroes.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes/sample-po-combo-heroes.component.html
@@ -5,7 +5,7 @@
       [(ngModel)]="heroName"
       p-field-label="nickname"
       p-field-value="name"
-      p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
+      p-filter-service="https://po-sample-api.fly.dev/v1/heroes"
       p-label="Search a Hero"
       p-sort
       (p-change)="onChangeHero($event)"

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes/sample-po-combo-heroes.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes/sample-po-combo-heroes.component.ts
@@ -26,6 +26,6 @@ export class SamplePoComboHeroesComponent {
   }
 
   private getHero(heroName: string) {
-    return this.http.get(`https://po-sample-api.herokuapp.com/v1/heroes/${heroName}`);
+    return this.http.get(`https://po-sample-api.fly.dev/v1/heroes/${heroName}`);
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-hotels/sample-po-combo-hotels.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-hotels/sample-po-combo-hotels.component.html
@@ -63,7 +63,7 @@
       p-field-value="value"
       p-label="Search a hotel"
       p-sort
-      p-filter-service="https://po-sample-api.herokuapp.com/v1/hotels"
+      p-filter-service="https://po-sample-api.fly.dev/v1/hotels"
       [p-filter-params]="filterParams"
     >
     </po-combo>

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-infinity-scroll/sample-po-combo-infinity-scroll.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-infinity-scroll/sample-po-combo-infinity-scroll.component.html
@@ -1,7 +1,7 @@
 <div class="po-row">
   <po-widget class="po-lg-6">
     <po-combo
-      p-filter-service="https://po-sample-api.herokuapp.com/v1/people"
+      p-filter-service="https://po-sample-api.fly.dev/v1/people"
       p-label="People"
       name="people"
       [(ngModel)]="peopleName"

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-infinity-scroll/sample-po-combo-infinity-scroll.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-infinity-scroll/sample-po-combo-infinity-scroll.component.ts
@@ -17,6 +17,6 @@ export class SamplePoComboInfinityScrollComponent {
   }
 
   private getPeople(peopleId: string) {
-    return this.http.get(`https://po-sample-api.herokuapp.com/v1/people/${peopleId}`);
+    return this.http.get(`https://po-sample-api.fly.dev/v1/people/${peopleId}`);
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -135,7 +135,7 @@
       name="filterService"
       [(ngModel)]="filterService"
       p-clean
-      p-help="https://po-sample-api.herokuapp.com/v1/heroes"
+      p-help="https://po-sample-api.fly.dev/v1/heroes"
       p-label="Filter Service"
     >
     </po-input>

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-transfer/sample-po-combo-transfer.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-transfer/sample-po-combo-transfer.component.html
@@ -20,7 +20,7 @@
       [(ngModel)]="contact"
       p-field-value="id"
       p-field-label="name"
-      p-filter-service="https://po-sample-api.herokuapp.com/v1/people"
+      p-filter-service="https://po-sample-api.fly.dev/v1/people"
       p-icon="po-icon-user"
       p-label="To contact"
       p-placeholder="Select a contact"

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-basic/sample-po-lookup-basic.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-basic/sample-po-lookup-basic.component.html
@@ -2,7 +2,7 @@
   name="lookup"
   p-field-label="label"
   p-field-value="value"
-  p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
+  p-filter-service="https://po-sample-api.fly.dev/v1/heroes"
   p-label="PO Lookup"
 >
 </po-lookup>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -79,7 +79,7 @@
       name="filterService"
       [(ngModel)]="filterService"
       p-clean
-      p-help="https://po-sample-api.herokuapp.com/v1/people"
+      p-help="https://po-sample-api.fly.dev/v1/people"
       p-label="Filter Service"
     >
     </po-input>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.component.html
@@ -5,7 +5,7 @@
     [(ngModel)]="multiLookup"
     p-field-label="label"
     p-field-value="value"
-    p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
+    p-filter-service="https://po-sample-api.fly.dev/v1/heroes"
     p-label="Search a Hero"
     [p-multiple]="true"
     (p-change)="changeOptions($event)"

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.service.ts
@@ -11,6 +11,6 @@ export class SamplePoLookupMultipleService {
 
   getHeroes(data): Observable<any> {
     const values = data?.length ? data.toString() : data;
-    return this.http.get(`https://po-sample-api.herokuapp.com/v1/heroes?value=${values}`).pipe(pluck('items'));
+    return this.http.get(`https://po-sample-api.fly.dev/v1/heroes?value=${values}`).pipe(pluck('items'));
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup.service.ts
@@ -7,7 +7,7 @@ import { PoLookupFilter, PoLookupFilteredItemsParams } from '@po-ui/ng-component
 
 @Injectable()
 export class SamplePoLookupService implements PoLookupFilter {
-  private url = 'https://po-sample-api.herokuapp.com/v1/heroes';
+  private url = 'https://po-sample-api.fly.dev/v1/heroes';
 
   constructor(private httpClient: HttpClient) {}
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.service.ts
@@ -14,13 +14,13 @@ export class SamplePoMultiselectHeroesService implements PoMultiselectFilter {
     const params = { filter: value };
 
     return this.http
-      .get(`https://po-sample-api.herokuapp.com/v1/heroes?page=1&pageSize=10`, { params })
+      .get(`https://po-sample-api.fly.dev/v1/heroes?page=1&pageSize=10`, { params })
       .pipe(map((response: { items: Array<PoMultiselectOption> }) => response.items));
   }
 
   getObjectsByValues(value: Array<string | number>): Observable<Array<PoMultiselectOption>> {
     return this.http
-      .get(`https://po-sample-api.herokuapp.com/v1/heroes/?value=${value.toString()}`)
+      .get(`https://po-sample-api.fly.dev/v1/heroes/?value=${value.toString()}`)
       .pipe(map((response: { items: Array<PoMultiselectOption> }) => response.items));
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
@@ -90,7 +90,7 @@
       name="filterService"
       [(ngModel)]="filterService"
       p-clean
-      p-help="https://po-sample-api.herokuapp.com/v1/heroes"
+      p-help="https://po-sample-api.fly.dev/v1/heroes"
       p-label="Filter Service"
     >
     </po-input>

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.component.html
@@ -40,7 +40,7 @@
     >
       <ng-template p-select-option-template let-option>
         <div class="sample-select-option-template-container">
-          <po-avatar p-size="xs" p-src="https://po-sample-api.herokuapp.com/v1/sampleSelect/{{ option.value }}.png">
+          <po-avatar p-size="xs" p-src="https://po-sample-api.fly.dev/v1/sampleSelect/{{ option.value }}.png">
           </po-avatar>
 
           <div class="sample-select-option-template-margin">

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class SamplePoSelectCustomerRegistrationService {
-  private url: string = 'https://po-sample-api.herokuapp.com/v1/sampleSelect';
+  private url: string = 'https://po-sample-api.fly.dev/v1/sampleSelect';
 
   constructor(private http: HttpClient) {}
 

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-basic/sample-po-upload-basic.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-basic/sample-po-upload-basic.component.html
@@ -1,2 +1,2 @@
-<po-upload name="upload" p-label="PO Upload" p-url="https://po-sample-api.herokuapp.com/v1/uploads/addFile">
+<po-upload name="upload" p-label="PO Upload" p-url="https://po-sample-api.fly.dev/v1/uploads/addFile">
 </po-upload>

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
@@ -92,7 +92,7 @@ export class SamplePoUploadLabsComponent implements OnInit {
     this.properties = [];
     this.restrictions = {};
     this.upload = undefined;
-    this.url = 'https://po-sample-api.herokuapp.com/v1/uploads/addFile';
+    this.url = 'https://po-sample-api.fly.dev/v1/uploads/addFile';
     this.headers = undefined;
     this.headersLabs = undefined;
   }

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-resume-drag-drop/sample-po-upload-resume-drag-drop.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-resume-drag-drop/sample-po-upload-resume-drag-drop.component.html
@@ -20,7 +20,7 @@
       p-drag-drop-height="160"
       p-label="Resume"
       p-required
-      p-url="https://po-sample-api.herokuapp.com/v1/uploads/addFile"
+      p-url="https://po-sample-api.fly.dev/v1/uploads/addFile"
       p-restrictions="{maxFileSize: '204800'}"
       (p-error)="resumeUploadError()"
       (p-success)="resumeUploadSuccess()"

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-resume/sample-po-upload-resume.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-resume/sample-po-upload-resume.component.html
@@ -18,7 +18,7 @@
       [(ngModel)]="resume"
       p-label="Resume"
       p-required
-      p-url="https://po-sample-api.herokuapp.com/v1/uploads/addFile"
+      p-url="https://po-sample-api.fly.dev/v1/uploads/addFile"
       [p-restrictions]="{ maxFileSize: '204800' }"
       (p-error)="resumeUploadError()"
       (p-success)="resumeUploadSuccess()"

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-rs/sample-po-upload-rs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-rs/sample-po-upload-rs.component.html
@@ -55,7 +55,7 @@
               p-hide-select-button
               p-hide-send-button
               p-required
-              p-url="https://po-sample-api.herokuapp.com/v1/uploads/addFile"
+              p-url="https://po-sample-api.fly.dev/v1/uploads/addFile"
               [p-restrictions]="restrictions"
             >
             </po-upload>

--- a/projects/ui/src/lib/components/po-link/samples/sample-po-link-heroes/sample-po-link-heroes.component.html
+++ b/projects/ui/src/lib/components/po-link/samples/sample-po-link-heroes/sample-po-link-heroes.component.html
@@ -1,4 +1,4 @@
-<po-table p-service-api="https://po-sample-api.herokuapp.com/v1/heroes" [p-columns]="columns">
+<po-table p-service-api="https://po-sample-api.fly.dev/v1/heroes" [p-columns]="columns">
   <ng-template p-table-column-template [p-property]="'nickname'" let-value>
     <po-link [p-label]="value" [p-url]="'https://www.google.com/search?q=' + value" p-open-new-tab="true"></po-link>
   </ng-template>

--- a/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-human-resources/sample-po-menu-human-resources.service.ts
+++ b/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-human-resources/sample-po-menu-human-resources.service.ts
@@ -8,7 +8,7 @@ import { PoMenuFilter, PoMenuItemFiltered } from '@po-ui/ng-components';
 
 @Injectable()
 export class SamplePoMenuHumanResourcesService implements PoMenuFilter {
-  private url: string = 'https://po-sample-api.herokuapp.com/v1/menus';
+  private url: string = 'https://po-sample-api.fly.dev/v1/menus';
 
   constructor(private http: HttpClient) {}
 

--- a/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.html
+++ b/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.html
@@ -111,7 +111,7 @@
           [(ngModel)]="service"
           p-clean
           p-label="Service"
-          p-help="https://po-sample-api.herokuapp.com/v1/menus"
+          p-help="https://po-sample-api.fly.dev/v1/menus"
         >
         </po-input>
 

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
@@ -51,7 +51,7 @@
       name="breadcrumbFavorite"
       [(ngModel)]="breadcrumb.favorite"
       p-clean
-      p-help="https://po-sample-api.herokuapp.com/v1/favorite"
+      p-help="https://po-sample-api.fly.dev/v1/favorite"
       p-label="Breadcrumb favorite"
     >
     </po-input>

--- a/projects/ui/src/lib/components/po-page/po-page-detail/samples/sample-po-page-detail-labs/sample-po-page-detail-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-detail/samples/sample-po-page-detail-labs/sample-po-page-detail-labs.component.html
@@ -26,7 +26,7 @@
           name="breadcrumbFavorite"
           [(ngModel)]="breadcrumb.favorite"
           p-clean
-          p-help="https://po-sample-api.herokuapp.com/v1/favorite"
+          p-help="https://po-sample-api.fly.dev/v1/favorite"
           p-label="Breadcrumb favorite"
         >
         </po-input>

--- a/projects/ui/src/lib/components/po-page/po-page-edit/samples/sample-po-page-edit-labs/sample-po-page-edit-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/samples/sample-po-page-edit-labs/sample-po-page-edit-labs.component.html
@@ -36,7 +36,7 @@
           name="breadcrumbFavorite"
           [(ngModel)]="breadcrumb.favorite"
           p-clean
-          p-help="https://po-sample-api.herokuapp.com/v1/favorite"
+          p-help="https://po-sample-api.fly.dev/v1/favorite"
           p-label="Breadcrumb favorite"
         >
         </po-input>

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-labs/sample-po-page-list-labs.component.html
@@ -61,7 +61,7 @@
       name="breadcrumbFavorite"
       [(ngModel)]="breadcrumb.favorite"
       p-clean
-      p-help="https://po-sample-api.herokuapp.com/v1/favorite"
+      p-help="https://po-sample-api.fly.dev/v1/favorite"
       p-label="Breadcrumb favorite"
     >
     </po-input>

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-active/sample-po-stepper-active.service.ts
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-active/sample-po-stepper-active.service.ts
@@ -5,7 +5,7 @@ import { HttpClient } from '@angular/common/http';
   providedIn: 'root'
 })
 export class SamplePoStepperActiveService {
-  private url: string = 'https://po-sample-api.herokuapp.com/v1/sampleSelect';
+  private url: string = 'https://po-sample-api.fly.dev/v1/sampleSelect';
 
   constructor(private http: HttpClient) {}
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-with-api/sample-po-table-with-api.component.html
@@ -2,7 +2,7 @@
   <po-input
     class="po-md-12"
     p-label="URL API service"
-    p-help="https://po-sample-api.herokuapp.com/v1/heroes"
+    p-help="https://po-sample-api.fly.dev/v1/heroes"
     [(ngModel)]="service"
     (p-change)="changeService(service)"
   >

--- a/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
+++ b/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
@@ -19,7 +19,7 @@ describe('PoTableService', () => {
   });
 
   it('setUrl: should be called and set api url', () => {
-    const url = 'https://po-sample-api.herokuapp.com/v1/heroes';
+    const url = 'https://po-sample-api.fly.dev/v1/heroes';
 
     service.setUrl(url);
 
@@ -47,7 +47,7 @@ describe('PoTableService', () => {
   });
 
   it('getFilteredItems: to have been called and call backend', () => {
-    service['url'] = 'https://po-sample-api.herokuapp.com/v1/heroes';
+    service['url'] = 'https://po-sample-api.fly.dev/v1/heroes';
 
     const filteredParams = {
       order: '-name',

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.ts
@@ -90,7 +90,7 @@ export class SamplePoHttpInterceptorLabsComponent implements OnDestroy, OnInit {
     const params = { status: this.status || '' };
 
     this.apiSubscription = this.http
-      .post(`https://po-sample-api.herokuapp.com/v1/messages`, body, { headers, params })
+      .post(`https://po-sample-api.fly.dev/v1/messages`, body, { headers, params })
       .subscribe();
   }
 

--- a/projects/ui/src/lib/interceptors/po-http-request/samples/sample-po-http-request-interceptor-labs.component.html
+++ b/projects/ui/src/lib/interceptors/po-http-request/samples/sample-po-http-request-interceptor-labs.component.html
@@ -7,7 +7,7 @@
     class="po-lg-6"
     name="url"
     [(ngModel)]="url"
-    p-help="https://po-sample-api.herokuapp.com/v1/people"
+    p-help="https://po-sample-api.fly.dev/v1/people"
     p-label="URL"
     p-required
   >


### PR DESCRIPTION
Altera todas as menções de 'https://po-sample-api.herokuapp.com/*' para 'https://po-sample-api.fly.dev/*'. Devido a mudança de servidor, do heroku para fly.io.

Fixes #1429, #1430, #1431, #1432, #1433, #1434, #1435, #1436, #1437

**po-sample-api**

**#1437**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
As API's de po-sample-api estão usando uma url base para um servidor heroku ('*.herokuapp.com/*), contudo, a aplicação foi mudada para um servidor do fly.io. Sendo necessário atualizar as urls base.

**Qual o novo comportamento?**
Todas as url base que antes direcionavam para '*.herokuapp.com/*' foram alteradas para '*.fly.dev/*'.

**Simulação**
