### PR TITLE
fix(combo): corrige carregamento da lista após limpar campo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -492,13 +492,14 @@ describe('PoComboBaseComponent:', () => {
       spyOn(component, 'getObjectByValue');
       spyOn(component, 'updateSelectedValue');
       spyOn(component, 'updateComboList');
+      spyOn(component, <any>'updateHasNext');
 
       component.writeValue(null);
 
       expect(component.getOptionFromValue).not.toHaveBeenCalled();
       expect(component.getObjectByValue).not.toHaveBeenCalled();
       expect(component.updateSelectedValue).toHaveBeenCalledWith(null);
-      expect(component.updateComboList).toHaveBeenCalled();
+      expect(component['updateHasNext']).toHaveBeenCalled();
     });
 
     it('should call `updateSelectedValue` when contains `options` and param is a `validValue`', () => {
@@ -1435,6 +1436,16 @@ describe('PoComboBaseComponent:', () => {
       expect(component.updateComboList).toHaveBeenCalled();
       expect(component.initInputObservable).toHaveBeenCalled();
       expect(component.selectedValue).toEqual(undefined);
+    });
+
+    it('clear: should set hasNext to true if `infiniteScrool` is true', () => {
+      component['defaultService'].hasNext = false;
+      component.infiniteScroll = true;
+      component.service = defaultService;
+
+      component.clear('');
+
+      expect(component['defaultService'].hasNext).toEqual(true);
     });
 
     it(`checkIfService: should return 'label' if contain service and param is 'label'`, () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -819,6 +819,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     } else {
       this.updateSelectedValue(null);
       this.updateComboList();
+      this.updateHasNext();
     }
   }
 
@@ -855,6 +856,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     this.updateSelectedValue(null);
     this.updateComboList();
     this.initInputObservable();
+    this.updateHasNext();
   }
 
   protected configAfterSetFilterService(service: PoComboFilter | string) {
@@ -1044,6 +1046,12 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
 
     if (oldOption && oldOption[this.dynamicLabel]) {
       return this.updateSelectedValue(oldOption);
+    }
+  }
+
+  private updateHasNext() {
+    if (this.service && this.infiniteScroll) {
+      this.defaultService.hasNext = true;
     }
   }
 


### PR DESCRIPTION
**combo**

**DTHFUI-6818**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Lista só é carregada no segundo clique após limpar o campo e a lista esteja com hasNext=false

**Qual o novo comportamento?**
Lista é carregada normalmente após limpar o campo e a lista esteja com hasNext=false


**Simulação**
Testar todos os exemplos do portal e app: 
[app.zip](https://github.com/po-ui/po-angular/files/10490969/app.zip)
