### PR TITLE
fix(tooltip): corrige remoção de tooltip em coluna do tipo link

### DIFF
--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.spec.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.spec.ts
@@ -117,6 +117,14 @@ describe('PoTooltipDirective', () => {
     });
   });
 
+  it('should call hideTooltip in ngOnDestroy', () => {
+    spyOn(directive, 'hideTooltip');
+
+    directive.ngOnDestroy();
+
+    expect(directive.hideTooltip).toHaveBeenCalled();
+  });
+
   it('should call initScrollEventListenerFunction in ngOnInit', () => {
     spyOn(directive, 'initScrollEventListenerFunction');
 
@@ -300,6 +308,7 @@ describe('PoTooltipDirective', () => {
     expect(directive.renderer.removeChild).toHaveBeenCalled();
     expect(directive.tooltipContent).toBe(undefined);
   }));
+
   it('should call hideTooltip in mouse click', fakeAsync(() => {
     spyOn(directive, 'hideTooltip');
     directive.appendInBody = undefined;
@@ -346,15 +355,6 @@ describe('PoTooltipDirective', () => {
     expect(directive.divContent.outerHTML.indexOf('abc') === -1).toBeTruthy();
   });
 
-  it('should`t concat the same text value', () => {
-    directive.lastTooltipText = 'Teste';
-    directive.tooltip = 'Teste\nTeste';
-
-    directive.updateTextContent();
-
-    expect(directive.divContent.textContent).toEqual('Teste');
-  });
-
   it('should hide tooltip when have tooltipContent', () => {
     spyOn(directive, <any>'removeScrollEventListener');
 
@@ -362,6 +362,15 @@ describe('PoTooltipDirective', () => {
 
     expect(getComputedStyle(directive.tooltipContent).getPropertyValue('visibility')).toEqual('hidden');
     expect(directive['removeScrollEventListener']).toHaveBeenCalled();
+  });
+
+  it('should`t concat the same text value', () => {
+    directive.lastTooltipText = 'Teste';
+    directive.tooltip = 'Teste\nTeste';
+
+    directive.updateTextContent();
+
+    expect(directive.divContent.textContent).toEqual('Teste');
   });
 
   it('removeScrollEventListener: shoult call window.removeEventListener', () => {

--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener, OnInit, Renderer2 } from '@angular/core';
+import { Directive, ElementRef, HostListener, OnInit, Renderer2, OnDestroy } from '@angular/core';
 
 import { PoTooltipBaseDirective } from './po-tooltip-base.directive';
 import { PoTooltipControlPositionService } from './po-tooltip-control-position.service';
@@ -30,7 +30,7 @@ const nativeElements = ['input', 'button'];
   selector: '[p-tooltip]',
   providers: [PoTooltipControlPositionService]
 })
-export class PoTooltipDirective extends PoTooltipBaseDirective implements OnInit {
+export class PoTooltipDirective extends PoTooltipBaseDirective implements OnInit, OnDestroy {
   private arrowDirection: string;
   private divArrow;
   private divContent;
@@ -47,6 +47,14 @@ export class PoTooltipDirective extends PoTooltipBaseDirective implements OnInit
     private poControlPosition: PoTooltipControlPositionService
   ) {
     super();
+  }
+
+  ngOnDestroy(): void {
+    this.hideTooltip();
+  }
+
+  ngOnInit() {
+    this.initScrollEventListenerFunction();
   }
 
   @HostListener('mouseenter') onMouseEnter() {
@@ -83,10 +91,6 @@ export class PoTooltipDirective extends PoTooltipBaseDirective implements OnInit
     if (!this.displayTooltip && (event.code === 'Escape' || event.keyCode === 27)) {
       this.removeTooltipAction();
     }
-  }
-
-  ngOnInit() {
-    this.initScrollEventListenerFunction();
   }
 
   protected addTooltipAction() {


### PR DESCRIPTION
**TOOLTIP>**

**DTHFUI-6956**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Tooltip se mantém após redirecionamento utilizando coluna do tipo link

**Qual o novo comportamento?**
Tooltip deixa de se manter após redirecionamento utilizando coluna do tipo link

**Simulação**
Utilizar esse [app.zip](https://github.com/po-ui/po-angular/files/10492985/app.zip)

