### PR TITLE
refactor(button): remove a propriedade `p-type`

### DIFF
--- a/projects/ui/src/lib/components/po-button/po-button-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.spec.ts
@@ -37,15 +37,15 @@ describe('PoButtonBaseComponent', () => {
 
   it('should update property `p-kind` with valid values', () => {
     component.danger = false;
-    const validValues = ['primary', 'secondary', 'tertiary', 'danger'];
+    const validValues = ['primary', 'secondary', 'tertiary'];
 
-    expectPropertiesValues(component, 'type', validValues, validValues);
+    expectPropertiesValues(component, 'kind', validValues, validValues);
   });
 
   it('should update property `p-kind` with `secondary` when invalid values', () => {
     const invalidValues = [undefined, null, '', true, false, 0, 1, 'aa', [], {}];
 
-    expectPropertiesValues(component, 'type', invalidValues, 'secondary');
+    expectPropertiesValues(component, 'kind', invalidValues, 'secondary');
   });
 
   it('should set `p-danger` with false if `p-kind` is tertiary', () => {

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -124,33 +124,6 @@ export class PoButtonBaseComponent {
   }
 
   /**
-   * @deprecated 15.x.x
-   *
-   * @optional
-   *
-   * @description
-   *
-   * **Deprecated 15.x.x**. Utilizar `p-kind` no lugar.
-   *
-   * Define o estilo do `po-button`.
-   *
-   * Valore válidos:
-   *  - `default`: **Deprecated 15.x.x**. Utilizar `p-kind="secondary"`.
-   *  - `primary`: deixa o `po-button` com destaque, deve ser usado para ações primárias.
-   *  - `danger`: **Deprecated 15.x.x**. Utilizar `p-danger`.
-   *  - `link`: **Deprecated 15.x.x**. Utilizar `p-kind="tertiary"`.
-   *
-   * @default `secondary`
-   */
-  @Input('p-type') set type(value: string) {
-    this.kind = value;
-  }
-
-  get type(): string {
-    return this.kind;
-  }
-
-  /**
    * @optional
    *
    * @description


### PR DESCRIPTION
**PO-BUTTON**

**DTHFUI-6884**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente possui propriedade `p-type` depreciada da v15.x.x.

**Qual o novo comportamento?**
Componente deixa de ter propriedade `p-type` depreciada da v15.x.x. Utilizando propriedade `p-kind` no lugar.

**PR Adicional:**
- https://github.com/po-ui/po-style/pull/377