### PR TITLE
fix(language): reset de linguagem como parâmetro

### DIFF
--- a/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
+++ b/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
@@ -77,4 +77,14 @@ export interface PoI18nConfig {
    * > Caso a constante contenha alguma literal que o serviço não possua será utilizado a literal da constante.
    */
   contexts: object;
+
+  /**
+   *
+   * Habilita a limpeza das variáveis de localização e linguagem padrão do localStorage ao recarregar a aplicação
+   *
+   * > Ao utilizar o método `setLanguage` com o parâmetro `reload` a limpeza não é feita
+   *
+   * @default false
+   */
+  resetAfterReload?: boolean;
 }

--- a/projects/ui/src/lib/services/po-language/po-language.service.spec.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.spec.ts
@@ -138,6 +138,14 @@ describe('PoLanguageService:', () => {
       expect(service.languageDefault).toBeNull();
     });
 
+    it(`languageDefault: should call 'localStorage.removeItem'`, () => {
+      spyOn(localStorage, 'removeItem');
+
+      service.clearLanguageLocaleConfig();
+
+      expect(localStorage.removeItem).toHaveBeenCalled();
+    });
+
     describe('getNumberSeparators:', () => {
       it(`should return language separators if language param is undefined.`, () => {
         spyOn(service, 'getShortLanguage').and.returnValue('pt');

--- a/projects/ui/src/lib/services/po-language/po-language.service.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.ts
@@ -8,9 +8,6 @@ import {
   poLocaleThousandSeparatorList
 } from './po-language.constant';
 
-localStorage.removeItem('PO_DEFAULT_LANGUAGE');
-localStorage.removeItem('PO_USER_LOCALE');
-
 const poDefaultLanguage = 'PO_DEFAULT_LANGUAGE';
 const poLocaleKey = 'PO_USER_LOCALE';
 
@@ -147,5 +144,16 @@ export class PoLanguageService {
     const thousandSeparator = thousand.separator ?? '.';
 
     return { decimalSeparator, thousandSeparator };
+  }
+
+  /**
+   * @description
+   *
+   * Apaga as configurações de locale e language do localStorage
+   *
+   */
+  clearLanguageLocaleConfig() {
+    localStorage.removeItem(poDefaultLanguage);
+    localStorage.removeItem(poLocaleKey);
   }
 }


### PR DESCRIPTION
Devido a quebra do comportamento padrão do setLanguage quanto a limpeza do storage, foi adicionada a opção 'resetAfterReload' como configuração do modulo de linguagem

Fixes #1457

**Language**

**1457**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A linguagem após refresh não é mantida pois a configuração foi apagado do localStorage (PR https://github.com/po-ui/po-angular/pull/1343 Issue https://github.com/po-ui/po-angular/issues/1331), nunca aplicando a linguagem escolhida.

**Qual o novo comportamento?**
Caso a aplicação escolha apagar as configurações ao fazer refresh pode utilizar o parâmetro 'resetAfterReload' na configuração do 'PoI18nModule'.
O comportamento de não apagar é mantido por padrão.
Caso seja utilizado o método 'setLanguage' com reload 'true', também não é apagado mesmo que no module esteja configurado com a propriedade 'resetAfterReload'.

**Simulação**

Utilizar o código dentro do App do projeto: https://gist.github.com/guilnorth/6c82c17a1ac59262d19ce9fb199b7880