### PR TITLE
docs(page-dynamic-edit): ajusta a documentação do componente

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -329,20 +329,24 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
    * ou passando apenas as literais que deseja customizar
    *
    * ```
-   *  const customLiterals: PoPageDynamicSearchLiterals = {
+   *  const customLiterals: PoPageDynamicEditLiterals = {
    *    detailActionNew: 'Incluir',
    *    pageActionCancel: 'Descartar',
    *    pageActionSave: 'Gravar',
    *    pageActionSaveNew: 'Gravar e incluir',
+   *    registerNotFound: 'Nenhum registro encontrado.',
+   *    saveNotificationSuccessSave: 'Item salvo com sucesso.',
+   *    saveNotificationSuccessUpdate: 'Item atualizado com sucesso.',
+   *    saveNotificationWarning: 'Necessário preencher o formulário corretamente.'
    *  };
    * ```
    *
    * E para carregar as literais customizadas, basta apenas passar o objeto para o componente.
    *
    * ```
-   * <po-page-dynamic-search
+   * <po-page-dynamic-edit
    *   [p-literals]="customLiterals">
-   * </po-page-dynamic-search>
+   * </po-page-dynamic-edit>
    * ```
    *
    * > O valor padrão será traduzido de acordo com o idioma configurado no [`PoI18nService`](/documentation/po-i18n) ou *browser*.


### PR DESCRIPTION
Foi adicionado a lista completa de literais onde é possível customizar.

Foi também corrigido o nome do componente na documentação

Fixes #1470

**Page Dynamic Edit**

**1470**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Os exemplos de customização dos literais não trazem a lista completa.

**Qual o novo comportamento?**
Foi adicionado na documentação a lista completa dos literais que podem ser customizados.

**Simulação**
Pode ser verificada no portal