### PR TITLE
fix(dynamic-table): corrige paginação dos itens

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -668,6 +668,58 @@ describe('PoPageDynamicTableComponent:', () => {
         expect(component['page']).toEqual(2);
       }));
 
+      it('should keep the first item found that is equal to the response items', fakeAsync(() => {
+        component['page'] = 1;
+        component.fields = [
+          { property: 'seqItem', key: true },
+          { property: 'id', key: false, visible: false }
+        ];
+
+        const response = {
+          items: [{ name: 'Steve', id: 1, seqItem: 9 }],
+          hasNext: true,
+          page: 2
+        };
+
+        component.serviceApi = 'localHost';
+        component.items = [{ name: 'Anne', id: 2, seqItem: 9 }];
+
+        spyOn(component['poPageDynamicService'], 'getResources').and.returnValue(of(response));
+
+        component['loadData']({ page: 2 }).subscribe();
+
+        tick(100);
+
+        expect(component.items).toEqual([{ name: 'Anne', id: 2, seqItem: 9 }]);
+        expect(component['page']).toEqual(2);
+      }));
+
+      it('should keep the initial item if the response is empty', fakeAsync(() => {
+        component['page'] = 1;
+        component.fields = [
+          { property: 'seqItem', key: true },
+          { property: 'id', key: true, visible: false }
+        ];
+
+        const response = {
+          items: [],
+          hasNext: true,
+          page: 2
+        };
+
+        component.serviceApi = 'localHost';
+        component.items = [{ name: 'Anne', id: 2, seqItem: 9 }];
+
+        spyOn(component['poPageDynamicService'], 'getResources').and.returnValue(of(response));
+        spyOn(utilsFunctions, 'removeDuplicateItemsWithArrayKey');
+
+        component['loadData']({ page: 2 }).subscribe();
+
+        tick(100);
+
+        expect(component.items).toEqual([{ name: 'Anne', id: 2, seqItem: 9 }]);
+      }));
+
       it('should call loadData with quickSearchValue', fakeAsync(() => {
         const activatedRoute: any = {
           snapshot: {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -699,8 +699,13 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
 
     return this.poPageDynamicService.getResources(fullParams).pipe(
       tap(response => {
-        removeDuplicateItemsWithArrayKey(response.items, this.items, this.keys);
-        this.items = fullParams.page === 1 ? response.items : [...this.items, ...response.items];
+        let newArray;
+        if (fullParams.page === 1) {
+          newArray = removeDuplicateItemsWithArrayKey(response.items, response.items, this.keys);
+        } else {
+          newArray = removeDuplicateItemsWithArrayKey(this.items, response.items, this.keys);
+        }
+        this.items = newArray ? [...newArray] : this.items;
         this.page = fullParams.page;
         this.hasNext = response.hasNext;
       })

--- a/projects/templates/src/lib/utils/util.spec.ts
+++ b/projects/templates/src/lib/utils/util.spec.ts
@@ -398,8 +398,14 @@ describe('Function removeDuplicateItemsWithArrayKey:', () => {
     ];
 
     const key = [];
+
+    const resultExpected = removeDuplicateItemsWithArrayKey(item, item2, key);
+
     removeDuplicateItemsWithArrayKey(item, item2, key);
-    expect(item2).toEqual([
+    expect(resultExpected).toEqual([
+      { country: 'brasil', id: '1' },
+      { country: 'china', id: '2' },
+      { country: 'japao', id: '3' },
       { country: 'chile', id: '4' },
       { country: 'canada', id: '5' }
     ]);
@@ -419,8 +425,13 @@ describe('Function removeDuplicateItemsWithArrayKey:', () => {
     ];
 
     const key = ['country'];
+    const resultExpected = removeDuplicateItemsWithArrayKey(item, item2, key);
+
     removeDuplicateItemsWithArrayKey(item, item2, key);
-    expect(item2).toEqual([
+    expect(resultExpected).toEqual([
+      { country: 'brasil', id: '1' },
+      { country: 'china', id: '2' },
+      { country: 'japao', id: '3' },
       { country: 'chile', id: '4' },
       { country: 'canada', id: '5' }
     ]);
@@ -440,8 +451,12 @@ describe('Function removeDuplicateItemsWithArrayKey:', () => {
     ];
 
     const key = ['country', 'id'];
-    removeDuplicateItemsWithArrayKey(item, item2, key);
-    expect(item2).toEqual([
+    const resultExpected = removeDuplicateItemsWithArrayKey(item, item2, key);
+
+    expect(resultExpected).toEqual([
+      { country: 'brasil', id: '1' },
+      { country: 'china', id: '2' },
+      { country: 'japao', id: '3' },
       { country: 'chile', id: '4' },
       { country: 'canada', id: '5' }
     ]);

--- a/projects/templates/src/lib/utils/util.ts
+++ b/projects/templates/src/lib/utils/util.ts
@@ -410,7 +410,7 @@ export function removeDuplicateItems(item, item2, key) {
 }
 
 /**
- * Remove objetos duplicados passando um array de propriedades.
+ * Recebe dois arrays de objetos e remove os itens duplicados utilizando uma propriedade(key) para comparação.
  *
  * Exemplo:
  *
@@ -418,36 +418,20 @@ export function removeDuplicateItems(item, item2, key) {
  * item: [{country: 'japao'}, {country: 'brasil'} , {country: 'china'}]
  * item2: [{country: 'chile'}, {country: 'brasil'}, {country: 'canada'}]
  * key: '[country]'
- * Resultado:
- *    item2 = [{country: 'chile'}, {country: 'canada'} ]
+ * Resultado do retorno:
+ *    [{country: 'chile'}, {country: 'canada'}, {country: 'japao'}, {country: 'china'}]
  * ```
  *
  *
- * @param item lista comparada.
- * @param item2 lista para remover items duplicados.
- * @param key um array de propriedades que vão ser utilizadas para a comparação.
+ * @param item : primeira lista de itens.
+ * @param item2 : segunda lista de itens.
+ * @param key : um array de propriedades que vão ser utilizadas para a comparação.
  */
-export function removeDuplicateItemsWithArrayKey(item, item2, key) {
-  if (!key.length) {
-    removeDuplicateItems(item, item2, 'id');
-  } else if (key.length === 1) {
-    removeDuplicateItems(item, item2, key[0]);
-  } else {
-    let myKey;
-    let newArray;
-    let result;
+export function removeDuplicateItemsWithArrayKey(item, item2, keys) {
+  const newKey = keys.length ? keys : ['id'];
 
-    const allEqual = arr => arr.every(val => val === arr[0]);
-
-    for (let i = 0; i < key.length; i++) {
-      newArray = [...item].map(entry => entry[key[i]]).concat([...item2].map(entry => entry[key[i]]));
-      result = allEqual(newArray);
-      if (!result) {
-        myKey = key[i];
-        break;
-      }
-    }
-
-    removeDuplicateItems(item, item2, myKey);
-  }
+  const combinedArray = item.concat(item2);
+  return combinedArray.filter(
+    (obj, index) => index === combinedArray.findIndex(innerObj => newKey.every(key => innerObj[key] === obj[key]))
+  );
 }


### PR DESCRIPTION
**dynamic-table**

**DTHFUI-7087**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
não está removendo de forma correta os itens duplicados

**Qual o novo comportamento?**
Está removendo de forma correta os itens duplicados


**Simulação**

testar sample do portal e testar o seguinte app com 3 exemplos:
[app.zip](https://github.com/po-ui/po-angular/files/10854093/app.zip)

Para testar o primeiro exemplo, deve rodar localmente (npm run start) o po-sample-api na branch : 'dynamic-table/teste-task6749'

