### PR TITLE
fix(table): ajusta exibição de itens sem refresh

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-heroes/sample-po-multiselect-heroes.component.ts
@@ -30,7 +30,7 @@ export class SamplePoMultiselectHeroesComponent {
   }
 
   changeOptions(event): void {
-    this.heroes = event;
+    this.heroes = [...event];
   }
 
   openLink(value) {

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -1224,7 +1224,7 @@ describe('PoTableBaseComponent:', () => {
 
         component.setTableResponseProperties(data);
 
-        expect(component.items).toBe(items);
+        expect(component.items).toEqual(items);
         expect(component.showMoreDisabled).toBeFalsy();
         expect(component.loading).toBeFalsy();
       });
@@ -1237,7 +1237,7 @@ describe('PoTableBaseComponent:', () => {
 
         component.setTableResponseProperties(data);
 
-        expect(component.items).toBe(items);
+        expect(component.items).toEqual(items);
         expect(component.showMoreDisabled).toBeTruthy();
         expect(component.loading).toBeFalsy();
       });

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -366,7 +366,7 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * > Se falso, será inicializado como um *array* vazio.
    */
   @Input('p-items') set items(items: Array<any>) {
-    this._items = Array.isArray(items) ? items : [];
+    this._items = Array.isArray(items) ? [...items] : [];
 
     // when haven't items, selectAll should be unchecked.
     if (!this.hasItems) {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -78,6 +78,12 @@ import { PoTableService } from './services/po-table.service';
  *  <file name="sample-po-table-components/sample-po-table-components.component.css"> </file>
  * </example>
  *
+ * <example name="po-table-heroes" title="PO Table - Heroes">
+ *  <file name="sample-po-table-heroes/sample-po-table-heroes.component.ts"> </file>
+ *  <file name="sample-po-table-heroes/sample-po-table-heroes.component.html"> </file>
+ *  <file name="sample-po-table-heroes/sample-po-table-heroes.service.ts"> </file>
+ * </example>
+ *
  */
 @Component({
   selector: 'po-table',

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.html
@@ -1,0 +1,30 @@
+<div class="po-row po-pb-2">
+  <div class="po-md-6">
+    <div class="po-font-text-bold">Choose one or more heroes for your team</div>
+    <po-table
+      #POItemsOri
+      [p-columns]="columns"
+      [p-infinite-scroll]="true"
+      p-selectable="true"
+      [p-hide-select-all]="true"
+      p-infinite-scroll-distance="80"
+      (p-selected)="changeOptions($event, 'new')"
+      (p-unselected)="changeOptions($event, 'change')"
+      p-height="300"
+      [p-items]="items"
+    >
+    </po-table>
+  </div>
+  <div class="po-md-6">
+    <div class="po-font-text-bold">Here your chosen heroes</div>
+    <po-table
+      #POItemsSelected
+      [p-columns]="columns"
+      [p-striped]="true"
+      [p-infinite-scroll]="true"
+      p-height="300"
+      [p-items]="itemsSelected"
+    >
+    </po-table>
+  </div>
+</div>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.ts
@@ -1,0 +1,51 @@
+import { Component, ViewChild, OnInit } from '@angular/core';
+import { PoTableColumn, PoTableComponent } from '@po-ui/ng-components';
+
+import { SamplePoTableHeroesService } from './sample-po-table-heroes.service';
+
+@Component({
+  selector: 'sample-po-table-heroes',
+  templateUrl: './sample-po-table-heroes.component.html',
+  providers: [SamplePoTableHeroesService]
+})
+export class SamplePoTableHeroesComponent implements OnInit {
+  @ViewChild('POItemsOri', { static: true }) poItemsOri: PoTableComponent;
+  @ViewChild('POItemsSelected', { static: true }) poItemsSelected: PoTableComponent;
+
+  items: Array<any> = [];
+  itemsSelected: Array<any> = [];
+  columns: Array<PoTableColumn>;
+
+  constructor(private service: SamplePoTableHeroesService) {}
+
+  ngOnInit(): void {
+    this.getColumns();
+    this.getItems();
+  }
+
+  getColumns(): void {
+    this.columns = this.service.getColumns();
+  }
+
+  getItems(): void {
+    this.service.getItems().subscribe({
+      next: res => (this.items = res),
+      error: err => console.error(err)
+    });
+  }
+
+  changeOptions(event, type): void {
+    if (type === 'new') {
+      this.itemsSelected.push({
+        id: event.id,
+        label: event.label,
+        email: event.email
+      });
+      this.itemsSelected = [...this.itemsSelected];
+    } else {
+      const index = this.itemsSelected.findIndex(el => el.id === event.id);
+      this.poItemsSelected.removeItem(index);
+      this.itemsSelected = [...this.poItemsSelected.items];
+    }
+  }
+}

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.service.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { pluck } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { PoTableColumn, PoTableComponent } from '@po-ui/ng-components';
+
+@Injectable()
+export class SamplePoTableHeroesService {
+  constructor(private http: HttpClient) {}
+  getColumns(): Array<PoTableColumn> {
+    return [
+      { property: 'id', label: 'Id', type: 'string', width: '90px' },
+      { property: 'label', label: 'Name', type: 'string', width: '90px' },
+      { property: 'email', label: 'E-mail', type: 'string', width: '120px' }
+    ];
+  }
+
+  getItems(): Observable<any> {
+    return this.http.get('https://po-sample-api.fly.dev/v1/heroes').pipe(pluck('items'));
+  }
+}


### PR DESCRIPTION
**TABLE**

**DTHFUI-6695**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o PoTable não está atualizando os itens sem refresh.

**Qual o novo comportamento?**
Agora o PoTable atualiza os itens sem refresh.

**Simulação**
Simular nos Samples do Portal e utilizar este [App.zip](https://github.com/po-ui/po-angular/files/9974306/App.zip).
