### PR TITLE
feat(page-job-scheduler): adiciona funcionalidade de template na parametrização

### DIFF
--- a/projects/templates/src/lib/components/po-page-job-scheduler/index.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/index.ts
@@ -3,3 +3,5 @@ export * from './po-page-job-scheduler.component';
 export * from './po-page-job-scheduler.module';
 
 export * from './interfaces/po-job-scheduler.interface';
+
+export * from './po-page-job-scheduler-parameters';

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-execution/po-page-job-scheduler-execution.component.html
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-execution/po-page-job-scheduler-execution.component.html
@@ -98,7 +98,7 @@
 
   <ng-template #lookupProcessesID>
     <po-lookup
-      *ngIf="noParameters"
+      *ngIf="noParameters && noCustomParamsComponent"
       class="po-md-12"
       name="processID"
       [(ngModel)]="value.processID"

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-execution/po-page-job-scheduler-execution.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-execution/po-page-job-scheduler-execution.component.ts
@@ -25,6 +25,7 @@ export class PoPageJobSchedulerExecutionComponent implements OnInit, AfterViewIn
   @Input('p-literals') literals = <any>{};
 
   @Input('p-no-parameters') noParameters: Boolean = true;
+  @Input('p-no-custom-params-component') noCustomParamsComponent: Boolean = true;
 
   @Output('p-change-process') changeProcess: EventEmitter<any> = new EventEmitter<any>();
 
@@ -89,7 +90,7 @@ export class PoPageJobSchedulerExecutionComponent implements OnInit, AfterViewIn
       weekly: this.weeklyTempalte
     };
 
-    if (this.noParameters) {
+    if (this.noParameters && this.noCustomParamsComponent) {
       this.checkExistsProcessesAPI();
     }
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/index.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/index.ts
@@ -1,0 +1,1 @@
+export * from './po-job-scheduler-parameters-template';

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-job-scheduler-parameters-template/index.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-job-scheduler-parameters-template/index.ts
@@ -1,0 +1,1 @@
+export * from './po-job-scheduler-parameters-template.directive';

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-job-scheduler-parameters-template/po-job-scheduler-parameters-template.directive.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-job-scheduler-parameters-template/po-job-scheduler-parameters-template.directive.spec.ts
@@ -1,0 +1,9 @@
+import { PoJobSchedulerParametersTemplateDirective } from './po-job-scheduler-parameters-template.directive';
+
+describe('PoComboOptionTemplateDirective:', () => {
+  const component = new PoJobSchedulerParametersTemplateDirective(null);
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-job-scheduler-parameters-template/po-job-scheduler-parameters-template.directive.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-job-scheduler-parameters-template/po-job-scheduler-parameters-template.directive.ts
@@ -1,0 +1,58 @@
+import { Directive, Input, TemplateRef } from '@angular/core';
+
+/**
+ * @usedBy PoPageJobScheduler
+ *
+ * @description
+ *
+ * Esta diretiva permite personalizar o conteúdo da etapa de parametrização do componente de PoPageJobScheduler.
+ *
+ *
+ * Para repassar as alterações realizadas no componente customizado ao model do PoPageJobScheduler, deve
+ * ser atualizado os valores através da propriedade p-execution-parameter. Dessa forma as alterações serão adicionadas ao
+ * atributo executionParameter do objeto de envio a Api.
+ * É possível também controlar a permissão de avançar, fazendo uso da propriedade p-disable-advance.
+ *
+ * ```
+ * ...
+ * <po-page-job-scheduler [p-service-api]="serviceApi">
+ *     <ng-template p-combo-option-template [p-execution-parameter]="executionParameter" [p-disable-advance]="disableAdvance">
+ *       <option-template [option]="option"></option-template>
+ *     </ng-template>
+ * </po-page-job-scheduler>
+ * ...
+ * ```
+ *
+ */
+@Directive({
+  selector: '[p-job-scheduler-parameters-template]'
+})
+export class PoJobSchedulerParametersTemplateDirective {
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Objeto que deve conter as alterações feitas pelo componente de template que serão repassadas dentro do atributo
+   * `executionParameter` para envio na api.
+   *
+   * > O componente deve manter essa propriedade atualizada. É chamada após o avançar da etapa de parametrização.
+   */
+  @Input('p-execution-parameter') executionParameter: Object;
+
+  /**
+   * @optional
+   *
+   * @default false
+   *
+   * @description
+   *
+   * Determina se deve desabilitar o botão de avançar para a próxima etapa
+   *
+   * > Pode ser utilizado para validar campos antes de avançar.
+   */
+  @Input('p-disable-advance') disabledAdvance: boolean = false;
+
+  // Necessário manter templateRef para o funcionamento do row template.
+  constructor(public templateRef: TemplateRef<any>) {}
+}

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.html
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.html
@@ -1,4 +1,10 @@
-<ng-container *ngIf="parameters && parameters.length; then formFieldsTemplate; else parametersNotFoundTemplate">
+<ng-container
+  *ngIf="
+    parameters && parameters.length;
+    then formFieldsTemplate;
+    else (parametersTemplate?.templateRef && templateContent) || parametersNotFoundTemplate
+  "
+>
 </ng-container>
 
 <ng-template #parametersNotFoundTemplate>
@@ -15,3 +21,5 @@
     <po-dynamic-form p-group-form [p-fields]="parameters" [p-value]="value"> </po-dynamic-form>
   </form>
 </ng-template>
+
+<ng-template #templateContent [ngTemplateOutlet]="parametersTemplate?.templateRef"> </ng-template>

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChild } from
 import { NgForm } from '@angular/forms';
 
 import { PoDynamicFormField } from '@po-ui/ng-components';
+import { PoJobSchedulerParametersTemplateDirective } from './po-job-scheduler-parameters-template';
 
 @Component({
   selector: 'po-page-job-scheduler-parameters',
@@ -13,6 +14,8 @@ export class PoPageJobSchedulerParametersComponent implements AfterViewInit {
   @Input('p-literals') literals = <any>{};
 
   @Input('p-parameters') parameters: Array<PoDynamicFormField> = [];
+
+  @Input('p-template') parametersTemplate: PoJobSchedulerParametersTemplateDirective;
 
   @Input('p-value') value;
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.html
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.html
@@ -15,6 +15,7 @@
         <div class="po-row">
           <po-page-job-scheduler-execution
             [p-no-parameters]="parametersEmpty"
+            [p-no-custom-params-component]="!parametersTemplate?.templateRef"
             [hidden]="step !== 1"
             #schedulerExecution
             class="po-md-12"
@@ -26,12 +27,14 @@
           </po-page-job-scheduler-execution>
 
           <po-page-job-scheduler-parameters
-            *ngIf="step === 2"
+            *ngIf="stepParametersInitialized"
+            [hidden]="step !== 2"
             #schedulerParameters
             class="po-md-12"
             [p-literals]="literals"
             [p-parameters]="parameters || []"
             [(p-value)]="model.executionParameter"
+            [p-template]="parametersTemplate"
           >
           </po-page-job-scheduler-parameters>
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
@@ -218,7 +218,8 @@ describe('PoPageJobSchedulerComponent:', () => {
           markAsDirtyInvalidControls: () => {},
           changePageActionsBySteps: () => {},
           setModelRecurrent: () => {},
-          hidesSecretValues: () => {}
+          hidesSecretValues: () => {},
+          templateHasDisable: () => false
         };
       });
 
@@ -485,7 +486,8 @@ describe('PoPageJobSchedulerComponent:', () => {
             form: {
               invalid: true
             }
-          }
+          },
+          templateHasDisable: () => false
         };
 
         expect(component['isDisabledAdvance'].call(fakeThis)).toBe(true);
@@ -494,7 +496,8 @@ describe('PoPageJobSchedulerComponent:', () => {
       it(`should return 'false' if 'step' is 2 and 'schedulerParameters' is undefined`, () => {
         const fakeThis = {
           step: 2,
-          schedulerParameters: undefined
+          schedulerParameters: undefined,
+          templateHasDisable: () => false
         };
 
         expect(component['isDisabledAdvance'].call(fakeThis)).toBe(false);
@@ -507,7 +510,8 @@ describe('PoPageJobSchedulerComponent:', () => {
             form: {
               invalid: true
             }
-          }
+          },
+          templateHasDisable: () => false
         };
 
         expect(component['isDisabledAdvance'].call(fakeThis)).toBe(true);
@@ -516,7 +520,8 @@ describe('PoPageJobSchedulerComponent:', () => {
       it(`should return 'false' if 'step' is 1 and 'schedulerExecution' is undefined`, () => {
         const fakeThis = {
           step: 1,
-          schedulerExecution: undefined
+          schedulerExecution: undefined,
+          templateHasDisable: () => false
         };
 
         expect(component['isDisabledAdvance'].call(fakeThis)).toBe(false);
@@ -526,10 +531,21 @@ describe('PoPageJobSchedulerComponent:', () => {
         const fakeThis = {
           step: undefined,
           schedulerExecution: undefined,
-          schedulerParameters: undefined
+          schedulerParameters: undefined,
+          templateHasDisable: () => false
         };
 
         expect(component['isDisabledAdvance'].call(fakeThis)).toBe(false);
+      });
+
+      it(`should return 'true' if 'step' is 2 and 'templateHasDisable' return true`, () => {
+        const fakeThis = {
+          step: 2,
+          schedulerParameters: undefined,
+          templateHasDisable: () => true
+        };
+
+        expect(component['isDisabledAdvance'].call(fakeThis)).toBe(true);
       });
     });
 
@@ -705,6 +721,62 @@ describe('PoPageJobSchedulerComponent:', () => {
         component['save'](model, paramId);
 
         expect(component['emitSuccessMessage']).toHaveBeenCalledWith(saveNotificationSuccessSave, saveOperation);
+      });
+    });
+
+    describe('templateHasDisable:', () => {
+      it(`should return 'true' if has 'parametersTemplate.templateRef' and 'parametersTemplate.disabledAdvance' is true`, () => {
+        const fakeThis = {
+          step: 2,
+          parametersTemplate: {
+            templateRef: {},
+            disabledAdvance: true
+          }
+        };
+        expect(component['templateHasDisable'].call(fakeThis)).toBe(true);
+      });
+
+      it(`should return 'false' if has no 'parametersTemplate.templateRef'`, () => {
+        const fakeThis = {
+          step: 2,
+          parametersTemplate: {
+            templateRef: undefined,
+            disabledAdvance: true
+          }
+        };
+        expect(component['templateHasDisable'].call(fakeThis)).toBe(false);
+      });
+
+      it(`should return 'false' if 'parametersTemplate.disabledAdvance' is false`, () => {
+        const fakeThis = {
+          step: 2,
+          parametersTemplate: {
+            templateRef: {},
+            disabledAdvance: false
+          }
+        };
+        expect(component['templateHasDisable'].call(fakeThis)).toBe(false);
+      });
+    });
+
+    describe('setPropertiesFromTemplate:', () => {
+      it(`should set' model.executionParameter' with 'parametersTemplate.executionParameter' template data`, () => {
+        const fakeThis = {
+          parametersTemplate: {
+            templateRef: {},
+            executionParameter: {
+              user: 'test'
+            }
+          },
+          model: {
+            recurrent: true,
+            periodicity: '',
+            executionParameter: {}
+          }
+        };
+        const expected = { user: 'test' };
+        component['setPropertiesFromTemplate'].call(fakeThis);
+        expect(fakeThis.model.executionParameter).toEqual(expected);
       });
     });
   });

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.module.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.module.ts
@@ -21,15 +21,17 @@ import { PoPageJobSchedulerLookupService } from './po-page-job-scheduler-lookup.
 import { PoPageJobSchedulerParametersComponent } from './po-page-job-scheduler-parameters/po-page-job-scheduler-parameters.component';
 import { PoPageJobSchedulerService } from './po-page-job-scheduler.service';
 import { PoPageJobSchedulerSummaryComponent } from './po-page-job-scheduler-summary/po-page-job-scheduler-summary.component';
+import { PoJobSchedulerParametersTemplateDirective } from './po-page-job-scheduler-parameters';
 
 @NgModule({
   declarations: [
     PoPageJobSchedulerComponent,
     PoPageJobSchedulerExecutionComponent,
     PoPageJobSchedulerParametersComponent,
-    PoPageJobSchedulerSummaryComponent
+    PoPageJobSchedulerSummaryComponent,
+    PoJobSchedulerParametersTemplateDirective
   ],
-  exports: [PoPageJobSchedulerComponent],
+  exports: [PoPageJobSchedulerComponent, PoJobSchedulerParametersTemplateDirective],
   imports: [
     CommonModule,
     FormsModule,


### PR DESCRIPTION
Permite definir um componente para ser renderizado na etapa de parametrização através de template. As alterações são repassadas através da propriedade p-execution-parameter.

Fixes #1491

**po-page-job-scheduler**

**#1491**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não é possível definir um componente personalizado na etapa de parametrização, somente renderizado o `po-dynamic-form` com as informações de fields ou com a url de parâmetros.

**Qual o novo comportamento?**
É possível passar um componente através de template, utilizando-se a diretiva `p-job-scheduler-parameters-template`. 
Para que o model do JobScheduler contenha os valores alterados no componente de template, deve ser repassado através da propriedade `p-execution-parameter`.

**Simulação**
https://gist.github.com/guilnorth/288214616b305fc37067906306a731eb