### PR TITLE
feat(po-table): adiciona `boolean` em `PoTableColumnLabel`

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
@@ -27,7 +27,9 @@ describe('PoTableColumnLabelComponent:', () => {
     labels = [
       { value: 'success', label: 'Success', color: 'color-11' },
       { value: 'warning', label: 'Warning', color: 'color-08' },
-      { value: 1, label: 'Danger', color: 'color-07' }
+      { value: 1, label: 'Danger', color: 'color-07' },
+      { value: true, label: 'Success', color: 'color-11' },
+      { value: false, label: 'Warning', color: 'color-08' }
     ];
   });
 

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
@@ -41,5 +41,5 @@ export interface PoTableColumnLabel {
   tooltip?: string;
 
   /** Valor que será usado como referência para exibição do conteúdo na coluna. */
-  value: string | number;
+  value: string | number | boolean;
 }


### PR DESCRIPTION
**po-table**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente não permite passar valores do tipo boolean para propriedade labels quando o strict mode está ativado.

**Qual o novo comportamento?**
O componente agora aceita passar valores do tipo boolean para propriedade labels quando o strict mode está ativado.

**Simulação**
Utilizar os samples do Portal.
