### PR TITLE
fix(http-request): remove headers customizados

### DIFF
--- a/projects/ui/src/lib/interceptors/po-http-request/po-http-request-interceptor.service.spec.ts
+++ b/projects/ui/src/lib/interceptors/po-http-request/po-http-request-interceptor.service.spec.ts
@@ -42,6 +42,27 @@ describe('PoHttpRequestInterceptorService: ', () => {
     expect(httpRequestInterceptor).toBeTruthy();
   });
 
+  it('should remove `X-PO-Screen-Lock` from request', inject(
+    [HttpClient, HttpTestingController],
+    (http: HttpClient, httpMock: HttpTestingController) => {
+      const headers = new HttpHeaders().set('X-PO-Screen-Lock', 'true');
+      http.get('/data', { headers }).subscribe();
+      const req = httpMock.match('/data');
+
+      expect(req[0].request.headers.has('X-PO-Screen-Lock')).toEqual(false);
+    }
+  ));
+  it('should remove `X-PO-No-Count-Pending-Requests` from request', inject(
+    [HttpClient, HttpTestingController],
+    (http: HttpClient, httpMock: HttpTestingController) => {
+      const headers = new HttpHeaders().set('X-PO-No-Count-Pending-Requests', 'true');
+      http.get('/data', { headers }).subscribe();
+      const req = httpMock.match('/data');
+
+      expect(req[0].request.headers.has('X-PO-No-Count-Pending-Requests')).toEqual(false);
+    }
+  ));
+
   describe('Methods: ', () => {
     it('getCountPendingRequests: should return observable when call `getCountPendingRequests` method.', () => {
       const observable = httpRequestInterceptor.getCountPendingRequests();

--- a/projects/ui/src/lib/interceptors/po-http-request/po-http-request-interceptor.service.ts
+++ b/projects/ui/src/lib/interceptors/po-http-request/po-http-request-interceptor.service.ts
@@ -148,7 +148,7 @@ export class PoHttpRequestInterceptorService implements HttpInterceptor {
 
     headersParams.forEach(headerParam => {
       if (request.headers.has(headerParam)) {
-        request.headers.delete(headerParam);
+        request = request.clone({ headers: request.headers.delete(headerParam) });
         isRequestClone = true;
       }
     });


### PR DESCRIPTION
**HTTP-REQUEST-INTERCEPTOR**

**DTHFUI-6485**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o HttpInterceptor acaba deixando passar os headers customizados 'X-PO-No-Count-Pending-Requests' e 'X-PO-Screen-Lock' que 
 são utilizados apenas pelo frontend.

**Qual o novo comportamento?**
Agora os headers customizados 'X-PO-No-Count-Pending-Requests' e 'X-PO-Screen-Lock' são removidos antes do envio para o backend

**Simulação**
Testar no sample do Portal ou pelo [app.zip](https://github.com/po-ui/po-angular/files/10070921/app.zip)
