### PR TITLE
fix(widget): corrige borda sendo apagada com `p-no-shadow`

### DIFF
--- a/projects/ui/src/lib/components/po-widget/po-widget.component.html
+++ b/projects/ui/src/lib/components/po-widget/po-widget.component.html
@@ -3,7 +3,7 @@
   [class.po-widget]="!primary"
   [class.po-widget-disabled]="disabled"
   [class.po-widget-primary]="primary"
-  [class.po-widget-no-shadow]="noShadow"
+  [class.po-widget-no-shadow]="click.observers.length && noShadow"
   [style.background-image]="background ? 'url(' + background + ')' : undefined"
   (click)="onClick($event)"
   (keydown)="onKeyDown($event)"

--- a/projects/ui/src/lib/components/po-widget/po-widget.component.spec.ts
+++ b/projects/ui/src/lib/components/po-widget/po-widget.component.spec.ts
@@ -42,12 +42,27 @@ describe('PoWidgetComponent with only body', () => {
     expect(nativeElement.querySelector('.po-widget-no-shadow')).toBeFalsy();
   });
 
-  it('should set noShadow to true', () => {
+  it('should`t set noShadow to true if the widget is not clickable', () => {
     const nativeElement = fixture.nativeElement;
     component.noShadow = true;
     fixture.detectChanges();
+    expect(nativeElement.querySelector('.po-widget-no-shadow')).toBeFalsy();
+  });
 
+  it('should set noShadow in template if the widget is clickable and noShadow is true', () => {
+    component.click.subscribe(() => {});
+    component.noShadow = true;
+    const nativeElement = fixture.nativeElement;
+    fixture.detectChanges();
     expect(nativeElement.querySelector('.po-widget-no-shadow')).toBeTruthy();
+  });
+
+  it('should`t set noShadow in template if the widget is clickable and noShadow is false', () => {
+    component.click.subscribe(() => {});
+    component.noShadow = false;
+    const nativeElement = fixture.nativeElement;
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('.po-widget-no-shadow')).toBeFalsy();
   });
 });
 

--- a/projects/ui/src/lib/components/po-widget/samples/sample-po-widget-labs/sample-po-widget-labs.component.html
+++ b/projects/ui/src/lib/components/po-widget/samples/sample-po-widget-labs/sample-po-widget-labs.component.html
@@ -4,7 +4,6 @@
   [p-disabled]="properties.includes('disabled')"
   [p-height]="height"
   [p-help]="help"
-  [p-no-shadow]="properties.includes('noShadow')"
   [p-primary]="properties.includes('primaryWidget')"
   [p-primary-label]="primaryLabel"
   [p-secondary-label]="secondaryLabel"

--- a/projects/ui/src/lib/components/po-widget/samples/sample-po-widget-labs/sample-po-widget-labs.component.ts
+++ b/projects/ui/src/lib/components/po-widget/samples/sample-po-widget-labs/sample-po-widget-labs.component.ts
@@ -19,7 +19,6 @@ export class SamplePoWidgetLabsComponent implements OnInit {
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'disabled', label: 'Disabled' },
-    { value: 'noShadow', label: 'No Shadow' },
     { value: 'primaryWidget', label: 'Primary Widget' }
   ];
 


### PR DESCRIPTION
**widget**

**fixes-DTHFUI-7003**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
p-no-shadow está apagando a borda de um widget não clicavel

**Qual o novo comportamento?**
p-no-shadow não está apagando a borda de um widget não clicavel


**Simulação**
PR STYLE: https://github.com/po-ui/po-style/pull/384
testar portal e app:

html :
```
<po-page-default>
  <po-widget p-title="title" (p-click)="teste($event)" [p-no-shadow]="true"></po-widget>
  <br>
  <br>
  <br>
  <po-widget p-title="title"  [p-no-shadow]="true"></po-widget>

</po-page-default>

```

ts: 
```
teste(event) {
    console.log('click')
  }

```