### PR TITLE
feat(input): adiciona a propriedade p-uppercase

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
@@ -224,6 +224,36 @@ describe('PoInputGeneric:', () => {
     expect(fakeThis.inputEl.nativeElement.value).toBe('12345');
   });
 
+  it('should call "callOnChange" on eventInput without uppercase', () => {
+    const fakeThis = {
+      upperCase: false,
+      callOnChange: (v: any) => {},
+      validMaxLength: component.validMaxLength,
+      inputEl: component.inputEl
+    };
+    fakeEvent.target.value = 'teste';
+
+    spyOn(fakeThis, 'callOnChange');
+    component.eventOnInput.call(fakeThis, fakeEvent);
+    expect(fakeThis.callOnChange).toHaveBeenCalledWith('teste');
+    expect(fakeThis.inputEl.nativeElement.value).toBe('teste');
+  });
+
+  it('should call "callOnChange" on eventInput with uppercase', () => {
+    const fakeThis = {
+      upperCase: true,
+      callOnChange: (v: any) => {},
+      validMaxLength: component.validMaxLength,
+      inputEl: component.inputEl
+    };
+    fakeEvent.target.value = 'teste';
+
+    spyOn(fakeThis, 'callOnChange');
+    component.eventOnInput.call(fakeThis, fakeEvent);
+    expect(fakeThis.callOnChange).toHaveBeenCalledWith('TESTE');
+    expect(fakeThis.inputEl.nativeElement.value).toBe('TESTE');
+  });
+
   it('should call mask.blur on eventInput with mask', () => {
     const fakeThis = {
       mask: true,

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -87,6 +87,10 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
       this.inputEl.nativeElement.value = this.objMask.valueToInput;
       value = this.objMask.valueToModel;
     }
+    this.inputEl.nativeElement.value = this.upperCase
+      ? String(this.inputEl.nativeElement.value).toUpperCase()
+      : this.inputEl.nativeElement.value;
+    value = this.upperCase ? value.toUpperCase() : value;
     this.callOnChange(value);
   }
 

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -98,6 +98,14 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
   @Input('p-optional') optional: boolean;
 
   /**
+   * @description
+   *
+   * Converte o conteúdo do campo em maiúsulo automaticamente.
+   *
+   */
+  @Input('p-upper-case') @InputBoolean() upperCase: boolean = false;
+
+  /**
    * @optional
    *
    * @description

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
@@ -17,6 +17,7 @@
   [p-placeholder]="placeholder"
   [p-required]="properties?.includes('required')"
   [p-readonly]="properties?.includes('readonly')"
+  [p-upper-case]="properties?.includes('uppercase')"
   [p-show-required]="properties?.includes('showRequired')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
@@ -34,6 +34,7 @@ export class SamplePoInputLabsComponent implements OnInit {
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
     { value: 'required', label: 'Required' },
+    { value: 'uppercase', label: 'Upper Case' },
     { value: 'showRequired', label: 'Show Required' }
   ];
 


### PR DESCRIPTION
**INPUT**

**#1520**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não existe uma propriedade para transformar o model em caixa alta. 

**Qual o novo comportamento?**
Com a propriedade p-uppercase, todo o conteúdo do model é transformado em caixa alta.


**Simulação**
[1520-p-uppercase.zip](https://github.com/po-ui/po-angular/files/10025725/1520-p-uppercase.zip)

- https://github.com/po-ui/po-angular/issues/1520
