### PR TITLE
fix(number): ajusta o comportamento das teclas `Home` e `End`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
@@ -125,7 +125,9 @@ export abstract class PoNumberBaseComponent extends PoInputGeneric {
       'Up',
       'Down',
       'Tab',
-      'Delete'
+      'Delete',
+      'Home',
+      'End'
     ];
 
     return controlKeys.indexOf(event.key) !== -1;


### PR DESCRIPTION
Ajusta o comportamento das teclas `Home` e `End` podendo também combinar com as teclas `Shift` + `Home` ou `Shift` + `End`.

Fixes #1233

**Number**

**1233**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando tem números no componente, ao ser pressionado o `Shift` + `Home` ou `Shift` + `End`, não vai ao início ou final dos números selecionando o conteúdo.

**Qual o novo comportamento?**
Quando tem números no componente, ao ser pressionado o `Shift` + `Home` ou `Shift` + `End`, vai ao início ou final dos números selecionando o conteúdo.

**Simulação**
A simulação pode ser feita através do portal. 
