### PR TITLE
feat(dynamic-form): exibição do errorMessage

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -687,6 +687,26 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         expect(component['getComponentControl'](field)).toBe(expectedValue);
         expect(component['isUpload']).toHaveBeenCalled();
       });
+
+      it('should return `upload` if type is `upload` and has a `url`', () => {
+        const expectedValue = 'upload';
+        const field = { type: 'upload', property: 'upload', url: 'http://fakeurl.com' };
+
+        spyOn(component, <any>'isUpload').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isUpload']).toHaveBeenCalled();
+      });
+
+      it("should return `input` if type is `upload` and hasn't a `url`", () => {
+        const expectedValue = 'input';
+        const field = { type: 'upload', property: 'upload' };
+
+        spyOn(component, <any>'isUpload').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isUpload']).toHaveBeenCalled();
+      });
     });
 
     it('isCombo: should return `true` if `optionsService` is defined string', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -29,6 +29,8 @@ export class PoDynamicFormFieldsBaseComponent {
 
   visibleFields: Array<PoDynamicFormFieldInternal> = [];
 
+  invalidField: boolean = false;
+
   private _fields: Array<PoDynamicFormField>;
   private _validateFields: Array<string>;
   private _value?: any = {};

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -1,3 +1,4 @@
+<po-loading-overlay [hidden]="isLoadingValidate"></po-loading-overlay>
 <div class="po-row" *ngIf="visibleFields && visibleFields.length > 0">
   <ng-container *ngFor="let field of visibleFields; trackBy: trackBy">
     <po-divider *ngIf="field?.divider?.trim()" class="po-sm-12" [p-label]="field.divider"> </po-divider>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -23,7 +23,11 @@ describe('PoDynamicFormFieldsComponent: ', () => {
 
     fixture = TestBed.createComponent(PoDynamicFormFieldsComponent);
     component = fixture.componentInstance;
-    component['form'] = <any>{ touched: true };
+    component['form'] = <any>{
+      touched: true,
+      control: { disable: () => {}, enable: () => {} },
+      controls: { name: { setErrors: () => {} } }
+    };
 
     fixture.detectChanges();
 
@@ -367,6 +371,16 @@ describe('PoDynamicFormFieldsComponent: ', () => {
       component['applyFieldValidation'](index, validatedField);
 
       expect(component.value).toEqual(value);
+    });
+
+    it('applyFieldValidation: should change invalidField variable value to true', () => {
+      const index = 0;
+      const validatedField = { field: { property: 'test2', required: false, visible: true }, invalid: true };
+
+      component.fields = [{ property: 'test1', required: true, visible: true }];
+
+      component['applyFieldValidation'](index, validatedField);
+      expect(component.invalidField).toEqual(true);
     });
 
     it('applyFieldValidation: should call `detectChanges`', () => {
@@ -873,6 +887,23 @@ describe('PoDynamicFormFieldsComponent: ', () => {
         const validate = () => ({
           value: expectedValue,
           field: { help: 'new help' }
+        });
+
+        component.fields[0].validate = validate;
+
+        spyOn(component['validationService'], 'sendFieldChange').and.returnValue(of(validate()));
+        await component.onChangeField(component.visibleFields[0]);
+
+        expect(component.value.name).toBe(expectedValue);
+      });
+
+      it('should update field with invalid value', async () => {
+        const expectedValue = 'new value';
+
+        const validate = () => ({
+          value: expectedValue,
+          field: { help: 'new help' },
+          invalid: true
         });
 
         component.fields[0].validate = validate;

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-validation/po-dynamic-form-field-validation.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-validation/po-dynamic-form-field-validation.interface.ts
@@ -21,4 +21,7 @@ export interface PoDynamicFormFieldValidation {
 
   /** Novo valor do campo */
   value?: any;
+
+  /** Informa se o novo valor é valido ou inválido */
+  invalid?: boolean;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic.module.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic.module.ts
@@ -16,6 +16,7 @@ import { PoDynamicFormValidationService } from './po-dynamic-form/po-dynamic-for
 import { PoDynamicViewComponent } from './po-dynamic-view/po-dynamic-view.component';
 import { PoDynamicViewService } from './po-dynamic-view/po-dynamic-view.service';
 import { PoImageModule } from '../po-image';
+import { PoLoadingModule } from '../po-loading';
 
 @NgModule({
   imports: [
@@ -26,7 +27,8 @@ import { PoImageModule } from '../po-image';
     PoFieldModule,
     PoTagModule,
     PoTimeModule,
-    PoImageModule
+    PoImageModule,
+    PoLoadingModule
   ],
   declarations: [PoDynamicFormComponent, PoDynamicFormFieldsComponent, PoDynamicViewComponent],
   exports: [PoDynamicFormComponent, PoDynamicViewComponent],


### PR DESCRIPTION
Realizado melhoria para que seja possível informar se um campo é valido ou não, independente de seguir os padrões definidos no pattern ou no valor mínimo/máximo do campo.

Fixes DTHFUI-6637

**< dynamic-form >**

**< DTHFUI-6637 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Hoje a mensagem de erro só é apresentada se o campo não respeita o pattern ou o tamanho mínimo/máximo.

**Qual o novo comportamento?**
Caso a validação retorne o atributo "invalid" na interface PoDynamicFormFieldValidation como verdadeiro, o errorMessage do campo é apresentado, independente de respeitar ou não o pattern, valor mínimo ou máximo.

**Simulação**
Montar um formulário dinâmico e na validação retornar retornar a propriedade "invalid" como true