### PR TITLE
feat(page-job-scheduler): adiciona a propriedade p-before-send

### DIFF
--- a/projects/templates/src/lib/components/po-page-job-scheduler/interfaces/po-job-scheduler-internal.interface.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/interfaces/po-job-scheduler-internal.interface.ts
@@ -1,4 +1,6 @@
 export interface PoJobSchedulerInternal {
+  [property: string | number]: any;
+
   dayOfMonth?: number;
 
   frequency?: object;

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler-base.component.ts
@@ -195,6 +195,30 @@ export class PoPageJobSchedulerBaseComponent implements OnDestroy {
     return this._orientation;
   }
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Função chamada após realizar a confirmação da execução no PoPageJobScheduler.
+   * Permite alterar os valores do model do PoPageJobScheduler antes de realizar o envio para a Api.
+   *
+   * > Deve retornar um objeto do tipo `PoPageJobScheduler` para ser adicionado ao model do PoPageJobScheduler.
+   *
+   * > Ao ser disparada, a mesma receberá por parâmetro o model do PoPageJobScheduler de interface `PoJobSchedulerInternal`.
+   *
+   * O contexto da função que será chamada, será o mesmo que o do `PoPageJobScheduler`, então para poder alterar
+   * para o contexto do componente que o está utilizando, pode ser utilizado a propriedade `bind` do Javascript.
+   * Por exemplo, para a função `beforeSend`:
+   *
+   * ```
+   * <po-page-job-scheduler [p-service-api]="serviceApi" [p-parameters]="params" [p-before-send]="beforeSend.bind(this)">
+   * ...
+   * </po-page-job-scheduler>
+   * ```
+   */
+  @Input('p-before-send') beforeSendAction: (model: PoJobSchedulerInternal) => PoJobSchedulerInternal;
+
   model: PoJobSchedulerInternal = new PoPageJobSchedulerInternal();
 
   private _subscription = new Subscription();

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
@@ -404,6 +404,31 @@ describe('PoPageJobSchedulerComponent:', () => {
         expect(component['save']).toHaveBeenCalled();
         expect(paramConfirm.message).toBe(component.literals.confirmUpdateMessage);
       });
+
+      it(`should call 'poDialogservice.confirm' and change model with 'beforeSendAction' data`, () => {
+        component['activatedRoute'].snapshot.params['id'] = 'param';
+        let paramConfirm;
+        let modelCustom: any;
+        const customParams = {
+          customParam: 'customValue',
+          processId: 'processIdValue'
+        };
+        component.beforeSendAction = model => ({ ...model, ...customParams });
+
+        spyOn(component['poDialogService'], 'confirm').and.callFake(param => (paramConfirm = param));
+
+        spyOn(component, <any>'save');
+        spyOn(component, <any>'beforeSendAction').and.callFake(model => {
+          modelCustom = { ...model, ...customParams };
+          return modelCustom;
+        });
+
+        component['confirmJobScheduler']();
+        paramConfirm.confirm();
+
+        expect(component['beforeSendAction']).toHaveBeenCalled();
+        expect(component['save']).toHaveBeenCalledWith(modelCustom, 'param');
+      });
     });
 
     it(`emitSuccessMessage: should call 'poNotification.success' with message and call 'resetJobSchedulerForm'`, async () => {

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.ts
@@ -194,7 +194,9 @@ export class PoPageJobSchedulerComponent extends PoPageJobSchedulerBaseComponent
       title: this.literals.confirmation,
       message: confirmMessage,
       confirm: () => {
-        const model = { ...this.model };
+        const beforeSendModel = this.beforeSendAction ? this.beforeSendAction(this.model) : undefined;
+
+        const model = { ...(beforeSendModel || this.model) };
 
         this.save(model, paramId);
       }


### PR DESCRIPTION
Permite adicionar parâmetros no json de envio ao endpoint no componente po-page-job-scheduler ao concluir os passos do job scheduler através da propriedade p-before-send.

Fixes #1468

**po-page-job-scheduler**

**#1468**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não é possível adicionar parâmetros customizados pois ao utilizar o 'p-value' apenas é possível manter valores de fora da propriedade 'executionParameter', pois essa propriedade é usada como model do componente da etapa de parametrização perdendo os valores definidos de início.
Alguns parâmetros não precisam ser mostrados nem preenchidos pelo usuário, porém precisam ser enviados ao endpoint chamado ao concluir os passos do job scheduler.

**Qual o novo comportamento?**
Através da propriedade 'p-before-send', é possível alterar o model do job scheduler. Esta função ao ser chamada passa o próprio model e espera receber o model com as customizações necessárias.

**Simulação**
Gist: https://gist.github.com/guilnorth/d1b4e2113f225c19fbde378a2b741013