### PR TITLE
fix(tooltip): corrige remoção de tooltip

### DIFF
--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.spec.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.spec.ts
@@ -60,6 +60,26 @@ describe('PoTooltipDirective', () => {
       expect(spyRemoveTooltipAction).not.toHaveBeenCalled();
     });
 
+    it('mouseClick: shouldn`t call removeTooltipAction if `displayTooltip` is true', () => {
+      directive.displayTooltip = true;
+
+      const spyRemoveTooltipAction = spyOn(directive, <any>'removeTooltipAction');
+
+      directive.onMouseClick();
+
+      expect(spyRemoveTooltipAction).not.toHaveBeenCalled();
+    });
+
+    it('mouseClick: should call removeTooltipAction if `displayTooltip` is false', () => {
+      directive.displayTooltip = false;
+
+      const spyRemoveTooltipAction = spyOn(directive, <any>'removeTooltipAction');
+
+      directive.onMouseClick();
+
+      expect(spyRemoveTooltipAction).toHaveBeenCalled();
+    });
+
     it('focusout: shouldn`t call removeTooltipAction if `displayTooltip` is true', () => {
       directive.displayTooltip = true;
 
@@ -277,6 +297,33 @@ describe('PoTooltipDirective', () => {
 
     directive.onMouseEnter();
     directive.onMouseLeave();
+
+    tick(100);
+
+    expect(directive.hideTooltip).not.toHaveBeenCalled();
+    expect(directive.renderer.removeChild).toHaveBeenCalled();
+    expect(directive.tooltipContent).toBe(undefined);
+  }));
+  it('should call hideTooltip in mouse click', fakeAsync(() => {
+    spyOn(directive, 'hideTooltip');
+    directive.appendInBody = undefined;
+
+    directive.onMouseClick();
+
+    tick(100);
+
+    expect(directive.hideTooltip).toHaveBeenCalled();
+  }));
+
+  it('shouldn`t call hideTooltip in mouse click if `appendInBody` is true', fakeAsync(() => {
+    spyOn(directive, 'hideTooltip');
+    spyOn(directive.renderer, 'removeChild');
+    directive.appendInBody = true;
+    directive.tooltip = 'TEXT';
+    directive.tooltipContent = false;
+
+    directive.onMouseEnter();
+    directive.onMouseClick();
 
     tick(100);
 

--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
@@ -61,6 +61,12 @@ export class PoTooltipDirective extends PoTooltipBaseDirective implements OnInit
     }
   }
 
+  @HostListener('click') onMouseClick() {
+    if (!this.displayTooltip) {
+      this.removeTooltipAction();
+    }
+  }
+
   @HostListener('focusout') onFocusOut() {
     if (!this.displayTooltip) {
       this.removeTooltipAction();


### PR DESCRIPTION
**TOOLTIP**

**DTHFUI-6771**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente quando se clica num link com tooltip e redireciona a página, o mesmo não remove o tooltip.


**Qual o novo comportamento?**
Agora ao clicar em um link com tooltip e redireciona a página o mesmo é removido.

**Simulação**

Utilizar este [APP.zip](https://github.com/po-ui/po-angular/files/10167057/APP.zip) e testar no sample `PO Table - Po Field Components`.
