### PR TITLE
feat(modal): adiciona evento `p-close`

### DIFF
--- a/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
@@ -1,4 +1,4 @@
-import { Input, EventEmitter, Directive } from '@angular/core';
+import { Input, EventEmitter, Directive, Output } from '@angular/core';
 
 import { convertToBoolean } from './../../utils/util';
 import { PoModalAction } from './po-modal-action.interface';
@@ -26,6 +26,9 @@ import { poModalLiterals } from './po-modal.literals';
 export class PoModalBaseComponent {
   /** Título da modal. */
   @Input('p-title') title: string;
+
+  /** Evento disparado ao fechar o modal. */
+  @Output('p-close') closeModal: EventEmitter<any> = new EventEmitter();
 
   /**
    * Deve ser definido um objeto que implementa a interface `PoModalAction` contendo a label e a função da primeira ação.
@@ -112,6 +115,8 @@ export class PoModalBaseComponent {
 
   /** Função para fechar a modal. */
   close(xClosed = false): void {
+    this.closeModal.emit();
+
     this.isHidden = true;
     if (xClosed) {
       this.onXClosed.emit(xClosed);


### PR DESCRIPTION
Adiciona evento `p-close` que é disparado quando o modal é fechado:
- Pelo botão `Fechar`;
- Pelo `X` da interface do modal;
- Pela tecla `ESC`;

Fixes #1217

**Modal**

**1217**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando o modal é fechado pela tecla "ESC", não é disparado nenhum evento para que o usuário possa executar alguma ação.

**Qual o novo comportamento?**
Quando o modal é fechado pela tecla "ESC" ou de qualquer outra forma, será disparado um evento para que o usuário possa executar alguma ação.


**Simulação**
Pode ser simulado pelo [App](https://github.com/po-ui/po-angular/files/10368814/app.zip).
