### PR TITLE
feat(dynamic-form): adiciona escolha entre `po-switch` ou `po-checkbox`

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-force-component.enum.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-force-component.enum.ts
@@ -5,6 +5,21 @@
  *
  * Enum para definição do tipo de componente a ser renderizado.
  */
+export enum ForceBooleanComponentEnum {
+  /** Força a renderização de um po-switch */
+  switch = 'switch',
+
+  /** Força a renderização de um po-checkbox */
+  checkbox = 'checkbox'
+}
+
+/**
+ * @usedBy PoDynamicFormComponent
+ *
+ * @description
+ *
+ * Enum para definição do tipo de componente a ser renderizado.
+ */
 export enum ForceOptionComponentEnum {
   /** Força a renderização de um po-radio-group independente da quantidade do opções */
   radioGroup = 'radioGroup',

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -17,7 +17,7 @@ import { PoLookupAdvancedFilter } from '../../po-field/po-lookup/interfaces/po-l
 import { PoLookupColumn } from '../../po-field/po-lookup/interfaces/po-lookup-column.interface';
 import { PoMultiselectOption } from '../../po-field/po-multiselect/po-multiselect-option.interface';
 import { PoSelectOption } from '../../po-field/po-select/po-select-option.interface';
-import { ForceOptionComponentEnum } from '../po-dynamic-field-force-component.enum';
+import { ForceBooleanComponentEnum, ForceOptionComponentEnum } from '../po-dynamic-field-force-component.enum';
 
 import { PoDynamicField } from '../po-dynamic-field.interface';
 
@@ -497,6 +497,15 @@ export interface PoDynamicFormField extends PoDynamicField {
    * `url + ?page=1&pageSize=20&name=Tony%20Stark,Peter%20Parker,Gohan`
    */
   advancedFilters?: Array<PoLookupAdvancedFilter>;
+
+  /**
+   * Valores aceitos:
+   * - ForceBooleanComponentEnum.switch
+   * - ForceBooleanComponentEnum.checkbox
+   *
+   */
+  forceBooleanComponentType?: ForceBooleanComponentEnum;
+
   /**
    * pode ser utilizada em conjunto com a propriedade `options` forçando o componente a renderizar um `po-select` ou `po-radio-group`.
    *

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -7,7 +7,7 @@ import * as PoDynamicUtil from '../../po-dynamic.util';
 import { PoDynamicFieldType } from '../../po-dynamic-field-type.enum';
 import { PoDynamicFormFieldsBaseComponent } from './po-dynamic-form-fields-base.component';
 import { PoDynamicFormField } from '../po-dynamic-form-field.interface';
-import { ForceOptionComponentEnum } from '../../po-dynamic-field-force-component.enum';
+import { ForceBooleanComponentEnum, ForceOptionComponentEnum } from '../../po-dynamic-field-force-component.enum';
 
 describe('PoDynamicFormFieldsBaseComponent:', () => {
   let component: PoDynamicFormFieldsBaseComponent;
@@ -609,6 +609,16 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         expect(component['getComponentControl'](field)).toBe(expectedValue);
       });
 
+      it('should return checkbox if `forceBooleanComponentType` is checkbox', () => {
+        const expectedValue = ForceBooleanComponentEnum.checkbox;
+        const field: PoDynamicFormField = {
+          property: 'test',
+          forceBooleanComponentType: ForceBooleanComponentEnum.checkbox
+        };
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+      });
+
       it('should return select if `forceOptionsComponentType` is select', () => {
         const expectedValue = ForceOptionComponentEnum.select;
         const field: PoDynamicFormField = {
@@ -630,10 +640,10 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
           ]
         };
 
-        spyOn(component, <any>'verifyforceOptionComponent').and.callThrough();
+        spyOn(component, <any>'verifyForceOptionComponent').and.callThrough();
 
         expect(component['getComponentControl'](field)).toBe(expectedValue);
-        expect(component['verifyforceOptionComponent']).toHaveBeenCalled();
+        expect(component['verifyForceOptionComponent']).toHaveBeenCalled();
       });
 
       it('shouldn`t return select if `forceOptionsComponentType` is select but optionsMulti is true', () => {
@@ -662,10 +672,10 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
           ]
         };
 
-        spyOn(component, <any>'verifyforceOptionComponent').and.callThrough();
+        spyOn(component, <any>'verifyForceOptionComponent').and.callThrough();
 
         expect(component['getComponentControl'](field)).toBe(expectedValue);
-        expect(component['verifyforceOptionComponent']).toHaveBeenCalled();
+        expect(component['verifyForceOptionComponent']).toHaveBeenCalled();
       });
 
       it('should return `upload` if type is `upload` and has a `url`', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -150,7 +150,13 @@ export class PoDynamicFormFieldsBaseComponent {
   private getComponentControl(field: PoDynamicFormField = <any>{}) {
     const type = field && field.type ? field.type.toLocaleLowerCase() : 'string';
 
-    const forceOptionComponent = this.verifyforceOptionComponent(field);
+    const { forceBooleanComponentType } = field;
+    const forceOptionComponent = this.verifyForceOptionComponent(field);
+
+    if (forceBooleanComponentType) {
+      return forceBooleanComponentType;
+    }
+
     if (forceOptionComponent) {
       const { forceOptionsComponentType } = field;
       return forceOptionsComponentType;
@@ -257,7 +263,7 @@ export class PoDynamicFormFieldsBaseComponent {
     return url && type === 'upload';
   }
 
-  private verifyforceOptionComponent(field: PoDynamicFormField) {
+  private verifyForceOptionComponent(field: PoDynamicFormField) {
     const { optionsMulti, optionsService, forceOptionsComponentType } = field;
 
     if (forceOptionsComponentType && !optionsMulti && !optionsService) {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -190,6 +190,20 @@
     >
     </po-switch>
 
+    <po-checkbox
+      #component
+      *ngIf="compareTo(field.control, 'checkbox')"
+      [name]="field.property"
+      [(ngModel)]="value[field.property]"
+      [ngClass]="field.componentClass"
+      [p-auto-focus]="field.focus"
+      [p-disabled]="isDisabled(field)"
+      [p-label]="field.label"
+      [p-size]="field.size"
+      (p-change)="onChangeField(field)"
+    >
+    </po-checkbox>
+
     <po-combo
       #component
       *ngIf="compareTo(field.control, 'combo')"

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.html
@@ -9,6 +9,8 @@
 >
 </po-dynamic-form>
 
+<br />
+
 <div class="po-row">
   <po-button
     class="po-md-3"

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -4,7 +4,8 @@ import {
   PoDynamicFormField,
   PoDynamicFormFieldChanged,
   PoDynamicFormValidation,
-  PoNotificationService
+  PoNotificationService,
+  ForceBooleanComponentEnum
 } from '@po-ui/ng-components';
 import { PoDynamicFormRegisterService } from './sample-po-dynamic-form-register.service';
 
@@ -159,6 +160,13 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
         { console: 'Xbox Series S|X', code: 'XSSX' }
       ],
       optionsMulti: true
+    },
+    {
+      property: 'agree',
+      gridColumns: 12,
+      label: 'Do you agree?',
+      type: 'boolean',
+      forceBooleanComponentType: ForceBooleanComponentEnum.checkbox
     },
     {
       property: 'image',


### PR DESCRIPTION
O usuário poderá escolher entre um `po-checkbox` ou um `po-switch` para exibição dentro de um `po-dynamic-form`.

Fixes #1420, DTHFUI-5286

**Dynamic Form**

**1420**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O tipo `boolean` renderiza somente o `po-switch`.

**Qual o novo comportamento?**
O usuário poderá escolher entre um `po-checkbox` ou um `po-switch` para exibição dentro de um `po-dynamic-form`.


**Simulação**
Pode ser feito no portal ou pelo [App](https://github.com/po-ui/po-angular/files/9883275/app.zip).
