### PR TITLE
feat(dynamic-form): permite utilização da propriedade 'showRequired'

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -23,6 +23,7 @@
       [p-optional]="field.optional"
       [p-readonly]="field.readonly"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
     >
@@ -46,6 +47,7 @@
       [p-optional]="field.optional"
       [p-readonly]="field.readonly"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
     >
     </po-datepicker-range>
@@ -70,6 +72,7 @@
       [p-optional]="field.optional"
       [p-pattern]="field.pattern"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-icon]="field.icon"
@@ -99,6 +102,7 @@
       [p-step]="field.step"
       [p-readonly]="field.readonly"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-icon]="field.icon"
@@ -130,6 +134,7 @@
       [p-optional]="field.optional"
       [p-readonly]="field.readonly"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-placeholder]="field.placeholder"
@@ -150,6 +155,7 @@
       [p-optional]="field.optional"
       [p-options]="field.options"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
       [p-readonly]="field.readonly"
@@ -170,6 +176,7 @@
       [p-optional]="field.optional"
       [p-options]="field.options"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
     >
     </po-radio-group>
@@ -213,6 +220,7 @@
       [p-optional]="field.optional"
       [p-sort]="field.sort"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field, $event)"
       [p-icon]="field.icon"
       [p-placeholder]="field.placeholder"
@@ -251,6 +259,7 @@
       [p-no-autocomplete]="field.noAutocomplete"
       [p-optional]="field.optional"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
       [p-advanced-filters]="field.advancedFilters"
@@ -273,6 +282,7 @@
       [p-optional]="field.optional"
       [p-options]="field.options"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
     >
     </po-checkbox-group>
@@ -292,6 +302,7 @@
       [p-optional]="field.optional"
       [p-options]="field.options"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
       [p-field-label]="field.fieldLabel"
@@ -321,6 +332,7 @@
       [p-optional]="field.optional"
       [p-readonly]="field.readonly"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       [p-rows]="field.rows"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
@@ -349,6 +361,7 @@
       [p-pattern]="field.pattern"
       [p-readonly]="field.readonly"
       [p-required]="field.required"
+      [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-placeholder]="field.placeholder"

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-basic/sample-po-dynamic-form-basic.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-basic/sample-po-dynamic-form-basic.component.html
@@ -1,1 +1,1 @@
-<po-dynamic-form [p-fields]="[{ property: 'name' }]"> </po-dynamic-form>
+<po-dynamic-form [p-fields]="[{ property: 'name', required: true, showRequired: true }]"> </po-dynamic-form>

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.html
@@ -9,6 +9,7 @@
   [p-optional]="properties.includes('optional')"
   [p-options]="options"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   (p-change)="changeEvent('p-change')"
 >
 </po-checkbox-group>

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.ts
@@ -29,7 +29,8 @@ export class SamplePoCheckboxGroupLabsComponent implements OnInit {
     { value: 'disabled', label: 'Disabled' },
     { value: 'indeterminate', label: 'Indeterminate' },
     { value: 'optional', label: 'Optional' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   ngOnInit() {

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -21,6 +21,7 @@
   [p-options]="options"
   [p-placeholder]="placeholder"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   [p-sort]="properties.includes('sort')"
   (p-change)="changeEvent('p-change')"
 >

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
@@ -57,6 +57,7 @@ export class SamplePoComboLabsComponent implements OnInit {
     { value: 'optional', label: 'Optional' },
     { value: 'disabledInitFilter', label: 'Disabled Init Filter' },
     { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' },
     { value: 'sort', label: 'Sort' },
     { value: 'clean', label: 'Clean' },
     { value: 'disabledTabFilter', label: 'Disabled Tab Filter' }

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
@@ -14,6 +14,7 @@
   [p-optional]="properties.includes('optional')"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   [p-start-date]="startDate"
   [p-locale]="locale"
   (p-change)="changeEvent('p-change')"

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
@@ -32,7 +32,8 @@ export class SamplePoDatepickerRangeLabsComponent implements OnInit {
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   public readonly localeOptions: Array<PoSelectOption> = [

--- a/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
@@ -17,6 +17,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
 >

--- a/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.ts
@@ -31,7 +31,8 @@ export class SamplePoDatepickerLabsComponent implements OnInit {
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   public readonly formatOptions: Array<PoRadioGroupOption> = [

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
@@ -17,6 +17,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   [p-thousand-maxlength]="thousandMaxlength"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
@@ -40,7 +40,8 @@ export class SamplePoDecimalLabsComponent implements OnInit {
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   get maxDecimalsLength() {

--- a/projects/ui/src/lib/components/po-field/po-email/samples/sample-po-email-labs/sample-po-email-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-email/samples/sample-po-email-labs/sample-po-email-labs.component.html
@@ -13,6 +13,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
@@ -17,6 +17,7 @@
   [p-placeholder]="placeholder"
   [p-required]="properties?.includes('required')"
   [p-readonly]="properties?.includes('readonly')"
+  [p-show-required]="properties?.includes('showRequired')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
@@ -33,7 +33,8 @@ export class SamplePoInputLabsComponent implements OnInit {
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   ngOnInit() {

--- a/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.html
@@ -14,6 +14,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"

--- a/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.ts
@@ -24,7 +24,8 @@ export class SamplePoLoginLabsComponent implements OnInit {
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   ngOnInit() {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -16,6 +16,7 @@
   [p-optional]="properties.includes('optional')"
   [p-placeholder]="placeholder"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   [p-infinite-scroll]="properties.includes('infiniteScroll')"
   [p-multiple]="properties.includes('multiple')"
   [p-auto-height]="properties.includes('autoHeight')"

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
@@ -57,6 +57,7 @@ export class SamplePoLookupLabsComponent implements OnInit {
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' },
     { value: 'infiniteScroll', label: 'Infinite Scroll' },
     { value: 'multiple', label: 'Multiple' },
     { value: 'autoHeight', label: 'Auto Height' }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
@@ -19,6 +19,7 @@
     [p-placeholder]="placeholder"
     [p-placeholder-search]="placeholderSearch"
     [p-required]="properties.includes('required')"
+    [p-show-required]="properties.includes('showRequired')"
     [p-sort]="properties.includes('sort')"
     (p-change)="changeEvent('p-change')"
   >

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
@@ -36,6 +36,7 @@ export class SamplePoMultiselectLabsComponent implements OnInit {
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' },
     { value: 'disabled', label: 'Disabled' },
     { value: 'optional', label: 'Optional' },
     { value: 'hideSearch', label: 'Hide Search' },

--- a/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.html
@@ -17,6 +17,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   [p-step]="step"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"

--- a/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.ts
@@ -33,7 +33,8 @@ export class SamplePoNumberLabsComponent implements OnInit {
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   ngOnInit() {

--- a/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.html
@@ -15,6 +15,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"

--- a/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.ts
@@ -26,7 +26,8 @@ export class SamplePoPasswordLabsComponent implements OnInit {
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   ngOnInit() {

--- a/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.html
@@ -8,6 +8,7 @@
   [p-optional]="properties.includes('optional')"
   [p-options]="options"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   [p-size]="size"
   (p-change)="changeEvent('p-change')"
 >

--- a/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.ts
@@ -27,7 +27,8 @@ export class SamplePoRadioGroupLabsComponent implements OnInit {
   readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'disabled', label: 'Disabled' },
     { value: 'optional', label: 'Optional' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   readonly sizesOptions: Array<PoRadioGroupOption> = [

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
@@ -10,6 +10,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
 >

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.ts
@@ -20,6 +20,7 @@ export class SamplePoRichTextLabsComponent implements OnInit {
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
     { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' },
     { value: 'disabledTextAlign', label: 'Disabled Text Align' }
   ];
 

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.html
@@ -10,6 +10,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.ts
@@ -20,6 +20,7 @@ export class SamplePoSelectLabsComponent implements OnInit {
     { value: 'disabled', label: 'Disabled' },
     { value: 'optional', label: 'Optional' },
     { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' },
     { value: 'readonly', label: 'Read Only' }
   ];
 

--- a/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.html
@@ -10,6 +10,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   [p-rows]="rows"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"

--- a/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.ts
@@ -21,7 +21,8 @@ export class SamplePoTextareaLabsComponent implements OnInit {
     { value: 'disabled', label: 'Disabled' },
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
-    { value: 'required', label: 'Required' }
+    { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   ngOnInit() {

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
@@ -16,6 +16,7 @@
   [p-multiple]="properties.includes('multiple')"
   [p-optional]="properties.includes('optional')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   [p-restrictions]="restrictions"
   [p-url]="url"
   [p-headers]="headers"

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
@@ -32,6 +32,7 @@ export class SamplePoUploadLabsComponent implements OnInit {
     { value: 'multiple', label: 'Multiple upload' },
     { value: 'optional', label: 'Optional' },
     { value: 'required', label: 'Required' },
+    { value: 'showRequired', label: 'Show Required' },
     { value: 'restrictionsInfo', label: 'Hide Restrictions Info' },
     { value: 'selectButton', label: 'Hide Select Files Button' },
     { value: 'sendButton', label: 'Hide Send Files Button' }

--- a/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.html
@@ -13,6 +13,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-show-required]="properties.includes('showRequired')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"

--- a/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.ts
@@ -23,6 +23,7 @@ export class SamplePoUrlLabsComponent implements OnInit {
     { value: 'noAutocomplete', label: 'No Autocomplete' },
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
+    { value: 'showRequired', label: 'Show Required' },
     { value: 'required', label: 'Required' }
   ];
 


### PR DESCRIPTION
**dynamic-form e fields**

**DTHFUI-6809**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o po-dynamic-form tem a propriedade 'showRequired' mas não repassa para os componentes dentro dele. 

**Qual o novo comportamento?**
É possível utilizar a propriedade 'showRequired' nos componentes do po-dynamic-form

**Simulação**
fields -> Através dos samples labs do portal
dynamic-form -> sample-basic