### PR TITLE
feat(disclaimer): adiciona `literals` para o botão de remover

### DIFF
--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.spec.ts
@@ -1,8 +1,10 @@
+import { PoLanguageService } from './../../services/po-language/po-language.service';
 import { PoDisclaimerBaseComponent } from './po-disclaimer-base.component';
+
 import { expectSettersMethod } from './../../util-test/util-expect.spec';
 
 describe('PoDisclaimerBaseComponent', () => {
-  const component = new PoDisclaimerBaseComponent();
+  const component = new PoDisclaimerBaseComponent(new PoLanguageService());
 
   it('should be created', () => {
     expect(component instanceof PoDisclaimerBaseComponent).toBeTruthy();
@@ -65,6 +67,11 @@ describe('PoDisclaimerBaseComponent', () => {
     component.value = 'Valor';
 
     expect(component.getLabel()).toBe('Label');
+  });
+
+  it('should set aria-label', () => {
+    component.label = 'Label';
+    expect(component.setAriaLabel()).toContain('Label Remove');
   });
 
   it('should get label as value', () => {

--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.ts
@@ -1,6 +1,8 @@
+import { PoLanguageService } from './../../services/po-language/po-language.service';
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
 import { convertToBoolean } from '../../utils/util';
+import { PoDisclaimerLiterals } from './po-disclaimer.literals';
 
 const PO_DISCLAIMER_TYPES = ['default', 'danger'];
 const PO_DISCLAIMER_DEFAULT_TYPE = 'default';
@@ -39,6 +41,7 @@ export class PoDisclaimerBaseComponent {
    */
   @Output('p-close-action') closeAction: EventEmitter<any> = new EventEmitter<any>();
 
+  literals: any;
   showDisclaimer = true;
 
   private _type: string = 'default';
@@ -76,6 +79,13 @@ export class PoDisclaimerBaseComponent {
     return this._type;
   }
 
+  constructor(private languageService: PoLanguageService) {
+    const language = this.languageService.getShortLanguage();
+    this.literals = {
+      ...PoDisclaimerLiterals[language]
+    };
+  }
+
   close(): void {
     this.showDisclaimer = false;
     this.closeAction.emit({ value: this.value, label: this.label, property: this.property });
@@ -83,5 +93,9 @@ export class PoDisclaimerBaseComponent {
 
   getLabel() {
     return this.label ? this.label : this.value;
+  }
+
+  setAriaLabel() {
+    return this.label ? this.label + ' ' + this.literals.remove : this.value + ' ' + this.literals.remove;
   }
 }

--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.html
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.html
@@ -16,8 +16,8 @@
 
     <span
       *ngIf="hideClose === false"
+      [attr.aria-label]="setAriaLabel()"
       [attr.role]="!hideClose ? 'button' : ''"
-      [attr.aria-label]="getLabel()"
       class="po-disclaimer-remove po-icon po-icon-close po-clickable"
       tabindex="0"
       [class.po-disclaimer-remove-danger]="type === 'danger'"

--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.literals.ts
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.literals.ts
@@ -1,0 +1,14 @@
+export const PoDisclaimerLiterals = {
+  en: {
+    remove: 'Remove'
+  },
+  es: {
+    remove: 'Eliminar'
+  },
+  pt: {
+    remove: 'Remover'
+  },
+  ru: {
+    remove: 'удалять'
+  }
+};


### PR DESCRIPTION
**DISCLAIMER**

**DTHFUI-6894**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente não tem literais para o botão de remover

**Qual o novo comportamento?**
Componente passa a ter literais para o botão de remover


**Simulação**
[Portal](https://po-ui.io/documentation/po-disclaimer-group)  testando com `NVDA`