### PR TITLE
feat(dynamic-view): permitir passar `options` e atribuir `label`

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
@@ -155,4 +155,30 @@ export interface PoDynamicViewField extends PoDynamicField {
    *  **Componentes compatíveis:** `po-image`.
    */
   image?: boolean;
+
+  /**
+   * Lista de opções que podem ser vinculadas à propriedade p-value.
+   * Quando uma opção de valor é passada, sua propriedade label será atribuída à propriedade p-value.
+   *
+   * Exemplo de utilização:
+   *
+   * ```
+   * fields = [
+   *     {
+   *       property: 'name', options: [
+   *         {label: 'Anna', value: '1'},
+   *         {label: 'Jhon', value: '2'},
+   *         {label: 'Mark', value: '3'}
+   *       ]
+   *     }
+   *   ];
+   * ```
+   *
+   * ```
+   * <!-- Passando o valor 2 referente ao Jhon -->
+   * <po-dynamic-view [p-fields]="fields" [p-value]="{ name: '2' }"> </po-dynamic-view>
+   * ```
+   *
+   */
+  options?: Array<{ label: string; value: string | number }>;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.html
@@ -13,7 +13,7 @@
 </div>
 
 <ng-template #poInfo let-field>
-  <po-info [ngClass]="field.cssClass" [p-label]="field.label" [p-value]="field.value"> </po-info>
+  <po-info [ngClass]="field.cssClass" [p-label]="field.label" [p-value]="setFieldValue(field)"> </po-info>
 </ng-template>
 
 <ng-template #poTag let-field>
@@ -23,7 +23,7 @@
     [p-icon]="field.icon"
     [p-inverse]="field.inverse"
     [p-label]="field.label"
-    [p-value]="field.value"
+    [p-value]="setFieldValue(field)"
   >
   </po-tag>
 </ng-template>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
@@ -234,6 +234,34 @@ describe('PoDynamicViewComponent:', () => {
       expect(component['setFieldsOnLoad']).toHaveBeenCalledWith(fakeDataOnLoad.fields);
       expect(component['getVisibleFields']).toHaveBeenCalled();
     });
+
+    it(`setFieldValue: should return the label of the selected option if options exist and a match is found`, () => {
+      const field = {
+        value: 'value1',
+        options: [
+          { value: 'value1', label: 'label1' },
+          { value: 'value2', label: 'label2' },
+          { value: 'value3', label: 'label3' }
+        ]
+      };
+
+      field.value = 'value2';
+      expect(component.setFieldValue(field)).toEqual('label2');
+    });
+
+    it(`setFieldValue: should return the field value if options exist but no match is found'`, () => {
+      const field = {
+        value: 'value1',
+        options: [
+          { value: 'value1', label: 'label1' },
+          { value: 'value2', label: 'label2' },
+          { value: 'value3', label: 'label3' }
+        ]
+      };
+
+      field.value = 'value4';
+      expect(component.setFieldValue(field)).toEqual('value4');
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
@@ -55,6 +55,15 @@ export class PoDynamicViewComponent extends PoDynamicViewBaseComponent implement
     }
   }
 
+  setFieldValue(field) {
+    if (field.options) {
+      const selectedOption = field.options.find(option => option.value === field.value);
+      return selectedOption ? selectedOption.label : field.value;
+    } else {
+      return field.value;
+    }
+  }
+
   private async getValuesAndFieldsFromLoad(): Promise<{ value?: any; fields?: Array<PoDynamicViewField> }> {
     let valueAndFieldsFromLoad;
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.ts
@@ -23,7 +23,22 @@ export class SamplePoDynamicViewEmployeeComponent {
     { property: 'city', label: 'City', divider: 'Address' },
     { property: 'addressStreet', label: 'Street' },
     { property: 'addressNumber', label: 'Number' },
-    { property: 'zipCode', label: 'Zip Code' }
+    { property: 'zipCode', label: 'Zip Code' },
+    {
+      property: 'marriedStatus',
+      options: [{ label: 'MARRIED', value: '1' }],
+      label: 'Marital status',
+      divider: 'ADDITIONAL DATA',
+      tag: true,
+      color: '#C596E7'
+    },
+    {
+      property: 'children',
+      options: [
+        { label: 'yes ', value: '1' },
+        { label: 'no', value: '2' }
+      ]
+    }
   ];
 
   employee = {
@@ -44,6 +59,8 @@ export class SamplePoDynamicViewEmployeeComponent {
     wage: 8000.5,
     availability: 'Available',
     admissionDate: '2014-10-14T13:45:00-00:00',
-    hoursPerDay: '08:30:00'
+    hoursPerDay: '08:30:00',
+    marriedStatus: '1',
+    children: '1'
   };
 }


### PR DESCRIPTION
**DYNAMIC-VIEW**

**DTHFUI-7097**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente não possuia propriedade `options` para exibir a label da opção selecionada.

**Qual o novo comportamento?**
Componente passa a ter propriedade `options` para exibir a label da opção selecionada.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/10875282/app.zip) e Portal sample `Dynamic View - Employee`
