### PR TITLE
fix(dynamic-table): corrige a paginação do componente

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -614,6 +614,60 @@ describe('PoPageDynamicTableComponent:', () => {
         expect(component.quickSearchWidth).toEqual(response.quickSearchWidth);
       }));
 
+      it('should add item and change pagination to next page', fakeAsync(() => {
+        component['page'] = 1;
+
+        const response = {
+          items: [{ name: 'Steve', id: 1 }],
+          hasNext: true,
+          page: 2
+        };
+
+        component.serviceApi = 'localHost';
+        component.items = [{ name: 'Anne', id: 2 }];
+
+        spyOn(component['poPageDynamicService'], 'getResources').and.returnValue(of(response));
+
+        component['loadData']({ page: 2 }).subscribe();
+
+        tick(100);
+
+        expect(component.items).toEqual([
+          { name: 'Anne', id: 2 },
+          { name: 'Steve', id: 1 }
+        ]);
+        expect(component['page']).toEqual(2);
+      }));
+
+      it('should add item and change pagination to next page with more than one key', fakeAsync(() => {
+        component['page'] = 1;
+        component.fields = [
+          { property: 'seqItem', key: true },
+          { property: 'id', key: true, visible: false }
+        ];
+
+        const response = {
+          items: [{ name: 'Steve', id: 1, seqItem: 9 }],
+          hasNext: true,
+          page: 2
+        };
+
+        component.serviceApi = 'localHost';
+        component.items = [{ name: 'Anne', id: 2, seqItem: 9 }];
+
+        spyOn(component['poPageDynamicService'], 'getResources').and.returnValue(of(response));
+
+        component['loadData']({ page: 2 }).subscribe();
+
+        tick(100);
+
+        expect(component.items).toEqual([
+          { name: 'Anne', id: 2, seqItem: 9 },
+          { name: 'Steve', id: 1, seqItem: 9 }
+        ]);
+        expect(component['page']).toEqual(2);
+      }));
+
       it('should call loadData with quickSearchValue', fakeAsync(() => {
         const activatedRoute: any = {
           snapshot: {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -38,7 +38,7 @@ import { PoPageDynamicTableBeforeDuplicate } from './interfaces/po-page-dynamic-
 import { PoPageDynamicTableBeforeRemoveAll } from './interfaces/po-page-dynamic-table-before-remove-all.interface';
 import { PoPageDynamicTableCustomAction } from './interfaces/po-page-dynamic-table-custom-action.interface';
 import { PoPageDynamicTableCustomTableAction } from './interfaces/po-page-dynamic-table-custom-table-action.interface';
-import { isExternalLink, openExternalLink, removeDuplicateItems } from '../../utils/util';
+import { isExternalLink, openExternalLink, removeDuplicateItemsWithArrayKey } from '../../utils/util';
 import { PoPageDynamicSearchLiterals } from '../po-page-dynamic-search/po-page-dynamic-search-literals.interface';
 
 const PAGE_SIZE_DEFAULT = 10;
@@ -688,8 +688,6 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   }
 
   private loadData(params: { page?: number; search?: string } = {}) {
-    const key = this.keys[0] ?? 'id';
-
     if (!this.serviceApi) {
       this.poNotification.error(this.literals.loadDataErrorNotification);
       return EMPTY;
@@ -701,7 +699,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
 
     return this.poPageDynamicService.getResources(fullParams).pipe(
       tap(response => {
-        removeDuplicateItems(response.items, this.items, key);
+        removeDuplicateItemsWithArrayKey(response.items, this.items, this.keys);
         this.items = fullParams.page === 1 ? response.items : [...this.items, ...response.items];
         this.page = fullParams.page;
         this.hasNext = response.hasNext;

--- a/projects/templates/src/lib/utils/util.spec.ts
+++ b/projects/templates/src/lib/utils/util.spec.ts
@@ -26,7 +26,8 @@ import {
   validateDateRange,
   validValue,
   valuesFromObject,
-  removeDuplicateItems
+  removeDuplicateItems,
+  removeDuplicateItemsWithArrayKey
 } from './util';
 import { changeChromeProperties } from '../util-test/util-expect.spec';
 
@@ -379,6 +380,93 @@ describe('Function removeDuplicateItems:', () => {
     const key = 'country';
     removeDuplicateItems(item, item2, key);
     expect(item2).toEqual([{ country: 'chile' }, { country: 'canada' }]);
+  });
+});
+
+describe('Function removeDuplicateItemsWithArrayKey:', () => {
+  it('should remove duplicate items with `id` property by sending an empty array', () => {
+    const item = [
+      { country: 'brasil', id: '1' },
+      { country: 'china', id: '2' },
+      { country: 'japao', id: '3' }
+    ];
+
+    const item2 = [
+      { country: 'brasil', id: '1' },
+      { country: 'chile', id: '4' },
+      { country: 'canada', id: '5' }
+    ];
+
+    const key = [];
+    removeDuplicateItemsWithArrayKey(item, item2, key);
+    expect(item2).toEqual([
+      { country: 'chile', id: '4' },
+      { country: 'canada', id: '5' }
+    ]);
+  });
+
+  it('should remove duplicate items by sending a property', () => {
+    const item = [
+      { country: 'brasil', id: '1' },
+      { country: 'china', id: '2' },
+      { country: 'japao', id: '3' }
+    ];
+
+    const item2 = [
+      { country: 'brasil', id: '1' },
+      { country: 'chile', id: '4' },
+      { country: 'canada', id: '5' }
+    ];
+
+    const key = ['country'];
+    removeDuplicateItemsWithArrayKey(item, item2, key);
+    expect(item2).toEqual([
+      { country: 'chile', id: '4' },
+      { country: 'canada', id: '5' }
+    ]);
+  });
+
+  it('should remove duplicate items by sending more than one comparison property', () => {
+    const item = [
+      { country: 'brasil', id: '1' },
+      { country: 'china', id: '2' },
+      { country: 'japao', id: '3' }
+    ];
+
+    const item2 = [
+      { country: 'brasil', id: '1' },
+      { country: 'chile', id: '4' },
+      { country: 'canada', id: '5' }
+    ];
+
+    const key = ['country', 'id'];
+    removeDuplicateItemsWithArrayKey(item, item2, key);
+    expect(item2).toEqual([
+      { country: 'chile', id: '4' },
+      { country: 'canada', id: '5' }
+    ]);
+  });
+
+  it('should`t remove items with same property value but different object', () => {
+    const item = [
+      { country: 'brasil', capital: '1' },
+      { country: 'china', capital: '1' },
+      { country: 'japao', capital: '1' }
+    ];
+
+    const item2 = [
+      { country: 'argentina', capital: '1' },
+      { country: 'chile', capital: '1' },
+      { country: 'canada', capital: '1' }
+    ];
+
+    const key = ['capital', 'country'];
+    removeDuplicateItemsWithArrayKey(item, item2, key);
+    expect(item2).toEqual([
+      { country: 'argentina', capital: '1' },
+      { country: 'chile', capital: '1' },
+      { country: 'canada', capital: '1' }
+    ]);
   });
 });
 

--- a/projects/templates/src/lib/utils/util.ts
+++ b/projects/templates/src/lib/utils/util.ts
@@ -414,3 +414,46 @@ export function removeDuplicateItems(item, item2, key) {
     }
   }
 }
+
+/**
+ * Remove objetos duplicados passando um array de propriedades.
+ *
+ * Exemplo:
+ *
+ * ```
+ * item: [{country: 'japao'}, {country: 'brasil'} , {country: 'china'}]
+ * item2: [{country: 'chile'}, {country: 'brasil'}, {country: 'canada'}]
+ * key: '[country]'
+ * Resultado:
+ *    item2 = [{country: 'chile'}, {country: 'canada'} ]
+ * ```
+ *
+ *
+ * @param item lista comparada.
+ * @param item2 lista para remover items duplicados.
+ * @param key um array de propriedades que vão ser utilizadas para a comparação.
+ */
+export function removeDuplicateItemsWithArrayKey(item, item2, key) {
+  if (!key.length) {
+    removeDuplicateItems(item, item2, 'id');
+  } else if (key.length === 1) {
+    removeDuplicateItems(item, item2, key[0]);
+  } else {
+    let myKey;
+    let newArray;
+    let result;
+
+    const allEqual = arr => arr.every(val => val === arr[0]);
+
+    for (let i = 0; i < key.length; i++) {
+      newArray = [...item].map(entry => entry[key[i]]).concat([...item2].map(entry => entry[key[i]]));
+      result = allEqual(newArray);
+      if (!result) {
+        myKey = key[i];
+        break;
+      }
+    }
+
+    removeDuplicateItems(item, item2, myKey);
+  }
+}


### PR DESCRIPTION
Corrige paginação do componente quando usado mais de uma chave, sendo uma delas com o mesmo valor

fixes DTHFUI-6749

**dynamic-table**

**DTHFUI-6749**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando utilizada mais de uma key, sendo uma delas com o mesmo valor, a paginação não está sendo feita de forma correta

**Qual o novo comportamento?**

Quando utilizada mais de uma key, sendo uma delas com o mesmo valor, a paginação está sendo feita de forma correta

**Simulação**
entrar na branch "dynamic-table/teste-task6749" do po-sample-api e rodar  ```npm run start:dev```
App: 
[app.zip](https://github.com/po-ui/po-angular/files/10078948/app.zip)
