### PR TITLE
feat(datepicker-range): suporte locale russo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -96,11 +96,15 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('should be update property p-locale', () => {
-      // expectPropertiesValues(component, 'locale', '', 'pt'); // @TODO: corrigir teste
       expectPropertiesValues(component, 'locale', ['pt', 'x'], 'pt');
       expectPropertiesValues(component, 'locale', 'en', 'en');
       expectPropertiesValues(component, 'locale', 'es', 'es');
       expectPropertiesValues(component, 'locale', 'ru', 'ru');
+    });
+
+    it('should be update property p-locale with the default value ', () => {
+      component['language'] = 'pt';
+      expectPropertiesValues(component, 'locale', '', 'pt');
     });
 
     it('disabled: should update with true value.', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -5,10 +5,17 @@ import { poLocaleDefault } from '../../../services/po-language/po-language.const
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
 import { requiredFailed } from '../validators';
 import { PoDateService } from './../../../services/po-date/po-date.service';
-import { convertIsoToDate, convertToBoolean, setYearFrom0To100, validateDateRange } from './../../../utils/util';
+import {
+  convertIsoToDate,
+  convertToBoolean,
+  setYearFrom0To100,
+  validateDateRange,
+  replaceFormatSeparator
+} from './../../../utils/util';
 import { PoDatepickerRangeLiterals } from './interfaces/po-datepicker-range-literals.interface';
 import { PoDatepickerRange } from './interfaces/po-datepicker-range.interface';
 import { poDatepickerRangeLiteralsDefault } from './po-datepicker-range.literals';
+import { PoMask } from '../po-input/po-mask';
 
 /**
  * @description
@@ -115,6 +122,7 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   protected isDateRangeInputFormatValid: boolean = true;
   protected isStartDateRangeInputValid: boolean = true;
   protected onTouchedModel: any;
+  protected poMaskObject: PoMask;
 
   private _clean?: boolean = false;
   private _disabled?;
@@ -384,8 +392,14 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   @Input('p-locale') set locale(value: string) {
     if (value) {
       this._locale = value.length >= 2 ? value : poLocaleDefault;
+      this.poMaskObject = this.buildMask(
+        replaceFormatSeparator(this.format, this.languageService.getDateSeparator(this.locale))
+      );
     } else {
       this._locale = this.language;
+      this.poMaskObject = this.buildMask(
+        replaceFormatSeparator(this.format, this.languageService.getDateSeparator(this.locale))
+      );
     }
   }
 
@@ -393,7 +407,7 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
     return this._locale || this.language;
   }
 
-  constructor(protected poDateService: PoDateService, languageService: PoLanguageService) {
+  constructor(protected poDateService: PoDateService, private languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();
   }
 
@@ -505,6 +519,17 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
     }
 
     this.updateScreenByModel(this.dateRange);
+  }
+
+  // Retorna um objeto do tipo PoMask com a mascara configurada.
+  protected buildMask(format: string = this.format): PoMask {
+    let mask = format.toUpperCase();
+
+    mask = mask.replace(/DD/g, '99');
+    mask = mask.replace(/MM/g, '99');
+    mask = mask.replace(/YYYY/g, '9999');
+
+    return new PoMask(mask, true);
   }
 
   protected dateFormatFailed(value: string): boolean {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
@@ -256,6 +256,33 @@ describe('PoDatepickerRangeComponent:', () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    it(`ngOnChanges: shouldn't call 'updateScreenByModel' if 'changes' contain locale`, () => {
+      const changes: any = {
+        locale: 'pt'
+      };
+
+      const spy = spyOn(component, <any>'buildMask');
+
+      component.ngOnChanges(changes);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it(`ngOnChanges: shouldn't call 'updateScreenByModel' if 'changes' contain locale and contain 'dateRange'`, () => {
+      const changes: any = {
+        locale: 'pt'
+      };
+      component.dateRange = { start: '2023-01-25', end: '2023-02-21' };
+
+      const spyBuildMask = spyOn(component, <any>'buildMask');
+      const spyUpdateScreenByModel = spyOn(component, <any>'updateScreenByModel');
+
+      component.ngOnChanges(changes);
+
+      expect(spyBuildMask).toHaveBeenCalled();
+      expect(spyUpdateScreenByModel).toHaveBeenCalled();
+    });
+
     it('clear: should call `updateScreenByModel`, `resetDateRangeInputValidation` and `updateModel`', () => {
       spyOn(component, 'updateScreenByModel');
       spyOn(component, <any>'resetDateRangeInputValidation');
@@ -602,6 +629,13 @@ describe('PoDatepickerRangeComponent:', () => {
       const date = [undefined, '3', '2018'];
 
       expect(component['formatDate'](format, ...date)).toBe('2018-03-0');
+    });
+
+    it('formatDate: should convert date to `yyyy-mm-` with default format value', () => {
+      component['format'] = 'yyyy-mm-dd';
+      const date = [undefined, '3', '2018'];
+
+      expect(component['formatDate'](undefined, ...date)).toBe('2018-03-0');
     });
 
     it('formatScreenToModel: should return empty string if value is undefined', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -24,7 +24,7 @@ describe('PoDatepickerBaseComponent:', () => {
   const languageService: PoLanguageService = new PoLanguageService();
 
   beforeEach(() => {
-    component = new PoDatepickerComponent();
+    component = new PoDatepickerComponent(languageService);
     component['shortLanguage'] = 'pt';
   });
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -9,7 +9,8 @@ import {
   formatYear,
   isTypeof,
   setYearFrom0To100,
-  validateDateRange
+  validateDateRange,
+  replaceFormatSeparator
 } from '../../../utils/util';
 import { dateFailed, requiredFailed } from './../validators';
 import { InputBoolean } from '../../../decorators';
@@ -290,13 +291,17 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
       value = value.toLowerCase();
       if (value.match(/dd/) && value.match(/mm/) && value.match(/yyyy/)) {
         this._format = value;
-        this.objMask = this.buildMask(this.replaceFormatSeparator());
+        this.objMask = this.buildMask(
+          replaceFormatSeparator(this.format, this.languageService.getDateSeparator(this.locale))
+        );
         this.refreshValue(this.date);
         return;
       }
     }
     this._format = poDatepickerFormatDefault;
-    this.objMask = this.buildMask(this.replaceFormatSeparator());
+    this.objMask = this.buildMask(
+      replaceFormatSeparator(this.format, this.languageService.getDateSeparator(this.locale))
+    );
   }
 
   get format() {
@@ -337,10 +342,14 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   @Input('p-locale') set locale(value: string) {
     if (value) {
       this._locale = value.length >= 2 ? value : poLocaleDefault;
-      this.objMask = this.buildMask(this.replaceFormatSeparator());
+      this.objMask = this.buildMask(
+        replaceFormatSeparator(this.format, this.languageService.getDateSeparator(this.locale))
+      );
     } else {
       this._locale = this.shortLanguage;
-      this.objMask = this.buildMask(this.replaceFormatSeparator());
+      this.objMask = this.buildMask(
+        replaceFormatSeparator(this.format, this.languageService.getDateSeparator(this.locale))
+      );
     }
     this.refreshValue(this.date);
   }
@@ -348,7 +357,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
     return this._locale || this.shortLanguage;
   }
 
-  constructor() {}
+  constructor(protected languageService: PoLanguageService) {}
 
   set date(value: any) {
     this._date = typeof value === 'string' ? convertIsoToDate(value, false, false) : value;
@@ -360,7 +369,9 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
 
   ngOnInit() {
     // Classe de máscara
-    this.objMask = this.buildMask(this.replaceFormatSeparator());
+    this.objMask = this.buildMask(
+      replaceFormatSeparator(this.format, this.languageService.getDateSeparator(this.locale))
+    );
   }
 
   // Converte um objeto string em Date
@@ -483,8 +494,6 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
 
     return new PoMask(mask, true);
   }
-
-  protected abstract replaceFormatSeparator(): any;
 
   abstract writeValue(value: any): void;
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -699,7 +699,7 @@ describe('PoDatepickerComponent:', () => {
       const expectedData: any = '28/02/2019';
 
       spyOn(UtilsFunctions, 'formatYear').and.returnValue('2019');
-      spyOn(component, <any>'replaceFormatSeparator').and.returnValue('28/02/2019');
+      spyOn(UtilsFunctions, <any>'replaceFormatSeparator').and.returnValue('28/02/2019');
 
       const formattedDate = component.formatToDate(newDate);
       expect(formattedDate).toBe(expectedData);
@@ -1144,36 +1144,6 @@ describe('PoDatepickerComponent:', () => {
 
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
-    });
-  });
-  describe('replaceFormatSeparator: ', () => {
-    it('should show date separator as . according to russian locale selected', () => {
-      component.locale = 'ru';
-      component.format = 'dd/mm/yyyy';
-      const expectedFormat = 'dd.mm.yyyy';
-      const newFormat = component['replaceFormatSeparator']();
-      expect(newFormat).toBe(expectedFormat);
-    });
-    it('should show date separator as / according to portuguese locale selected', () => {
-      component.locale = 'pt';
-      component.format = 'dd/mm/yyyy';
-      const expectedFormat = 'dd/mm/yyyy';
-      const newFormat = component['replaceFormatSeparator']();
-      expect(newFormat).toBe(expectedFormat);
-    });
-    it('should show date separator as / according to english locale selected', () => {
-      component.locale = 'en';
-      component.format = 'dd/mm/yyyy';
-      const expectedFormat = 'dd/mm/yyyy';
-      const newFormat = component['replaceFormatSeparator']();
-      expect(newFormat).toBe(expectedFormat);
-    });
-    it('should show date separator as / according to spanish locale selected', () => {
-      component.locale = 'es';
-      component.format = 'dd/mm/yyyy';
-      const expectedFormat = 'dd/mm/yyyy';
-      const newFormat = component['replaceFormatSeparator']();
-      expect(newFormat).toBe(expectedFormat);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -12,7 +12,15 @@ import {
 } from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { formatYear, isKeyCodeEnter, isKeyCodeSpace, isMobile, setYearFrom0To100, uuid } from '../../../utils/util';
+import {
+  formatYear,
+  isKeyCodeEnter,
+  isKeyCodeSpace,
+  isMobile,
+  setYearFrom0To100,
+  uuid,
+  replaceFormatSeparator
+} from '../../../utils/util';
 import { PoControlPositionService } from './../../../services/po-control-position/po-control-position.service';
 
 import { PoCalendarComponent } from '../../po-calendar/po-calendar.component';
@@ -110,12 +118,12 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
   }
 
   constructor(
+    protected languageService: PoLanguageService,
     private controlPosition: PoControlPositionService,
-    private languageService: PoLanguageService,
     private renderer: Renderer2,
     el: ElementRef
   ) {
-    super();
+    super(languageService);
     this.shortLanguage = this.languageService.getShortLanguage();
     this.el = el;
     const language = languageService.getShortLanguage();
@@ -296,7 +304,7 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
       return undefined;
     }
 
-    let dateFormatted = this.replaceFormatSeparator();
+    let dateFormatted = replaceFormatSeparator(this.format, this.languageService.getDateSeparator(this.locale));
 
     dateFormatted = dateFormatted.replace('dd', ('0' + value.getDate()).slice(-2));
     dateFormatted = dateFormatted.replace('mm', ('0' + (value.getMonth() + 1)).slice(-2));
@@ -368,16 +376,6 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
   /* istanbul ignore next */
   verifyMobile() {
     return isMobile();
-  }
-
-  // Retorna o formato de acordo com o locale.
-  protected replaceFormatSeparator() {
-    let newFormat = this.format;
-    const newDateSeparator = this.languageService.getDateSeparator(this.locale);
-    if (newDateSeparator !== '/') {
-      newFormat = newFormat.replace(/\//g, newDateSeparator);
-    }
-    return newFormat;
   }
 
   private closeCalendar() {

--- a/projects/ui/src/lib/utils/util.spec.ts
+++ b/projects/ui/src/lib/utils/util.spec.ts
@@ -1599,4 +1599,21 @@ describe('sortFields:', () => {
 
     expect(result).toEqual(expectedFields);
   });
+
+  describe('replaceFormatSeparator: ', () => {
+    it('should show date separator as . according to russian locale selected', () => {
+      const separator = '.';
+      const format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd.mm.yyyy';
+      const newFormat = UtilFunctions.replaceFormatSeparator(format, separator);
+      expect(newFormat).toBe(expectedFormat);
+    });
+    it('should show date separator as / according to portuguese locale selected', () => {
+      const separator = '/';
+      const format = 'dd/mm/yyyy';
+      const expectedFormat = 'dd/mm/yyyy';
+      const newFormat = UtilFunctions.replaceFormatSeparator(format, separator);
+      expect(newFormat).toBe(expectedFormat);
+    });
+  });
 });

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -603,3 +603,12 @@ export function getFocusableElements(parentElement: Element): NodeListOf<Element
   const focusableElements = 'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"]';
   return parentElement.querySelectorAll(focusableElements);
 }
+
+// Retorna o formato de acordo com o locale.
+export function replaceFormatSeparator(format: string, separator: string) {
+  let newFormat = format;
+  if (separator !== '/') {
+    newFormat = newFormat.replace(/\//g, separator);
+  }
+  return newFormat;
+}


### PR DESCRIPTION
**datepicker-range**

**DTHFUI-6949**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
datepicker com locale russo estava com o formato dd/mm/yyyy

**Qual o novo comportamento?**
datepicker com locale russo está com o formato dd.mm.yyyy

**Simulação**
Testar labs do DATEPICKER-RANGE e do DATEPICKER