### PR TITLE
fix(datepicker-range): corrige locale Russia

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -16,6 +16,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
   class PoDatepickerRangeComponent extends PoDatepickerRangeBaseComponent {
     updateScreenByModel(dateRange: PoDatepickerRange) {}
     resetDateRangeInputValidation() {}
+    replaceFormatSeparator(): any {}
   }
 
   const mockedService: any = {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -111,7 +111,6 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   errorMessage: string = '';
   dateRange: PoDatepickerRange = { start: '', end: '' };
 
-  protected format: any = 'dd/mm/yyyy';
   protected isDateRangeInputFormatValid: boolean = true;
   protected isStartDateRangeInputValid: boolean = true;
   protected onTouchedModel: any;
@@ -393,8 +392,8 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
     return this._locale || this.language;
   }
 
-  constructor(protected poDateService: PoDateService, languageService: PoLanguageService) {
-    this.language = languageService.getShortLanguage();
+  constructor(protected poDateService: PoDateService, protected poLanguageService: PoLanguageService) {
+    this.language = poLanguageService.getShortLanguage();
   }
 
   // Função implementada do ControlValueAccessor
@@ -594,4 +593,6 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   protected abstract resetDateRangeInputValidation(): void;
 
   protected abstract updateScreenByModel(dateRange: PoDatepickerRange);
+
+  protected abstract replaceFormatSeparator(): any;
 }

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
@@ -2210,4 +2210,35 @@ describe('PoDatepickerRangeComponent:', () => {
       expect(poDatepickerField.classList).not.toContain('po-datepicker-range-field-focused');
     });
   });
+
+  describe('replaceFormatSeparator: ', () => {
+    it('should show date separator as . according to russian locale selected', () => {
+      component.locale = 'ru';
+      component.format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd.mm.yyyy';
+      const newFormat = component['replaceFormatSeparator']();
+      expect(newFormat).toBe(expectedFormat);
+    });
+    it('should show date separator as / according to portuguese locale selected', () => {
+      component.locale = 'pt';
+      component.format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd/mm/yyyy';
+      const newFormat = component['replaceFormatSeparator']();
+      expect(newFormat).toBe(expectedFormat);
+    });
+    it('should show date separator as / according to english locale selected', () => {
+      component.locale = 'en';
+      component.format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd/mm/yyyy';
+      const newFormat = component['replaceFormatSeparator']();
+      expect(newFormat).toBe(expectedFormat);
+    });
+    it('should show date separator as / according to spanish locale selected', () => {
+      component.locale = 'es';
+      component.format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd/mm/yyyy';
+      const newFormat = component['replaceFormatSeparator']();
+      expect(newFormat).toBe(expectedFormat);
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
@@ -2214,28 +2214,28 @@ describe('PoDatepickerRangeComponent:', () => {
   describe('replaceFormatSeparator: ', () => {
     it('should show date separator as . according to russian locale selected', () => {
       component.locale = 'ru';
-      component.format = 'dd/mm/yyyy';
+      component['format'] = 'dd/mm/yyyy';
       const expectedFormat = 'dd.mm.yyyy';
       const newFormat = component['replaceFormatSeparator']();
       expect(newFormat).toBe(expectedFormat);
     });
     it('should show date separator as / according to portuguese locale selected', () => {
       component.locale = 'pt';
-      component.format = 'dd/mm/yyyy';
+      component['format'] = 'dd/mm/yyyy';
       const expectedFormat = 'dd/mm/yyyy';
       const newFormat = component['replaceFormatSeparator']();
       expect(newFormat).toBe(expectedFormat);
     });
     it('should show date separator as / according to english locale selected', () => {
       component.locale = 'en';
-      component.format = 'dd/mm/yyyy';
+      component['format'] = 'dd/mm/yyyy';
       const expectedFormat = 'dd/mm/yyyy';
       const newFormat = component['replaceFormatSeparator']();
       expect(newFormat).toBe(expectedFormat);
     });
     it('should show date separator as / according to spanish locale selected', () => {
       component.locale = 'es';
-      component.format = 'dd/mm/yyyy';
+      component['format'] = 'dd/mm/yyyy';
       const expectedFormat = 'dd/mm/yyyy';
       const newFormat = component['replaceFormatSeparator']();
       expect(newFormat).toBe(expectedFormat);

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -94,6 +94,7 @@ export class PoDatepickerRangeComponent
   private eventResizeListener;
   private poDatepickerRangeElement: ElementRef<any>;
   private poMaskObject: PoMask;
+  private format: any = 'dd/mm/yyyy';
 
   get autocomplete() {
     return this.noAutocomplete ? 'off' : 'on';
@@ -139,11 +140,12 @@ export class PoDatepickerRangeComponent
     private controlPosition: PoControlPositionService,
     private renderer: Renderer2,
     private cd: ChangeDetectorRef,
+    poLanguageService: PoLanguageService,
     poDateService: PoDateService,
-    poDatepickerRangeElement: ElementRef,
-    poLanguageService: PoLanguageService
+    poDatepickerRangeElement: ElementRef
   ) {
     super(poDateService, poLanguageService);
+
     this.poDatepickerRangeElement = poDatepickerRangeElement;
   }
 
@@ -170,7 +172,7 @@ export class PoDatepickerRangeComponent
 
   ngOnInit() {
     // Classe de máscara
-    this.poMaskObject = this.buildMask();
+    this.poMaskObject = this.buildMask(this.replaceFormatSeparator());
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -310,7 +312,7 @@ export class PoDatepickerRangeComponent
   }
 
   // Retorna um objeto do tipo PoMask com a mascara configurada.
-  private buildMask(): PoMask {
+  private buildMask(format: string = this.format): PoMask {
     let mask = this.format.toUpperCase();
 
     mask = mask.replace(/DD/g, '99');
@@ -321,7 +323,7 @@ export class PoDatepickerRangeComponent
   }
 
   private formatDate(format: string, day: string = '', month: string = '', year: string = ''): string {
-    let dateFormatted = format;
+    let dateFormatted = this.replaceFormatSeparator();
 
     day = day && day.includes('T') ? day.slice(0, 2) : day;
 
@@ -580,5 +582,14 @@ export class PoDatepickerRangeComponent
       this.isCalendarVisible = false;
     }
     this.cd.markForCheck();
+  }
+
+  protected replaceFormatSeparator() {
+    let newFormat = this.format;
+    const newDateSeparator = this.poLanguageService.getDateSeparator(this.locale);
+    if (newDateSeparator !== '/') {
+      newFormat = newFormat.replace(/\//g, newDateSeparator);
+    }
+    return newFormat;
   }
 }


### PR DESCRIPTION
**< DATEPICKER RANGE>**

**< DTHFUI-6948 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
 O po-datepicker-range não respeita o locale da Rússia apresentando '/' ao invés de  '.'para o usuário.

**Qual o novo comportamento?**
O componente apresenta corretamente a data utilizando '.' na formatação quando o locale é da Rússia

**Simulação**
Alterar o navegador para o idioma russo
Simulação no portal e no app
[app.zip](https://github.com/po-ui/po-angular/files/10446053/app.zip)
