### PR TITLE
fix(tabs): adiciona tradução para a palavra "Mais"

### DIFF
--- a/projects/ui/src/lib/components/po-tabs/po-tabs.component.html
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.component.html
@@ -23,7 +23,7 @@
       #tabDropdown
       *ngIf="isShowTabDropdown"
       class="po-tab-button po-tab-dropdown"
-      p-label="Mais"
+      [p-label]="literals.moreTabs"
       [p-small]="small"
       [p-tabs]="overflowedTabs"
       (p-activated)="onTabActive($event)"

--- a/projects/ui/src/lib/components/po-tabs/po-tabs.component.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.component.ts
@@ -1,10 +1,27 @@
 import { ChangeDetectorRef, Component, ContentChildren, QueryList, ViewChild } from '@angular/core';
 
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+
 import { isMobile } from './../../utils/util';
 
 import { PoTabComponent } from './po-tab/po-tab.component';
 import { PoTabDropdownComponent } from './po-tab-dropdown/po-tab-dropdown.component';
 import { PoTabsBaseComponent } from './po-tabs-base.component';
+
+export const poTabsLiterals: Object = {
+  en: <any>{
+    moreTabs: 'More'
+  },
+  es: <any>{
+    moreTabs: 'Más'
+  },
+  pt: <any>{
+    moreTabs: 'Mais'
+  },
+  ru: <any>{
+    moreTabs: 'Ещё'
+  }
+};
 
 const poTabsMaxNumberOfTabs = 5;
 
@@ -44,11 +61,17 @@ export class PoTabsComponent extends PoTabsBaseComponent {
   @ViewChild('tabDropdown', { static: true }) tabDropdown: PoTabDropdownComponent;
 
   maxNumberOfTabs = poTabsMaxNumberOfTabs;
+  literals;
 
   private previousActiveTab: PoTabComponent;
 
-  constructor(private changeDetector: ChangeDetectorRef) {
+  constructor(private changeDetector: ChangeDetectorRef, private languageService: PoLanguageService) {
     super();
+    const language = languageService.getShortLanguage();
+
+    this.literals = {
+      ...poTabsLiterals[language]
+    };
   }
 
   get isMobileDevice() {


### PR DESCRIPTION
Adicionada a tradução para a palavra "Mais" quando as abas forem apresentadas de forma agrupada e em idioma diferente de português.

Fixes #1577

**Tabs**

**1577**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando as abas são apresentadas de forma agrupada e em idioma diferente de português, a palavra "Mais" não tem tradução para o idioma do navegador.

**Qual o novo comportamento?**
Quando as abas são apresentadas de forma agrupada e em idioma diferente de português, a palavra "Mais" foi adicionada a tradução para o idioma do navegador.

**Simulação**
Pode ser feita a simulação com o [App](https://github.com/po-ui/po-angular/files/10551956/app.zip)
