### PR TITLE
fix(dynamic-table/lookup): arruma acúmulo de registros do filtro

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -2721,5 +2721,53 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(tableActions.length).toEqual(1);
       expect(tableActions[0].label).toEqual('Details');
     });
+
+    it('onSort: should sort list of items in ascending order', () => {
+      component.height = 400;
+      component.items = [
+        { label: 'ghi', id: 3 },
+        { label: 'abc', id: 2 },
+        { label: 'def', id: 1 }
+      ];
+
+      component.onSort({
+        column: {
+          label: 'Label',
+          property: 'label',
+          visible: true
+        },
+        type: PoTableColumnSortType.Ascending
+      });
+
+      expect(component.items).toEqual([
+        { label: 'abc', id: 2 },
+        { label: 'def', id: 1 },
+        { label: 'ghi', id: 3 }
+      ]);
+    });
+
+    it('onSort: should sort list of items in descending  order', () => {
+      component.height = 400;
+      component.items = [
+        { label: 'ghi', id: 3 },
+        { label: 'abc', id: 2 },
+        { label: 'def', id: 1 }
+      ];
+
+      component.onSort({
+        column: {
+          label: 'Label',
+          property: 'label',
+          visible: true
+        },
+        type: PoTableColumnSortType.Descending
+      });
+
+      expect(component.items).toEqual([
+        { label: 'ghi', id: 3 },
+        { label: 'def', id: 1 },
+        { label: 'abc', id: 2 }
+      ]);
+    });
   });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -561,6 +561,10 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   }
 
   onSort(sortedColumn: PoTableColumnSort) {
+    if (this.height) {
+      const order = sortedColumn.type === 'ascending' ? true : false;
+      util.sortArrayOfObjects(this.items, sortedColumn.column.property, order);
+    }
     this.sortedColumn = sortedColumn;
   }
 

--- a/projects/templates/src/lib/utils/util.spec.ts
+++ b/projects/templates/src/lib/utils/util.spec.ts
@@ -27,7 +27,8 @@ import {
   validValue,
   valuesFromObject,
   removeDuplicateItems,
-  removeDuplicateItemsWithArrayKey
+  removeDuplicateItemsWithArrayKey,
+  sortArrayOfObjects
 } from './util';
 import { changeChromeProperties } from '../util-test/util-expect.spec';
 
@@ -1156,5 +1157,51 @@ describe('Function removeKeysProperties:', () => {
     const keys = ['id'];
 
     expect(removeKeysProperties(keys, newItemValue)).toEqual(expectedResult);
+  });
+});
+
+describe('Function sortArrayOfObjects:', () => {
+  it('should sort the array of objects in ascending order based on the country key', () => {
+    const items = [{ country: 'japao' }, { country: 'brasil' }, { country: 'china' }];
+    const sortedItems = sortArrayOfObjects(items, 'country', true);
+
+    expect(sortedItems).toEqual([{ country: 'brasil' }, { country: 'china' }, { country: 'japao' }]);
+  });
+
+  it('should sort the array of objects in descending order based on the country key', () => {
+    const items = [{ country: 'japao' }, { country: 'brasil' }, { country: 'china' }];
+    const sortedItems = sortArrayOfObjects(items, 'country', false);
+
+    expect(sortedItems).toEqual([{ country: 'japao' }, { country: 'china' }, { country: 'brasil' }]);
+  });
+
+  it('should sort the array of objects in ascending order based on the country id', () => {
+    const items = [
+      { country: 'japao', id: 1 },
+      { country: 'brasil', id: 3 },
+      { country: 'china', id: 2 }
+    ];
+    const sortedItems = sortArrayOfObjects(items, 'id', true);
+
+    expect(sortedItems).toEqual([
+      { country: 'japao', id: 1 },
+      { country: 'china', id: 2 },
+      { country: 'brasil', id: 3 }
+    ]);
+  });
+
+  it('should sort the array of objects in descending order based on the country id', () => {
+    const items = [
+      { country: 'japao', id: 1 },
+      { country: 'brasil', id: 3 },
+      { country: 'china', id: 2 }
+    ];
+    const sortedItems = sortArrayOfObjects(items, 'id', false);
+
+    expect(sortedItems).toEqual([
+      { country: 'brasil', id: 3 },
+      { country: 'china', id: 2 },
+      { country: 'japao', id: 1 }
+    ]);
   });
 });

--- a/projects/templates/src/lib/utils/util.ts
+++ b/projects/templates/src/lib/utils/util.ts
@@ -435,3 +435,36 @@ export function removeDuplicateItemsWithArrayKey(item, item2, keys) {
     (obj, index) => index === combinedArray.findIndex(innerObj => newKey.every(key => innerObj[key] === obj[key]))
   );
 }
+
+/**
+ * Recebe um array de objetos para ordenação utilizando chave como comparativo e
+ * se a order é crescente(true) ou descrescente(false)
+ *
+ * Exemplo:
+ *
+ * ```
+ * items: [{country: 'japao'}, {country: 'brasil'} , {country: 'china'}]
+ * key: 'country'
+ * isAscendingOrder: true
+ * Resultado do retorno:
+ *    [{country: 'brasil'}, {country: 'china'} , {country: 'japao'}]
+ * ```
+ *
+ *
+ * @param items : lista de itens.
+ * @param key : propriedade utilizada na comparação.
+ * @param isAscendingOrder : ordenação crescente ou descrescente.
+ */
+export function sortArrayOfObjects(items, key, isAscendingOrder) {
+  return items.sort((a, b) => {
+    const valueA = a[key];
+    const valueB = b[key];
+
+    if (typeof valueA === 'number' && typeof valueB === 'number') {
+      return isAscendingOrder ? valueA - valueB : valueB - valueA;
+    } else {
+      const compareResult = valueA.toString().localeCompare(valueB.toString());
+      return isAscendingOrder ? compareResult : -compareResult;
+    }
+  });
+}

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
@@ -449,5 +449,51 @@ describe('PoLookupModalComponent', () => {
 
       expect(component.selecteds).toEqual(expectedSelecteds);
     });
+
+    it('sortBy: should sort list of items in ascending order', () => {
+      component.items = [
+        { label: 'ghi', id: 3 },
+        { label: 'abc', id: 2 },
+        { label: 'def', id: 1 }
+      ];
+
+      component.sortBy({
+        column: {
+          label: 'Label',
+          property: 'label',
+          visible: true
+        },
+        type: PoTableColumnSortType.Ascending
+      });
+
+      expect(component.items).toEqual([
+        { label: 'abc', id: 2 },
+        { label: 'def', id: 1 },
+        { label: 'ghi', id: 3 }
+      ]);
+    });
+
+    it('sortBy: should sort list of items in descending  order', () => {
+      component.items = [
+        { label: 'ghi', id: 3 },
+        { label: 'abc', id: 2 },
+        { label: 'def', id: 1 }
+      ];
+
+      component.sortBy({
+        column: {
+          label: 'Label',
+          property: 'label',
+          visible: true
+        },
+        type: PoTableColumnSortType.Descending
+      });
+
+      expect(component.items).toEqual([
+        { label: 'ghi', id: 3 },
+        { label: 'def', id: 1 },
+        { label: 'abc', id: 2 }
+      ]);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
@@ -18,6 +18,7 @@ import { PoLookupModalBaseComponent } from '../po-lookup-modal/po-lookup-modal-b
 import { PoLanguageService } from './../../../../services/po-language/po-language.service';
 import { PoDynamicFormComponent } from './../../../po-dynamic/po-dynamic-form/po-dynamic-form.component';
 import { PoTableComponent } from './../../../po-table/po-table.component';
+import { sortArrayOfObjects } from '../../../../utils/util';
 
 /**
  * @docsPrivate
@@ -104,6 +105,9 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
   }
 
   sortBy(sort: PoTableColumnSort) {
+    const order = sort.type === 'ascending' ? true : false;
+    sortArrayOfObjects(this.items, sort.column.property, order);
+
     this.sort = sort;
   }
 

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -388,34 +388,6 @@ describe('PoTableBaseComponent:', () => {
 
     expect(component.items).toEqual(sortedItemsAsc);
   });
-
-  it('should set items with newItem and items', () => {
-    component.items = [{ 'label': 'test2' }];
-
-    component.height = 300;
-    component['sortArrayWithHeight']([{ 'label': 'test3' }]);
-
-    expect(component.items).toEqual([{ 'label': 'test2' }, { 'label': 'test3' }]);
-  });
-
-  it('should set new items if there are no items ', () => {
-    component.items = [];
-
-    component.height = 300;
-    component['sortArrayWithHeight']([{ 'label': 'test' }]);
-
-    expect(component.items).toEqual([{ 'label': 'test' }]);
-  });
-
-  it('should set empty array if there are no items', () => {
-    component.items = [];
-
-    component.height = 300;
-    component['sortArrayWithHeight'](null);
-
-    expect(component.items).toEqual([]);
-  });
-
   it(`should has service and sort set 'sortStore'`, () => {
     const column = component.columns[1];
     component.serviceApi = 'https://po-ui.io';

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -366,11 +366,7 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * > Se falso, será inicializado como um *array* vazio.
    */
   @Input('p-items') set items(items: Array<any>) {
-    if (this.height) {
-      this.sortArrayWithHeight(items);
-    } else {
-      this._items = Array.isArray(items) ? items : [];
-    }
+    this._items = Array.isArray(items) ? [...items] : [];
 
     // when haven't items, selectAll should be unchecked.
     if (!this.hasItems) {
@@ -997,27 +993,6 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     }
 
     return `${column.property}`;
-  }
-
-  private sortArrayWithHeight(items: Array<any>) {
-    if (this.items && this.items.length > 0) {
-      const object = this.items[0];
-      const key = Object.keys(object)[0];
-      const arrayKeys = new Set(this.items.map(d => d[key]));
-      const merged = [...items.filter(d => !arrayKeys.has(d[key]))];
-      let temporaryArray;
-
-      if (merged.length < 1) {
-        temporaryArray = [...items];
-      } else {
-        temporaryArray = [...this.items];
-      }
-      const newArray = [...temporaryArray, ...merged];
-
-      this._items = [...newArray];
-    } else {
-      this._items = Array.isArray(items) ? [...items] : [];
-    }
   }
 
   protected abstract calculateHeightTableContainer(height);

--- a/projects/ui/src/lib/utils/util.spec.ts
+++ b/projects/ui/src/lib/utils/util.spec.ts
@@ -32,7 +32,8 @@ import {
   valuesFromObject,
   removeDuplicatedOptionsWithFieldValue,
   removeUndefinedAndNullOptionsWithFieldValue,
-  isValidImageBase64
+  isValidImageBase64,
+  sortArrayOfObjects
 } from './util';
 
 import * as UtilFunctions from './util';
@@ -1627,5 +1628,49 @@ describe('replaceFormatSeparator: ', () => {
     const expectedFormat = 'dd/mm/yyyy';
     const newFormat = UtilFunctions.replaceFormatSeparator(format, separator);
     expect(newFormat).toBe(expectedFormat);
+  });
+
+  it('should sort the array of objects in ascending order based on the country key', () => {
+    const items = [{ country: 'japao' }, { country: 'brasil' }, { country: 'china' }];
+    const sortedItems = UtilFunctions.sortArrayOfObjects(items, 'country', true);
+
+    expect(sortedItems).toEqual([{ country: 'brasil' }, { country: 'china' }, { country: 'japao' }]);
+  });
+
+  it('should sort the array of objects in descending order based on the country key', () => {
+    const items = [{ country: 'japao' }, { country: 'brasil' }, { country: 'china' }];
+    const sortedItems = UtilFunctions.sortArrayOfObjects(items, 'country', false);
+
+    expect(sortedItems).toEqual([{ country: 'japao' }, { country: 'china' }, { country: 'brasil' }]);
+  });
+
+  it('should sort the array of objects in ascending order based on the country id', () => {
+    const items = [
+      { country: 'japao', id: 1 },
+      { country: 'brasil', id: 3 },
+      { country: 'china', id: 2 }
+    ];
+    const sortedItems = UtilFunctions.sortArrayOfObjects(items, 'id', true);
+
+    expect(sortedItems).toEqual([
+      { country: 'japao', id: 1 },
+      { country: 'china', id: 2 },
+      { country: 'brasil', id: 3 }
+    ]);
+  });
+
+  it('should sort the array of objects in descending order based on the country id', () => {
+    const items = [
+      { country: 'japao', id: 1 },
+      { country: 'brasil', id: 3 },
+      { country: 'china', id: 2 }
+    ];
+    const sortedItems = UtilFunctions.sortArrayOfObjects(items, 'id', false);
+
+    expect(sortedItems).toEqual([
+      { country: 'brasil', id: 3 },
+      { country: 'china', id: 2 },
+      { country: 'japao', id: 1 }
+    ]);
   });
 });

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -624,3 +624,38 @@ export function replaceFormatSeparator(format: string, separator: string) {
   }
   return newFormat;
 }
+
+/**
+ * Recebe um array de objetos para ordenação utilizando chave como comparativo e
+ * se a order é crescente(true) ou descrescente(false)
+ *
+ * Exemplo:
+ *
+ * ```
+ * items: [{country: 'japao'}, {country: 'brasil'} , {country: 'china'}]
+ * key: 'country'
+ * isAscendingOrder: true
+ * Resultado do retorno:
+ *    [{country: 'brasil'}, {country: 'china'} , {country: 'japao'}]
+ * ```
+ *
+ *
+ * @param items : lista de itens.
+ * @param key : propriedade utilizada na comparação.
+ * @param isAscendingOrder : ordenação crescente ou descrescente.
+ */
+export function sortArrayOfObjects(items, key, isAscendingOrder) {
+  if (items) {
+    return items.sort((a, b) => {
+      const valueA = a[key];
+      const valueB = b[key];
+
+      if (typeof valueA === 'number' && typeof valueB === 'number') {
+        return isAscendingOrder ? valueA - valueB : valueB - valueA;
+      } else {
+        const compareResult = valueA.toString().localeCompare(valueB.toString());
+        return isAscendingOrder ? compareResult : -compareResult;
+      }
+    });
+  }
+}


### PR DESCRIPTION
**dthf UI 7091**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
dynamic table e lookup está acumulando pesquisa ao realizar filtro

**Qual o novo comportamento?**
dynamic table e lookup não estão acumulando pesquisa ao realizar filtro


**Simulação**
realizar o build antes de testar app e portal
testar app e samples do portal do dynamic table, table e lookup

app:

```
<po-lookup
  name="lookup"
  p-field-label="label"
  p-field-value="value"
  p-filter-service="https://po-sample-api.fly.dev/v1/heroes"
  p-label="PO Lookup"
>
</po-lookup>


<po-page-dynamic-table p-title="Po Page Dynamic Table" p-service-api="https://po-sample-api.fly.dev/v1/people">
</po-page-dynamic-table>


<po-page-dynamic-table p-height="700" p-title="Po Page Dynamic Table" p-service-api="https://po-sample-api.fly.dev/v1/people">
</po-page-dynamic-table>

```