### PR TITLE
docs(page-dynamic-table): atualiza url base da API

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-basic/sample-po-page-dynamic-table-basic.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-basic/sample-po-page-dynamic-table-basic.component.html
@@ -1,2 +1,2 @@
-<po-page-dynamic-table p-title="Po Page Dynamic Table" p-service-api="https://po-sample-api.herokuapp.com/v1/people">
+<po-page-dynamic-table p-title="Po Page Dynamic Table" p-service-api="https://po-sample-api.fly.dev/v1/people">
 </po-page-dynamic-table>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.ts
@@ -14,7 +14,7 @@ import {
 export class SamplePoPageDynamicTableHotelsComponent {
   @ViewChild('hotelDetailModal') hotelDetailModal!: PoModalComponent;
 
-  readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/hotels';
+  readonly serviceApi = 'https://po-sample-api.fly.dev/v1/hotels';
 
   actionsRight = true;
   detailedHotel: any;

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   templateUrl: './sample-po-page-dynamic-table-people.component.html'
 })
 export class SamplePoPageDynamicTablePeopleComponent {
-  readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+  readonly serviceApi = 'https://po-sample-api.fly.dev/v1/people';
 
   readonly fields: Array<any> = [
     { property: 'id', key: true, visible: false },

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -20,7 +20,7 @@ export class SamplePoPageDynamicTableUsersComponent {
   @ViewChild('userDetailModal') userDetailModal!: PoModalComponent;
   @ViewChild('dependentsModal') dependentsModal!: PoModalComponent;
 
-  readonly serviceApi = 'https://po-sample-api.herokuapp.com/v1/people';
+  readonly serviceApi = 'https://po-sample-api.fly.dev/v1/people';
 
   actionsRight = false;
   detailedUser: any;


### PR DESCRIPTION
Alteramos o servidor do projeto po-sample-api do heroku para o fly.io, portanto se faz necessário a troca da url base das API's.

Fixes #1433

**Page Dynamic Table**

**1433**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O projeto usa a API do po-sample-api do heroku.

**Qual o novo comportamento?**
O projeto passa a usar a API po-sample-api do fly.io.

**Simulação**
Pode ser feita no portal