### PR TITLE
fix(language): ajusta o `setLanguage` com `reload`

### DIFF
--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
@@ -240,6 +240,7 @@ export class PoI18nBaseService {
     this.languageService.setLanguage(language);
 
     if (reload) {
+      this.languageService.setKeepLanguage();
       reloadCurrentPage();
     }
   }

--- a/projects/ui/src/lib/services/po-language/po-language.service.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.ts
@@ -8,10 +8,8 @@ import {
   poLocaleThousandSeparatorList
 } from './po-language.constant';
 
-localStorage.removeItem('PO_DEFAULT_LANGUAGE');
-localStorage.removeItem('PO_USER_LOCALE');
-
 const poDefaultLanguage = 'PO_DEFAULT_LANGUAGE';
+const poKeepLanguage = 'PO_KEEP_LANGUAGE';
 const poLocaleKey = 'PO_USER_LOCALE';
 
 /**
@@ -25,7 +23,14 @@ const poLocaleKey = 'PO_USER_LOCALE';
   providedIn: 'root'
 })
 export class PoLanguageService {
-  constructor() {}
+  constructor() {
+    const keepLanguage = localStorage.getItem(poKeepLanguage) === 'true';
+    if (!keepLanguage) {
+      localStorage.removeItem(poDefaultLanguage);
+      localStorage.removeItem(poLocaleKey);
+    }
+    localStorage.removeItem(poKeepLanguage);
+  }
 
   set languageDefault(language: string) {
     if (language && isLanguage(language)) {
@@ -86,6 +91,18 @@ export class PoLanguageService {
     const shortLanguage = getShortLanguage(language);
 
     return poLocales.includes(shortLanguage) ? shortLanguage : poLocaleDefault;
+  }
+
+  /**
+   * @description
+   *
+   * Método para preservar o idioma salvo no *storage*, durante o reinicio da aplicação
+   *
+   * @default `true`
+   *
+   */
+  setKeepLanguage(value: boolean = true) {
+    localStorage.setItem(poKeepLanguage, String(value));
   }
 
   /**


### PR DESCRIPTION
Ao deletar as variáveis do localStorage quebrou-se o comportamento padrão do `setLanguage` quando solicitado o `reload` da aplicação.

Fixes #1457

**Language**

**1457**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A linguagem após refresh não é mantida pois a configuração foi apagado do localStorage (PR https://github.com/po-ui/po-angular/pull/1343 Issue https://github.com/po-ui/po-angular/issues/1331), nunca aplicando a linguagem escolhida.

**Qual o novo comportamento?**
A linguagem após refresh é mantida pois a configuração do localStorage foi preservada.

**Simulação**
A simulação pode ser feita com este [App](https://github.com/po-ui/po-angular/files/9816141/app.zip).
