### PR TITLE
feat(page-dynamic-search): melhora o disclaimer para campos booleanos

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -462,6 +462,42 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(component['setDisclaimers'](filters)).toEqual(result);
     });
 
+    it('getFilterValueToDisclaimer: should return true if field type is PoDynamicFieldType.Boolean', () => {
+      const field = { type: PoDynamicFieldType.Boolean, property: '1', label: 'boolean' };
+      const value = true;
+
+      const result = component['getFilterValueToDisclaimer'](field, value);
+
+      expect(result).toBe(true);
+    });
+
+    it('getFilterValueToDisclaimer: should return yes if field type is PoDynamicFieldType.Boolean', () => {
+      const field = { type: PoDynamicFieldType.Boolean, property: '1', label: 'boolean', booleanTrue: 'Yes' };
+      const value = true;
+
+      const result = component['getFilterValueToDisclaimer'](field, value);
+
+      expect(result).toBe('Yes');
+    });
+
+    it('getFilterValueToDisclaimer: should return false if field type is PoDynamicFieldType.Boolean', () => {
+      const field = { type: PoDynamicFieldType.Boolean, property: '1', label: 'boolean' };
+      const value = false;
+
+      const result = component['getFilterValueToDisclaimer'](field, value);
+
+      expect(result).toBe(false);
+    });
+
+    it('getFilterValueToDisclaimer: should return no if field type is PoDynamicFieldType.Boolean', () => {
+      const field = { type: PoDynamicFieldType.Boolean, property: '1', label: 'boolean', booleanFalse: 'No' };
+      const value = false;
+
+      const result = component['getFilterValueToDisclaimer'](field, value);
+
+      expect(result).toBe('No');
+    });
+
     it('getFilterValueToDisclaimer: should return formated date if field type is PoDynamicFieldType.Date', () => {
       const field = { type: PoDynamicFieldType.Date, property: '1', label: 'date' };
       const value = '2020-08-12';

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -243,6 +243,10 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
   }
 
   private getFilterValueToDisclaimer(field: any, value: any, optionsServiceObjectsList?: Array<PoComboOption>) {
+    if (field.type === PoDynamicFieldType.Boolean) {
+      value = value ? field.booleanTrue || value : field.booleanFalse || value;
+    }
+
     if (field.optionsService && optionsServiceObjectsList) {
       return this.optionsServiceDisclaimerLabel(value, optionsServiceObjectsList);
     }


### PR DESCRIPTION
Melhora o disclaimer para campos booleanos, exibindo o atributo `booleanTrue` ou `booleanFalse` quando os mesmos forem diferentes de `undefined` ao invés do atributo `value`.

Fixes #1307

**Page Dynamic Search**

**1307**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao adicionar um campo do tipo booleano nos filtros da pesquisa avançada, selecioná-lo e pressionar o botão pesquisar, é exibido o disclaimer com o valor `true` ou `false` separado por ":". Exemplo: Nome do campo: true

**Qual o novo comportamento?**
Ao adicionar um campo do tipo booleano nos filtros da pesquisa avançada, selecioná-lo e pressionar o botão pesquisar, é exibido o disclaimer com o valor do `booleanTrue` ou `booleanFalse` separado por ":". Exemplo: Nome do campo: Sim

**Simulação**
Pode ser realizado a simulação neste [App](https://github.com/po-ui/po-angular/files/10761857/app.zip).
