### PR TITLE
docs(sync): ajusta novo endereço po-sample-conference

### DIFF
--- a/docs/guides/sync-fundamentals.md
+++ b/docs/guides/sync-fundamentals.md
@@ -113,8 +113,8 @@ import { PoSyncSchema } from '@po-ui/ng-sync';
 
 const conferenceSchema: PoSyncSchema = {
   // Endpoint para o método GET
-  getUrlApi: 'https://po-sample-conference.herokuapp.com/conferences',
-  diffUrlApi: 'https://po-sample-conference.herokuapp.com/conferences/diff',
+  getUrlApi: 'https://po-sample-conference.fly.dev/conferences',
+  diffUrlApi: 'https://po-sample-conference.fly.dev/conferences/diff',
   deletedField: 'isDeleted',
   fields: [ 'id', 'title', 'date', 'location', 'description' ],
   idField: 'id',
@@ -190,8 +190,8 @@ propriedade `deletedField` na interface [PoSyncSchema](/documentation/po-sync), 
 import { PoSyncSchema } from '@po-ui/ng-sync';
 
 const conferenceSchema: PoSyncSchema = {
-  getUrlApi: 'https://po-sample-conference.herokuapp.com/conferences',
-  diffUrlApi: 'https://po-sample-conference.herokuapp.com/conferences/diff',
+  getUrlApi: 'https://po-sample-conference.fly.dev/conferences',
+  diffUrlApi: 'https://po-sample-conference.fly.dev/conferences/diff',
   // Definição do nome do campo
   deletedField: 'isDeleted',
   fields: [ 'id', 'title', 'date', 'location', 'description' ],
@@ -218,7 +218,7 @@ tiveram a última atualização maior ou igual a data que foi recebida como par�
 sincronizados serão retornados. Para cada um dos *schemas* é necessário ter um *endpoint* de sincronização.
 
 Abra o seu navegador e acesse a URL
-https://po-sample-conference.herokuapp.com/conferences/diff/2018-10-08T13:23:31.893Z.
+https://po-sample-conference.fly.dev/conferences/diff/2018-10-08T13:23:31.893Z.
 
 O *endpoint* de sincronização deve retornar uma resposta com a estrutura como a da URL acima, por exemplo:
 
@@ -251,9 +251,9 @@ abaixo:
 import { PoSyncSchema } from '@po-ui/ng-sync';
 
 const conferenceSchema: PoSyncSchema = {
-  getUrlApi: 'https://po-sample-conference.herokuapp.com/conferences',
+  getUrlApi: 'https://po-sample-conference.fly.dev/conferences',
   // Definição da URL de sincronização
-  diffUrlApi: 'https://po-sample-conference.herokuapp.com/conferences/diff',
+  diffUrlApi: 'https://po-sample-conference.fly.dev/conferences/diff',
   deletedField: 'isDeleted',
   fields: [ 'id', 'title', 'date', 'location', 'description' ],
   idField: 'id',

--- a/docs/guides/sync-get-started.md
+++ b/docs/guides/sync-get-started.md
@@ -171,8 +171,8 @@ Crie o arquivo `src/app/home/conference-schema.constants.ts` e adicione o conte√
 import { PoSyncSchema } from '@po-ui/ng-sync';
 
 export const conferenceSchema: PoSyncSchema = {
-  getUrlApi: 'https://po-sample-conference.herokuapp.com/conferences',
-  diffUrlApi: 'https://po-sample-conference.herokuapp.com/conferences/diff',
+  getUrlApi: 'https://po-sample-conference.fly.dev/conferences',
+  diffUrlApi: 'https://po-sample-conference.fly.dev/conferences/diff',
   deletedField: 'deleted',
   fields: [ 'id', 'title', 'location', 'description' ],
   idField: 'id',


### PR DESCRIPTION
**SYNC**

**DTHFUI-6640**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Documentação aponta para heroku

**Qual o novo comportamento?**
Ajusta novo endereço do po-sample-conference após migração do heroku para fly.io

**Simulação**
Getting started do Portal