### PR TITLE
fix(datepicker): suporte locale russo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -16,6 +16,7 @@ import { PoLanguageService } from '../../../services/po-language/po-language.ser
 class PoDatepickerComponent extends PoDatepickerBaseComponent {
   writeValue(value: any): void {}
   refreshValue(value: Date): void {}
+  replaceFormatSeparator(): any {}
 }
 
 describe('PoDatepickerBaseComponent:', () => {
@@ -23,7 +24,7 @@ describe('PoDatepickerBaseComponent:', () => {
   const languageService: PoLanguageService = new PoLanguageService();
 
   beforeEach(() => {
-    component = new PoDatepickerComponent(languageService);
+    component = new PoDatepickerComponent();
     component['shortLanguage'] = 'pt';
   });
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -128,6 +128,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   protected onChangeModel: any = null;
   protected validatorChange: any;
   protected onTouchedModel: any = null;
+  protected shortLanguage: string;
 
   private _format?: string = poDatepickerFormatDefault;
   private _isoFormat: PoDatepickerIsoFormat;
@@ -135,7 +136,6 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   private _minDate: Date;
   private _noAutocomplete?: boolean = false;
   private _placeholder?: string = '';
-  private shortLanguage: string;
   private previousValue: any;
   private _date: Date;
 
@@ -290,13 +290,13 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
       value = value.toLowerCase();
       if (value.match(/dd/) && value.match(/mm/) && value.match(/yyyy/)) {
         this._format = value;
-        this.objMask = this.buildMask();
+        this.objMask = this.buildMask(this.replaceFormatSeparator());
         this.refreshValue(this.date);
         return;
       }
     }
     this._format = poDatepickerFormatDefault;
-    this.objMask = this.buildMask();
+    this.objMask = this.buildMask(this.replaceFormatSeparator());
   }
 
   get format() {
@@ -337,17 +337,18 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   @Input('p-locale') set locale(value: string) {
     if (value) {
       this._locale = value.length >= 2 ? value : poLocaleDefault;
+      this.objMask = this.buildMask(this.replaceFormatSeparator());
     } else {
       this._locale = this.shortLanguage;
+      this.objMask = this.buildMask(this.replaceFormatSeparator());
     }
+    this.refreshValue(this.date);
   }
   get locale() {
     return this._locale || this.shortLanguage;
   }
 
-  constructor(private languageService: PoLanguageService) {
-    this.shortLanguage = this.languageService.getShortLanguage();
-  }
+  constructor() {}
 
   set date(value: any) {
     this._date = typeof value === 'string' ? convertIsoToDate(value, false, false) : value;
@@ -359,7 +360,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
 
   ngOnInit() {
     // Classe de máscara
-    this.objMask = this.buildMask();
+    this.objMask = this.buildMask(this.replaceFormatSeparator());
   }
 
   // Converte um objeto string em Date
@@ -473,8 +474,8 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   }
 
   // Retorna um objeto do tipo PoMask com a mascara configurada.
-  protected buildMask() {
-    let mask = this.format.toUpperCase();
+  protected buildMask(format: string = this.format) {
+    let mask = format.toUpperCase();
 
     mask = mask.replace(/DD/g, '99');
     mask = mask.replace(/MM/g, '99');
@@ -482,6 +483,8 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
 
     return new PoMask(mask, true);
   }
+
+  protected abstract replaceFormatSeparator(): any;
 
   abstract writeValue(value: any): void;
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -702,16 +702,15 @@ describe('PoDatepickerComponent:', () => {
     });
 
     it('formatToDate: shouldn`t call `formatYear` with date year', () => {
-      const fakeThis = { format: 'dd/mm/yyyy' };
-      const newDate = {
-        getDate: () => 28,
-        getMonth: () => 1,
-        getFullYear: () => 2019
-      };
-      const formatedDate: any = '28/02/2019';
-      spyOn(UtilsFunctions, 'formatYear').and.returnValue('2019');
+      component.format = 'dd/mm/yyyy';
+      const newDate: Date = new Date(2019, 2, 28);
+      const expectedData: any = '28/02/2019';
 
-      expect(component.formatToDate.call(fakeThis, newDate)).toBe(formatedDate);
+      spyOn(UtilsFunctions, 'formatYear').and.returnValue('2019');
+      spyOn(component, <any>'replaceFormatSeparator').and.returnValue('28/02/2019');
+
+      const formattedDate = component.formatToDate(newDate);
+      expect(formattedDate).toBe(expectedData);
     });
 
     it('formatToDate: should return `undefined` if `value` is undefined', () => {
@@ -1030,7 +1029,6 @@ describe('PoDatepickerComponent:', () => {
       component.onKeyup.call(fakeThis, {});
       expect(fakeThis.controlModel).toHaveBeenCalled();
     });
-
     it(`onKeyPress: should call 'isKeyCodeEnter' and check if typed key is enter.`, () => {
       const eventEnterKey = { keyCode: 13 };
 
@@ -1154,6 +1152,36 @@ describe('PoDatepickerComponent:', () => {
 
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
+    });
+  });
+  describe('replaceFormatSeparator: ', () => {
+    it('should show date separator as . according to russian locale selected', () => {
+      component.locale = 'ru';
+      component.format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd.mm.yyyy';
+      const newFormat = component['replaceFormatSeparator']();
+      expect(newFormat).toBe(expectedFormat);
+    });
+    it('should show date separator as / according to portuguese locale selected', () => {
+      component.locale = 'pt';
+      component.format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd/mm/yyyy';
+      const newFormat = component['replaceFormatSeparator']();
+      expect(newFormat).toBe(expectedFormat);
+    });
+    it('should show date separator as / according to english locale selected', () => {
+      component.locale = 'en';
+      component.format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd/mm/yyyy';
+      const newFormat = component['replaceFormatSeparator']();
+      expect(newFormat).toBe(expectedFormat);
+    });
+    it('should show date separator as / according to spanish locale selected', () => {
+      component.locale = 'es';
+      component.format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd/mm/yyyy';
+      const newFormat = component['replaceFormatSeparator']();
+      expect(newFormat).toBe(expectedFormat);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -111,11 +111,12 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
 
   constructor(
     private controlPosition: PoControlPositionService,
-    languageService: PoLanguageService,
+    private languageService: PoLanguageService,
     private renderer: Renderer2,
     el: ElementRef
   ) {
-    super(languageService);
+    super();
+    this.shortLanguage = this.languageService.getShortLanguage();
     this.el = el;
     const language = languageService.getShortLanguage();
     this.literals = {
@@ -295,7 +296,7 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
       return undefined;
     }
 
-    let dateFormatted = this.format;
+    let dateFormatted = this.replaceFormatSeparator();
 
     dateFormatted = dateFormatted.replace('dd', ('0' + value.getDate()).slice(-2));
     dateFormatted = dateFormatted.replace('mm', ('0' + (value.getMonth() + 1)).slice(-2));
@@ -367,6 +368,16 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
   /* istanbul ignore next */
   verifyMobile() {
     return isMobile();
+  }
+
+  // Retorna o formato de acordo com o locale.
+  protected replaceFormatSeparator() {
+    let newFormat = this.format;
+    const newDateSeparator = this.languageService.getDateSeparator(this.locale);
+    if (newDateSeparator !== '/') {
+      newFormat = newFormat.replace(/\//g, newDateSeparator);
+    }
+    return newFormat;
   }
 
   private closeCalendar() {

--- a/projects/ui/src/lib/services/po-language/po-language.constant.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.constant.ts
@@ -1,4 +1,4 @@
-import { PoLanguage, PoNumberSeparator } from './po-language.interface';
+import { PoLanguage, PoNumberSeparator, PoDateSeparator } from './po-language.interface';
 
 /**
  * @description
@@ -75,4 +75,21 @@ export const poLocaleThousandSeparatorList: Array<PoNumberSeparator> = [
   { separator: '.', language: 'es' },
   { separator: '.', language: 'pt' },
   { separator: ' ', language: 'ru' }
+];
+
+/**
+ * @description
+ *
+ * <a id="poLocaleDateSeparatorList"></a>
+ *
+ *
+ * A constante poLocaleDateSeparatorList possui o separador de data por locale de suporte padrão do Po-UI
+ *
+ * @usedBy PoI18nModule
+ */
+export const poLocaleDateSeparatorList: Array<PoDateSeparator> = [
+  { separator: '/', locale: 'en' },
+  { separator: '/', locale: 'es' },
+  { separator: '/', locale: 'pt' },
+  { separator: '.', locale: 'ru' }
 ];

--- a/projects/ui/src/lib/services/po-language/po-language.interface.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.interface.ts
@@ -44,3 +44,25 @@ export interface PoNumberSeparator {
    */
   separator?: string;
 }
+/**
+ * @description
+ *
+ * <a id="PoDateSeparator"></a>
+ *
+ * Interface para o separador de data das linguagens disponíveis no sistema.
+ *
+ * @usedBy PoI18nModule
+ */
+export interface PoDateSeparator {
+  /**
+   * Código do locale [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+   * > Exemplo: 'pt','en'
+   */
+  locale?: string;
+
+  /**
+   * Separador de data
+   * > Exemplo: '/','.','-'
+   */
+  separator?: string;
+}

--- a/projects/ui/src/lib/services/po-language/po-language.service.spec.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.spec.ts
@@ -6,7 +6,7 @@ describe('PoLanguageService:', () => {
   let service: PoLanguageService;
   const poLocaleKey = 'PO_USER_LOCALE';
   const poDefaultLanguage = 'PO_DEFAULT_LANGUAGE';
-  const languages = { pt: 'pt', ptBr: 'pt-BR', en: 'en', enUs: 'en-US', es: 'es', esEs: 'es-ES' };
+  const languages = { pt: 'pt', ptBr: 'pt-BR', en: 'en', enUs: 'en-US', es: 'es', esEs: 'es-ES', ru: 'ru-RU' };
 
   beforeEach(() => {
     service = new PoLanguageService();
@@ -90,7 +90,7 @@ describe('PoLanguageService:', () => {
       expect(service.getShortLanguage()).toBe(languages.pt);
     });
 
-    it('getShortLanguage: should return default language `pt` if language is different of `pt`, `en` or `es`.', () => {
+    it('getShortLanguage: should return default language `pt` if language is different of `pt`, `en`, `ru` or `es`.', () => {
       spyOn(service, 'getLanguage').and.returnValue('de');
 
       expect(service.getShortLanguage()).toBe(languages.pt);
@@ -174,6 +174,23 @@ describe('PoLanguageService:', () => {
         const { decimalSeparator, thousandSeparator } = service.getNumberSeparators('error');
         expect(decimalSeparator).toBe(',');
         expect(thousandSeparator).toBe('.');
+      });
+    });
+    describe('getDateSeparator:', () => {
+      it(`should return language date separator '/' if language param is 'pt'.`, () => {
+        spyOn(service, 'getShortLanguage').and.returnValue('pt');
+        const dateSeparator = service.getDateSeparator();
+        expect(dateSeparator).toBe('/');
+      });
+      it(`should return language date separator '/' if language param is not one of the valids'.`, () => {
+        spyOn(service, 'getShortLanguage').and.returnValue('de');
+        const dateSeparator = service.getDateSeparator();
+        expect(dateSeparator).toBe('/');
+      });
+      it(`should return language date separator '.' if language param is 'ru'.`, () => {
+        spyOn(service, 'getShortLanguage').and.returnValue('ru');
+        const dateSeparator = service.getDateSeparator();
+        expect(dateSeparator).toBe('.');
       });
     });
   });

--- a/projects/ui/src/lib/services/po-language/po-language.service.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.ts
@@ -5,7 +5,8 @@ import {
   poLocaleDecimalSeparatorList,
   poLocaleDefault,
   poLocales,
-  poLocaleThousandSeparatorList
+  poLocaleThousandSeparatorList,
+  poLocaleDateSeparatorList
 } from './po-language.constant';
 
 localStorage.removeItem('PO_DEFAULT_LANGUAGE');
@@ -147,5 +148,22 @@ export class PoLanguageService {
     const thousandSeparator = thousand.separator ?? '.';
 
     return { decimalSeparator, thousandSeparator };
+  }
+
+  /**
+   * @description
+   *
+   * Método que retorna o separador de datas
+   *
+   * @param language sigla do idioma.
+   *
+   * Esta sigla deve ser composta por duas letras representando o idioma
+   *
+   * > Caso seja informado um valor diferente deste padrão, o mesmo será ignorado.
+   */
+  getDateSeparator(language?: string) {
+    language = language || this.getShortLanguage();
+    const separatorChar = poLocaleDateSeparatorList.find(separator => separator.locale === language) ?? {};
+    return separatorChar.separator ?? '/';
   }
 }


### PR DESCRIPTION
**poDatePicker**

**1506**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O separador do picture do locale russo para datas nao eh suportado
exemplo: mostra a data como 12/01/2022

**Qual o novo comportamento?**
O separador do picture do locale russo para datas  eh suportado
exemplo: mostra a data como 12.01.2022
**Simulação**
