### PR TITLE
docs(select): atualiza url base da API

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.component.html
@@ -40,7 +40,7 @@
     >
       <ng-template p-select-option-template let-option>
         <div class="sample-select-option-template-container">
-          <po-avatar p-size="xs" p-src="https://po-sample-api.herokuapp.com/v1/sampleSelect/{{ option.value }}.png">
+          <po-avatar p-size="xs" p-src="https://po-sample-api.fly.dev/v1/sampleSelect/{{ option.value }}.png">
           </po-avatar>
 
           <div class="sample-select-option-template-margin">

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-customer-registration/sample-po-select-customer-registration.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class SamplePoSelectCustomerRegistrationService {
-  private url: string = 'https://po-sample-api.herokuapp.com/v1/sampleSelect';
+  private url: string = 'https://po-sample-api.fly.dev/v1/sampleSelect';
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
Altera o  `p-src` do `po-avatar` no componente `sample-po-select-customer-registration.component.html`
de: https://po-sample-api.herokuapp.com/v1/sampleSelect/{{ option.value }}.png
para: https://po-sample-api.fly.dev/v1/sampleSelect/{{ option.value }}.png

Altera a `url` do serviço `sample-po-select-customer-registration.service.ts` 
de: https://po-sample-api.herokuapp.com/v1/sampleSelect
para: https://po-sample-api.fly.dev/v1/sampleSelect

Devido a mudança de servidor do heroku para o fly.io.

Fixes https://github.com/po-ui/po-angular/issues/1454

po-select

https://github.com/po-ui/po-angular/issues/1454
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
