### PR TITLE
feat(dynamic-form): adiciona po-upload

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-type.enum.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-type.enum.ts
@@ -21,9 +21,12 @@ export enum PoDynamicFieldType {
   /** Utilizado para informar/exibir hora. */
   Time = 'time',
 
-  /** Valor númerico. */
+  /** Valor numérico. */
   Number = 'number',
 
   /** Texto. */
-  String = 'string'
+  String = 'string',
+
+  /** Utilizado para fazer uploads de arquivos. */
+  Upload = 'upload'
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -92,7 +92,7 @@ export interface PoDynamicFormField extends PoDynamicField {
    * Máscara para o campo.
    *
    * **Componentes compatíveis:** `po-input`.
-   > também é atribuído ao utilizar a propriedade `type: time`.
+   * > também é atribuído ao utilizar a propriedade `type: time`.
    */
   mask?: string;
 
@@ -100,7 +100,7 @@ export interface PoDynamicFormField extends PoDynamicField {
    * Define que o valor do componente será conforme especificado na mascára. O valor padrão é `false`.
    *
    * **Componentes compatíveis:** `po-input`.
-   > também é atribuído ao utilizar a propriedade `type: time`.
+   * > também é atribuído ao utilizar a propriedade `type: time`.
    * */
   maskFormatModel?: boolean;
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -9,7 +9,9 @@ import {
   PoLookupLiterals,
   PoMultiselectFilterMode,
   PoMultiselectLiterals,
-  PoSwitchLabelPosition
+  PoSwitchLabelPosition,
+  PoUploadLiterals,
+  PoUploadFileRestrictions
 } from '../../po-field';
 import { PoLookupAdvancedFilter } from '../../po-field/po-lookup/interfaces/po-lookup-advanced-filter.interface';
 import { PoLookupColumn } from '../../po-field/po-lookup/interfaces/po-lookup-column.interface';
@@ -348,7 +350,7 @@ export interface PoDynamicFormField extends PoDynamicField {
   /**
    * Permite a seleção de múltiplos itens.
    *
-   * **Componente compatível:** `po-lookup`
+   * **Componente compatível:** `po-lookup`, `po-upload`
    */
   multiple?: boolean;
 
@@ -366,7 +368,7 @@ export interface PoDynamicFormField extends PoDynamicField {
   noAutocomplete?: boolean;
 
   /**
-   * Posição de exibição do rótulo do PoSwich.
+   * Posição de exibição do rótulo do PoSwitch.
    * > Por padrão exibe à direita.
    */
   labelPosition?: PoSwitchLabelPosition;
@@ -392,7 +394,7 @@ export interface PoDynamicFormField extends PoDynamicField {
    *
    * **Componentes compatíveis:** `po-lookup`, `po-multiselect`, `po-combo`, `po-datepicker-range`
    */
-  literals?: PoLookupLiterals | PoMultiselectLiterals | PoComboLiterals | PoDatepickerRangeLiterals;
+  literals?: PoLookupLiterals | PoMultiselectLiterals | PoComboLiterals | PoDatepickerRangeLiterals | PoUploadLiterals;
 
   /**
    * Se verdadeiro ativa a funcionalidade de scroll infinito para o combo ou lookup, ao chegar ao fim da tabela executará nova busca dos dados conforme paginação.
@@ -525,4 +527,128 @@ export interface PoDynamicFormField extends PoDynamicField {
    * **Componentes compatíveis**: `po-lookup`
    */
   columnRestoreManager?: Function;
+
+  /**
+   * URL que deve ser feita a requisição com os arquivos selecionados.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  url?: string;
+
+  /**
+   * Define se o envio do arquivo será automático ao selecionar o mesmo.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  autoUpload?: boolean;
+
+  /**
+   * Permite a seleção de diretórios contendo um ou mais arquivos para envio.
+   *
+   * > A habilitação desta propriedade se restringe apenas à seleção de diretórios.
+   *
+   * > Definição não suportada pelo browser **Internet Explorer**, todavia será possível a seleção de arquivos padrão.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  directory?: boolean;
+
+  /**
+   * Exibe a área onde é possível arrastar e selecionar os arquivos. Quando estiver definida, omite o botão para seleção de arquivos
+   * automaticamente.
+   *
+   * > Recomendamos utilizar apenas um `po-upload` com esta funcionalidade por tela.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  dragDrop?: boolean;
+
+  /**
+   * Define em *pixels* a altura da área onde podem ser arrastados os arquivos. A altura mínima aceita é `160px`.
+   *
+   * > Esta propriedade funciona somente se a propriedade `p-drag-drop` estiver habilitada.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  dragDropHeight?: number;
+
+  /**
+   * Objeto que segue a definição da interface `PoUploadFileRestrictions`,
+   * que possibilita definir tamanho máximo/mínimo e extensão dos arquivos permitidos.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  restrictions?: PoUploadFileRestrictions;
+
+  /**
+   * Objeto que contém os cabeçalhos que será enviado na requisição dos arquivos.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  headers?: { [name: string]: string | Array<string> };
+
+  /**
+   * Oculta visualmente as informações de restrições para o upload.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  hideRestrictionsInfo?: boolean;
+
+  /**
+   * Omite o botão de seleção de arquivos.
+   *
+   * > Caso o valor definido seja `true`, caberá ao desenvolvedor a responsabilidade
+   * pela chamada do método `selectFiles()` para seleção de arquivos.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  hideSelectButton?: boolean;
+
+  /**
+   * Omite o botão de envio de arquivos.
+   *
+   * > Caso o valor definido seja `true`, caberá ao desenvolvedor a responsabilidade
+   * pela chamada do método `sendFiles()` para envio do(s) arquivo(s) selecionado(s).
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  hideSendButton?: boolean;
+
+  /**
+   * Define se a indicação de campo obrigatório será exibida.
+   *
+   * > Não será exibida a indicação se:
+   * - Não possuir `p-help` e/ou `p-label`.
+   */
+  showRequired?: boolean;
+
+  /**
+   * Evento será disparado quando ocorrer algum erro no envio do arquivo.
+   * > Por parâmetro será passado o objeto do retorno que é do tipo `HttpErrorResponse`.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  onError?: Function;
+
+  /**
+   * Evento será disparado quando o envio do arquivo for realizado com sucesso.
+   * > Por parâmetro será passado o objeto do retorno que é do tipo `HttpResponse`.
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  onSuccess?: Function;
+
+  /**
+   * Função que será executada no momento de realizar o envio do arquivo,
+   * onde será possível adicionar informações ao parâmetro que será enviado na requisição.
+   * É passado por parâmetro um objeto com o arquivo e a propriedade data nesta propriedade pode ser informado algum dado,
+   * que será enviado em conjunto com o arquivo na requisição, por exemplo:
+   *
+   * ```
+   *   event.data = {id: 'id do usuário'};
+   * ```
+   *
+   * **Componente compatível**: `po-upload`
+   */
+  onUpload?: Function;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -667,6 +667,26 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         expect(component['getComponentControl'](field)).toBe(expectedValue);
         expect(component['verifyforceOptionComponent']).toHaveBeenCalled();
       });
+
+      it('should return `upload` if type is `upload` and has a `url`', () => {
+        const expectedValue = 'upload';
+        const field = { type: 'upload', property: 'upload', url: 'http://fakeurl.com' };
+
+        spyOn(component, <any>'isUpload').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isUpload']).toHaveBeenCalled();
+      });
+
+      it("should return `input` if type is `upload` and hasn't a `url`", () => {
+        const expectedValue = 'input';
+        const field = { type: 'upload', property: 'upload' };
+
+        spyOn(component, <any>'isUpload').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isUpload']).toHaveBeenCalled();
+      });
     });
 
     it('isCombo: should return `true` if `optionsService` is defined string', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -65,7 +65,7 @@ export class PoDynamicFormFieldsBaseComponent {
     return value === compareTo;
   }
 
-  // retorna um array com os objetos configurados e visiveis.
+  // retorna um array com os objetos configurados e visíveis.
   protected getVisibleFields() {
     const visibleFields = [];
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -184,6 +184,8 @@ export class PoDynamicFormFieldsBaseComponent {
       return 'textarea';
     } else if (this.isPassword(field)) {
       return 'password';
+    } else if (this.isUpload(field)) {
+      return 'upload';
     }
 
     return 'input';
@@ -247,6 +249,12 @@ export class PoDynamicFormFieldsBaseComponent {
     const { optionsMulti, options } = field;
 
     return !optionsMulti && !!options && options.length <= 3;
+  }
+
+  private isUpload(field: PoDynamicFormField) {
+    const { url, type } = field;
+
+    return url && type === 'upload';
   }
 
   private verifyforceOptionComponent(field: PoDynamicFormField) {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -354,5 +354,37 @@
       [p-placeholder]="field.placeholder"
     >
     </po-password>
+
+    <po-upload
+      #component
+      *ngIf="compareTo(field.control, 'upload')"
+      [(ngModel)]="value[field.property]"
+      [ngClass]="field.componentClass"
+      [p-auto-upload]="field.autoUpload"
+      [p-directory]="field.directory"
+      [p-disabled]="isDisabled(field)"
+      [p-drag-drop]="field.dragDrop"
+      [p-drag-drop-height]="field.dragDropHeight"
+      [p-restrictions]="field.restrictions"
+      [p-headers]="field.headers"
+      [p-help]="field.help"
+      [p-hide-restrictions-info]="field.hideRestrictionsInfo"
+      [p-hide-select-button]="field.hideSelectButton"
+      [p-hide-send-button]="field.hideSendButton"
+      [p-multiple]="field.multiple"
+      [p-label]="field.label"
+      [p-literals]="field.literals"
+      [name]="field.property"
+      (p-error)="field.onError($event)"
+      (p-success)="field.onSuccess($event)"
+      (p-upload)="field.onUpload($event)"
+      [p-optional]="field.optional"
+      [p-required]="field.required"
+      [p-show-required]="field.showRequired"
+      (p-change)="onChangeField(field)"
+      (p-change-model)="onChangeFieldModel(field)"
+      [p-url]="field.url"
+    >
+    </po-upload>
   </ng-container>
 </div>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -159,6 +159,15 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
         { console: 'Xbox Series S|X', code: 'XSSX' }
       ],
       optionsMulti: true
+    },
+    {
+      property: 'image',
+      type: 'upload',
+      gridColumns: 12,
+      gridSmColumns: 12,
+      label: 'Upload your background',
+      optional: true,
+      url: 'https://po-sample-api.fly.dev/v1/uploads/addFile'
     }
   ];
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -205,7 +205,7 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    */
   @Input('p-optional') optional: boolean;
 
-  /** Objeto que contém os cabeçalhos que será enviado na requisição dos arquvios. */
+  /** Objeto que contém os cabeçalhos que será enviado na requisição dos arquivos. */
   @Input('p-headers') headers: { [name: string]: string | Array<string> };
 
   /**
@@ -215,11 +215,11 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * Função que será executada no momento de realizar o envio do arquivo,
    * onde será possível adicionar informações ao parâmetro que será enviado na requisição.
-   * É passado por parâmetro um objeto com o arquivo e a propiedade data nesta propriedade pode ser informado algum dado,
+   * É passado por parâmetro um objeto com o arquivo e a propriedade data nesta propriedade pode ser informado algum dado,
    * que será enviado em conjunto com o arquivo na requisição, por exemplo:
    *
    * ```
-   *   event.data = {id: 'id do usuario'};
+   *   event.data = {id: 'id do usuário'};
    * ```
    */
   @Output('p-upload') onUpload: EventEmitter<any> = new EventEmitter<any>();


### PR DESCRIPTION
**DYNAMIC-FORM**

**DTHFUI-3223**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não era possível utilizar o componente `po-upload` dentro do `po-dynamic-form`.

**Qual o novo comportamento?**
Agora é possível utilizar o componente `po-upload` dentro do `po-dynamic-form` junto com todas as suas propriedades.

**Simulação**
Verificar no Portal e utilizar o seguinte [App.zip](https://github.com/po-ui/po-angular/files/9873602/app.zip)
