### PR TITLE
fix(widget): corrige comportamento indevido no componente

### DIFF
--- a/projects/ui/src/lib/components/po-widget/po-widget.component.spec.ts
+++ b/projects/ui/src/lib/components/po-widget/po-widget.component.spec.ts
@@ -89,6 +89,7 @@ describe('PoWidgetComponent with title and actions', () => {
   });
 
   it('should simulate widget click.', () => {
+    component.click.subscribe(() => {});
     spyOn(component.click, 'emit');
 
     component.onClick(eventClick);
@@ -96,7 +97,17 @@ describe('PoWidgetComponent with title and actions', () => {
     expect(component.click.emit).toHaveBeenCalled();
   });
 
+  it('should`t emit click if widget is not clickable', () => {
+    component.click.unsubscribe();
+    spyOn(component.click, 'emit');
+
+    component.onClick(eventClick);
+
+    expect(component.click.emit).not.toHaveBeenCalled();
+  });
+
   it('should simulate widget selected with keyboard (key which mode)', () => {
+    component.click.subscribe(() => {});
     const fakeEvent: any = {
       which: 32,
       preventDefault: () => {}
@@ -109,6 +120,7 @@ describe('PoWidgetComponent with title and actions', () => {
   });
 
   it('should simulate widget selected with keyboard (key code mode)', () => {
+    component.click.subscribe(() => {});
     const fakeEvent: any = {
       keyCode: 32,
       preventDefault: () => {}
@@ -118,6 +130,20 @@ describe('PoWidgetComponent with title and actions', () => {
     component.onKeyDown(fakeEvent);
 
     expect(component.click.emit).toHaveBeenCalled();
+  });
+
+  it('should`t emit click with keyboard if widget is not clickable', () => {
+    component.click.unsubscribe();
+    const fakeEvent: any = {
+      keyCode: 32,
+      preventDefault: () => {}
+    };
+
+    spyOn(component.click, 'emit');
+
+    component.onKeyDown(fakeEvent);
+
+    expect(component.click.emit).not.toHaveBeenCalled();
   });
 
   describe('Properties:', () => {
@@ -158,6 +184,7 @@ describe('PoWidgetComponent with title and actions', () => {
     });
 
     it('onClick: should call click.emit if disabled is false', () => {
+      component.click.subscribe(() => {});
       const mouseEvent: MouseEvent = new MouseEvent('click');
 
       component.disabled = false;
@@ -416,6 +443,7 @@ describe('PoWidgetComponent with title and actions', () => {
     });
 
     it('should be called the click event when clicked on the `po-widget` area.', () => {
+      component.click.subscribe(() => {});
       const test = nativeElement.querySelector('.po-widget');
 
       spyOn(component.click, 'emit');

--- a/projects/ui/src/lib/components/po-widget/po-widget.component.ts
+++ b/projects/ui/src/lib/components/po-widget/po-widget.component.ts
@@ -51,13 +51,17 @@ export class PoWidgetComponent extends PoWidgetBaseComponent implements OnInit {
   }
 
   onClick(event: MouseEvent) {
-    if (!this.disabled) {
+    if (this.click.observed && !this.disabled) {
       this.click.emit(event);
     }
   }
 
   onKeyDown(event: KeyboardEvent) {
-    if (!this.disabled && (event.which === PoKeyCodeEnum.space || event.keyCode === PoKeyCodeEnum.space)) {
+    if (
+      this.click.observed &&
+      !this.disabled &&
+      (event.which === PoKeyCodeEnum.space || event.keyCode === PoKeyCodeEnum.space)
+    ) {
       this.click.emit(event);
 
       event.preventDefault();


### PR DESCRIPTION
**widget**

**DTHFUI-6727**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente emite click se o wiget é clicável ou não. Componente quando utilizado com campos de input não consegue dar espaço quando o widget não é clicavel

**Qual o novo comportamento?**
Componente não emite click se o wiget é clicável ou não. Componente quando utilizado com campos de input consegue dar espaço quando o widget não é clicavel

**Simulação**
app: 
[app.zip](https://github.com/po-ui/po-angular/files/10067425/app.zip)
