### PR TITLE
fix(page-dynamic-table): corrige ordenação após paginação

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -380,6 +380,42 @@ describe('PoTableBaseComponent:', () => {
     expect(component.items).toEqual(sortedItemsAsc);
   });
 
+  it('should sort values if has `p-height`', () => {
+    const column = component.columns[1];
+    const sortedItemsAsc = items.slice().sort((a, b) => a.numberData - b.numberData);
+    component.height = 300;
+    component['sortArray'](column, true);
+
+    expect(component.items).toEqual(sortedItemsAsc);
+  });
+
+  it('should set items with newItem and items', () => {
+    component.items = [{ 'label': 'test2' }];
+
+    component.height = 300;
+    component['sortArrayWithHeight']([{ 'label': 'test3' }]);
+
+    expect(component.items).toEqual([{ 'label': 'test2' }, { 'label': 'test3' }]);
+  });
+
+  it('should set new items if there are no items ', () => {
+    component.items = [];
+
+    component.height = 300;
+    component['sortArrayWithHeight']([{ 'label': 'test' }]);
+
+    expect(component.items).toEqual([{ 'label': 'test' }]);
+  });
+
+  it('should set empty array if there are no items', () => {
+    component.items = [];
+
+    component.height = 300;
+    component['sortArrayWithHeight'](null);
+
+    expect(component.items).toEqual([]);
+  });
+
   it(`should has service and sort set 'sortStore'`, () => {
     const column = component.columns[1];
     component.serviceApi = 'https://po-ui.io';

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -366,7 +366,11 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * > Se falso, será inicializado como um *array* vazio.
    */
   @Input('p-items') set items(items: Array<any>) {
-    this._items = Array.isArray(items) ? [...items] : [];
+    if (this.height) {
+      this.sortArrayWithHeight(items);
+    } else {
+      this._items = Array.isArray(items) ? items : [];
+    }
 
     // when haven't items, selectAll should be unchecked.
     if (!this.hasItems) {
@@ -939,11 +943,13 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   }
 
   private sortArray(column: PoTableColumn, ascending: boolean) {
-    const itemsList = [...this.items];
+    const itemsList = this.height ? [...this.items] : this.items;
     itemsList.sort((leftSide, rightSide): number =>
       sortValues(leftSide[column.property], rightSide[column.property], ascending)
     );
-    this.items = itemsList;
+    if (this.height) {
+      this.items = itemsList;
+    }
   }
 
   private unselectOtherRows(rows: Array<any>, row) {
@@ -991,6 +997,27 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     }
 
     return `${column.property}`;
+  }
+
+  private sortArrayWithHeight(items: Array<any>) {
+    if (this.items && this.items.length > 0) {
+      const object = this.items[0];
+      const key = Object.keys(object)[0];
+      const arrayKeys = new Set(this.items.map(d => d[key]));
+      const merged = [...items.filter(d => !arrayKeys.has(d[key]))];
+      let temporaryArray;
+
+      if (merged.length < 1) {
+        temporaryArray = [...items];
+      } else {
+        temporaryArray = [...this.items];
+      }
+      const newArray = [...temporaryArray, ...merged];
+
+      this._items = [...newArray];
+    } else {
+      this._items = Array.isArray(items) ? [...items] : [];
+    }
   }
 
   protected abstract calculateHeightTableContainer(height);


### PR DESCRIPTION
**page-dynamic-table**

**DTHFUI-7058**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não mantém a ordenação após paginação da tabela

**Qual o novo comportamento?**
Mantém a ordenação após paginação da tabela

**Simulação**
testar todos os samples do portal da TABLE e do DYNAMIC-TABLE