### PR TITLE
test(dynamic-view): inclui teste para o `po-image`

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
@@ -253,6 +253,18 @@ describe('PoDynamicViewComponent:', () => {
       expect(nativeElement.querySelector('po-tag')).toBeTruthy();
     });
 
+    it(`should create 'po-image' if have a 'image' property`, () => {
+      component.fields = [{ property: 'cpf', label: 'CPF', image: true }];
+
+      component.ngOnChanges({
+        fields: new SimpleChange(null, component.fields, true)
+      });
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('po-image')).toBeTruthy();
+    });
+
     it(`should create 'po-info' if haven't a 'tag' property`, () => {
       component.fields = [{ property: 'cpf', label: 'CPF' }];
 
@@ -265,13 +277,14 @@ describe('PoDynamicViewComponent:', () => {
       expect(nativeElement.querySelector('po-info')).toBeTruthy();
     });
 
-    it(`should create 'po-info' and 'po-tag' if have a one or more items with 'tag' property and one or more items
+    it(`should create 'po-info', 'po-tag' and 'po-image if have a one or more items with 'tag' property and one or more items
     without 'tag' property`, () => {
       component.fields = [
         { property: 'cpf', label: 'CPF' },
         { property: 'name', label: 'NAME', tag: true },
         { property: 'rg', label: 'RG' },
-        { property: 'address', label: 'ADDRESS', tag: true }
+        { property: 'address', label: 'ADDRESS', tag: true },
+        { property: 'image', label: 'IMAGE', image: true }
       ];
 
       component.ngOnChanges({
@@ -282,6 +295,7 @@ describe('PoDynamicViewComponent:', () => {
 
       expect(nativeElement.querySelector('po-info')).toBeTruthy();
       expect(nativeElement.querySelector('po-tag')).toBeTruthy();
+      expect(nativeElement.querySelector('po-image')).toBeTruthy();
     });
 
     it(`should create 'po-info' and 'po-divider' if haven't tag property and have a 'divider' property`, () => {
@@ -335,7 +349,14 @@ describe('PoDynamicViewComponent:', () => {
         { property: 'address', divider: 'Address data' }
       ];
 
-      component.fields = [...fieldsDivider, ...fieldsTag, ...fieldsInfo];
+      const fieldsImage = [
+        { property: 'image1', label: 'IMAGE1', image: true },
+        { property: 'image2', label: 'IMAGE2', image: true },
+        { property: 'image3', label: 'IMAGE3', image: true },
+        { property: 'image4', label: 'IMAGE4', image: true }
+      ];
+
+      component.fields = [...fieldsDivider, ...fieldsTag, ...fieldsInfo, ...fieldsImage];
 
       component.ngOnChanges({
         fields: new SimpleChange(null, component.fields, true)
@@ -346,10 +367,12 @@ describe('PoDynamicViewComponent:', () => {
       const infoElement = nativeElement.querySelectorAll('po-info');
       const tagElement = nativeElement.querySelectorAll('po-tag');
       const dividerElement = nativeElement.querySelectorAll('po-divider');
+      const imageElement = nativeElement.querySelectorAll('po-image');
 
       expect(infoElement.length).toBe(fieldsInfo.length + fieldsDivider.length);
       expect(dividerElement.length).toBe(fieldsDivider.length);
       expect(tagElement.length).toBe(fieldsTag.length);
+      expect(imageElement.length).toBe(fieldsImage.length);
     });
 
     it(`should create 'po-tag' with icon if properties 'tag' and 'icon' contain values.`, () => {


### PR DESCRIPTION
**DYNAMIC-VIEW**

**DTHFUI-6841**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente não tinha teste unitário para o `po-image`

**Qual o novo comportamento?**
Componente passa a ter teste unitário para o `po-image`

**Simulação**
Rodar `npm run test:ui` e conferir no coverage
