### PR TITLE
fix(select): ajusta a exibição da opção quando o `value` igual a zero

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
@@ -12,7 +12,7 @@
       #select
       class="po-select"
       [attr.name]="name"
-      [class.po-select-placeholder]="!selectedValue && !!placeholder"
+      [class.po-select-placeholder]="!selectedValue?.toString() && !!placeholder"
       [disabled]="disabled"
       [id]="id"
       [required]="required"
@@ -20,10 +20,10 @@
       (change)="onSelectChange($event.target.value)"
     >
       <option
-        *ngIf="!selectedValue || !!placeholder"
+        *ngIf="!selectedValue?.toString() || !!placeholder"
         [disabled]="!!placeholder"
-        [hidden]="!selectedValue && !placeholder"
-        [selected]="!selectedValue"
+        [hidden]="!selectedValue?.toString() && !placeholder"
+        [selected]="!selectedValue?.toString()"
         [value]="placeholder ?? ''"
       >
         {{ placeholder }}


### PR DESCRIPTION
Ajusta a exibição da opção selecionada, quando o `value` for `number` e igual a zero.

Fixes #1473

**Select**

**1473**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A opção selecionada não é exibida quando o `value` for igual a zero, a opção anterior for diferente da selecionada e diferente de branco.

**Qual o novo comportamento?**
A opção selecionada é exibida quando o `value` for igual a zero, a opção anterior for diferente da selecionada e diferente de branco.

**Simulação**
Não é possível simular no portal, pois no exemplo que lá existe o `value` é `string`. 
Use este [App](https://github.com/po-ui/po-angular/files/10035725/app.zip) para a simulação, seguindo as instruções abaixo:

1. Primeiro selecione uma opção diferente de `Teste 0`;
2. Depois selecione a opção `Teste 0`;

