### PR TITLE
fix(table): mantém ordenação em tabela sem altura

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -99,7 +99,20 @@ describe('PoTableBaseComponent:', () => {
     expectPropertiesValues(component, 'items', invalidValues, []);
   });
 
+  it('should set items with value default when invalid values if contain height', () => {
+    component.height = 400;
+    const invalidValues = [undefined, null, false, 0, 'a'];
+
+    expectPropertiesValues(component, 'items', invalidValues, []);
+  });
+
   it('should set items with values received when valid values', () => {
+    expectPropertiesValues(component, 'items', [items], [items]);
+    expectPropertiesValues(component, 'items', [], []);
+  });
+
+  it('should set items with values received when valid values if contain height', () => {
+    component.height = 400;
     expectPropertiesValues(component, 'items', [items], [items]);
     expectPropertiesValues(component, 'items', [], []);
   });

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -366,7 +366,11 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * > Se falso, será inicializado como um *array* vazio.
    */
   @Input('p-items') set items(items: Array<any>) {
-    this._items = Array.isArray(items) ? [...items] : [];
+    if (this.height) {
+      this._items = Array.isArray(items) ? [...items] : [];
+    } else {
+      this._items = Array.isArray(items) ? items : [];
+    }
 
     // when haven't items, selectAll should be unchecked.
     if (!this.hasItems) {


### PR DESCRIPTION
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
não mantém ordenação em tabela sem altura

**Qual o novo comportamento?**
mantém ordenação em tabela sem altura


**Simulação**
testar samples do portal