### PR TITLE
docs(lookup): atualiza url base da API

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-basic/sample-po-lookup-basic.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-basic/sample-po-lookup-basic.component.html
@@ -2,7 +2,7 @@
   name="lookup"
   p-field-label="label"
   p-field-value="value"
-  p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
+  p-filter-service="https://po-sample-api.fly.dev/v1/heroes"
   p-label="PO Lookup"
 >
 </po-lookup>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -79,7 +79,7 @@
       name="filterService"
       [(ngModel)]="filterService"
       p-clean
-      p-help="https://po-sample-api.herokuapp.com/v1/people"
+      p-help="https://po-sample-api.fly.dev/v1/people"
       p-label="Filter Service"
     >
     </po-input>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.component.html
@@ -5,7 +5,7 @@
     [(ngModel)]="multiLookup"
     p-field-label="label"
     p-field-value="value"
-    p-filter-service="https://po-sample-api.herokuapp.com/v1/heroes"
+    p-filter-service="https://po-sample-api.fly.dev/v1/heroes"
     p-label="Search a Hero"
     [p-multiple]="true"
     (p-change)="changeOptions($event)"

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.service.ts
@@ -11,6 +11,6 @@ export class SamplePoLookupMultipleService {
 
   getHeroes(data): Observable<any> {
     const values = data?.length ? data.toString() : data;
-    return this.http.get(`https://po-sample-api.herokuapp.com/v1/heroes?value=${values}`).pipe(pluck('items'));
+    return this.http.get(`https://po-sample-api.fly.dev/v1/heroes?value=${values}`).pipe(pluck('items'));
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup.service.ts
@@ -7,7 +7,7 @@ import { PoLookupFilter, PoLookupFilteredItemsParams } from '@po-ui/ng-component
 
 @Injectable()
 export class SamplePoLookupService implements PoLookupFilter {
-  private url = 'https://po-sample-api.herokuapp.com/v1/heroes';
+  private url = 'https://po-sample-api.fly.dev/v1/heroes';
 
   constructor(private httpClient: HttpClient) {}
 


### PR DESCRIPTION
Alteramos o servidor do projeto po-sample-api do heroku para o fly.io, portanto se faz necessário a troca da url base das API's.

Fixes #1452

**Lookup**

**1452**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O projeto usa a API po-sample-api do heroku,

**Qual o novo comportamento?**
O projeto vai usar a API po-sample-api do fly.io,

**Simulação**
Pode ser feita no portal