### PR TITLE
fix(number): desativa ação de incremento e decremento

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.spec.ts
@@ -199,5 +199,11 @@ describe('PoNumberComponent:', () => {
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.querySelector('po-clean')).toBe(null);
     });
+
+    it('should avoid pattern on scroll event', () => {
+      const event = new WheelEvent('wheel', { cancelable: true });
+      component.onWheel(event);
+      expect(event.defaultPrevented).toBeTruthy();
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
@@ -1,5 +1,13 @@
 import { AbstractControl, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
-import { ChangeDetectorRef, ChangeDetectionStrategy, Component, ElementRef, forwardRef, Input } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  forwardRef,
+  Input,
+  HostListener
+} from '@angular/core';
 
 import { minFailed, maxFailed } from '../validators';
 
@@ -87,6 +95,11 @@ export class PoNumberComponent extends PoNumberBaseComponent {
   /* istanbul ignore next */
   constructor(el: ElementRef, cd: ChangeDetectorRef) {
     super(el, cd);
+  }
+
+  @HostListener('wheel', ['$event'])
+  onWheel(event: Event) {
+    event.preventDefault();
   }
 
   extraValidation(abstractControl: AbstractControl): { [key: string]: any } {


### PR DESCRIPTION
**NUMBER**

**DTHFUI-7129**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente em navegador Firefox ao rolar scroll do mouse em cima do contador acontece ação de incremento e decremento.

**Qual o novo comportamento?**
Componente em navegador Firefox ao rolar scroll do mouse em cima do contador não acontece ação de incremento e decremento.

**Simulação**
[Portal](https://po-ui.io/)