### PR TITLE
fix(calendar): corrige seguencia de meses no modo range

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
@@ -160,6 +160,44 @@ describe('PoCalendarBaseComponent:', () => {
       expect(component.activateDate.getMonth()).toBe(9);
     });
 
+    it('setActivateDate: should keep the initial month and the following month when selecting the last day of the month', () => {
+      const date = '2023-03-31';
+
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+
+      component['setActivateDate'](date);
+
+      const { start, end } = component.activateDate;
+
+      expect(start instanceof Date).toBe(true);
+      expect(end instanceof Date).toBe(true);
+
+      expect(start.getMonth()).toBe(2);
+      expect(start.getFullYear()).toBe(2023);
+
+      expect(end.getMonth()).toBe(3);
+      expect(end.getFullYear()).toBe(2023);
+    });
+
+    it('setActivateDate: should keep the start month and the after month when selecting the first day of the month', () => {
+      const date = '2023-03-01';
+
+      spyOnProperty(component, 'isRange').and.returnValue(true);
+
+      component['setActivateDate'](date);
+
+      const { start, end } = component.activateDate;
+
+      expect(start instanceof Date).toBe(true);
+      expect(end instanceof Date).toBe(true);
+
+      expect(start.getMonth()).toBe(2);
+      expect(start.getFullYear()).toBe(2023);
+
+      expect(end.getMonth()).toBe(3);
+      expect(end.getFullYear()).toBe(2023);
+    });
+
     it('verifyActivateDate: `activateDate` should receive `minDate` if the minimum date is later than today', () => {
       const today = new Date();
       component.minDate = new Date(new Date(today).setMonth(today.getMonth() + 1));

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
@@ -158,12 +158,33 @@ export class PoCalendarBaseComponent {
   }
 
   protected setActivateDate(date?: Date | string) {
+    let newData;
+    if (typeof date !== 'string') {
+      const temporaryDate = new Date(date);
+      const year = temporaryDate.getFullYear();
+      const month = ('0' + (temporaryDate.getMonth() + 1)).slice(-2);
+      const day = ('0' + temporaryDate.getDate()).slice(-2);
+      const formattedDate = `${year}-${month}-${day}`;
+      newData = formattedDate + 'T00:00:00';
+    } else {
+      newData = date + 'T00:00:00';
+    }
     const activateDate = date ? date : this.verifyActivateDate();
 
+    let checkedStart;
+    let checkedEnd;
+
     if (this.isRange) {
-      const checkedStart =
-        typeof activateDate === 'string' ? this.poDate.convertIsoToDate(activateDate) : new Date(activateDate);
-      const checkedEnd = new Date(new Date(checkedStart).setMonth(checkedStart.getMonth() + 1));
+      if (new Date(newData).getDate() > 28) {
+        checkedStart = new Date(activateDate);
+        checkedEnd = new Date(checkedStart.getFullYear(), checkedStart.getMonth() + 1, 0, 23, 59, 59, 999);
+        checkedEnd.setMilliseconds(checkedEnd.getMilliseconds() + 1);
+      } else {
+        checkedStart =
+          typeof activateDate === 'string' ? this.poDate.convertIsoToDate(activateDate) : new Date(activateDate);
+        checkedEnd = new Date(new Date(checkedStart).setMonth(checkedStart.getMonth() + 1));
+      }
+
       this.activateDate = { start: checkedStart, end: checkedEnd };
     } else {
       this.activateDate = new Date(activateDate);

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
@@ -442,6 +442,82 @@ describe('PoCalendarComponent:', () => {
       expect(component.activateDate.end.getFullYear()).toEqual(2010);
     });
 
+    it(`onHeaderChange: change the header correctly when the selected date is in the middle of the month`, () => {
+      const start = new Date('Wed Mar 15 2023 00:00:00');
+      const end = new Date('Sat Apr 01 2023 00:00:00');
+
+      component.activateDate = { start, end };
+
+      const nextMonth = 1;
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+
+      component.onHeaderChange({ month: nextMonth, year: 2023 }, 'start');
+
+      expect(component.activateDate.start.getMonth()).toEqual(nextMonth);
+      expect(component.activateDate.start.getFullYear()).toEqual(2023);
+
+      expect(component.activateDate.end.getMonth()).toEqual(nextMonth + 1);
+      expect(component.activateDate.end.getFullYear()).toEqual(2023);
+    });
+
+    it(`onHeaderChange: change the header correctly when the selected date is on the last day of the month`, () => {
+      const start = new Date('Thu Mar 31 2023 00:00:00');
+      const end = new Date('Sat Apr 01 2023 00:00:00');
+
+      component.activateDate = { start, end };
+
+      const nextMonth = 1;
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+
+      component.onHeaderChange({ month: nextMonth, year: 2023 }, 'start');
+
+      expect(component.activateDate.start.getMonth()).toEqual(nextMonth);
+      expect(component.activateDate.start.getFullYear()).toEqual(2023);
+
+      expect(component.activateDate.end.getMonth()).toEqual(nextMonth + 1);
+      expect(component.activateDate.end.getFullYear()).toEqual(2023);
+    });
+
+    it(`onHeaderChange: change the header correctly when the previous month is in another year`, () => {
+      const start = new Date('Tue Jan 03 2023 00:00:00');
+      const end = new Date('Wed Feb 01 2023 00:00:00');
+
+      component.activateDate = { start, end };
+
+      const nextMonth = 11;
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+
+      component.onHeaderChange({ month: nextMonth, year: 2022 }, 'start');
+
+      expect(component.activateDate.start.getMonth()).toEqual(nextMonth);
+      expect(component.activateDate.start.getFullYear()).toEqual(2022);
+
+      expect(component.activateDate.end.getMonth()).toEqual(0);
+      expect(component.activateDate.end.getFullYear()).toEqual(2023);
+    });
+
+    it(`onHeaderChange: change header correctly when next month is in later year`, () => {
+      const start = new Date('Fri Nov 03 2023 00:00:00 ');
+      const end = new Date('Fri Dec 01 2023 00:00:00');
+
+      component.activateDate = { start, end };
+
+      const nextMonth = 0;
+
+      spyOnProperty(component, <any>'isRange').and.returnValue(true);
+
+      component.onHeaderChange({ month: nextMonth, year: 2024 }, 'end');
+
+      expect(component.activateDate.start.getMonth()).toEqual(11);
+      expect(component.activateDate.start.getFullYear()).toEqual(2023);
+
+      expect(component.activateDate.end.getMonth()).toEqual(nextMonth);
+      expect(component.activateDate.end.getFullYear()).toEqual(2024);
+    });
+
     it(`onHeaderChange: `, () => {
       const start = new Date(2011, 0, 10);
       const end = new Date(2011, 1, 10);

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
@@ -127,14 +127,26 @@ export class PoCalendarComponent extends PoCalendarBaseComponent implements OnIn
 
       if (partType === 'end') {
         const newYear = month === 0 ? year - 1 : year;
+        const daysInMonth = new Date(newYear, month, 0).getDate();
 
-        newStart = new Date(new Date(start.setMonth(month - 1)).setFullYear(newYear));
-        newEnd = new Date(new Date(end.setMonth(month)).setFullYear(year));
+        if (year !== newYear) {
+          newStart = new Date(year, month - 1, Math.min(start.getDate(), daysInMonth));
+          newEnd = new Date(year, month, Math.min(end.getDate(), daysInMonth));
+        } else {
+          newStart = new Date(newYear, month - 1, Math.min(start.getDate(), daysInMonth));
+          newEnd = new Date(newYear, month, Math.min(end.getDate(), daysInMonth));
+        }
       } else {
         const newYear = month === 11 ? year + 1 : year;
+        const daysInMonth = new Date(newYear, month + 1, 0).getDate();
 
-        newEnd = new Date(new Date(end.setMonth(month + 1)).setFullYear(newYear));
-        newStart = new Date(new Date(start.setMonth(month)).setFullYear(year));
+        if (year !== newYear) {
+          newEnd = new Date(year, month + 1, Math.min(end.getDate(), daysInMonth));
+          newStart = new Date(year, month, Math.min(start.getDate(), daysInMonth));
+        } else {
+          newEnd = new Date(newYear, month + 1, Math.min(end.getDate(), daysInMonth));
+          newStart = new Date(newYear, month, Math.min(start.getDate(), daysInMonth));
+        }
       }
 
       this.activateDate = { start: newStart, end: newEnd };


### PR DESCRIPTION
**CALENDAR**

**DTHFUI-7053**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao selecionar dia 31 no calendário o mesmo pulava 1 mês a frente no modo range.

**Qual o novo comportamento?**
Ao selecionar dia 31 no calendário o mesmo apresenta seguencia de meses corretamente no modo range.

**Simulação**
Portal sample `PO Calendar Labs`
