### PR TITLE
feat(listbox): novo componente

### DIFF
--- a/projects/ui/src/lib/components/components.module.ts
+++ b/projects/ui/src/lib/components/components.module.ts
@@ -39,6 +39,7 @@ import { PoIconModule } from './po-icon/po-icon.module';
 import { PoLinkModule } from './po-link/po-link.module';
 import { PoLabelModule } from './po-label/po-label.module';
 import { PoImageModule } from './po-image/po-image.module';
+import { PoListBoxModule } from './po-listbox/po-listbox.module';
 
 @NgModule({
   imports: [
@@ -61,6 +62,7 @@ import { PoImageModule } from './po-image/po-image.module';
     PoIconModule,
     PoInfoModule,
     PoListViewModule,
+    PoListBoxModule,
     PoLoadingModule,
     PoMenuModule,
     PoMenuPanelModule,
@@ -102,6 +104,7 @@ import { PoImageModule } from './po-image/po-image.module';
     PoIconModule,
     PoInfoModule,
     PoListViewModule,
+    PoListBoxModule,
     PoLoadingModule,
     PoMenuModule,
     PoMenuPanelModule,

--- a/projects/ui/src/lib/components/index.ts
+++ b/projects/ui/src/lib/components/index.ts
@@ -18,6 +18,7 @@ export * from './po-gauge/index';
 export * from './po-grid/index';
 export * from './po-icon/index';
 export * from './po-info/index';
+export * from './po-listbox/index';
 export * from './po-list-view/index';
 export * from './po-loading/index';
 export * from './po-menu-panel/index';

--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.spec.ts
@@ -161,6 +161,7 @@ describe('PoDropdownComponent: ', () => {
     it('onScroll: should call `hideDropdown` if `open` is `true`', () => {
       component['open'] = true;
       spyOn(component, <any>'hideDropdown');
+      component.actions = [{ label: 'action1', action: () => {} }];
 
       component['onScroll']({ target: {} });
 

--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.ts
@@ -75,7 +75,7 @@ export class PoDropdownComponent extends PoDropdownBaseComponent {
   }
 
   private onScroll = ({ target }): void => {
-    if (this.open && target.className !== 'po-popup-container') {
+    if (this.open && target.className !== 'po-popup-container' && this.actions.length < 6) {
       this.hideDropdown();
     }
   };

--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -19,6 +19,7 @@ import { PoServicesModule } from '../../services/services.module';
 import { PoTableModule } from '../po-table/po-table.module';
 import { PoTooltipModule } from './../../directives/po-tooltip/po-tooltip.module';
 import { PoIconModule } from '../po-icon/po-icon.module';
+import { PoListBoxModule } from '../po-listbox/po-listbox.module';
 
 import { PoComboComponent } from './po-combo/po-combo.component';
 import { PoComboOptionTemplateDirective } from './po-combo/po-combo-option-template/po-combo-option-template.directive';
@@ -91,7 +92,8 @@ import { PoLabelModule } from '../po-label';
     PoTooltipModule,
     PoIconModule,
     PoCheckboxModule,
-    PoLabelModule
+    PoLabelModule,
+    PoListBoxModule
   ],
   exports: [
     PoCheckboxGroupModule,

--- a/projects/ui/src/lib/components/po-listbox/enums/po-item-list-type.enum.ts
+++ b/projects/ui/src/lib/components/po-listbox/enums/po-item-list-type.enum.ts
@@ -1,0 +1,6 @@
+export enum PoItemListType {
+  action = 'action',
+  check = 'check',
+  option = 'option',
+  danger = 'danger'
+}

--- a/projects/ui/src/lib/components/po-listbox/index.ts
+++ b/projects/ui/src/lib/components/po-listbox/index.ts
@@ -1,0 +1,4 @@
+export * from './po-item-list/po-item-list.component';
+export * from './po-listbox.component';
+
+export * from './po-listbox.module';

--- a/projects/ui/src/lib/components/po-listbox/interfaces/po-listbox-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-listbox/interfaces/po-listbox-literals.interface.ts
@@ -1,0 +1,11 @@
+/**
+ * @usedBy PoListBoxComponent
+ *
+ * @description
+ *
+ * Interface para definição de literais utilizadas no `po-listbox`
+ */
+export interface PoListBoxLiterals {
+  /** Texto exibido quando não houver itens na lista */
+  noItems?: string;
+}

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/interfaces/po-item-list-action.interface.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/interfaces/po-item-list-action.interface.ts
@@ -1,16 +1,6 @@
 import { TemplateRef } from '@angular/core';
 
-/**
- * @usedBy PoPopupComponent
- *
- * @description
- *
- * Interface para lista de ações do componente.
- */
-export interface PoPopupAction {
-  /** Rótulo da ação. */
-  label: string;
-
+export interface PoItemListAction {
   /**
    * Ação que será executada, sendo possível passar o nome ou a referência da função.
    *
@@ -19,6 +9,13 @@ export interface PoPopupAction {
    * Exemplo: `action: this.myFunction.bind(this)`
    */
   action?: Function;
+
+  /**
+   * Função que deve retornar um booleano para habilitar ou desabilitar a ação para o registro selecionado.
+   *
+   * Também é possível informar diretamente um valor booleano que vai habilitar ou desabilitar a ação para todos os registros.
+   */
+  disabled?: boolean | Function;
 
   /**
    * @description
@@ -62,32 +59,26 @@ export interface PoPopupAction {
    */
   icon?: string | TemplateRef<void>;
 
-  /** Atribui uma linha separadora acima do item. */
-  separator?: boolean;
-
-  /**
-   * Função que deve retornar um booleano para habilitar ou desabilitar a ação para o registro selecionado.
-   *
-   * Também é possível informar diretamente um valor booleano que vai habilitar ou desabilitar a ação para todos os registros.
-   */
-  disabled?: boolean | Function;
-
-  /**
-   * @description
-   *
-   * Define a cor do item, sendo `default` o padrão.
-   *
-   * Valores válidos:
-   *  - `default`
-   *  - `danger` - indicado para ações exclusivas (excluir, sair).
-   */
-  type?: string;
+  /** Rótulo da ação. */
+  label: string;
 
   /** URL utilizada no redirecionamento das páginas. */
   url?: string;
-
-  /** Define se a ação está selecionada. */
   selected?: boolean;
+
+  /** Atribui uma linha separadora acima do item. */
+  separator?: boolean;
+  /**
+   * @description
+   *
+   * Define a cor do item, sendo `action` o padrão.
+   *
+   * Valores válidos:
+   *  - `action`
+   *  - `check`
+   *  - `option`
+   */
+  type?: string;
 
   /**
    * @description
@@ -104,4 +95,12 @@ export interface PoPopupAction {
    *
    */
   visible?: boolean | Function;
+  /**
+   * @description
+   *
+   * Define se o item vai ter o estilo danger ou não.
+   *
+   * Deve ser usado para mostrar uma ação de exclusão ou de saída.
+   */
+  danger?: boolean;
 }

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/interfaces/po-item-list-option-group.interface.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/interfaces/po-item-list-option-group.interface.ts
@@ -1,0 +1,9 @@
+import { PoItemListOption } from './po-item-list-option.interface';
+
+export interface PoItemListOptionGroup {
+  /** Rótulo da ação. */
+  label: string;
+
+  /** Array de PoItemListOption */
+  options: Array<PoItemListOption>;
+}

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/interfaces/po-item-list-option.interface.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/interfaces/po-item-list-option.interface.ts
@@ -1,0 +1,7 @@
+export interface PoItemListOption {
+  /** Rótulo do Item. */
+  label?: string;
+
+  /** Valor do Item. */
+  value: string | number;
+}

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list-base.component.spec.ts
@@ -1,0 +1,106 @@
+import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
+import { PoItemListBaseComponent } from './po-item-list-base.component';
+
+describe('PoListBoxBaseComponent', () => {
+  const component = new PoItemListBaseComponent();
+
+  it('should be created', () => {
+    expect(component instanceof PoItemListBaseComponent).toBeTruthy();
+  });
+
+  describe('Properties: ', () => {
+    it('should update property `p-type` with valid values', () => {
+      const validValues = ['action', 'check', 'option'];
+
+      expectPropertiesValues(component, 'type', validValues, validValues);
+    });
+    it('should update property `p-type` with invalid values', () => {
+      const invalidValues = ['secondary', 'primary', 'default'];
+
+      expectPropertiesValues(component, 'type', invalidValues, 'action');
+    });
+
+    it('should set _visible to true if value is true, null or undefined', () => {
+      component.visible = true;
+      expect(component['_visible']).toBe(true);
+
+      component.visible = null;
+      expect(component['_visible']).toBe(true);
+
+      component.visible = undefined;
+      expect(component['_visible']).toBe(true);
+    });
+
+    it('should set _visible to false if value is not a function or a truthy value', () => {
+      component.visible = false;
+      expect(component['_visible']).toBe(false);
+
+      component.visible = '';
+      expect(component['_visible']).toBe(false);
+
+      component.visible = 0;
+      expect(component['_visible']).toBe(false);
+    });
+
+    it('should set _visible to the result of the function if value is a function', () => {
+      const fn = () => true;
+      component.visible = fn;
+      expect(component['_visible']).toBe(true);
+
+      const fn2 = () => false;
+      component.visible = fn2;
+      expect(component['_visible']).toBe(false);
+
+      const fn3 = () => null;
+      component.visible = fn3;
+      expect(component['_visible']).toBe(true);
+
+      const fn4 = () => undefined;
+      component.visible = fn4;
+      expect(component['_visible']).toBe(true);
+    });
+
+    it('should set _disabled if value is function that return true', () => {
+      component.disabled = () => true;
+      expect(component['_disabled']).toBeTrue();
+    });
+
+    it('should set _disabled if value is true', () => {
+      component.disabled = true;
+      expect(component['_disabled']).toBeTrue();
+    });
+
+    it('should set _disabled if value is false', () => {
+      component.disabled = () => false;
+      expect(component['_disabled']).toBeFalse();
+    });
+
+    it('should set true if value is null', () => {
+      component.disabled = null;
+      expect(component['_disabled']).toBeFalse();
+    });
+
+    it('should set true if value is undefined', () => {
+      component.disabled = undefined;
+      expect(component['_disabled']).toBeFalse();
+    });
+
+    it('should set _disabled to the result of the function if value is a function', () => {
+      const fn = () => true;
+      component.disabled = fn;
+      expect(component['_disabled']).toBe(true);
+
+      const fn2 = () => false;
+      component.disabled = fn2;
+      expect(component['_disabled']).toBe(false);
+
+      const fn3 = () => null;
+      component.disabled = fn3;
+      expect(component['_disabled']).toBe(false);
+
+      const fn4 = () => undefined;
+      component.disabled = fn4;
+      expect(component['_disabled']).toBe(false);
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list-base.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list-base.component.ts
@@ -1,0 +1,153 @@
+import { Directive, EventEmitter, HostBinding, Input, Output, TemplateRef } from '@angular/core';
+import { InputBoolean } from '../../../decorators';
+import { PoItemListType } from '../enums/po-item-list-type.enum';
+import { PoItemListAction } from './interfaces/po-item-list-action.interface';
+import { PoItemListOptionGroup } from './interfaces/po-item-list-option-group.interface';
+import { PoItemListOption } from './interfaces/po-item-list-option.interface';
+
+/**
+ * @description
+ *
+ * O componente `po-item-list` é a menor parte da lista de ação que compõem o componente [**PO Listbox**](/documentation/po-listbox).
+ */
+@Directive()
+export class PoItemListBaseComponent {
+  private _label: string;
+  private _value: string;
+  private _type!: PoItemListType;
+  private _visible: boolean = true;
+  private _disabled: boolean = false;
+
+  @HostBinding('attr.p-type')
+  @Input('p-type')
+  set type(value: string) {
+    this._type = PoItemListType[value] ?? 'action';
+  }
+
+  get type(): PoItemListType {
+    return this._type;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o estado como visível.
+   *
+   * @default `true`
+   */
+  @Input('p-visible')
+  set visible(value: any) {
+    if (typeof value === 'function') {
+      this._visible = this.checkFunctionVisible(value());
+    } else if (value === true || value === null || value === undefined) {
+      this._visible = true;
+    } else {
+      this._visible = false;
+    }
+  }
+
+  get visible(): boolean {
+    return this._visible;
+  }
+
+  @Input('p-item') item: PoItemListAction | PoItemListOption | PoItemListOptionGroup | any;
+
+  /** Texto de exibição do item. */
+  @Input('p-label') label: string;
+
+  /** Valor do item. */
+  @Input('p-value') value: string;
+
+  @Input('p-danger') @InputBoolean() danger: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o estado como desabilitado.
+   *
+   * @default `false`
+   */
+  @Input('p-disabled')
+  set disabled(value: any) {
+    if (typeof value === 'function') {
+      this._disabled = this.checkFunctionDisabled(value());
+    } else if (value === false || value === null || value === undefined) {
+      this._disabled = false;
+    } else {
+      this._disabled = true;
+    }
+  }
+
+  get disabled(): boolean {
+    return this._disabled;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define se a ação está selecionada.
+   *
+   * @default `false`
+   */
+  @Input('p-selected') @InputBoolean() selected: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Atribui uma linha separadora acima do item.
+   *
+   * @default `false`
+   */
+  @Input('p-separator') @InputBoolean() separator: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define um ícone que será exibido ao lado esquerdo do rótulo.
+   */
+  @Input('p-icon') icon: string | TemplateRef<void>;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Ação a ser realizada ao clicar no item do tipo `option`.
+   */
+  @Output('p-click-item') clickItem = new EventEmitter<PoItemListAction | any>();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Ação a ser realizada ao selecionar no item do type `check`.
+   */
+  @Output('p-select-item') selectItem = new EventEmitter<PoItemListOption | PoItemListOptionGroup | any>();
+
+  constructor() {}
+
+  private checkFunctionVisible(value: any) {
+    if (value === null || value === undefined || value === true) {
+      return true;
+    }
+    return false;
+  }
+
+  private checkFunctionDisabled(value: any) {
+    if (value === null || value === undefined || value === false) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.html
@@ -1,0 +1,41 @@
+<ng-container [ngSwitch]="type">
+  <div
+    *ngSwitchDefault
+    #itemList
+    [class.po-item-list__separator]="separator"
+    [class.po-item-list__disabled]="disabled || !visible"
+    [class.po-item-list__selected]="selected && !disabled"
+    [attr.aria-disabled]="disabled || !visible"
+    [attr.aria-label]="label"
+    [class.po-item-list__danger]="danger"
+    class="po-item-list po-item-list__action"
+  >
+    <po-icon *ngIf="icon" class="po-popup-icon-item po-icon" [p-icon]="icon"></po-icon>
+    <span class="po-item-list-label">{{ label }}</span>
+  </div>
+  <div
+    *ngSwitchCase="'option'"
+    #itemList
+    [class.po-item-list__separator]="separator"
+    [class.po-item-list__selected]="selected && !disabled"
+    [class.po-item-list__disabled]="disabled"
+    [attr.aria-disabled]="disabled"
+    [attr.aria-label]="label"
+    class="po-item-list po-item-list__option"
+    (click)="onSelectItem({label})"
+  >
+    <span class="po-item-list-label">{{ label }}</span>
+  </div>
+
+  <div
+    *ngSwitchCase="'check'"
+    [class.po-item-list__separator]="separator"
+    [class.po-item-list__selected]="selected && !disabled"
+    [class.po-item-list__disabled]="disabled"
+    [attr.aria-disabled]="disabled"
+    [attr.aria-label]="label"
+    class="po-item-list po-item-list__check"
+  >
+    <po-checkbox [p-label]="label" (p-change)="onSelectItem({label})" [p-disabled]="disabled"></po-checkbox>
+  </div>
+</ng-container>

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.spec.ts
@@ -1,0 +1,78 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { PoItemListComponent } from './po-item-list.component';
+import * as UtilFunctions from './../../../utils/util';
+
+describe('PoItemListComponent', () => {
+  let component: PoItemListComponent;
+  let fixture: ComponentFixture<PoItemListComponent>;
+
+  let nativeElement: any;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [PoItemListComponent],
+      imports: [RouterTestingModule],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoItemListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    nativeElement = fixture.debugElement.nativeElement;
+  });
+
+  it('should create', () => {
+    expect(component instanceof PoItemListComponent).toBeTruthy();
+  });
+
+  describe('Methods:', () => {
+    describe('onSelectItem:', () => {
+      it('should be called', () => {
+        spyOn(component.selectItem, 'emit');
+        const item = { label: 'a', value: 'a' };
+        component.onSelectItem(item);
+
+        expect(component.selectedView).toBe(item);
+        expect(component.selectItem.emit).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Templates:', () => {
+    it('should de set type `action`', () => {
+      component.type = 'action';
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-item-list__action')).toBeTruthy();
+    });
+    it('should de set type `option`', () => {
+      component.type = 'option';
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-item-list__option')).toBeTruthy();
+    });
+    it('should de set type `check`', () => {
+      component.type = 'check';
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-item-list__check')).toBeTruthy();
+    });
+
+    it('should be set label', () => {
+      component.label = 'PO UI';
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-item-list-label').innerHTML).toBe('PO UI');
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.ts
@@ -1,0 +1,30 @@
+import { Component, ElementRef, EventEmitter, HostBinding, Input, Output, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+import { isExternalLink, isTypeof, openExternalLink } from '../../../utils/util';
+
+import { PoItemListAction } from './interfaces/po-item-list-action.interface';
+import { PoItemListOptionGroup } from './interfaces/po-item-list-option-group.interface';
+import { PoItemListOption } from './interfaces/po-item-list-option.interface';
+import { PoItemListBaseComponent } from './po-item-list-base.component';
+
+@Component({
+  selector: 'po-item-list',
+  templateUrl: './po-item-list.component.html'
+})
+export class PoItemListComponent extends PoItemListBaseComponent {
+  @ViewChild('itemList', { static: true }) itemList: ElementRef;
+
+  selectedView: PoItemListOption;
+
+  protected param;
+  protected clickListener: () => void;
+
+  constructor(private router: Router) {
+    super();
+  }
+
+  onSelectItem(itemListOption: PoItemListOption | PoItemListOptionGroup | any): void {
+    this.selectedView = itemListOption;
+    this.selectItem.emit(itemListOption);
+  }
+}

--- a/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.spec.ts
@@ -1,0 +1,112 @@
+import { expectPropertiesValues } from '../../util-test/util-expect.spec';
+
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
+import { PoListBoxBaseComponent, poListBoxLiteralsDefault } from './po-listbox-base.component';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+
+describe('PoListboxBaseComponent', () => {
+  const languageService = new PoLanguageService();
+  const component = new PoListBoxBaseComponent(languageService);
+
+  it('should be created', () => {
+    expect(component instanceof PoListBoxBaseComponent).toBeTruthy();
+  });
+
+  describe('Properties: ', () => {
+    it('should update property `p-type` with valid values', () => {
+      const validValues = ['action', 'check', 'option'];
+
+      expectPropertiesValues(component, 'type', validValues, validValues);
+    });
+    it('should update property `p-type` with invalid values', () => {
+      const invalidValues = ['secondary', 'primary', 'default'];
+
+      expectPropertiesValues(component, 'type', invalidValues, 'action');
+    });
+
+    it('should update property `p-items` with valid values', () => {
+      const items = [
+        { label: 'a', value: 'a' },
+        { label: 'b', value: 'b' },
+        { label: 'c', value: 'c' }
+      ];
+      const validValues = [items];
+
+      expectPropertiesValues(component, 'items', validValues, validValues);
+    });
+    it('should update property `p-items` with valid values', () => {
+      const invalidValues = ['items', undefined];
+
+      expectPropertiesValues(component, 'items', invalidValues, []);
+    });
+
+    describe('p-literals:', () => {
+      it('should be in portuguese if browser is setted with an unsuported language', () => {
+        component['language'] = 'zw';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poListBoxLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should be in portuguese if browser is setted with `pt`', () => {
+        component['language'] = 'pt';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poListBoxLiteralsDefault.pt);
+      });
+
+      it('should be in english if browser is setted with `en`', () => {
+        component['language'] = 'en';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poListBoxLiteralsDefault.en);
+      });
+
+      it('should be in spanish if browser is setted with `es`', () => {
+        component['language'] = 'es';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poListBoxLiteralsDefault.es);
+      });
+
+      it('should be in russian if browser is setted with `ru`', () => {
+        component['language'] = 'ru';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poListBoxLiteralsDefault.ru);
+      });
+
+      it('should accept custom literals', () => {
+        component['language'] = poLocaleDefault;
+
+        const customLiterals = Object.assign({}, poListBoxLiteralsDefault[poLocaleDefault]);
+
+        // Custom some literals
+        customLiterals.noItems = 'No data custom';
+
+        component.literals = customLiterals;
+
+        expect(component.literals).toEqual(customLiterals);
+      });
+
+      it('should update property with default literals if is setted with invalid values', () => {
+        const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
+
+        component['language'] = poLocaleDefault;
+
+        expectPropertiesValues(component, 'literals', invalidValues, poListBoxLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should get literals directly from poListBoxLiteralsDefault if it not initialized', () => {
+        component['language'] = 'pt';
+        component['_literals'] = null;
+        expect(component.literals).toEqual(poListBoxLiteralsDefault['pt']);
+      });
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.ts
@@ -1,0 +1,83 @@
+import { Directive, EventEmitter, Input, Output } from '@angular/core';
+
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { InputBoolean } from '../../decorators';
+import { PoItemListType } from './enums/po-item-list-type.enum';
+import { PoItemListAction } from './po-item-list/interfaces/po-item-list-action.interface';
+
+import { PoItemListOptionGroup } from './po-item-list/interfaces/po-item-list-option-group.interface';
+import { PoItemListOption } from './po-item-list/interfaces/po-item-list-option.interface';
+import { PoListBoxLiterals } from './interfaces/po-listbox-literals.interface';
+
+export const poListBoxLiteralsDefault = {
+  en: <PoListBoxLiterals>{
+    noItems: 'No items found'
+  },
+  es: <PoListBoxLiterals>{
+    noItems: 'No se encontraron artículos'
+  },
+  pt: <PoListBoxLiterals>{
+    noItems: 'Nenhum item encontrado'
+  },
+  ru: <PoListBoxLiterals>{
+    noItems: 'ничего не найдено'
+  }
+};
+
+/**
+ * @description
+ * O componente `po-listbox` é uma caixa suspensa que aparece sobre a interface após ser acionado por um gatilho visível em tela, como o dropdown. Ele apoia trazendo agrupamentos de opções. O componente listbox é composto pelo componente [**PO Item List**](/documentation/po-item-list).
+ */
+@Directive()
+export class PoListBoxBaseComponent {
+  private _items: Array<PoItemListOption | PoItemListOptionGroup | any> = [];
+  private _type!: PoItemListType;
+  private _literals: PoListBoxLiterals;
+  private language: string = poLocaleDefault;
+
+  @Input('p-visible') @InputBoolean() visible: boolean = false;
+
+  @Input('p-type') set type(value: string) {
+    this._type = PoItemListType[value] ?? 'action';
+  }
+
+  get type(): PoItemListType {
+    return this._type;
+  }
+
+  @Input('p-items') set items(items: Array<PoItemListAction | PoItemListOption | PoItemListOptionGroup | any>) {
+    this._items = Array.isArray(items) ? items : [];
+  }
+
+  get items(): Array<PoItemListAction | PoItemListOption | PoItemListOptionGroup | any> {
+    return this._items;
+  }
+
+  @Input('p-literals') set literals(value: PoListBoxLiterals) {
+    if (value instanceof Object && !(value instanceof Array)) {
+      this._literals = {
+        ...poListBoxLiteralsDefault[poLocaleDefault],
+        ...poListBoxLiteralsDefault[this.language],
+        ...value
+      };
+    } else {
+      this._literals = poListBoxLiteralsDefault[this.language];
+    }
+  }
+
+  get literals() {
+    return this._literals || poListBoxLiteralsDefault[this.language];
+  }
+
+  // parâmetro que pode ser passado para o popup ao clicar em um item
+  @Input('p-param') param?;
+
+  @Output('p-select-item') selectItem = new EventEmitter<PoItemListOption | PoItemListOptionGroup | any>();
+
+  @Output('p-close') closeEvent = new EventEmitter<any>();
+
+  constructor(languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
+}

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
@@ -1,0 +1,30 @@
+<div #listbox class="po-listbox" [attr.p-type]="type" [hidden]="visible">
+  <ng-content select="[p-popup-header-template]"></ng-content>
+  <ul #listboxItemList cdkListbox class="po-listbox-list">
+    <li
+      class="po-listbox-item"
+      *ngFor="let item of items"
+      [cdkOption]="item.label"
+      [cdkOptionDisabled]="item.disabled || item.visible === false"
+      [attr.aria-selected]="item.selected"
+      (click)="onSelectItem(item)"
+      (keydown)="onKeyDown(item, $event)"
+    >
+      <po-item-list
+        *ngIf="returnBooleanValue(item, 'visible') !== false"
+        [attr.data-item-list]="item | json"
+        [p-label]="item.label"
+        [p-value]="item.value"
+        [p-disabled]="item.disabled"
+        [p-selected]="item.selected"
+        [p-separator]="item.separator"
+        [p-visible]="item.visible"
+        [p-danger]="item.type === 'danger'"
+        [p-icon]="item.icon"
+        [p-type]="type"
+        [p-item]="item"
+        (p-select-item)="onSelectItem(item)"
+      ></po-item-list>
+    </li>
+  </ul>
+</div>

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
@@ -1,0 +1,291 @@
+import { NO_ERRORS_SCHEMA, SimpleChange } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PoListBoxComponent } from './po-listbox.component';
+import * as UtilFunctions from './../../utils/util';
+
+describe('PoListBoxComponent', () => {
+  let component: PoListBoxComponent;
+  let fixture: ComponentFixture<PoListBoxComponent>;
+
+  let nativeElement: any;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [PoListBoxComponent],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoListBoxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    nativeElement = fixture.debugElement.nativeElement;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Methods:', () => {
+    describe('ngAfterViewInit:', () => {
+      it('should have been called', () => {
+        spyOn(component, <any>'setListBoxMaxHeight');
+
+        component.ngAfterViewInit();
+
+        expect(component['setListBoxMaxHeight']).toHaveBeenCalled();
+      });
+
+      it('should call focus', () => {
+        component.items = [{ label: 'Item 1', value: 1 }];
+        fixture.detectChanges();
+
+        spyOn(component.listboxItemList.nativeElement, 'focus');
+
+        component.ngAfterViewInit();
+
+        expect(component.listboxItemList.nativeElement.focus).toHaveBeenCalled();
+      });
+
+      describe('openUrl:', () => {
+        beforeEach(() => {
+          component.items = [{ label: 'a', value: 'a', url: 'http://google.com.br' }];
+        });
+        it('should be open a external link', () => {
+          const url = 'http://google.com';
+          spyOn(UtilFunctions, <any>'openExternalLink');
+          component['openUrl'](url);
+
+          expect(UtilFunctions.openExternalLink).toHaveBeenCalledWith(url);
+        });
+
+        it('should be open a internal route', () => {
+          spyOn(UtilFunctions, 'isExternalLink');
+          spyOn(component['router'], <any>'navigate');
+          const url = '/home';
+
+          component['openUrl'](url);
+
+          expect(UtilFunctions.isExternalLink).toHaveBeenCalled();
+          expect(component['router'].navigate).toHaveBeenCalledWith([url]);
+        });
+      });
+
+      describe('returnBooleanValue:', () => {
+        it('should be called with value', () => {
+          const item = { label: 'a', action: () => {}, value: 'a' };
+          const expected = component['returnBooleanValue'](item, 'value');
+          expect(expected).toBeTruthy();
+        });
+        it('should be called with function', () => {
+          const item = { label: 'a', action: () => {}, value: 'a' };
+          const expected = component['returnBooleanValue'](item, 'action');
+          expect(expected).toBe(item.action());
+        });
+      });
+
+      describe('onSelectItem:', () => {
+        it('should be called and disabled is true', () => {
+          const item = { label: 'a', action: () => {}, value: 'a', disabled: true };
+          spyOn(component, <any>'openUrl');
+          spyOn<any>(item, 'action');
+
+          component.onSelectItem(item);
+
+          expect(item.action).not.toHaveBeenCalled();
+          expect(component['openUrl']).not.toHaveBeenCalled();
+        });
+
+        it('should be called with action', () => {
+          const item = { label: 'a', action: () => {}, value: 'a' };
+          spyOn(component, <any>'openUrl');
+          spyOn<any>(item, 'action');
+
+          component.onSelectItem(item);
+
+          expect(item.action).toHaveBeenCalled();
+          expect(component['openUrl']).not.toHaveBeenCalled();
+        });
+
+        it('should be called with url', () => {
+          const item = { label: 'a', url: 'http://fakeurl.com', value: 'a' };
+          const url = 'http://fakeurl.com';
+          spyOn(component, <any>'openUrl');
+
+          component.onSelectItem(item);
+
+          expect(component['openUrl']).toHaveBeenCalledWith(url);
+        });
+
+        it('should`n called openUrl if visible is false', () => {
+          const item = { label: 'a', url: 'http://fakeurl.com', value: 'a', visible: false };
+          const url = 'http://fakeurl.com';
+          spyOn(component, <any>'openUrl');
+
+          component.onSelectItem(item);
+
+          expect(component['openUrl']).not.toHaveBeenCalledWith(url);
+        });
+
+        it('should`n called openUrl if visible is true and not disabled', () => {
+          const item = { label: 'a', url: 'http://fakeurl.com', value: 'a', visible: true };
+          const url = 'http://fakeurl.com';
+          spyOn(component, <any>'openUrl');
+
+          component.onSelectItem(item);
+
+          expect(component['openUrl']).toHaveBeenCalledWith(url);
+        });
+
+        it('should`n be called action if visible is false', () => {
+          const item = { label: 'a', action: () => {}, value: 'a', visible: false };
+          spyOn(component, <any>'openUrl');
+          spyOn<any>(item, 'action');
+
+          component.onSelectItem(item);
+
+          expect(item.action).not.toHaveBeenCalled();
+          expect(component['openUrl']).not.toHaveBeenCalled();
+        });
+
+        it('should be called action if visible is true and not disabled', () => {
+          const item = { label: 'a', action: () => {}, value: 'a', visible: true };
+          spyOn(component, <any>'openUrl');
+          spyOn<any>(item, 'action');
+
+          component.onSelectItem(item);
+
+          expect(item.action).toHaveBeenCalled();
+          expect(component['openUrl']).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('ngOnChanges:', () => {
+      it(`should call 'setListBoxMaxHeight' when has changes`, () => {
+        spyOn(component, <any>'setListBoxMaxHeight');
+        component.items = [
+          { label: 'Item 1', value: 1 },
+          { label: 'Item 2', value: 2 },
+          { label: 'Item 3', value: 3 }
+        ];
+
+        component.ngOnChanges({
+          items: new SimpleChange(null, component.items, true)
+        });
+
+        expect(component['setListBoxMaxHeight']).toHaveBeenCalled();
+      });
+
+      it(`should'n call 'setListBoxMaxHeight' when has changes`, () => {
+        spyOn(component, <any>'setListBoxMaxHeight');
+        component.items = [
+          { label: 'Item 1', value: 1 },
+          { label: 'Item 2', value: 2 },
+          { label: 'Item 3', value: 3 }
+        ];
+
+        component.ngOnChanges();
+
+        expect(component['setListBoxMaxHeight']).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('setListBoxMaxHeight', () => {
+      it('should be call `renderer.setStyle` when has more than 6 items', () => {
+        spyOn<any>(component['renderer'], 'setStyle');
+        component.items = [
+          { label: 'Item 1', value: 1 },
+          { label: 'Item 2', value: 2 },
+          { label: 'Item 3', value: 3 },
+          { label: 'Item 4', value: 4 },
+          { label: 'Item 5', value: 5 },
+          { label: 'Item 6', value: 6 },
+          { label: 'Item 7', value: 7 }
+        ];
+
+        component['setListBoxMaxHeight']();
+
+        expect(component['renderer'].setStyle).toHaveBeenCalled();
+      });
+
+      it(`should'n be call 'renderer.setStyle' when has less then 6 items`, () => {
+        spyOn<any>(component['renderer'], 'setStyle');
+        component.items = [
+          { label: 'Item 1', value: 1 },
+          { label: 'Item 2', value: 2 },
+          { label: 'Item 3', value: 3 }
+        ];
+
+        component['setListBoxMaxHeight']();
+
+        expect(component['renderer'].setStyle).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('onKeydown:', () => {
+      it('should call onSelectItem if event is `enter`', () => {
+        const item = { label: 'a', value: 'a' };
+        const eventEnterKey = new KeyboardEvent('keydown', { 'code': 'Enter' });
+
+        spyOn(component, 'onSelectItem');
+
+        component.onKeyDown(item, eventEnterKey);
+
+        expect(component.onSelectItem).toHaveBeenCalled();
+      });
+
+      it('should call onSelectItem if event is `space`', () => {
+        const item = { label: 'a', value: 'a' };
+        const eventEnterKey = new KeyboardEvent('keydown', { 'code': 'Space' });
+
+        spyOn(component, 'onSelectItem');
+
+        component.onKeyDown(item, eventEnterKey);
+
+        expect(component.onSelectItem).toHaveBeenCalled();
+      });
+
+      it('should`t call onSelectItem if event is not `space` or `enter`', () => {
+        const item = { label: 'a', value: 'a' };
+        const eventEnterKey = new KeyboardEvent('keydown', { 'code': 'esc' });
+
+        spyOn(component, 'onSelectItem');
+
+        component.onKeyDown(item, eventEnterKey);
+
+        expect(component.onSelectItem).not.toHaveBeenCalled();
+      });
+
+      it('should call closeEvent if event is `Escape`', () => {
+        const item = { label: 'a', value: 'a' };
+        const eventEnterKey = new KeyboardEvent('keydown', { 'code': 'Escape' });
+
+        spyOn(component.closeEvent, 'emit');
+
+        component.onKeyDown(item, eventEnterKey);
+
+        expect(component.closeEvent.emit).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Templates:', () => {
+    it('should be show listbox when has items', () => {
+      const items = [
+        { label: 'a', value: 'a' },
+        { label: 'b', value: 'b' },
+        { label: 'c', value: 'c' },
+        { label: 'd', value: 'd' }
+      ];
+      component.items = items;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-listbox-item')).toBeTruthy();
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
@@ -1,0 +1,81 @@
+import { AfterViewInit, Component, ElementRef, OnChanges, Renderer2, SimpleChanges, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { PoListBoxBaseComponent } from './po-listbox-base.component';
+
+import { PoItemListOptionGroup } from './po-item-list/interfaces/po-item-list-option-group.interface';
+import { PoItemListOption } from './po-item-list/interfaces/po-item-list-option.interface';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { isExternalLink, isTypeof, openExternalLink } from '../../utils/util';
+
+@Component({
+  selector: 'po-listbox',
+  templateUrl: './po-listbox.component.html'
+})
+export class PoListBoxComponent extends PoListBoxBaseComponent implements AfterViewInit, OnChanges {
+  @ViewChild('listbox', { static: true }) listbox: ElementRef;
+  @ViewChild('listboxItemList', { static: true }) listboxItemList: ElementRef;
+
+  constructor(private renderer: Renderer2, languageService: PoLanguageService, private router: Router) {
+    super(languageService);
+  }
+
+  ngAfterViewInit(): void {
+    this.setListBoxMaxHeight();
+    this.listboxItemList.nativeElement.focus();
+  }
+
+  ngOnChanges(changes?: SimpleChanges): void {
+    if (changes?.items) {
+      this.setListBoxMaxHeight();
+    }
+  }
+
+  onSelectItem(itemListAction: PoItemListOption | PoItemListOptionGroup | any) {
+    const isVisible =
+      itemListAction.visible === undefined || itemListAction.visible === null || itemListAction.visible === true;
+    const actionNoDisabled = itemListAction && !this.returnBooleanValue(itemListAction, 'disabled') && isVisible;
+
+    if (itemListAction && itemListAction.action && actionNoDisabled) {
+      itemListAction.action(this.param || itemListAction);
+    }
+
+    if (itemListAction && itemListAction.url && actionNoDisabled) {
+      return this.openUrl(itemListAction.url);
+    }
+  }
+
+  onKeyDown(itemListAction: PoItemListOption | PoItemListOptionGroup | any, event?: KeyboardEvent) {
+    event.preventDefault();
+    if ((event && event.code === 'Enter') || event.code === 'Space') {
+      this.onSelectItem(itemListAction);
+    }
+
+    if (event && event.code === 'Escape') {
+      this.closeEvent.emit();
+    }
+  }
+
+  protected returnBooleanValue(itemListAction: any, property: string) {
+    return isTypeof(itemListAction[property], 'function')
+      ? itemListAction[property](this.param || itemListAction)
+      : itemListAction[property];
+  }
+
+  private setListBoxMaxHeight(): void {
+    const itemsLength = this.items.length;
+    if (itemsLength > 6) {
+      this.renderer.setStyle(this.listbox.nativeElement, 'maxHeight', `${44 * 6 - 44 / 3}px`);
+    }
+  }
+
+  private openUrl(url: string) {
+    if (isExternalLink(url)) {
+      return openExternalLink(url);
+    }
+
+    if (url) {
+      return this.router.navigate([url]);
+    }
+  }
+}

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.module.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CdkListboxModule } from '@angular/cdk/listbox';
+import { PoListBoxComponent } from './po-listbox.component';
+import { PoItemListComponent } from './po-item-list/po-item-list.component';
+import { PoCheckboxModule } from '../po-field/po-checkbox/po-checkbox.module';
+import { PoIconModule } from '../po-icon/po-icon.module';
+
+@NgModule({
+  declarations: [PoListBoxComponent, PoItemListComponent],
+  exports: [PoListBoxComponent],
+  imports: [CommonModule, PoCheckboxModule, PoIconModule, CdkListboxModule]
+})
+export class PoListBoxModule {}

--- a/projects/ui/src/lib/components/po-popup/po-popup.component.html
+++ b/projects/ui/src/lib/components/po-popup/po-popup.component.html
@@ -1,22 +1,11 @@
-<div #popupRef class="po-popup" *ngIf="showPopup">
+<div #popupRef class="po-popup" *ngIf="showPopup && actions.length && !checkAllActionIsInvisible()">
   <div *ngIf="!hideArrow" class="po-popup-arrow po-arrow-{{ arrowDirection }}"></div>
 
-  <ng-content select="[p-popup-header-template]"></ng-content>
-
   <div class="po-popup-container">
-    <ng-container *ngFor="let action of actions; let actionIndex = index">
-      <div
-        *ngIf="returnBooleanValue(action, 'visible') !== false"
-        [class.po-popup-item-default]="action.type !== 'danger'"
-        [class.po-popup-item-danger]="action.type === 'danger'"
-        [class.po-popup-item-disabled]="returnBooleanValue(action, 'disabled')"
-        [class.po-popup-item-separator]="action.separator && actionIndex !== 0"
-        [class.po-popup-item-selected]="action.selected"
-        (click)="onActionClick(action)"
-      >
-        <po-icon *ngIf="action.icon" class="po-popup-icon-item po-icon" [p-icon]="action.icon"></po-icon>
-        {{ action.label }}
+    <po-listbox #listbox p-type="action" [p-items]="actions" [p-param]="param" (p-close)="close()">
+      <div p-popup-header-template>
+        <ng-content select="[p-popup-header-template]"></ng-content>
       </div>
-    </ng-container>
+    </po-listbox>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-popup/po-popup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup.component.spec.ts
@@ -327,6 +327,26 @@ describe('PoPopupComponent:', () => {
       expect(component['removeListeners']).toHaveBeenCalled();
     });
 
+    it('checkAllActionIsInvisible: should return true is all itens are invisible', () => {
+      component.actions = [
+        { 'label': 'PO Popup', 'visible': false },
+        { 'label': 'PO Popup2', 'visible': false }
+      ];
+      const allInvisible = component['checkAllActionIsInvisible']();
+
+      expect(allInvisible).toBeTruthy();
+    });
+
+    it('checkAllActionIsInvisible: should return true is one item are visible', () => {
+      component.actions = [
+        { 'label': 'PO Popup', 'visible': false },
+        { 'label': 'PO Popup2', 'visible': true }
+      ];
+      const allInvisible = component['checkAllActionIsInvisible']();
+
+      expect(allInvisible).toBeFalsy();
+    });
+
     it(`closePopupOnClickout: should call 'close' if clickedOutDisabledItem, clickedOutTarget and
       clickedOutHeaderTemplate return true`, () => {
       spyOn(component, <any>'clickedOutDisabledItem').and.returnValue(true);
@@ -455,6 +475,11 @@ describe('PoPopupComponent:', () => {
         popupRef: {
           nativeElement: undefined
         },
+        listbox: {
+          nativeElement: {
+            querySelector: () => true
+          }
+        },
         target: undefined,
         position: undefined
       };
@@ -508,39 +533,6 @@ describe('PoPopupComponent:', () => {
       expect(nativeElement.querySelector('.po-popup')).toBeNull();
     });
 
-    it('should set class to default if type is different to danger', () => {
-      component.showPopup = true;
-
-      fixture.detectChanges();
-
-      expect(nativeElement.querySelectorAll('.po-popup-item-default').length).toBe(2);
-    });
-
-    it('should set class to danger if type is danger', () => {
-      component.showPopup = true;
-
-      fixture.detectChanges();
-
-      expect(nativeElement.querySelectorAll('.po-popup-item-danger').length).toBe(1);
-    });
-
-    it('should set class to separator if separator is true', () => {
-      component.showPopup = true;
-
-      fixture.detectChanges();
-
-      expect(nativeElement.querySelectorAll('.po-popup-item-separator').length).toBe(2);
-    });
-
-    it('should add `po-popup-item-selected` class if PopupAction.selected is true', () => {
-      component.actions = [{ label: 'PopupAction ', selected: true }];
-      component.showPopup = true;
-
-      fixture.detectChanges();
-
-      expect(nativeElement.querySelector('.po-popup-item-selected')).toBeTruthy();
-    });
-
     it('should not add `po-popup-item-selected` class if PopupAction.selected is false', () => {
       component.actions = [{ label: 'PopupAction ', selected: false }];
       component.showPopup = true;
@@ -548,15 +540,6 @@ describe('PoPopupComponent:', () => {
       fixture.detectChanges();
 
       expect(nativeElement.querySelector('.po-popup-item-selected')).toBeFalsy();
-    });
-
-    it('should display arrow.', () => {
-      component.hideArrow = false;
-      component.showPopup = true;
-
-      fixture.detectChanges();
-
-      expect(nativeElement.querySelector('.po-popup-arrow')).toBeTruthy();
     });
 
     it('shouldn´t display arrow.', () => {

--- a/projects/ui/src/lib/components/po-popup/po-popup.component.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup.component.ts
@@ -36,6 +36,7 @@ import { PoPopupBaseComponent } from './po-popup-base.component';
 })
 export class PoPopupComponent extends PoPopupBaseComponent {
   @ViewChild('popupRef', { read: ElementRef }) popupRef: ElementRef;
+  @ViewChild('listbox', { read: ElementRef }) listbox: ElementRef;
 
   constructor(
     viewContainerRef: ViewContainerRef,
@@ -102,6 +103,13 @@ export class PoPopupComponent extends PoPopupBaseComponent {
     this.showPopup && this.oldTarget === this.target ? this.close() : this.open(param);
   }
 
+  protected checkAllActionIsInvisible() {
+    if (this.actions.every(item => item.visible === false)) {
+      return true;
+    }
+    return false;
+  }
+
   private clickedOutDisabledItem(event) {
     const containsItemDisabled =
       this.elementContains(event.target, 'po-popup-item-disabled') ||
@@ -130,7 +138,7 @@ export class PoPopupComponent extends PoPopupBaseComponent {
   }
 
   private hasContentToShow() {
-    return !!(this.popupRef.nativeElement && this.popupRef.nativeElement.clientHeight);
+    return !!(this.popupRef?.nativeElement && this.listbox?.nativeElement);
   }
 
   private initializeListeners() {
@@ -146,7 +154,7 @@ export class PoPopupComponent extends PoPopupBaseComponent {
   }
 
   private onScroll = ({ target }): void => {
-    if (this.showPopup && target.className !== 'po-popup-container') {
+    if (this.showPopup && target.className !== 'po-popup-container' && this.actions.length < 6) {
       this.close();
     }
   };
@@ -174,16 +182,18 @@ export class PoPopupComponent extends PoPopupBaseComponent {
   }
 
   private setPosition() {
-    this.poControlPosition.setElements(
-      this.popupRef.nativeElement,
-      8,
-      this.target,
-      this.customPositions,
-      false,
-      this.isCornerAlign
-    );
-    this.poControlPosition.adjustPosition(this.position);
-    this.arrowDirection = this.poControlPosition.getArrowDirection();
+    if (this.listbox.nativeElement.querySelector('.po-listbox')) {
+      this.poControlPosition.setElements(
+        this.popupRef.nativeElement,
+        8,
+        this.target,
+        this.customPositions,
+        false,
+        this.isCornerAlign
+      );
+      this.poControlPosition.adjustPosition(this.position);
+      this.arrowDirection = this.poControlPosition.getArrowDirection();
+    }
   }
 
   private validateInitialContent() {

--- a/projects/ui/src/lib/components/po-popup/po-popup.module.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { PoIconModule } from '../po-icon/po-icon.module';
+import { PoListBoxModule } from '../po-listbox/po-listbox.module';
 
 import { PoPopupComponent } from './po-popup.component';
 
@@ -11,7 +11,7 @@ import { PoPopupComponent } from './po-popup.component';
  * Módulo do componente po-popup.
  */
 @NgModule({
-  imports: [CommonModule, PoIconModule],
+  imports: [CommonModule, PoListBoxModule],
   declarations: [PoPopupComponent],
   exports: [PoPopupComponent],
   providers: [],

--- a/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-email/sample-po-popup-email.component.ts
+++ b/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-email/sample-po-popup-email.component.ts
@@ -14,10 +14,9 @@ import { PoModalAction, PoModalComponent, PoPopupAction } from '@po-ui/ng-compon
       }
 
       .sample-popup-header-template {
-        background-color: #0c9abe;
         border-top-left-radius: 3px;
         border-top-right-radius: 3px;
-        color: #ffffff;
+        color: #0c9abe;
         padding-bottom: 5%;
         padding-left: 25%;
         padding-top: 5%;


### PR DESCRIPTION
**LISTBOX**

**DTHFUI-6733**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não existe um componente interno de listbox.

**Qual o novo comportamento?**
Cria componente interno listbox para ser reutilizado.

**Simulação**
Testar labs do portal

**PR's Relacionadas**
- https://github.com/po-ui/po-style/pull/378
- https://github.com/totvs/po-theme-totvs/pull/205