### PR TITLE
feat(table): reutiliza componente

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -230,6 +230,7 @@
         "quote-props": "off",
         "jsdoc/no-types": "off",
         "react/jsx-curly-spacing": "off",
+        "jsdoc/newline-after-description": "off",
         "react/jsx-equals-spacing": "off",
         "react/jsx-tag-spacing": [
           "off",

--- a/projects/portal/src/app/theme-builder/theme-builder.component.html
+++ b/projects/portal/src/app/theme-builder/theme-builder.component.html
@@ -1081,7 +1081,7 @@
     <hr [class.hide]="!linkView" />
 
     <div class="container-component">
-      <po-link #link [class.hide]="!linkView" name="link" p-label="PO Link"> </po-link>
+      <po-link #link id="myLink" [class.hide]="!linkView" name="link" p-label="PO Link"> </po-link>
     </div>
 
     <hr [class.hide]="!tooltipView" />

--- a/projects/portal/src/app/theme-builder/theme-builder.component.ts
+++ b/projects/portal/src/app/theme-builder/theme-builder.component.ts
@@ -528,7 +528,7 @@ export class ThemeBuilderComponent implements AfterViewInit {
 
     this.linkForm.reset();
     Object.keys(this.formPropertyDictLink).forEach((fieldName: string) => {
-      this.linkComponent.linkEl.nativeElement.style.setProperty(this.formPropertyDictLink[fieldName], null);
+      document.getElementById('myLink').style.setProperty(this.formPropertyDictLink[fieldName], null);
     });
 
     const tooltipElement = this.renderer.selectRootElement('.po-tooltip', true);
@@ -1037,29 +1037,32 @@ export class ThemeBuilderComponent implements AfterViewInit {
       this.resultModal['nativeElement'].innerHTML = '';
     }
   }
-
   private checkChangesLink(changes: { [key: string]: string }): void {
     if (!this.isEmpty(changes)) {
       this.resultLink['nativeElement'].innerHTML = 'po-link {<br>';
 
-      Object.keys(changes).forEach((fieldName: string) => {
-        let value;
-        if (typeof changes[fieldName] === 'number') {
-          value = `${changes[fieldName]}px`;
-        } else {
-          value = /color/i.test(fieldName) ? changes[fieldName] : `var(--${changes[fieldName]})`;
-        }
-        if (changes[fieldName]) {
-          this.linkComponent.linkEl.nativeElement.style.setProperty(this.formPropertyDictLink[fieldName], value);
-
-          this.resultLink['nativeElement'].innerHTML += `${this.formPropertyDictLink[fieldName]}: ${value};<br>`;
-        }
-      });
+      this.checkDiffLink(changes);
 
       this.resultLink['nativeElement'].innerHTML += '}';
     } else {
       this.resultLink['nativeElement'].innerHTML = '';
     }
+  }
+
+  private checkDiffLink(changes: any): void {
+    Object.keys(changes).forEach((fieldName: string) => {
+      let value;
+      if (typeof changes[fieldName] === 'number') {
+        value = `${changes[fieldName]}px`;
+      } else {
+        value = /color/i.test(fieldName) ? changes[fieldName] : `var(--${changes[fieldName]})`;
+      }
+
+      if (changes[fieldName]) {
+        document.getElementById('myLink').style.setProperty(this.formPropertyDictLink[fieldName], value);
+        this.resultLink['nativeElement'].innerHTML += `${this.formPropertyDictLink[fieldName]}: ${value};<br>`;
+      }
+    });
   }
 
   private checkChangesTooltip(changes: { [key: string]: string }): void {

--- a/projects/ui/src/lib/components/po-link/po-link-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-link/po-link-base.component.spec.ts
@@ -6,4 +6,27 @@ describe('PoLinkBaseComponent:', () => {
   it('should be created', () => {
     expect(component instanceof PoLinkBaseComponent).toBeTruthy();
   });
+
+  describe('Properties:', () => {
+    it('should set type with "externalLink"', () => {
+      component.url = 'https://po-ui.io';
+      component.label = 'link';
+
+      expect(component.type).toBe('externalLink');
+    });
+
+    it('should set type with "internalLink"', () => {
+      component.url = '/home';
+      component.label = 'link';
+
+      expect(component.type).toBe('internalLink');
+    });
+
+    it('should set type with "internalLink" if url is empty', () => {
+      component.url = '';
+      component.label = 'link';
+
+      expect(component.type).toBe('internalLink');
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-link/po-link-base.component.ts
+++ b/projects/ui/src/lib/components/po-link/po-link-base.component.ts
@@ -1,6 +1,7 @@
 import { Input, Directive, Output, EventEmitter } from '@angular/core';
 
 import { InputBoolean } from '../../decorators';
+import { isExternalLink } from '../../utils/util';
 
 /**
  * @description
@@ -33,14 +34,21 @@ export class PoLinkBaseComponent {
   /** Valor do rótulo a ser exibido. */
   @Input('p-label') label: string;
 
+  /** Indica se o link deverá ser aberto em uma nova aba. Sempre que utilizar essa propriedade, é importante informar isso ao usuário através da label. */
+  @Input('p-open-new-tab') @InputBoolean() openNewTab?: boolean = false;
+
   /** Url que será aberta ao clicar no link. */
   @Input('p-url') url: string;
+
+  get type(): string {
+    if (!this.url && this.action.observed) {
+      return 'action';
+    }
+    return isExternalLink(this.url) ? 'externalLink' : 'internalLink';
+  }
 
   /** Ação que será executada quando o usuário clicar sobre o `po-link`.
    * > Ao utilizar junto da propriedade `p-url` a ação será ignorada.
    */
   @Output('p-action') action = new EventEmitter<null>();
-
-  /** Indica se o link deverá ser aberto em uma nova aba. Sempre que utilizar essa propriedade, é importante informar isso ao usuário através da label. */
-  @Input('p-open-new-tab') @InputBoolean() openNewTab?: boolean = false;
 }

--- a/projects/ui/src/lib/components/po-link/po-link.component.html
+++ b/projects/ui/src/lib/components/po-link/po-link.component.html
@@ -1,10 +1,11 @@
-<a
-  #linkEl
-  (click)="onClick()"
-  [attr.role]="isActionUsed && !url ? 'button' : null"
-  tabindex="0"
-  class="po-link"
-  [attr.href]="url"
-  [attr.target]="openNewTab ? '_blank' : undefined"
-  >{{ label }}</a
->
+<ng-container [ngSwitch]="type">
+  <button *ngSwitchCase="'action'" class="po-link" type="button" (click)="onClick()">{{ label }}</button>
+
+  <a *ngSwitchCase="'externalLink'" class="po-link" [href]="url" [target]="openNewTab ? '_blank' : '_self'">{{
+    label
+  }}</a>
+
+  <a *ngSwitchCase="'internalLink'" class="po-link" [routerLink]="url">{{ label }}</a>
+
+  <a *ngSwitchDefault class="po-link" [href]="url">{{ label }}</a>
+</ng-container>

--- a/projects/ui/src/lib/components/po-link/po-link.component.ts
+++ b/projects/ui/src/lib/components/po-link/po-link.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 
 import { PoLinkBaseComponent } from './po-link-base.component';
 
@@ -26,14 +26,7 @@ import { PoLinkBaseComponent } from './po-link-base.component';
   selector: 'po-link',
   templateUrl: './po-link.component.html'
 })
-export class PoLinkComponent extends PoLinkBaseComponent implements OnInit {
-  @ViewChild('linkEl', { read: ElementRef, static: true }) linkEl: ElementRef;
-  protected isActionUsed = false;
-
-  ngOnInit(): void {
-    this.isActionUsed = this.action.observed;
-  }
-
+export class PoLinkComponent extends PoLinkBaseComponent {
   onClick() {
     if (this.url) {
       return;

--- a/projects/ui/src/lib/components/po-link/po-link.module.ts
+++ b/projects/ui/src/lib/components/po-link/po-link.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PoLinkComponent } from './po-link.component';
+import { RouterModule } from '@angular/router';
 
 /**
  * @description
@@ -9,7 +10,7 @@ import { PoLinkComponent } from './po-link.component';
  */
 @NgModule({
   declarations: [PoLinkComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   exports: [PoLinkComponent]
 })
 export class PoLinkModule {}

--- a/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.html
@@ -1,6 +1,3 @@
-<ng-container [ngSwitch]="type">
-  <p *ngSwitchCase="'disabled'" class="po-table-link-disabled">{{ value }}</p>
-  <a *ngSwitchCase="'action'" class="po-table-link" (click)="action(value, row)">{{ value }}</a>
-  <a *ngSwitchCase="'externalLink'" class="po-table-link" [href]="link" target="_blank">{{ value }}</a>
-  <a *ngSwitchCase="'internalLink'" class="po-table-link" [routerLink]="link">{{ value }}</a>
-</ng-container>
+<div class="po-table-link" [ngClass]="{ 'po-table-link-disabled': disabled }">
+  <po-link [p-label]="value" [p-open-new-tab]="openNewTab" [p-url]="link" (p-action)="action?.(value, row)"></po-link>
+</div>

--- a/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.html
@@ -1,3 +1,12 @@
 <div class="po-table-link" [ngClass]="{ 'po-table-link-disabled': disabled }">
-  <po-link [p-label]="value" [p-open-new-tab]="openNewTab" [p-url]="link" (p-action)="action?.(value, row)"></po-link>
+  <ng-container [ngSwitch]="type">
+    <po-link
+      *ngSwitchCase="'action'"
+      [p-label]="value"
+      [p-open-new-tab]="openNewTab"
+      (p-action)="action?.(value, row)"
+    ></po-link>
+    <po-link *ngSwitchCase="'externalLink'" [p-label]="value" [p-open-new-tab]="openNewTab" [p-url]="link"></po-link>
+    <po-link *ngSwitchCase="'internalLink'" [p-label]="value" [p-open-new-tab]="openNewTab" [p-url]="link"></po-link>
+  </ng-container>
 </div>

--- a/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.spec.ts
@@ -26,21 +26,6 @@ describe('PoTableColumnLinkComponent:', () => {
   });
 
   describe('Templates:', () => {
-    it('should execute the link action', () => {
-      component.action = () => {};
-      fixture.detectChanges();
-
-      spyOn(component, 'action');
-
-      const link = nativeElement.querySelector('.po-table-link');
-      const event = document.createEvent('MouseEvents');
-      event.initEvent('click', false, true);
-      link.dispatchEvent(event);
-      link.click();
-
-      expect(component.action).toHaveBeenCalled();
-    });
-
     it('should contain `po-table-link-disabled` class if disabled is true', () => {
       component.action = () => {};
       component.disabled = true;
@@ -63,80 +48,6 @@ describe('PoTableColumnLinkComponent:', () => {
       const poTableLinkDisabled = nativeElement.querySelector('.po-table-link-disabled');
 
       expect(poTableLinkDisabled).toBeFalsy();
-    });
-
-    it('should contain `href` if `type` is `externalLink`', () => {
-      component.disabled = false;
-      component.link = 'http://po.com.br';
-      component.value = 'link';
-
-      fixture.detectChanges();
-
-      const externalLink = nativeElement.querySelector('.po-table-link[href="http://po.com.br"]');
-      expect(externalLink).toBeTruthy();
-    });
-
-    it('should contain `routerLink` if `type` is `internalLink`', () => {
-      component.disabled = false;
-      component.link = '/home';
-      component.value = 'link';
-
-      fixture.detectChanges();
-
-      const internalLink = nativeElement.querySelector('.po-table-link[ng-reflect-router-link="/home"]');
-      expect(internalLink).toBeTruthy();
-    });
-  });
-
-  describe('Properties:', () => {
-    it('should set type with "action"', () => {
-      component.action = () => {};
-      component.disabled = false;
-      component.link = 'link';
-      component.value = 'link';
-
-      expect(component.type).toBe('action');
-    });
-
-    it('should set type with "externalLink"', () => {
-      component.disabled = false;
-      component.link = 'https://po-ui.io';
-      component.value = 'link';
-
-      expect(component.type).toBe('externalLink');
-    });
-
-    it('should set type with "internalLink"', () => {
-      component.disabled = false;
-      component.link = '/home';
-      component.value = 'link';
-
-      expect(component.type).toBe('internalLink');
-    });
-
-    it('should set type with "disabled"', () => {
-      component.action = () => {};
-      component.disabled = true;
-      component.link = 'link';
-      component.value = 'link';
-
-      expect(component.type).toBe('disabled');
-    });
-
-    it('should set type with "disabled"', () => {
-      component.disabled = true;
-      component.link = 'https://po-ui.io';
-      component.value = 'link';
-
-      expect(component.type).toBe('disabled');
-    });
-
-    it('should set type with "internalLink" if link is empty', () => {
-      component.disabled = false;
-      component.link = '';
-      component.value = 'link';
-
-      expect(component.type).toBe('internalLink');
     });
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.spec.ts
@@ -50,4 +50,39 @@ describe('PoTableColumnLinkComponent:', () => {
       expect(poTableLinkDisabled).toBeFalsy();
     });
   });
+
+  describe('Properties:', () => {
+    it('should set type with "action"', () => {
+      component.action = () => {};
+      component.disabled = false;
+      component.link = 'link';
+      component.value = 'link';
+
+      expect(component.type).toBe('action');
+    });
+
+    it('should set type with "externalLink"', () => {
+      component.disabled = false;
+      component.link = 'https://po-ui.io';
+      component.value = 'link';
+
+      expect(component.type).toBe('externalLink');
+    });
+
+    it('should set type with "internalLink"', () => {
+      component.disabled = false;
+      component.link = '/home';
+      component.value = 'link';
+
+      expect(component.type).toBe('internalLink');
+    });
+
+    it('should set type with "internalLink" if link is empty', () => {
+      component.disabled = false;
+      component.link = '';
+      component.value = 'link';
+
+      expect(component.type).toBe('internalLink');
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.ts
@@ -21,23 +21,9 @@ export class PoTableColumnLinkComponent {
 
   @Input('p-link') link: string;
 
+  @Input('p-open-new-tab') openNewTab: boolean = false;
+
   @Input('p-row') row;
 
   @Input('p-value') value: string;
-
-  get type() {
-    if (this.disabled) {
-      return 'disabled';
-    }
-
-    if (this.action) {
-      return 'action';
-    }
-
-    if (isExternalLink(this.link)) {
-      return 'externalLink';
-    }
-
-    return 'internalLink';
-  }
 }

--- a/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.ts
@@ -26,4 +26,12 @@ export class PoTableColumnLinkComponent {
   @Input('p-row') row;
 
   @Input('p-value') value: string;
+
+  get type() {
+    if (this.action) {
+      return 'action';
+    }
+
+    return isExternalLink(this.link) ? 'externalLink' : 'internalLink';
+  }
 }

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -519,27 +519,6 @@ describe('PoTableComponent:', () => {
     expect(links.length > 0).toBeTruthy();
   });
 
-  it('should contain the attribute ng-reflect-router-link when the item is internal link', () => {
-    component.columns = [{ property: 'name', label: 'País', type: 'link', link: 'link' }];
-    component.items = [{ name: 'França', link: 'home' }];
-    fixture.detectChanges();
-
-    const link = tableElement.querySelector('.po-table-link[ng-reflect-router-link="home"]');
-    expect(link).toBeTruthy();
-  });
-
-  it('should contain the attributes href and target when the item is external link', () => {
-    component.columns = [{ property: 'framework', label: 'Framework', type: 'link', link: 'link' }];
-    component.items = [{ name: 'PO', link: 'http://po.com.br' }];
-    fixture.detectChanges();
-
-    let link = tableElement.querySelector('.po-table-link[ng-reflect-router-link="home"]');
-    expect(link).toBeFalsy();
-
-    link = tableElement.querySelector('.po-table-link[href="http://po.com.br"][target="_blank"]');
-    expect(link).toBeTruthy();
-  });
-
   it('should remain on same page', () => {
     component.columns[2].type = 'link';
     component.items[0].link = undefined;

--- a/projects/ui/src/lib/components/po-table/po-table.module.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.module.ts
@@ -17,7 +17,7 @@ import { PoTooltipModule } from '../../directives/po-tooltip/index';
 import { PoIconModule } from './../po-icon/po-icon.module';
 import { PoCheckboxModule } from './../po-field/po-checkbox/po-checkbox.module';
 import { PoRadioModule } from './../po-field/po-radio/po-radio.module';
-import { PoLinkModule } from '../po-link';
+import { PoLinkModule } from '../po-link/po-link.module';
 
 import { PoTableColumnIconComponent } from './po-table-column-icon/po-table-column-icon.component';
 import { PoTableColumnLabelComponent } from './po-table-column-label/po-table-column-label.component';

--- a/projects/ui/src/lib/components/po-table/po-table.module.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.module.ts
@@ -17,6 +17,7 @@ import { PoTooltipModule } from '../../directives/po-tooltip/index';
 import { PoIconModule } from './../po-icon/po-icon.module';
 import { PoCheckboxModule } from './../po-field/po-checkbox/po-checkbox.module';
 import { PoRadioModule } from './../po-field/po-radio/po-radio.module';
+import { PoLinkModule } from '../po-link';
 
 import { PoTableColumnIconComponent } from './po-table-column-icon/po-table-column-icon.component';
 import { PoTableColumnLabelComponent } from './po-table-column-label/po-table-column-label.component';
@@ -55,7 +56,8 @@ import { PoTableListManagerComponent } from './po-table-list-manager/po-table-li
     PoTooltipModule,
     PoIconModule,
     PoCheckboxModule,
-    PoRadioModule
+    PoRadioModule,
+    PoLinkModule
   ],
   declarations: [
     PoTableComponent,


### PR DESCRIPTION
**TABLE**

**DTHFUI-7204**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente po-table-column-link não utiliza o componente po-link.

**Qual o novo comportamento?**
O componente po-table-column-link passa a utiliza o componente po-link.


**Style**
- https://github.com/po-ui/po-style/pull/408

**Simulação**
Portal