### PR TITLE
feat(checkbox): reutiliza componente `po-label`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
@@ -21,8 +21,15 @@
     >
     </span>
 
-    <label *ngIf="label" #checkboxLabel [for]="id" class="po-checkbox-label" tabindex="-1">
-      {{ label }}
-    </label>
+    <po-label
+      #checkboxLabel
+      *ngIf="label"
+      class="po-checkbox-label"
+      tabindex="-1"
+      [p-disabled]="disabled"
+      [p-for]="id"
+      [p-label]="label"
+    >
+    </po-label>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
@@ -10,6 +10,7 @@ describe('PoCheckboxComponent:', () => {
   let component: PoCheckboxComponent;
   let fixture: ComponentFixture<PoCheckboxComponent>;
   let nativeElement: any;
+  let labelField: any;
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
@@ -24,10 +25,16 @@ describe('PoCheckboxComponent:', () => {
 
     changeDetector = fixture.componentRef.injector.get(ChangeDetectorRef);
     changeDetector.detectChanges();
+
+    labelField = document.getElementsByClassName('po-checkbox-label');
   });
 
   it('should be created.', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should create a po-label for po-checkbox', () => {
+    expect(labelField).toBeTruthy();
   });
 
   describe('Methods:', () => {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.module.ts
@@ -3,10 +3,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { PoCheckboxComponent } from './po-checkbox.component';
+import { PoLabelModule } from '../../po-label/po-label.module';
 
 @NgModule({
   declarations: [PoCheckboxComponent],
-  imports: [CommonModule, FormsModule],
-  exports: [PoCheckboxComponent]
+  exports: [PoCheckboxComponent],
+  imports: [CommonModule, FormsModule, PoLabelModule]
 })
 export class PoCheckboxModule {}

--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -55,6 +55,7 @@ import { PoUploadFileRestrictionsComponent } from './po-upload/po-upload-file-re
 import { PoUrlComponent } from './po-url/po-url.component';
 import { PoCheckboxModule } from './po-checkbox/po-checkbox.module';
 import { PoRadioComponent } from './po-radio/po-radio.component';
+import { PoLabelModule } from '../po-label';
 
 /**
  * @description
@@ -88,7 +89,8 @@ import { PoRadioComponent } from './po-radio/po-radio.component';
     PoTableModule,
     PoTooltipModule,
     PoIconModule,
-    PoCheckboxModule
+    PoCheckboxModule,
+    PoLabelModule
   ],
   exports: [
     PoCheckboxGroupModule,
@@ -115,7 +117,8 @@ import { PoRadioComponent } from './po-radio/po-radio.component';
     PoUploadComponent,
     PoUrlComponent,
     PoRadioComponent,
-    PoCheckboxModule
+    PoCheckboxModule,
+    PoLabelModule
   ],
   declarations: [
     PoComboComponent,

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
@@ -9,6 +9,6 @@
       [required]="required"
       [value]="radioValue ?? ''"
     />
-    <po-label *ngIf="label" [p-label]="label"></po-label>
+    <po-label *ngIf="label" [p-disabled]="disabled" [p-label]="label"></po-label>
   </label>
 </div>

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
@@ -9,6 +9,6 @@
       [required]="required"
       [value]="radioValue ?? ''"
     />
-    <span *ngIf="label">{{ label }}</span>
+    <po-label *ngIf="label" [p-label]="label"></po-label>
   </label>
 </div>

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.spec.ts
@@ -9,6 +9,7 @@ describe('PoRadioComponent', () => {
   let component: PoRadioComponent;
   let fixture: ComponentFixture<PoRadioComponent>;
   let nativeElement: any;
+  let labelField: any;
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
@@ -24,10 +25,15 @@ describe('PoRadioComponent', () => {
     fixture.debugElement.injector.get(NG_VALUE_ACCESSOR);
 
     fixture.detectChanges();
+    labelField = document.getElementsByClassName('po-label');
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should create a po-label for po-radio', () => {
+    expect(labelField).toBeTruthy();
   });
 
   describe('Properties:', () => {

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
@@ -20,9 +20,8 @@
         </div>
       </div>
 
-      <span class="po-switch-label" (click)="eventClick()">
-        {{ value === true ? labelOn : labelOff }}
-      </span>
+      <po-label [p-disabled]="disabled" [p-label]="value === true ? labelOn : labelOff" (click)="eventClick()">
+      </po-label>
     </div>
   </div>
 

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
@@ -11,6 +11,7 @@ describe('PoSwitchComponent', () => {
   let component: PoSwitchComponent;
   let fixture: ComponentFixture<PoSwitchComponent>;
   let nativeElement: any;
+  let labelField: any;
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
@@ -21,12 +22,16 @@ describe('PoSwitchComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PoSwitchComponent);
     component = fixture.componentInstance;
-
+    labelField = document.getElementsByClassName('po-label');
     nativeElement = fixture.debugElement.nativeElement;
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should create a po-label for po-switch', () => {
+    expect(labelField).toBeTruthy();
   });
 
   describe('Properties:', () => {


### PR DESCRIPTION
**CHECKBOX
SWITCH
RADIO**

**DTHFUI-6764**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componentes `po-checkbox`, `po-radio`  e  `po-switch`  não reutilizam componente `po-label` nas opcões dos fields.

**Qual o novo comportamento?**
Componentes `po-checkbox`, `po-radio`  e  `po-switch` passam a reutilizar componente `po-label` nas opcões dos fields.

**PRs Adicionais:**
- https://github.com/po-ui/po-style/pull/372
- https://github.com/totvs/po-theme-totvs/pull/201


**Simulação**
 portal nos samples dos componentes.
