### PR TITLE
docs(page-dynamic-detail): altera url base da API

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-detail/samples/sample-po-page-dynamic-detail-user/sample-po-page-dynamic-detail-user.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-detail/samples/sample-po-page-dynamic-detail-user/sample-po-page-dynamic-detail-user.component.ts
@@ -8,7 +8,7 @@ import { PoPageDynamicDetailActions, PoPageDynamicDetailField } from '@po-ui/ng-
   templateUrl: './sample-po-page-dynamic-detail-user.component.html'
 })
 export class SamplePoPageDynamicDetailUserComponent {
-  public readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+  public readonly serviceApi = 'https://po-sample-api.fly.dev/v1/people';
 
   public readonly actions: PoPageDynamicDetailActions = {
     back: '/documentation/po-page-dynamic-table'


### PR DESCRIPTION
Muda `serviceApi` para 'https://po-sample-api.fly.dev/v1/people'. Devido a mundaça de servidor para o fly.io.

Fixes #1431

**page-dynamic-edit**

**#1431**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
