### PR TITLE
refactor(datepicker): remove classe não sendo mais utilizada

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
@@ -11,7 +11,7 @@
       <input
         #inp
         class="po-input po-datepicker"
-        [ngClass]="clean && inp.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
+        [class.po-input-icon-right]="clean && inp.value"
         type="text"
         [attr.name]="name"
         [autocomplete]="autocomplete"


### PR DESCRIPTION
**DATEPICKER**

**DTHFUI-7042**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente possui classe não sendo mais utilizada.

**Qual o novo comportamento?**
Componente deixa de possuir classe não utilizada.

**Simulação**
Portal sample Datepicker Labs com `clean`