### PR TITLE
fix(tag): altera cor do texto

### DIFF
--- a/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
@@ -354,7 +354,15 @@ describe('PoTagComponent:', () => {
       component.customColor = 'red';
 
       const result = component.styleTag();
-      expect(result).toEqual({ 'background-color': 'red' });
+      expect(result).toEqual({ 'background-color': 'red', 'color': 'white' });
+    });
+
+    it('styleTag : should change customTextColor to white if it is not defined and customColor is defined ', () => {
+      component.customTextColor = '';
+      component.customColor = 'red';
+
+      const result = component.styleTag();
+      expect(result).toEqual({ 'background-color': 'red', 'color': 'white' });
     });
 
     it('styleTag : should change the border if there is inverse and customColor', () => {

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.ts
@@ -88,7 +88,7 @@ export class PoTagComponent extends PoTagBaseComponent implements OnInit {
 
   styleTag() {
     if (!this.tagColor && !this.inverse) {
-      return { 'background-color': this.customColor };
+      return { 'background-color': this.customColor, 'color': 'white' };
     } else if (!this.tagColor && this.inverse && !this.customTextColor) {
       return { 'border': '1px solid ' + this.customColor };
     } else if (!this.tagColor && this.inverse && this.customTextColor) {


### PR DESCRIPTION
**TAG**

**DTHFUI-6842**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao customizar a cor do background (sem utilizar um tipo pré-estabelecido) a cor do texto está ficando preto.

**Qual o novo comportamento?**
Ao customizar a cor do background (sem utilizar um tipo pré-estabelecido) a cor do texto é branca, quando não definida uma cor de texto diferente.

**Simulação**
Portal sample po-tag
