### PR TITLE
feat(schematics): adiciona módulo `HttpClientModule`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ yarn install
 
 ### Passo 2 - Adiconando o pacote @po-ui/ng-components
 
-Utilizando o comando `ng add` do [Angular CLI](https://cli.angular.io/), vamos adicionar o **Po** em seu projeto e o mesmo se encarregará de configurar o tema, instalar o pacote e importar o módulo do **Po**.
+Utilizando o comando `ng add` do [Angular CLI](https://cli.angular.io/), vamos adicionar o **Po** em seu projeto e o mesmo se encarregará de configurar o tema, instalar o  guia de primeiros passos **Po**. Além de importar também o modulo **HttpClientModule**.
 
 Execute o comando abaixo na pasta raiz do seu projeto:
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -69,7 +69,7 @@ yarn install
 
 ### Passo 2 - Adiconando o pacote @po-ui/ng-components
 
-Utilizando o comando `ng add` do [Angular CLI](https://cli.angular.io/), vamos adicionar o **Po** em seu projeto e o mesmo se encarregará de configurar o tema, instalar o pacote e importar o módulo do **Po**.
+Utilizando o comando `ng add` do [Angular CLI](https://cli.angular.io/), vamos adicionar o **Po** em seu projeto e o mesmo se encarregará de configurar o tema, instalar o pacote e importar o módulo do **Po**. Além de importar também o modulo **HttpClientModule**.
 
 Execute o comando abaixo na pasta raiz do seu projeto:
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@angular/language-service": "~15.0.3",
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-angular": "^12.1.4",
-    "@po-ui/ng-schematics": "^6.0.0",
+    "@po-ui/ng-schematics": "^14.0.0",
     "@types/jasmine": "~4.3.0",
     "@types/jasminewd2": "~2.0.9",
     "@types/node": "^14.0.0",

--- a/projects/ui/README.md
+++ b/projects/ui/README.md
@@ -14,7 +14,7 @@ Biblioteca de componentes de UI para Angular.
 
 ### Adiconando o pacote @po-ui/ng-components
 
-Utilizando o comando `ng add` do [Angular CLI](https://cli.angular.io/), vamos adicionar o **Po** em seu projeto e o mesmo se encarregará de configurar o tema, instalar o pacote e importar o módulo do **Po**.
+Utilizando o comando `ng add` do [Angular CLI](https://cli.angular.io/), vamos adicionar o **Po** em seu projeto e o mesmo se encarregará de configurar o tema, instalar o pacote e importar o módulo do **Po**. Além de importar também o modulo **HttpClientModule**.
 
 Execute o comando abaixo na pasta raiz do seu projeto:
 

--- a/projects/ui/schematics/ng-add/index.spec.ts
+++ b/projects/ui/schematics/ng-add/index.spec.ts
@@ -57,6 +57,15 @@ xdescribe('Schematic: ng-add', () => {
 
       expect(fileContent).toContain(poModuleName);
     });
+
+    it('should add the httpClientModule to the project module', async () => {
+      const httpClientModuleName = 'HttpClientModule';
+
+      const tree = await runner.runSchematicAsync('ng-add-setup-project', componentOptions, appTree).toPromise();
+      const fileContent = getFileContent(tree, `projects/${componentOptions.name}/src/app/app.module.ts`);
+
+      expect(fileContent).toContain(httpClientModuleName);
+    });
   });
 
   describe('Theme configuration:', () => {

--- a/projects/ui/schematics/ng-add/setup-project.ts
+++ b/projects/ui/schematics/ng-add/setup-project.ts
@@ -12,6 +12,10 @@ import {
 const poModuleName = 'PoModule';
 const poModuleSourcePath = '@po-ui/ng-components';
 
+/** HttpClient Module name that will insert in app root module */
+const httpClientModuleName = 'HttpClientModule';
+const httpClientModuleSourcePath = '@angular/common/http';
+
 /**
  * Scaffolds the basics of a Angular Material application, this includes:
  *  - Add PO Module to app root module
@@ -21,6 +25,7 @@ const poModuleSourcePath = '@po-ui/ng-components';
 export default function (options: any): Rule {
   return chain([
     addModuleImportToRootModule(options, poModuleName, poModuleSourcePath),
+    addModuleImportToRootModule(options, httpClientModuleName, httpClientModuleSourcePath),
     addThemeToAppStyles(options),
     configureSideMenu(options)
   ]);


### PR DESCRIPTION
**SCHEMATICS**

**DTHFUI-6447**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao utilizar os schematics de add do PO UI o HttpClientModule não era importado no módulo root da aplicação.

**Qual o novo comportamento?**
Ao utilizar os schematics de add do PO UI o HttpClientModule passa a ser importado no módulo root da aplicação.

**Simulação**
Portal e Testar com o Verdaccio , ao utilizar ng add.

**Doc de auxílio:**
- https://docs.google.com/document/d/13CGDAYNLUT69eYsIJrOCNtt2BMByhoEmKr2x8S4g18k/edit?usp=sharing

