### PR TITLE
feat(combo): adiciona opção que desativa o armazenamento do último valor

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -591,6 +591,19 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     return this._literals || poComboLiteralsDefault[this.language];
   }
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define se o componente irá guardar o valor do model para evitar requisições repetidas.
+   *
+   * > Caso o valor seja `false`, o componente fará uma nova requisição mesmo que o valor procurado seja o mesmo do model.
+   *
+   * @default `true`
+   */
+  @Input('p-cache') @InputBoolean() cache?: boolean = true;
+
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();
   }

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -50,7 +50,7 @@
   </div>
 
   <div #containerElement class="po-combo-container" [hidden]="!comboOpen && !isServerSearching">
-    <ng-container *ngIf="visibleOptions.length; then visibleOptionsTemplate; else noDataTemplate"> </ng-container>
+    <ng-container *ngIf="checkTemplate(); then visibleOptionsTemplate; else noDataTemplate"> </ng-container>
     <div *ngIf="isServerSearching">
       <ng-container *ngIf="infiniteLoading; then infiniteLoadingTemplate; else normalLoadingTemplate"></ng-container>
     </div>

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -122,6 +122,14 @@ describe('PoComboComponent:', () => {
     expect(component.applyFilter).not.toHaveBeenCalled();
   });
 
+  it('should call apply filter when cache is false', () => {
+    component.isProcessingValueByTab = true;
+    component.cache = false;
+    spyOn(component, 'applyFilter');
+    component.controlApplyFilter('valor');
+    expect(component.applyFilter).toHaveBeenCalled();
+  });
+
   it('should apply filter and call searchForLabel', () => {
     const fakeService: any = getFakeService(null);
     component.service = fakeService;
@@ -1807,6 +1815,42 @@ describe('PoComboComponent:', () => {
 
       expect(component.visibleOptions).toEqual(optionFound);
       expect(fixture.debugElement.query(By.css('.po-combo-container-no-data'))).toBeNull();
+    });
+
+    it('checkTemplate: should return truthy if visibleOptions has items', () => {
+      component.visibleOptions = [{ label: '1', value: '1' }];
+
+      expect(component.checkTemplate()).toBeTruthy();
+    });
+
+    it('checkTemplate: should return false if visibleOptions is empty', () => {
+      component.visibleOptions = [];
+
+      expect(component.checkTemplate()).toBeFalsy();
+    });
+
+    it('checkTemplate: should return false if cache is false and isServerSearching is true', () => {
+      component.cache = false;
+      component.isServerSearching = true;
+      component.visibleOptions = [{ label: '1', value: '1' }];
+
+      expect(component.checkTemplate()).toBeFalsy();
+    });
+
+    it('checkTemplate: should return truthy if cache is false and isServerSearching is false', () => {
+      component.cache = false;
+      component.isServerSearching = false;
+      component.visibleOptions = [{ label: '1', value: '1' }];
+
+      expect(component.checkTemplate()).toBeTruthy();
+    });
+
+    it('checkTemplate: should return falsy if cache is false and isServerSearching is false but visibleOptions is empty', () => {
+      component.cache = false;
+      component.isServerSearching = false;
+      component.visibleOptions = [];
+
+      expect(component.checkTemplate()).toBeFalsy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -357,7 +357,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   controlApplyFilter(value) {
-    if (!this.isProcessingValueByTab && (!this.selectedOption || value !== this.selectedOption[this.dynamicLabel])) {
+    if (
+      (!this.isProcessingValueByTab && (!this.selectedOption || value !== this.selectedOption[this.dynamicLabel])) ||
+      !this.cache
+    ) {
       this.defaultService.hasNext = true;
       this.page = this.setPage();
       this.options = [];
@@ -636,6 +639,14 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     if (scrollPosition >= target.scrollHeight * (this.infiniteScrollDistance / 110)) {
       this.page++;
       this.applyFilter('', true);
+    }
+  }
+
+  checkTemplate() {
+    if (this.cache || this.infiniteScroll) {
+      return this.visibleOptions.length;
+    } else {
+      return !this.isServerSearching && this.visibleOptions.length;
     }
   }
 


### PR DESCRIPTION
Possibilita desabilitar que o combo guarde o ultimo valor e não gere nova requisição com a nova propriedade `p-cache`



**Combo**

**fixes DTHFUI-7179**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)


**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11141790/app.zip)
