### PR TITLE
fix(lookup):  corrige comportamento do gerenciador de colunas no po-lookup

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -7,6 +7,7 @@ import * as ValidatorsFunctions from '../validators';
 import { PoLookupFilter } from './interfaces/po-lookup-filter.interface';
 import { PoLookupBaseComponent } from './po-lookup-base.component';
 import { PoLookupFilterService } from './services/po-lookup-filter.service';
+import { PoLookupModalService } from './services/po-lookup-modal.service';
 
 class LookupFilterService implements PoLookupFilter {
   getObjectByValue(id: string): Observable<any> {
@@ -33,20 +34,22 @@ describe('PoLookupBaseComponent:', () => {
   let component: PoLookupComponent;
   let defaultService: PoLookupFilterService;
   let injector: Injector;
+  let poLookupModalService: PoLookupModalService;
 
   const fakeSubscription = <any>{ unsubscribe: () => {} };
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [],
-      providers: [LookupFilterService, Injector, NgControl]
+      providers: [LookupFilterService, Injector, NgControl, PoLookupModalService]
     });
   });
 
   beforeEach(() => {
     defaultService = new PoLookupFilterService(undefined);
     injector = TestBed.inject(Injector);
-    component = new PoLookupComponent(defaultService, injector);
+    poLookupModalService = TestBed.inject(PoLookupModalService);
+    component = new PoLookupComponent(defaultService, injector, poLookupModalService);
     component['keysDescription'] = ['label'];
   });
 
@@ -273,11 +276,18 @@ describe('PoLookupBaseComponent:', () => {
     component.multiple = true;
     component.fieldValue = 'value';
     component.filterService = 'http://url.com';
+    const column = [{ label: 'apelido', property: 'nickname' }];
 
     const changes: SimpleChanges = {
       multiple: {
         previousValue: false,
         currentValue: true,
+        firstChange: true,
+        isFirstChange: () => false
+      },
+      columns: {
+        previousValue: false,
+        currentValue: column,
         firstChange: true,
         isFirstChange: () => false
       }
@@ -292,11 +302,18 @@ describe('PoLookupBaseComponent:', () => {
     component.multiple = false;
     component.fieldValue = 'value';
     component.filterService = <any>{};
+    const column = [{ label: 'apelido', property: 'nickname' }];
 
     const changes: SimpleChanges = {
       multiple: {
         previousValue: false,
         currentValue: false,
+        firstChange: true,
+        isFirstChange: () => false
+      },
+      columns: {
+        previousValue: false,
+        currentValue: column,
         firstChange: true,
         isFirstChange: () => false
       }

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -24,6 +24,7 @@ import { PoLookupColumn } from './interfaces/po-lookup-column.interface';
 import { PoLookupFilter } from './interfaces/po-lookup-filter.interface';
 import { PoLookupLiterals } from './interfaces/po-lookup-literals.interface';
 import { PoLookupFilterService } from './services/po-lookup-filter.service';
+import { PoLookupModalService } from './services/po-lookup-modal.service';
 
 /**
  * @description
@@ -461,7 +462,11 @@ export abstract class PoLookupBaseComponent
     return this._disabled;
   }
 
-  constructor(private defaultService: PoLookupFilterService, @Inject(Injector) private injector: Injector) {}
+  constructor(
+    private defaultService: PoLookupFilterService,
+    @Inject(Injector) private injector: Injector,
+    public poLookupModalService: PoLookupModalService
+  ) {}
 
   ngOnDestroy() {
     if (this.getSubscription) {
@@ -483,6 +488,11 @@ export abstract class PoLookupBaseComponent
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    if (changes.columns?.currentValue) {
+      this.columns = changes.columns.currentValue;
+      this.poLookupModalService?.setChangeColumns(this.columns);
+    }
+
     if (changes.multiple && isTypeof(this.filterService, 'string')) {
       this.service.setConfig(this.filterService, this.fieldValue, this.multiple);
     }

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -125,11 +125,11 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
   constructor(
     private renderer: Renderer2,
     poLookupFilterService: PoLookupFilterService,
-    private poLookupModalService: PoLookupModalService,
+    poLookupModalService: PoLookupModalService,
     private cd: ChangeDetectorRef,
     injector: Injector
   ) {
-    super(poLookupFilterService, injector);
+    super(poLookupFilterService, injector, poLookupModalService);
   }
 
   ngAfterViewInit() {

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
@@ -103,4 +103,25 @@ describe('PoLookupModalService:', () => {
 
     expect(poLookupModalService.selectValue).toHaveBeenCalled();
   });
+
+  it('should call a setChangeColumns function', () => {
+    const columns = [{ label: 'apelido', property: 'nickname' }];
+
+    spyOn(poLookupModalService, 'setChangeColumns');
+
+    poLookupModalService.setChangeColumns(columns);
+
+    expect(poLookupModalService.setChangeColumns).toHaveBeenCalled();
+  });
+
+  it('should change the columns when componentRef is not null', () => {
+    const columns = [{ 'label': 'apelido', 'property': 'nickname' }];
+    params.service = lookupFilterService;
+
+    poLookupModalService.openModal(params);
+    poLookupModalService.setChangeColumns(columns);
+    poLookupModalService['componentRef'].changeDetectorRef.detectChanges();
+
+    expect(poLookupModalService['componentRef'].instance.columns).toEqual(columns);
+  });
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
@@ -87,6 +87,13 @@ export class PoLookupModalService {
     this.componentRef.instance.openModal();
   }
 
+  setChangeColumns(columns) {
+    if (this.componentRef !== null) {
+      this.componentRef.instance.columns = columns;
+      this.componentRef.changeDetectorRef.detectChanges();
+    }
+  }
+
   // Este metodo é chamado quando é selecionado um item na lookup modal.
   selectValue(value) {
     if (value) {


### PR DESCRIPTION
**< LOOKUP >**

**< DTFUI-6537 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
 Não é possível restaurar o padrão das colunas no gerenciador de colunas dentro do po-lookup.

**Qual o novo comportamento?**
É possível restaurar o padrão das colunas do gerenciador dentro do po-lookup mantendo a visibilidade das alterações.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/9779154/app.zip)
