### PR TITLE
feat(page-dynamic-edit): adiciona p-load-data

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -4,7 +4,7 @@ import { FormsModule, NgForm } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { throwError, of, EMPTY } from 'rxjs';
+import { throwError, of } from 'rxjs';
 
 import { PoDialogModule } from '@po-ui/ng-components';
 
@@ -745,6 +745,25 @@ describe('PoPageDynamicEditComponent: ', () => {
 
         tick();
       }));
+
+      it('should call `onLoadData` and set `model` with the custom data', fakeAsync(() => {
+        const id = '1';
+        const responseExpected = { name: 'angular' };
+        const customModelValue = { newValue: 'custom' };
+
+        const expectedModel = { ...responseExpected, ...customModelValue };
+
+        component.model = undefined;
+        component.onLoadData = model => ({ ...model, ...customModelValue });
+
+        spyOn(component['poPageDynamicService'], 'getResource').and.returnValue(of(responseExpected));
+
+        component['loadData'](id).subscribe(response => {
+          expect(component.model).toEqual(expectedModel);
+        });
+
+        tick();
+      }));
     });
 
     describe('saveOperation:', () => {
@@ -1318,6 +1337,71 @@ describe('PoPageDynamicEditComponent: ', () => {
 
         expect(component['formatUniqueKey']).not.toHaveBeenCalled();
         expect(expectedResult).toBe(undefined);
+      });
+    });
+
+    describe('beforeSetModel:', () => {
+      it('should call `onLoadData` and pass the model data', () => {
+        const responseParam = { name: 'angular' };
+        const customModelValue = { newValue: 'custom' };
+
+        component.model = undefined;
+        component.onLoadData = model => ({ ...model, ...customModelValue });
+
+        spyOn(component, 'onLoadData');
+
+        component['beforeSetModel'](responseParam);
+
+        expect(component['onLoadData']).toHaveBeenCalledWith(responseParam);
+      });
+
+      it('should set custom data to `model` when has param `onLoadData` as function', () => {
+        const responseParam = { name: 'angular' };
+        const customModelValue = { newValue: 'custom' };
+
+        const expectedModel = { ...responseParam, ...customModelValue };
+
+        component.model = undefined;
+        component.onLoadData = model => ({ ...model, ...customModelValue });
+        component['beforeSetModel'](responseParam);
+
+        expect(component.model).toEqual(expectedModel);
+      });
+
+      it('should set custom data to `model` when has param `onLoadData` as Observable', () => {
+        const responseParam = { name: 'angular' };
+        const customModelValue = { newValue: 'custom' };
+
+        const expectedModel = { ...responseParam, ...customModelValue };
+
+        component.model = undefined;
+        component.onLoadData = model => of({ ...model, ...customModelValue });
+        component['beforeSetModel'](responseParam);
+
+        expect(component.model).toEqual(expectedModel);
+      });
+
+      it('should set response to `model` if has no `onLoadData`', () => {
+        const expectedModel = { name: 'angular' };
+
+        component.model = undefined;
+        component.onLoadData = undefined;
+        component['beforeSetModel'](expectedModel);
+
+        expect(component.model).toEqual(expectedModel);
+      });
+
+      it('should set response to `model` if `onLoadData` return error', () => {
+        const expectedModel = { name: 'angular' };
+
+        component.model = undefined;
+        component.onLoadData = model => {
+          const err = new Error('test');
+          return throwError(() => err);
+        };
+        component['beforeSetModel'](expectedModel);
+
+        expect(component.model).toEqual(expectedModel);
       });
     });
   });


### PR DESCRIPTION
Permite alterar o model do componente po-page-dynamic-edit após feita a busca dos dados através da propriedade p-load-data.

Fixes #1633

**po-page-dynamic-edit**

**#1633**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Hoje o componente po-page-dynamic-edit busca os dados pela api informada e não há uma maneira de alterar antes de repassar ao model do componente.

**Qual o novo comportamento?**
Agora é possível passar uma função ao novo parâmetro **"p-load-data"** que recebe o model e pode fazer as alterações necessárias, para adicionar ou modificar valores antes destes serem repassados a variável de model do componente.

**Simulação**
https://gist.github.com/guilnorth/1f88de824abdf0754ec7145572f4c703