### PR TITLE
feat(table): reutiliza o componente `po-radio`

### DIFF
--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -50,6 +50,8 @@ export * from './po-radio/po-radio.component';
 export * from './po-checkbox-group/po-checkbox-group.module';
 export * from './po-datepicker/po-datepicker.module';
 export * from './po-checkbox/po-checkbox.module';
+export * from './po-radio-group/po-radio-group.module';
+export * from './po-radio/po-radio.module';
 
 export * from './po-field.module';
 

--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -5,6 +5,8 @@ import { FormsModule } from '@angular/forms';
 import { PoButtonGroupModule } from '../po-button-group/index';
 import { PoButtonModule } from '../po-button/index';
 import { PoCheckboxGroupModule } from './po-checkbox-group/po-checkbox-group.module';
+import { PoRadioGroupModule } from './po-radio-group/po-radio-group.module';
+import { PoRadioModule } from './po-radio/po-radio.module';
 import { PoContainerModule } from '../po-container/index';
 import { PoCalendarModule } from '../po-calendar/po-calendar.module';
 import { PoCleanModule } from './po-clean/po-clean.module';
@@ -42,7 +44,6 @@ import { PoRichTextToolbarComponent } from './po-rich-text/po-rich-text-toolbar/
 import { PoInputComponent } from './po-input/po-input.component';
 import { PoNumberComponent } from './po-number/po-number.component';
 import { PoPasswordComponent } from './po-password/po-password.component';
-import { PoRadioGroupComponent } from './po-radio-group/po-radio-group.component';
 import { PoSelectComponent } from './po-select/po-select.component';
 import { PoSwitchComponent } from './po-switch/po-switch.component';
 import { PoTextareaComponent } from './po-textarea/po-textarea.component';
@@ -54,7 +55,6 @@ import { PoUploadDragDropAreaComponent } from './po-upload/po-upload-drag-drop/p
 import { PoUploadFileRestrictionsComponent } from './po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component';
 import { PoUrlComponent } from './po-url/po-url.component';
 import { PoCheckboxModule } from './po-checkbox/po-checkbox.module';
-import { PoRadioComponent } from './po-radio/po-radio.component';
 import { PoLabelModule } from '../po-label';
 
 /**
@@ -79,6 +79,7 @@ import { PoLabelModule } from '../po-label';
     PoCleanModule,
     PoCalendarModule,
     PoCheckboxGroupModule,
+    PoRadioGroupModule,
     PoContainerModule,
     PoDatepickerModule,
     PoDisclaimerGroupModule,
@@ -92,11 +93,13 @@ import { PoLabelModule } from '../po-label';
     PoTooltipModule,
     PoIconModule,
     PoCheckboxModule,
+    PoRadioModule,
     PoLabelModule,
     PoListBoxModule
   ],
   exports: [
     PoCheckboxGroupModule,
+    PoRadioGroupModule,
     PoCleanModule,
     PoDatepickerModule,
     PoComboComponent,
@@ -112,15 +115,14 @@ import { PoLabelModule } from '../po-label';
     PoMultiselectComponent,
     PoNumberComponent,
     PoPasswordComponent,
-    PoRadioGroupComponent,
     PoRichTextComponent,
     PoSelectComponent,
     PoSwitchComponent,
     PoTextareaComponent,
     PoUploadComponent,
     PoUrlComponent,
-    PoRadioComponent,
     PoCheckboxModule,
+    PoRadioModule,
     PoLabelModule
   ],
   declarations: [
@@ -139,7 +141,6 @@ import { PoLabelModule } from '../po-label';
     PoMultiselectSearchComponent,
     PoNumberComponent,
     PoPasswordComponent,
-    PoRadioGroupComponent,
     PoRichTextBodyComponent,
     PoRichTextComponent,
     PoRichTextImageModalComponent,
@@ -154,8 +155,7 @@ import { PoLabelModule } from '../po-label';
     PoUploadDragDropAreaOverlayComponent,
     PoUploadDragDropAreaComponent,
     PoUploadFileRestrictionsComponent,
-    PoUrlComponent,
-    PoRadioComponent
+    PoUrlComponent
   ],
   providers: []
 })

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.module.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { PoFieldContainerModule } from '../po-field-container/po-field-container.module';
+
+import { PoRadioGroupComponent } from './po-radio-group.component';
+import { PoRadioModule } from '../po-radio/po-radio.module';
+
+/**
+ * @description
+ *
+ * Módulo do componente `po-radio-group`.
+ */
+@NgModule({
+  imports: [CommonModule, FormsModule, PoFieldContainerModule, PoRadioModule],
+  exports: [PoRadioGroupComponent],
+  declarations: [PoRadioGroupComponent]
+})
+export class PoRadioGroupModule {}

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.spec.ts
@@ -169,6 +169,16 @@ describe('PoRadioComponent', () => {
       expect(component.changeValue).toHaveBeenCalled();
     });
 
+    it('eventClick: should emit changeSelected', () => {
+      component.disabled = false;
+
+      spyOn(component.changeSelected, 'emit');
+
+      component.eventClick();
+
+      expect(component.changeSelected.emit).toHaveBeenCalled();
+    });
+
     it('focusOut: should remove attibute focus from label element', () => {
       component.radio.nativeElement.setAttribute('focus', '');
 

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.ts
@@ -3,9 +3,11 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   forwardRef,
   HostListener,
   Input,
+  Output,
   Renderer2,
   ViewChild
 } from '@angular/core';
@@ -61,6 +63,9 @@ export class PoRadioComponent extends PoFieldModel<boolean> {
   /** Define o status do *radio* */
   @Input('p-checked') checked: boolean = false;
 
+  /** Emite evento para a tabela ao selecionar ou desselecionar */
+  @Output('p-change-selected') changeSelected: EventEmitter<any> = new EventEmitter<any>();
+
   constructor(private changeDetector: ChangeDetectorRef, private renderer: Renderer2) {
     super();
   }
@@ -112,6 +117,7 @@ export class PoRadioComponent extends PoFieldModel<boolean> {
     if (!this.disabled) {
       this.changeValue(!this.value);
       this.changeDetector.detectChanges();
+      this.changeSelected.emit(null);
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.module.ts
@@ -1,0 +1,13 @@
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { PoRadioComponent } from './po-radio.component';
+import { PoLabelModule } from '../../po-label/po-label.module';
+
+@NgModule({
+  declarations: [PoRadioComponent],
+  exports: [PoRadioComponent],
+  imports: [CommonModule, FormsModule, PoLabelModule]
+})
+export class PoRadioModule {}

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -651,8 +651,7 @@
 </ng-template>
 
 <ng-template #inputRadio let-row>
-  <input type="radio" class="po-table-radio" [class.po-table-radio-checked]="row.$selected" />
-  <label class="po-table-radio-label po-clickable" (click)="selectable ? selectRow(row) : 'javascript:;'"></label>
+  <po-radio [p-checked]="row.$selected" (p-change-selected)="selectRow(row)" [name]="idRadio"></po-radio>
 </ng-template>
 
 <ng-template #inputCheckbox let-row>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -305,22 +305,6 @@ describe('PoTableComponent:', () => {
     expect(selectableColumn).toBeTruthy();
   });
 
-  it('should allow single row selection', () => {
-    component.selectable = true;
-    component.singleSelect = true;
-    component.hideSelectAll = true;
-    component.selectRow(component.items[0]);
-    component.selectRow(component.items[1]);
-
-    fixture.detectChanges();
-
-    const checkedColumns = tableElement.querySelectorAll('.po-table-radio-checked');
-    expect(checkedColumns.length).toBe(1);
-
-    const selectableHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox');
-    expect(selectableHeader).toBeFalsy();
-  });
-
   it('should select all rows', () => {
     component.selectable = true;
     component.selectAllRows();

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -14,7 +14,8 @@ import {
   ViewChildren,
   ViewContainerRef,
   ContentChildren,
-  TemplateRef
+  TemplateRef,
+  OnInit
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { Router } from '@angular/router';
@@ -33,6 +34,7 @@ import { PoTableCellTemplateDirective } from './po-table-cell-template/po-table-
 import { PoTableColumnTemplateDirective } from './po-table-column-template/po-table-column-template.directive';
 import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-arrow-direction.enum';
 import { PoTableService } from './services/po-table.service';
+import { uuid } from '../../utils/util';
 
 /**
  * @docsExtends PoTableBaseComponent
@@ -89,7 +91,7 @@ import { PoTableService } from './services/po-table.service';
   templateUrl: './po-table.component.html',
   providers: [PoDateService]
 })
-export class PoTableComponent extends PoTableBaseComponent implements AfterViewInit, DoCheck, OnDestroy {
+export class PoTableComponent extends PoTableBaseComponent implements AfterViewInit, DoCheck, OnDestroy, OnInit {
   @ContentChild(PoTableRowTemplateDirective, { static: true }) tableRowTemplate: PoTableRowTemplateDirective;
   @ContentChild(PoTableCellTemplateDirective) tableCellTemplate: PoTableCellTemplateDirective;
 
@@ -119,6 +121,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   itemSize: number = 32;
   lastVisibleColumnsSelected: Array<PoTableColumn>;
   tagColor: string;
+  idRadio: string;
 
   private _columnManagerTarget: ElementRef;
   private _columnManagerTargetFixed: ElementRef;
@@ -244,6 +247,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return (
       this.actions !== undefined && this.actions && this.actions.filter(action => action && action.visible !== false)
     );
+  }
+
+  ngOnInit() {
+    this.idRadio = `po-radio-${uuid()}`;
   }
 
   ngAfterViewInit() {

--- a/projects/ui/src/lib/components/po-table/po-table.module.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.module.ts
@@ -16,6 +16,7 @@ import { PoTimeModule } from '../../pipes/po-time/index';
 import { PoTooltipModule } from '../../directives/po-tooltip/index';
 import { PoIconModule } from './../po-icon/po-icon.module';
 import { PoCheckboxModule } from './../po-field/po-checkbox/po-checkbox.module';
+import { PoRadioModule } from './../po-field/po-radio/po-radio.module';
 
 import { PoTableColumnIconComponent } from './po-table-column-icon/po-table-column-icon.component';
 import { PoTableColumnLabelComponent } from './po-table-column-label/po-table-column-label.component';
@@ -53,7 +54,8 @@ import { PoTableListManagerComponent } from './po-table-list-manager/po-table-li
     PoTimeModule,
     PoTooltipModule,
     PoIconModule,
-    PoCheckboxModule
+    PoCheckboxModule,
+    PoRadioModule
   ],
   declarations: [
     PoTableComponent,


### PR DESCRIPTION
**table/ RADIO**

**DTHFUI-7124**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)



**Simulação**
testar samples do portal na table e lookup e testar app: 

[app.zip](https://github.com/po-ui/po-angular/files/11032286/app.zip)
