### PR TITLE
test(menu): ajusta testes comentados da v15.0.0-next.0

### DIFF
--- a/projects/ui/src/lib/components/po-menu-panel/po-menu-panel.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu-panel/po-menu-panel.component.spec.ts
@@ -106,7 +106,7 @@ describe('PoMenuPanelComponent: ', () => {
 
       component['clickMenuItem'](<any>component.menus[3]);
 
-      // expect(component.activeMenuItem).toBe(undefined);
+      expect(component.activeMenuItem).toBeDefined();
       expect(component.menus[3].action).toHaveBeenCalled();
     });
 

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
@@ -207,7 +207,7 @@ describe('PoMenuComponent:', () => {
     spyOn(component.menus[3], <any>'action');
 
     component['clickMenuItem'](component.menus[3]);
-    // expect(component.activeMenuItem).toBe(undefined);
+    expect(component.activeMenuItem).toBeDefined();
     expect(component.mobileOpened).toBeFalsy();
     expect(component.menus[3].action).toHaveBeenCalled();
   });
@@ -246,7 +246,7 @@ describe('PoMenuComponent:', () => {
 
   it('should open sub menu external link', () => {
     component['clickMenuItem'](component.menus[1].subItems[1]);
-    // expect(component.activeMenuItem).toBe(undefined);
+    expect(component.activeMenuItem).toBeDefined();
     expect(component.mobileOpened).toBe(false);
   });
 


### PR DESCRIPTION
**MENU**

**DTHFUI-6967**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Apresenta erros ao rodar camada de testes.

**Qual o novo comportamento?**
Deixa de apresentar erros ao rodar camada de testes.

**Simulação**
Rodar comando `npm run test:ui` e verificar se testes são `SUCCESS`