### PR TITLE
fix(upload): ajusta funcionamento do método clear

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
@@ -353,6 +353,7 @@ describe('PoUploadComponent:', () => {
       component.currentFiles = fileMock;
       spyOn(component, <any>'updateModel');
       spyOn(component, <any>'cleanInputValue');
+      spyOn(component['cd'], 'detectChanges');
 
       component.clear();
 
@@ -692,6 +693,7 @@ describe('PoUploadComponent:', () => {
     });
 
     it('cleanInputValue: should set input value to whitespace and set `calledByCleanInputValue` to true', () => {
+      spyOn(component['cd'], <any>'detectChanges');
       const calledByCleanInputValue = 'calledByCleanInputValue';
 
       component[calledByCleanInputValue] = false;
@@ -699,6 +701,7 @@ describe('PoUploadComponent:', () => {
 
       expect(component['inputFile'].nativeElement.value).toBe('');
       expect(component[calledByCleanInputValue]).toBeTruthy();
+      expect(component['cd'].detectChanges).toHaveBeenCalled();
     });
 
     it('updateFiles: should call `parseFiles` with `files` and `updateModel` with `currentFiles`', () => {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
@@ -335,6 +335,7 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
   private cleanInputValue() {
     this.calledByCleanInputValue = true;
     this.inputFile.nativeElement.value = '';
+    this.cd.detectChanges();
   }
 
   // função disparada na resposta do sucesso ou error


### PR DESCRIPTION
**< Po-upload >**

**< DTHFUI-6347 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
o método clear (Método responsável por limpar os arquivos selecionados) não está limpando os arquivos do po-upload

**Qual o novo comportamento?**
Limpa os arquivos selecionados conforme o esperado quando utiliza o método clear()

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/9878916/app.zip)
