### PR TITLE
fix(toaster): ajusta empilhamento das notificações

### DIFF
--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.spec.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.spec.ts
@@ -345,6 +345,45 @@ describe('PoToasterComponent', () => {
 
       expect(spyAction).toBeTruthy();
     });
+
+    it('should set the margin correctly for one toaster', fakeAsync(() => {
+      component.action = () => {};
+      component.actionLabel = 'changePosition';
+      component.toaster.nativeElement.className = 'po-toaster-visible';
+      const position = 1;
+
+      spyOn<any>(component, 'returnHeightToaster').and.returnValue(62);
+
+      component.changePosition(position);
+      tick();
+      component.orientation = PoToasterOrientation.Top;
+
+      expect((component as any).margin).toBe(78);
+
+      component.changePosition(position);
+      tick();
+      component.orientation = PoToasterOrientation.Bottom;
+
+      expect((component as any).margin).toBe(78);
+    }));
+
+    it('changePosition: Margin should receive the default value plus the next toaster concatenated by the default margin value', fakeAsync(() => {
+      const expectResult = 8 + 80 + 8 + 150 + 8;
+      spyOn(component, <any>'returnHeightToaster').and.callFake((position: number) => {
+        if (position === 1) {
+          return 80;
+        } else {
+          return 150;
+        }
+      });
+
+      component.changePosition(1);
+      tick();
+      component.changePosition(2);
+      tick();
+
+      expect(component['margin']).toEqual(expectResult);
+    }));
   });
 
   describe('Properties', () => {

--- a/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
+++ b/projects/ui/src/lib/services/po-notification/po-toaster/po-toaster.component.ts
@@ -10,8 +10,6 @@ import {
 
 import { Subject } from 'rxjs';
 
-import { poLocaleDefault } from '../../po-language/po-language.constant';
-
 import { PoLanguageService } from '../../po-language/po-language.service';
 import { poToasterLiterals } from './po-toaster.literals';
 
@@ -22,8 +20,6 @@ import { PoToasterOrientation } from './po-toaster-orientation.enum';
 import { PoButtonComponent } from '../../../components/po-button/po-button.component';
 
 const SPACE_BETWEEN_TOASTERS = 8;
-const TOASTER_HEIGHT_DEFAULT = 62;
-const TOASTER_HEIGHT_ACTION = 88;
 
 /**
  * @docsPrivate
@@ -57,7 +53,6 @@ export class PoToasterComponent extends PoToasterBaseComponent implements AfterV
   constructor(
     poLanguageService: PoLanguageService,
     public changeDetector: ChangeDetectorRef,
-    private elementeRef?: ElementRef,
     private renderer?: Renderer2
   ) {
     super();
@@ -77,14 +72,19 @@ export class PoToasterComponent extends PoToasterBaseComponent implements AfterV
 
   /* Muda a posição do Toaster na tela*/
   changePosition(position: number): void {
-    const toasterSize = document.body.offsetWidth < 961 && this.action ? TOASTER_HEIGHT_ACTION : TOASTER_HEIGHT_DEFAULT;
-    this.margin = SPACE_BETWEEN_TOASTERS + toasterSize * position + position * SPACE_BETWEEN_TOASTERS;
+    setTimeout(() => {
+      this.margin = SPACE_BETWEEN_TOASTERS;
 
-    if (this.orientation === PoToasterOrientation.Top) {
-      this.toaster.nativeElement.style.top = this.margin + 'px';
-    } else {
-      this.toaster.nativeElement.style.bottom = this.margin + 'px';
-    }
+      for (let i = 0; i < position; i++) {
+        this.margin += this.returnHeightToaster(i) + SPACE_BETWEEN_TOASTERS;
+      }
+
+      if (this.orientation === PoToasterOrientation.Top) {
+        this.toaster.nativeElement.style.top = this.margin + 'px';
+      } else {
+        this.toaster.nativeElement.style.bottom = this.margin + 'px';
+      }
+    });
   }
 
   /* Fecha o componente Toaster */
@@ -174,5 +174,12 @@ export class PoToasterComponent extends PoToasterBaseComponent implements AfterV
   /* Chama a função passada pelo atributo `action` */
   poToasterAction(event): void {
     this.action(this);
+  }
+
+  private returnHeightToaster(position) {
+    if (this.orientation === PoToasterOrientation.Top) {
+      return (document.querySelectorAll('.po-toaster-top')[position] as HTMLElement).offsetHeight;
+    }
+    return (document.querySelectorAll('.po-toaster-bottom')[position] as HTMLElement).offsetHeight;
   }
 }


### PR DESCRIPTION
**NOTIFICATION**

**DTHFUI-7212**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o componente `po-notification` não apresenta um empilhamento correto das notificações.

**Qual o novo comportamento?**
As notificações agora serão empilhadas corretamente


**Simulação**
Portal