### PR TITLE
feat(table): repassa propriedades do po-tag

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.html
@@ -1,3 +1,8 @@
-<span [class]="'po-table-column-label po-' + value?.color">
-  {{ value?.label }}
-</span>
+<po-tag
+  [p-color]="value?.color"
+  [p-value]="value?.label"
+  [p-text-color]="value?.textColor"
+  [p-icon]="value?.icon"
+  [p-type]="value?.type"
+>
+</po-tag>

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
@@ -32,26 +32,6 @@ describe('PoTableColumnLabelComponent:', () => {
     expect(component instanceof PoTableColumnLabelComponent).toBeTruthy();
   });
 
-  describe('Properties:', () => {
-    it('value: should call `poColorPaletteService.getColor` with value if value is defined', () => {
-      const value = { color: 'danger', label: 'Danger', value: 1 };
-
-      spyOn(component['poColorPaletteService'], 'getColor');
-
-      component.value = value;
-
-      expect(component['poColorPaletteService'].getColor).toHaveBeenCalledWith(value);
-    });
-
-    it('value: shouldn`t call `poColorPaletteService.getColor` if value is undefined', () => {
-      spyOn(component['poColorPaletteService'], 'getColor');
-
-      component.value = undefined;
-
-      expect(component['poColorPaletteService'].getColor).not.toHaveBeenCalled();
-    });
-  });
-
   describe('Templates:', () => {
     it('should show "Warning" text', () => {
       component.value = labels[1];

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
-import { PoColorPaletteService } from './../../../services/po-color-palette/po-color-palette.service';
 import { PoTableColumnLabel } from './po-table-column-label.interface';
 
 /**
@@ -17,19 +16,5 @@ import { PoTableColumnLabel } from './po-table-column-label.interface';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PoTableColumnLabelComponent {
-  private _value: PoTableColumnLabel;
-
-  /** Objeto com os dados do label */
-  @Input('p-value') set value(value: PoTableColumnLabel) {
-    if (value) {
-      value.color = this.poColorPaletteService.getColor(value);
-    }
-
-    this._value = value;
-  }
-  get value(): PoTableColumnLabel {
-    return this._value;
-  }
-
-  constructor(private poColorPaletteService: PoColorPaletteService) {}
+  @Input('p-value') value: PoTableColumnLabel;
 }

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
@@ -1,3 +1,6 @@
+import { TemplateRef } from '@angular/core';
+import { PoTagType } from '../../po-tag/enums/po-tag-type.enum';
+
 /**
  * @usedBy PoTableComponent, PoPageDynamicTableComponent
  *
@@ -28,6 +31,90 @@ export interface PoTableColumnLabel {
    * - <span class="dot po-color-12"></span> `color-12`
    */
   color?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Determina a cor do texto da tag. As maneiras de customizar as cores são:
+   * - Hexadeximal, por exemplo `#c64840`;
+   * - RGB, como `rgb(0, 0, 165)`;
+   * - O nome da cor, por exemplo `blue`;
+   * - Usando uma das cores do tema do PO:
+   * Valores válidos:
+   *  - <span class="dot po-color-01"></span> `color-01`
+   *  - <span class="dot po-color-02"></span> `color-02`
+   *  - <span class="dot po-color-03"></span> `color-03`
+   *  - <span class="dot po-color-04"></span> `color-04`
+   *  - <span class="dot po-color-05"></span> `color-05`
+   *  - <span class="dot po-color-06"></span> `color-06`
+   *  - <span class="dot po-color-07"></span> `color-07`
+   *  - <span class="dot po-color-08"></span> `color-08`
+   *  - <span class="dot po-color-09"></span> `color-09`
+   *  - <span class="dot po-color-10"></span> `color-10`
+   *  - <span class="dot po-color-11"></span> `color-11`
+   *  - <span class="dot po-color-12"></span> `color-12`
+   *
+   * - Para uma melhor acessibilidade no uso do componente é recomendável utilizar cores com um melhor contraste em relação ao background.
+   *
+   * > **Atenção:** A propriedade `p-type` sobrepõe esta definição.
+   */
+  textColor?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define ou ativa um ícone que será exibido ao lado do valor da *tag*.
+   *
+   * Quando `p-type` estiver definida, basta informar um valor igual a `true` para que o ícone seja exibido conforme descrições abaixo:
+   * - <span class="po-icon po-icon-ok"></span> - `success`
+   * - <span class="po-icon po-icon-warning"></span> - `warning`
+   * - <span class="po-icon po-icon-close"></span> - `danger`
+   * - <span class="po-icon po-icon-info"></span> - `info`
+   *
+   * Também É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * ```
+   * <po-tag p-icon="po-icon-user" p-value="PO Tag"></po-tag>
+   * ```
+   * como também utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
+   * ```
+   * <po-tag p-icon="fa fa-podcast" p-value="PO Tag"></po-button>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-tag [p-icon]="template" p-value="Tag template ionic"></po-button>
+   *
+   * <ng-template #template>
+   *  <ion-icon style="font-size: inherit" name="heart"></ion-icon>
+   * </ng-template>
+   * ```
+   * > Para o ícone enquadrar corretamente, deve-se utilizar `font-size: inherit` caso o ícone utilizado não aplique-o.
+   *
+   * @default `false`
+   */
+  icon?: boolean | string | TemplateRef<void>;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o tipo da *tag*.
+   *
+   * Valores válidos:
+   *  - `success`: cor verde utilizada para simbolizar sucesso ou êxito.
+   *  - `warning`: cor amarela que representa aviso ou advertência.
+   *  - `danger`: cor vermelha para erro ou aviso crítico.
+   *  - `info`: cor cinza escuro que caracteriza conteúdo informativo.
+   *
+   * > Quando esta propriedade for definida, irá sobrepor a definição de `p-color` e `p-icon` somente será exibido caso seja `true`.
+   *
+   * @default `info`
+   */
+  type?: PoTagType;
 
   /** Texto que será exibido na coluna. */
   label: string;

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -292,7 +292,7 @@
                   <po-table-subtitle-circle [p-subtitle]="getSubtitleColumn(row, column)"></po-table-subtitle-circle>
                 </span>
                 <span *ngSwitchCase="'label'">
-                  <po-tag [p-color]="getTagColor(row, column)" [p-value]="getTagValue(row, column)"> </po-tag>
+                  <po-table-column-label [p-value]="getColumnLabel(row, column)"> </po-table-column-label>
                 </span>
                 <span *ngSwitchDefault>{{ getCellData(row, column) }}</span>
               </div>
@@ -574,7 +574,7 @@
                 <po-table-subtitle-circle [p-subtitle]="getSubtitleColumn(row, column)"></po-table-subtitle-circle>
               </span>
               <span *ngSwitchCase="'label'">
-                <po-tag [p-color]="getTagColor(row, column)" [p-value]="getTagValue(row, column)"> </po-tag>
+                <po-table-column-label [p-value]="getColumnLabel(row, column)"> </po-table-column-label>
               </span>
               <span *ngSwitchDefault>{{ getCellData(row, column) }}</span>
             </div>

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -18,7 +18,7 @@ import {
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { Router } from '@angular/router';
-
+import { PoTableColumnLabel } from './po-table-column-label/po-table-column-label.interface';
 import { convertToBoolean } from '../../utils/util';
 import { PoDateService } from '../../services/po-date/po-date.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
@@ -443,15 +443,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return rowIcons;
   }
 
-  getTagColor(row: any, columnLabel: PoTableColumn) {
-    return columnLabel.labels.find(labelItem => this.getCellData(row, columnLabel) === labelItem.value)?.color;
-  }
-
-  getTagValue(row: any, columnLabel: PoTableColumn) {
-    return columnLabel.labels.find(labelItem => this.getCellData(row, columnLabel) === labelItem.value)?.label;
-  }
-
-  getColumnLabel(row: any, columnLabel: PoTableColumn) {
+  getColumnLabel(row: any, columnLabel: PoTableColumn): PoTableColumnLabel {
     return columnLabel.labels.find(labelItem => this.getCellData(row, columnLabel) === labelItem.value);
   }
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.service.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { PoTableColumn } from '@po-ui/ng-components';
+import { PoTableColumn, PoTagType } from '@po-ui/ng-components';
 
 @Injectable()
 export class SamplePoTableTransportService {
@@ -18,9 +18,10 @@ export class SamplePoTableTransportService {
         type: 'label',
         width: '8%',
         labels: [
-          { value: 'delivered', color: 'color-11', label: 'Delivered' },
-          { value: 'transport', color: 'color-08', label: 'Transport' },
-          { value: 'production', color: 'color-01', label: 'Production' }
+          { value: 'delivered', color: 'blue', label: 'Delivered' },
+          { value: 'transport', label: 'Transport', type: PoTagType.Success },
+          { value: 'production', color: ' #745678', label: 'Production' },
+          { value: 'stock', color: 'rgb(201, 53, 125)', label: 'Stock', icon: 'po-icon-stock' }
         ]
       }
     ];
@@ -92,6 +93,19 @@ export class SamplePoTableTransportService {
         license_plate: 'XXI2312',
         batch_product: 18041825,
         driver: 'Antonio Lima'
+      },
+      {
+        code: 1551,
+        product: 'Cream cheese',
+        customer: 'Barbosa',
+        quantity: 15,
+        icms: 1119,
+        exit_forecast: this.generateRandomDate(),
+        time_since_purchase: this.generateRandomTime(),
+        status: 'stock',
+        license_plate: 'XXI2359',
+        batch_product: 18041888,
+        driver: 'Vitoria Felix'
       }
     ];
   }


### PR DESCRIPTION
**TABLE**

**fixes DTHFUI-7094**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente não possuia propriedades do `po-tag`

**Qual o novo comportamento?**
Componente passa a possuir propriedades do `po-tag`

**Simulação**
Samples do portal e [app.zip](https://github.com/po-ui/po-angular/files/10983427/app.zip).

Obs: O texto da `tag` deixa de ser preto quando não é passado nenhuma cor do `PoColorPaletteEnum` por exemplo: red, rgb(201, 53, 125), #753399 ficando texto em branco.
