### PR TITLE
refactor(portal): remove notification do Hacktoberfest

### DIFF
--- a/projects/portal/src/app/app.component.ts
+++ b/projects/portal/src/app/app.component.ts
@@ -38,19 +38,9 @@ export class AppComponent implements OnInit {
       { icon: 'po-icon-social-twitter', link: 'https://twitter.com/@pouidev', label: 'Twitter' },
       { icon: 'po-icon-social-instagram', link: 'https://www.instagram.com/pouidev/', label: 'Instagram' }
     ];
-
-    setTimeout(this.showNotifications.bind(this), 1000);
   }
 
   openExternalLink(url) {
     window.open(url, '_blank');
-  }
-
-  private showNotifications() {
-    this.notification.information({
-      message: 'PO UI + Hacktoberfest 2022! Participe!',
-      action: this.openExternalLink.bind(this, 'https://github.com/po-ui/po-angular/issues/1413'),
-      actionLabel: 'Saber mais'
-    });
   }
 }


### PR DESCRIPTION
remove notification do hacktoberfest no fim do mês de outubro

**app-component**

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao abrir a home do portal  PO-UI o componente exibe a notificação sobre o evento "PO UI + Hacktoberfest 2022".

**Qual o novo comportamento?**
A notificação não é exibida ao abrir o portal PO-UI

**Simulação**
Abrir o portal PO-UI
