### PR TITLE
feat(image): novo componente po-image

### DIFF
--- a/projects/ui/src/lib/components/components.module.ts
+++ b/projects/ui/src/lib/components/components.module.ts
@@ -38,6 +38,7 @@ import { PoWidgetModule } from './po-widget/po-widget.module';
 import { PoIconModule } from './po-icon/po-icon.module';
 import { PoLinkModule } from './po-link/po-link.module';
 import { PoLabelModule } from './po-label/po-label.module';
+import { PoImageModule } from './po-image/po-image.module';
 
 @NgModule({
   imports: [
@@ -78,7 +79,8 @@ import { PoLabelModule } from './po-label/po-label.module';
     PoTreeViewModule,
     PoWidgetModule,
     PoLinkModule,
-    PoLabelModule
+    PoLabelModule,
+    PoImageModule
   ],
   exports: [
     PoAccordionModule,
@@ -118,7 +120,8 @@ import { PoLabelModule } from './po-label/po-label.module';
     PoTreeViewModule,
     PoWidgetModule,
     PoLinkModule,
-    PoLabelModule
+    PoLabelModule,
+    PoImageModule
   ],
   providers: [],
   bootstrap: []

--- a/projects/ui/src/lib/components/index.ts
+++ b/projects/ui/src/lib/components/index.ts
@@ -38,3 +38,4 @@ export * from './po-tree-view/index';
 export * from './po-widget/index';
 export * from './po-link/index';
 export * from './po-label/index';
+export * from './po-image/index';

--- a/projects/ui/src/lib/components/po-image/index.ts
+++ b/projects/ui/src/lib/components/po-image/index.ts
@@ -1,0 +1,3 @@
+export * from './po-image.component';
+
+export * from './po-image.module';

--- a/projects/ui/src/lib/components/po-image/po-image-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-image/po-image-base.component.spec.ts
@@ -1,0 +1,9 @@
+import { PoImageBaseComponent } from './po-image-base.component';
+
+describe('PoImageBaseComponent:', () => {
+  const component = new PoImageBaseComponent();
+
+  it('should be created', () => {
+    expect(component instanceof PoImageBaseComponent).toBeTruthy();
+  });
+});

--- a/projects/ui/src/lib/components/po-image/po-image-base.component.ts
+++ b/projects/ui/src/lib/components/po-image/po-image-base.component.ts
@@ -1,0 +1,60 @@
+import { Directive, Input } from '@angular/core';
+
+/**
+ * @description
+ *
+ * As imagens têm a função de traduzir visualmente ideias específicas ou mensagens complexas, mostrar um produto ou contar uma história, estabelecendo empatia e se conectando com os usuários.
+ *
+ * #### Boas Práticas
+ *
+ * O componente image foi projetado para atender os requisitos das Diretrizes de Acessibilidade para Conteúdo Web (WCAG) 2.1. Também foram estruturadas padrões de usabilidade para auxiliar na utilização do componente e garantir uma boa experiência para os usuários. Por isso, é muito importante que, ao aplicar esse componente, o proprietário do conteúdo leve em consideração alguns critérios e práticas:
+ * ##### Uso
+ * - Ao utilizar imagens, mantenha uma coerência entre elas no produto, de modo que compartilhem um mesmo estilo e intenção entre si.
+ * - Utilize imagens que expressem a mensagem e estilo do produto, respeitando as diretrizes e guia da marca.
+ * - Ao utilizar fotografias, é recomendável o uso de proporções de aspecto padrão, como 1:1, 3:1, 3:2, 16:9.
+ * - Mantenha um ponto focal na imagem, pois isso influencia em como ela se comportará em diferentes formatos. Isso também ajuda a transmitir a mensagem de forma objetiva e consistente.
+ *
+ * ##### Imagem como plano de fundo
+ * - Avalie se é realmente necessário o uso de imagem como plano de fundo e evite sempre que possível, pois pode ocasionar em um baixo contraste entre texto e imagem.
+ * - Caso utilize, redobre a atenção na escolha da imagem e certifique-se de que ela está adequada para a leitura do texto e não está sendo apenas um ruído.
+ * - Tenha especial atenção em telas menores. Embora seja possível posicionar o texto em uma área mais vazia ou escurecida, o texto e imagem se ajustam aos diferentes espaços, de acordo com o dispositivo. Muitas vezes acaba resultando no comprometimento tanto da leitura do texto e quando na visualização da imagem.
+ * - Verifique a taxa de contraste do texto em relação ao fundo. Deve ser suficiente para atender aos padrões de acessibilidade, sendo 4,5:1 para textos acima de 18pt ou bold e 7,1: 1 para textos menores que 18pt.
+ * - Se não tiver controle sobre qual imagem será colocada por trás do texto, o recomendado é não utilizar nesse formato.
+ *
+ * #### Acessibilidade tratada no componente
+ * As boas práticas de acessibilidade variam de acordo com tipo da imagem, que podem ser divididas em:
+ * - Imagem informativa simples, como por exemplo uma fotografia de um produto.
+ * - Imagem complexa, como um gráfico, infográfico ou diagrama.
+ * - Imagem decorativa, como um plano de fundo ou uma fotografia que ilustra um assunto, mas não é essencial para compreender a informação.
+ */
+@Directive()
+export class PoImageBaseComponent {
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a altura da imagem em *pixels*. Caso não seja definida,
+   * atribui o tamanho da imagem
+   */
+  @Input('p-height') height: number;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Defini o texto alternativo descrevendo a imagem.
+   */
+  @Input('p-alt') alternate: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Fonte da imagem que pode ser um caminho local (`./assets/images/logo-black-small.png`)
+   * ou um servidor externo (`https://po-ui.io/assets/images/logo-black-small.png`).
+   */
+  @Input('p-src') source: string;
+}

--- a/projects/ui/src/lib/components/po-image/po-image.component.html
+++ b/projects/ui/src/lib/components/po-image/po-image.component.html
@@ -1,0 +1,3 @@
+<po-container *ngIf="source">
+  <img class="po-image" [attr.alt]="alternate" [attr.height]="height" [attr.src]="source" />
+</po-container>

--- a/projects/ui/src/lib/components/po-image/po-image.component.spec.ts
+++ b/projects/ui/src/lib/components/po-image/po-image.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PoImageComponent } from './po-image.component';
+
+describe('PoLinkComponent', () => {
+  let component: PoImageComponent;
+  let fixture: ComponentFixture<PoImageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PoImageComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoImageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ui/src/lib/components/po-image/po-image.component.ts
+++ b/projects/ui/src/lib/components/po-image/po-image.component.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { PoImageBaseComponent } from './po-image-base.component';
+
+/**
+ * @docsExtends PoImageBaseComponent
+ *
+ * @example
+ *
+ * <example name="po-image-basic" title="PO Image Basic" >
+ *  <file name="sample-po-image-basic/sample-po-image-basic.component.html"> </file>
+ *  <file name="sample-po-image-basic/sample-po-image-basic.component.ts"> </file>
+ * </example>
+ *
+ * <example name="po-image-labs" title="PO Image Labs" >
+ *  <file name="sample-po-image-labs/sample-po-image-labs.component.html"> </file>
+ *  <file name="sample-po-image-labs/sample-po-image-labs.component.ts"> </file>
+ * </example>
+ *
+ * <example name="po-image-travel" title="PO Image Travel" >
+ *  <file name="sample-po-image-travel/sample-po-image-travel.component.html"> </file>
+ *  <file name="sample-po-image-travel/sample-po-image-travel.component.ts"> </file>
+ * </example>
+ *
+ */
+
+@Component({
+  selector: 'po-image',
+  templateUrl: './po-image.component.html'
+})
+export class PoImageComponent extends PoImageBaseComponent {}

--- a/projects/ui/src/lib/components/po-image/po-image.module.ts
+++ b/projects/ui/src/lib/components/po-image/po-image.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PoImageComponent } from './po-image.component';
+import { PoContainerModule } from '../po-container';
+
+/**
+ * @description
+ *
+ * Módulo do componente po-image
+ */
+@NgModule({
+  declarations: [PoImageComponent],
+  imports: [CommonModule, PoContainerModule],
+  exports: [PoImageComponent]
+})
+export class PoImageModule {}

--- a/projects/ui/src/lib/components/po-image/samples/sample-po-image-basic/sample-po-image-basic.component.html
+++ b/projects/ui/src/lib/components/po-image/samples/sample-po-image-basic/sample-po-image-basic.component.html
@@ -1,0 +1,1 @@
+<po-image [p-src]="srcImage" p-alt="teste de imagem" p-height="300"> </po-image>

--- a/projects/ui/src/lib/components/po-image/samples/sample-po-image-basic/sample-po-image-basic.component.ts
+++ b/projects/ui/src/lib/components/po-image/samples/sample-po-image-basic/sample-po-image-basic.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sample-po-image-basic',
+  templateUrl: './sample-po-image-basic.component.html'
+})
+export class SamplePoImageBasicComponent {
+  srcImage = 'https://raw.githubusercontent.com/po-ui/po-angular/master/docs/assets/po-logos/po_color_bg.svg';
+}

--- a/projects/ui/src/lib/components/po-image/samples/sample-po-image-labs/sample-po-image-labs.component.html
+++ b/projects/ui/src/lib/components/po-image/samples/sample-po-image-labs/sample-po-image-labs.component.html
@@ -1,0 +1,28 @@
+<po-image [p-src]="src" [p-alt]="alt" [p-height]="height"> </po-image>
+
+<hr />
+<form #f="ngForm">
+  <div class="po-row">
+    <po-input
+      class="po-md-6"
+      name="src"
+      [(ngModel)]="src"
+      p-clean
+      p-label="Source"
+      p-help="Enter a url or path of the image that will be displayed"
+    ></po-input>
+    <po-input
+      class="po-md-6"
+      name="alt"
+      [(ngModel)]="alt"
+      p-clean
+      p-label="Alternate"
+      p-help="Alternative text for image description. Ex.: Po Ui logo"
+    ></po-input>
+    <po-input class="po-md-6" name="height" [(ngModel)]="height" p-clean p-label="Height"></po-input>
+  </div>
+  <hr />
+  <div class="po-row">
+    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"></po-button>
+  </div>
+</form>

--- a/projects/ui/src/lib/components/po-image/samples/sample-po-image-labs/sample-po-image-labs.component.ts
+++ b/projects/ui/src/lib/components/po-image/samples/sample-po-image-labs/sample-po-image-labs.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'sample-po-image-labs',
+  templateUrl: './sample-po-image-labs.component.html'
+})
+export class SamplePoImageLabsComponent implements OnInit {
+  alt: string;
+  height: string | number;
+  src: string;
+
+  ngOnInit(): void {
+    this.restore();
+  }
+
+  restore() {
+    this.alt = undefined;
+    this.height = 'auto';
+    this.src = undefined;
+  }
+}

--- a/projects/ui/src/lib/components/po-image/samples/sample-po-image-travel/sample-po-image-travel.component.html
+++ b/projects/ui/src/lib/components/po-image/samples/sample-po-image-travel/sample-po-image-travel.component.html
@@ -1,0 +1,61 @@
+<div class="po-text-center">
+  <div class="po-font-title">Choosing a trip</div>
+</div>
+
+<div class="po-row">
+  <div class="po-md-3">
+    <po-image [p-src]="destinations" p-height="150"> </po-image>
+  </div>
+
+  <div class="po-md-9">
+    <form #bookingForm="ngForm">
+      <div class="po-row">
+        <po-select
+          class="po-md-4"
+          name="destinations"
+          [(ngModel)]="destinations"
+          p-label="Destinos"
+          [p-options]="travelOptions"
+        >
+        </po-select>
+
+        <po-select
+          class="po-md-4"
+          name="children"
+          [(ngModel)]="children"
+          p-label="Children"
+          [p-options]="childrenOptions"
+        >
+        </po-select>
+
+        <po-select class="po-md-4" name="adults" [(ngModel)]="adults" p-label="Adults" [p-options]="adultsOptions">
+        </po-select>
+      </div>
+
+      <div class="po-row">
+        <po-datepicker
+          #datepicker
+          class="po-md-4"
+          name="checkin"
+          [(ngModel)]="checkin"
+          p-label="Check In"
+          p-placeholder="dd/mm/yyyy"
+          p-required
+          [p-max-date]="checkout"
+        >
+        </po-datepicker>
+
+        <po-datepicker
+          class="po-md-4"
+          name="checkout"
+          [(ngModel)]="checkout"
+          p-label="Check Out"
+          p-placeholder="dd/mm/yyyy"
+          p-required
+          [p-min-date]="checkin"
+        >
+        </po-datepicker>
+      </div>
+    </form>
+  </div>
+</div>

--- a/projects/ui/src/lib/components/po-image/samples/sample-po-image-travel/sample-po-image-travel.component.ts
+++ b/projects/ui/src/lib/components/po-image/samples/sample-po-image-travel/sample-po-image-travel.component.ts
@@ -1,0 +1,63 @@
+import { Component, ViewChild } from '@angular/core';
+import { NgForm } from '@angular/forms';
+import { PoDatepickerComponent, PoNotificationService, PoSelectOption } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-image-travel',
+  templateUrl: './sample-po-image-travel.component.html'
+})
+export class SamplePoImageTravelComponent {
+  @ViewChild('bookingForm', { static: true }) form: NgForm;
+  @ViewChild('datepicker', { static: true }) datepickerComponent: PoDatepickerComponent;
+
+  adults: number = 1;
+  checkin: Date;
+  checkout: Date;
+  children: number = 0;
+  hotel: string;
+  destinations: string =
+    'https://images.unsplash.com/photo-1541336032412-2048a678540d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80';
+  filterParams = {};
+
+  readonly adultsOptions: Array<PoSelectOption> = [
+    { label: '1 Adult', value: 1 },
+    { label: '2 Adults', value: 2 },
+    { label: '3 Adults', value: 3 },
+    { label: '4 Adults', value: 4 }
+  ];
+
+  readonly childrenOptions: Array<PoSelectOption> = [
+    { label: 'No Child', value: 0 },
+    { label: '1 Child', value: 1 },
+    { label: '2 Children', value: 2 }
+  ];
+
+  readonly travelOptions: Array<PoSelectOption> = [
+    {
+      label: 'Nova york',
+      value:
+        'https://images.unsplash.com/photo-1541336032412-2048a678540d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80'
+    },
+    {
+      label: 'Bélgica',
+      value:
+        'https://images.unsplash.com/photo-1547057951-61fcf322bb1e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80'
+    },
+    {
+      label: 'Madrid',
+      value:
+        'https://images.unsplash.com/photo-1539037116277-4db20889f2d4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=870&q=80'
+    }
+  ];
+
+  constructor() {}
+
+  restore() {
+    this.adults = 1;
+    this.children = 0;
+    this.checkin = undefined;
+    this.checkout = undefined;
+    this.destinations =
+      'https://images.unsplash.com/photo-1541336032412-2048a678540d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80';
+  }
+}


### PR DESCRIPTION
**PO-IMAGE**

**DTHFUI-6612**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não possui componente de image.

**Qual o novo comportamento?**
Criado componente de image seguindo as definições do AnimaliaDS.

**Simulação**
`html`

```
<po-image 
    p-alt="teste de imagem" 
    p-height="300"
    [p-src]='srcImage' 
    >
</po-image>

<po-image 
    p-alt="teste de imagem" 
    p-height="300"
    [p-src]='srcImage' 
    >
</po-image>
```

`TS`

```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {

srcImage = 'https://images.unsplash.com/photo-1633409361618-c73427e4e206?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=880&q=80'
exAllowed = ['.png', '.jpg', '.gif'];

}
``` 
E portal.

**PRs Adicionais:**
- https://github.com/po-ui/po-style/pull/357


