### PR TITLE
feat(list-view): adiciona evento no botão de mostrar detalhes

### DIFF
--- a/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view-base.component.ts
@@ -78,6 +78,17 @@ export class PoListViewBaseComponent {
    */
   @Output('p-title-action') titleAction: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Ação que será executada ao clicar no botão exibir detalhes.
+   *
+   * Ao ser disparado, o método passa como parâmetros os detalhes que serão exibidos.
+   */
+  @Output('p-show-detail') showDetail: EventEmitter<any> = new EventEmitter<any>();
+
   popupTarget: any;
   selectAll: boolean = false;
   showHeader: boolean = false;

--- a/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
@@ -94,7 +94,12 @@
             </ng-template>
           </div>
 
-          <div @showHideDetail *ngIf="hasDetailTemplate && item.$showDetail" class="po-list-view-detail">
+          <div
+            @showHideDetail
+            (@showHideDetail.start)="item.$showDetail ? onAnimationEvent($event, item) : 'undefined'"
+            *ngIf="hasDetailTemplate && item.$showDetail"
+            class="po-list-view-detail"
+          >
             <ng-template
               [ngTemplateOutlet]="listViewDetailTemplate.templateRef"
               [ngTemplateOutletContext]="{ $implicit: item, index: index }"

--- a/projects/ui/src/lib/components/po-list-view/po-list-view.component.spec.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.component.spec.ts
@@ -15,6 +15,8 @@ describe('PoListViewComponent:', () => {
   let component: PoListViewComponent;
   let fixture: ComponentFixture<PoListViewComponent>;
   let debugElement;
+  let event: AnimationEvent;
+  let detail: any;
 
   const item = { id: 1, name: 'register' };
 
@@ -23,6 +25,9 @@ describe('PoListViewComponent:', () => {
       declarations: [PoListViewComponent],
       imports: [BrowserAnimationsModule, RouterTestingModule.withRoutes([]), PoButtonModule, PoPopupModule]
     }).compileComponents();
+
+    detail = { test: 'test' };
+    event = new AnimationEvent('animationstart', { animationName: 'test', elapsedTime: 100 });
 
     fixture = TestBed.createComponent(PoListViewComponent);
 
@@ -179,6 +184,14 @@ describe('PoListViewComponent:', () => {
       expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
       expect(component.poPopupComponent.toggle).toHaveBeenCalledWith(item);
       expect(component.popupTarget).toEqual(targetRef);
+    });
+
+    it(`onAnimationEvent: should emit detail on showDetail`, () => {
+      spyOn(component.showDetail, 'emit');
+
+      component.onAnimationEvent(event, detail);
+
+      expect(component.showDetail.emit).toHaveBeenCalledWith(detail);
     });
 
     it('trackBy: should return `index`', () => {

--- a/projects/ui/src/lib/components/po-list-view/po-list-view.component.ts
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.component.ts
@@ -140,6 +140,10 @@ export class PoListViewComponent extends PoListViewBaseComponent implements Afte
     this.poPopupComponent.toggle(item);
   }
 
+  onAnimationEvent(event: AnimationEvent, detail) {
+    this.showDetail.emit(detail);
+  }
+
   private checkItemsChange() {
     const changesItems = this.differ.diff(this.items);
 


### PR DESCRIPTION
**LIST-VIEW**

**fixes DTHFUI-7062**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente não possuia evento no botão de "Exibir detalhes"

**Qual o novo comportamento?**
Componente passa a ter evento no botão de "Exibir detalhes" 

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/10995025/app.zip)
