### PR TITLE
fix(dynamic-table): corrige valor `undefined` na requisicao

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -445,6 +445,20 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(component['params']).toEqual(quickSearchParams);
     });
 
+    it('onQuickSearch: should call `loadData` as default value of `search` if no value is sent in `quickSearchParam`', () => {
+      component.concatFilters = false;
+      const termTypedInQuickSearch = 'filterValue';
+
+      const quickSearchParams = { 'search': termTypedInQuickSearch };
+
+      spyOn(component, <any>'loadData').and.returnValue(EMPTY);
+
+      component.onQuickSearch(termTypedInQuickSearch);
+
+      expect(component['loadData']).toHaveBeenCalledWith({ page: 1, ...quickSearchParams });
+      expect(component['params']).toEqual(quickSearchParams);
+    });
+
     it('onQuickSearch: should call `loadData` with `undefined` and set `params` with `{}` if haven`t `filter`', () => {
       const filter = undefined;
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -260,7 +260,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   private _pageCustomActions: Array<PoPageDynamicTableCustomAction> = [];
   private _height: number;
   private _oldQuickSearchParam: string;
-  private _quickSearchParam: string;
+  private _quickSearchParam: string = 'search';
   private _quickSearchWidth: number;
   private _tableCustomActions: Array<PoPageDynamicTableCustomTableAction> = [];
 


### PR DESCRIPTION
fixes DTHFUI-6736

**dynamic-table**

**DTHFUI-6736**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Coloca valor `undefined` na requisicao quando nao passa valor no `p-quick-search-param`

**Qual o novo comportamento?**
Coloca valor padrão na requisicao quando nao passa valor no `p-quick-search-param`


**Simulação**
testar app, passando p-quick-search-param e sem passar o p-quick-search-param
[app.zip](https://github.com/po-ui/po-angular/files/9963943/app.zip)
