### PR TITLE
fix(po-tab): ajustado traducao

### DIFF
--- a/projects/ui/src/lib/components/po-tabs/po-tabs.component.html
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.component.html
@@ -23,7 +23,7 @@
       #tabDropdown
       *ngIf="isShowTabDropdown"
       class="po-tab-button po-tab-dropdown"
-      p-label="Mais"
+      [p-label]="literals.moreTabs"
       [p-small]="small"
       [p-tabs]="overflowedTabs"
       (p-activated)="onTabActive($event)"

--- a/projects/ui/src/lib/components/po-tabs/po-tabs.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.component.spec.ts
@@ -6,11 +6,13 @@ import * as UtilsFunction from './../../utils/util';
 
 import { PoTabsComponent } from './po-tabs.component';
 import { PoTabsModule } from './po-tabs.module';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 describe('PoTabsComponent:', () => {
   let component: PoTabsComponent;
   let fixture: ComponentFixture<PoTabsComponent>;
   let nativeElement: any;
+  let poLanguageService: PoLanguageService;
 
   let defaultTab;
   let activeTab;
@@ -19,12 +21,15 @@ describe('PoTabsComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [PoTabsModule]
+      imports: [PoTabsModule],
+      providers: [PoLanguageService]
     });
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoTabsComponent);
+    poLanguageService = TestBed.inject(PoLanguageService);
+
     component = fixture.componentInstance;
 
     defaultTab = { id: '1', active: false, label: 'Tab 1' };
@@ -243,6 +248,38 @@ describe('PoTabsComponent:', () => {
       component['activeDistinctTab']();
 
       expect(component['activeFirstTab']).toHaveBeenCalled();
+    });
+
+    it('should display small tabs', () => {
+      component.tabs = <any>[{ id: '0' }, { id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }];
+      component.small = true;
+      fixture.detectChanges();
+
+      const small = nativeElement.querySelector('.po-tab-button');
+
+      expect(small.getAttribute('ng-reflect-small')).toBeTruthy();
+    });
+
+    it('shouldn`t display small tabs', () => {
+      component.tabs = <any>[{ id: '0' }, { id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }];
+      component.small = false;
+      fixture.detectChanges();
+
+      const small = nativeElement.querySelector('.po-tab-button');
+
+      expect(small.getAttribute('ng-reflect-small')).toBe('false');
+    });
+
+    it('should return correct language', () => {
+      spyOn(poLanguageService, 'getShortLanguage').and.returnValue('en');
+      component.setLanguage();
+      expect(component.literals.moreTabs).toEqual('More');
+    });
+
+    it('should return default language', () => {
+      spyOn(poLanguageService, 'getShortLanguage').and.returnValue('xx');
+      component.setLanguage();
+      expect(component.literals.moreTabs).toEqual('Mais');
     });
   });
 

--- a/projects/ui/src/lib/components/po-tabs/po-tabs.component.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.component.ts
@@ -5,6 +5,8 @@ import { isMobile } from './../../utils/util';
 import { PoTabComponent } from './po-tab/po-tab.component';
 import { PoTabDropdownComponent } from './po-tab-dropdown/po-tab-dropdown.component';
 import { PoTabsBaseComponent } from './po-tabs-base.component';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../services/po-language/po-language.constant';
 
 const poTabsMaxNumberOfTabs = 5;
 
@@ -45,10 +47,30 @@ export class PoTabsComponent extends PoTabsBaseComponent {
 
   maxNumberOfTabs = poTabsMaxNumberOfTabs;
 
+  poTabsLiterals = {
+    en: {
+      moreTabs: 'More'
+    },
+    pt: {
+      moreTabs: 'Mais'
+    },
+    es: {
+      moreTabs: 'Más'
+    },
+    rus: {
+      moreTabs: 'Ещё'
+    }
+  };
+
+  literals: {
+    moreTabs: string;
+  };
+
   private previousActiveTab: PoTabComponent;
 
-  constructor(private changeDetector: ChangeDetectorRef) {
+  constructor(private changeDetector: ChangeDetectorRef, private languageService: PoLanguageService) {
     super();
+    this.setLanguage();
   }
 
   get isMobileDevice() {
@@ -66,6 +88,13 @@ export class PoTabsComponent extends PoTabsBaseComponent {
 
   get visibleTabs() {
     return this.tabs.filter(tab => !tab.hide);
+  }
+
+  setLanguage(): void {
+    this.literals = {
+      ...this.poTabsLiterals[poLocaleDefault],
+      ...this.poTabsLiterals[this.languageService.getShortLanguage()]
+    };
   }
 
   closePopover(): void {


### PR DESCRIPTION
Quando possuímos mais de 5 Tabs, o texto do dropdown sempre imprimia "Mais" ao invés de utilizar o idioma do navegador.

Fixes 1577

**po-tabs**

**1577**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O texto "Mais" não é traduzido para todos os idiomas

**Qual o novo comportamento?**
O texto "Mais" é traduzido de acordo com o idioma do navegador

**Simulação**
Acessar uma página com mais de 5 tabs usando um idioma diferente de pt-br