### PR TITLE
feat(divider): aplica estilo definido pelo DS

### DIFF
--- a/projects/ui/src/lib/components/po-divider/index.ts
+++ b/projects/ui/src/lib/components/po-divider/index.ts
@@ -1,3 +1,4 @@
+export * from './po-divider-size.enum';
 export * from './po-divider.component';
 
 export * from './po-divider.module';

--- a/projects/ui/src/lib/components/po-divider/po-divider-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-divider/po-divider-base.component.spec.ts
@@ -6,4 +6,32 @@ describe('PoDividerComponent:', () => {
   it('should be created', () => {
     expect(component instanceof PoDividerBaseComponent).toBeTruthy();
   });
+
+  it('should set Coordinates to divider small', () => {
+    component.borderWidth = 'small';
+
+    expect(component.coordinateX1).toEqual('0.1%');
+    expect(component.coordinateX2).toEqual('99.9%');
+  });
+
+  it('should set Coordinates to divider small if value invalid', () => {
+    component.borderWidth = 'extra-large';
+
+    expect(component.coordinateX1).toEqual('0.1%');
+    expect(component.coordinateX2).toEqual('99.9%');
+  });
+
+  it('should set Coordinates to divider medium', () => {
+    component.borderWidth = 'medium';
+
+    expect(component.coordinateX1).toEqual('0.2%');
+    expect(component.coordinateX2).toEqual('99.8%');
+  });
+
+  it('should set Coordinates to divider large', () => {
+    component.borderWidth = 'large';
+
+    expect(component.coordinateX1).toEqual('0.3%');
+    expect(component.coordinateX2).toEqual('99.7%');
+  });
 });

--- a/projects/ui/src/lib/components/po-divider/po-divider-base.component.ts
+++ b/projects/ui/src/lib/components/po-divider/po-divider-base.component.ts
@@ -1,4 +1,5 @@
-import { Input, Directive } from '@angular/core';
+import { Input, Directive, OnInit } from '@angular/core';
+import { PoDividerSize } from './po-divider-size.enum';
 
 /**
  * @description
@@ -7,7 +8,51 @@ import { Input, Directive } from '@angular/core';
  * e organização de informações em uma tela e sua característica é semelhante à tag `<hr>`.
  */
 @Directive()
-export class PoDividerBaseComponent {
+export class PoDividerBaseComponent implements OnInit {
+  coordinateX1: string;
+  coordinateX2: string;
+  private _borderWidth: string = PoDividerSize.small;
+
   /** Valor do rótulo a ser exibido. */
   @Input('p-label') label?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a espessura da linha.
+   *
+   * Valores válidos:
+   * - small
+   * - medium
+   * - large
+   *
+   * @default `small`
+   */
+  @Input('p-border-width') set borderWidth(value: string) {
+    this._borderWidth = PoDividerSize[value] ? PoDividerSize[value] : PoDividerSize.small;
+    this.getCoordinates();
+  }
+
+  get borderWidth() {
+    return this._borderWidth;
+  }
+
+  ngOnInit(): void {
+    this.getCoordinates();
+  }
+
+  getCoordinates() {
+    if (this.borderWidth === PoDividerSize.small) {
+      this.coordinateX1 = '0.1%';
+      this.coordinateX2 = '99.9%';
+    } else if (this.borderWidth === PoDividerSize.medium) {
+      this.coordinateX1 = '0.2%';
+      this.coordinateX2 = '99.8%';
+    } else {
+      this.coordinateX1 = '0.3%';
+      this.coordinateX2 = '99.7%';
+    }
+  }
 }

--- a/projects/ui/src/lib/components/po-divider/po-divider-size.enum.ts
+++ b/projects/ui/src/lib/components/po-divider/po-divider-size.enum.ts
@@ -1,0 +1,15 @@
+/**
+ * @usedBy PoDividerComponent
+ *
+ * @description
+ *
+ * Enum para definição da espessura da linha.
+ */
+export enum PoDividerSize {
+  /** A espessura da linha fica com 1px. */
+  small = 'small',
+  /** A espessura da linha fica com 2px. */
+  medium = 'medium',
+  /** A espessura da linha fica com 4px. */
+  large = 'large'
+}

--- a/projects/ui/src/lib/components/po-divider/po-divider.component.html
+++ b/projects/ui/src/lib/components/po-divider/po-divider.component.html
@@ -1,3 +1,6 @@
-<div class="po-divider">
+<div class="po-divider" [attr.p-size]="borderWidth">
   <div *ngIf="label" class="po-divider-label">{{ label }}</div>
+  <svg xmlns="http://www.w3.org/2000/svg">
+    <line [attr.x1]="coordinateX1" y1="50%" [attr.x2]="coordinateX2" y2="50%" />
+  </svg>
 </div>

--- a/projects/ui/src/lib/components/po-divider/samples/sample-po-divider-labs/sample-po-divider-labs.component.html
+++ b/projects/ui/src/lib/components/po-divider/samples/sample-po-divider-labs/sample-po-divider-labs.component.html
@@ -1,8 +1,16 @@
-<po-divider [p-label]="label"></po-divider>
+<po-divider [p-label]="label" [p-border-width]="borderWidth"></po-divider>
 
 <form #f="ngForm">
   <div class="po-row">
     <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+    <po-select
+      class="po-md-6"
+      name="borderWidth"
+      [(ngModel)]="borderWidth"
+      p-label="Border width"
+      [p-options]="borderWidthList"
+    >
+    </po-select>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-divider/samples/sample-po-divider-labs/sample-po-divider-labs.component.ts
+++ b/projects/ui/src/lib/components/po-divider/samples/sample-po-divider-labs/sample-po-divider-labs.component.ts
@@ -1,11 +1,20 @@
 import { Component, OnInit } from '@angular/core';
 
+import { PoSelectOption } from '@po-ui/ng-components';
+
 @Component({
   selector: 'sample-po-divider-labs',
   templateUrl: './sample-po-divider-labs.component.html'
 })
 export class SamplePoDividerLabsComponent implements OnInit {
+  borderWidth: string;
   label: string;
+
+  public readonly borderWidthList: Array<PoSelectOption> = [
+    { label: 'small', value: 'small' },
+    { label: 'medium', value: 'medium' },
+    { label: 'large', value: 'large' }
+  ];
 
   ngOnInit() {
     this.restore();
@@ -13,5 +22,6 @@ export class SamplePoDividerLabsComponent implements OnInit {
 
   restore() {
     this.label = undefined;
+    this.borderWidth = undefined;
   }
 }


### PR DESCRIPTION
**divider**

**DTHFUI-6663**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)



**Simulação**
style: https://github.com/po-ui/po-style/pull/358
totvs: https://github.com/totvs/po-theme-totvs/pull/189


testar portal e app:

```
<po-page-default>
  <po-divider></po-divider>

<po-divider p-border-width="small"></po-divider>
<po-divider p-border-width="medium"></po-divider>
<po-divider p-border-width="large"></po-divider>


<po-divider p-label="default"></po-divider>
<po-divider p-label="small" p-border-width="small"></po-divider>
<po-divider p-label="medium" p-border-width="medium"></po-divider>
<po-divider p-label="large" p-border-width="large"></po-divider>

</po-page-default>

```

custom: 
```
po-divider {
  --color: red;
  --stroke-linecap: square;
  --color-divider-label-color: blue;
}

```