### PR TITLE
feat(tag): implementa novas propriedades

### DIFF
--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.spec.ts
@@ -122,7 +122,7 @@ describe('PoDisclaimerGroupComponent:', () => {
 
       fixture.detectChanges();
 
-      expect(nativeElement.querySelector('.po-tag-value').innerHTML).toBe(component.literals.removeAll);
+      expect(nativeElement.querySelector('.po-tag-value span').innerHTML).toBe(component.literals.removeAll);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
@@ -6,6 +6,7 @@ import { PoColorPaletteEnum } from '../../enums/po-color-palette.enum';
 import { PoTagItem } from './interfaces/po-tag-item.interface';
 import { PoTagOrientation } from './enums/po-tag-orientation.enum';
 import { PoTagType } from './enums/po-tag-type.enum';
+import { InputBoolean } from '../../decorators';
 
 const poTagColors = (<any>Object).values(PoColorPaletteEnum);
 const poTagOrientationDefault = PoTagOrientation.Vertical;
@@ -32,6 +33,29 @@ export class PoTagBaseComponent {
    */
   @Input('p-label') label?: string;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Habilita a opção de remover a tag
+   *
+   * @default `false`
+   */
+  @Input('p-removable') @InputBoolean() removable: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Desabilita o `po-tag` e não permite que o usuário interaja com o mesmo.
+   * > A propriedade `p-disabled` somente terá efeito caso a propriedade `p-removable` esteja definida como `true`.
+   *
+   * @default `false`
+   */
+  @Input('p-disabled') @InputBoolean() disabled: boolean = false;
+
   /** Texto da tag. */
   @Input('p-value') value: string;
 
@@ -50,6 +74,15 @@ export class PoTagBaseComponent {
    * Ação que será executada ao clicar sobre o `po-tag` e que receberá como parâmetro um objeto contendo o seu valor e tipo.
    */
   @Output('p-click') click: EventEmitter<any> = new EventEmitter<PoTagItem>();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Ação que sera executada quando clicar sobre o ícone de remover no `po-tag`
+   */
+  @Output('p-close') remove: EventEmitter<null> = new EventEmitter<null>();
 
   public readonly poTagOrientation = PoTagOrientation;
   public customColor;
@@ -243,7 +276,9 @@ export class PoTagBaseComponent {
    * @default `info`
    */
   @Input('p-type') set type(value: PoTagType) {
-    this._type = (<any>Object).values(PoTagType).includes(value) ? value : undefined;
+    if (!this.removable) {
+      this._type = (<any>Object).values(PoTagType).includes(value) ? value : undefined;
+    }
   }
 
   get type(): PoTagType {

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.html
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.html
@@ -12,19 +12,21 @@
   <div class="po-tag-sub-container">
     <div
       class="po-tag"
-      [attr.role]="isClickable ? 'button' : ''"
-      [class.po-clickable]="isClickable"
-      [class.po-tag-inverse]="inverse && !type && !customTextColor"
+      [attr.role]="isClickable && !disabled ? 'button' : ''"
+      [class.po-clickable]="isClickable && !disabled && !removable"
+      [class.po-tag-inverse]="inverse && !type && !customTextColor && !removable"
+      [class.po-tag-removable]="removable"
+      [class.po-tag-disabled]="disabled && removable"
       [ngClass]="tagColor"
       [ngStyle]="styleTag()"
-      tabindex="0"
+      [tabindex]="isClickable && !removable ? 0 : -1"
       (click)="onClick()"
       (keydown.enter)="onKeyPressed($event)"
       (keydown.space)="$event.preventDefault()"
       (keyup.space)="onKeyPressed($event)"
     >
       <po-icon
-        *ngIf="icon"
+        *ngIf="icon && !removable"
         class="po-tag-icon"
         [p-icon]="!type ? icon : iconFromType"
         [ngStyle]="
@@ -37,17 +39,30 @@
       >
       </po-icon>
 
+      <div class="po-tag-value">
+        <span
+          [ngStyle]="
+            !tagColor && inverse && !customTextColor
+              ? { 'color': customColor }
+              : !type && customTextColor && !removable
+              ? { 'color': customTextColor }
+              : ''
+          "
+          >{{ value }}</span
+        >
+      </div>
+
       <span
-        class="po-tag-value"
-        [ngStyle]="
-          !tagColor && inverse && !customTextColor
-            ? { 'color': customColor }
-            : !type && customTextColor
-            ? { 'color': customTextColor }
-            : ''
-        "
-        >{{ value }}</span
+        *ngIf="removable"
+        [attr.aria-label]="setAriaLabel()"
+        class="po-tag-remove po-icon po-icon-close"
+        [class.po-clickable]="!disabled"
+        [tabindex]="!disabled ? 0 : -1"
+        [attr.role]="!disabled ? 'button' : ''"
+        (click)="onClose()"
+        (keydown.enter)="onClose()"
       >
+      </span>
     </div>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
@@ -184,6 +184,39 @@ describe('PoTagComponent:', () => {
 
       expect(spyOnClick).not.toHaveBeenCalled();
     });
+
+    it('onClose: Should have been called onClose', () => {
+      spyOn(component.click, <any>'emit');
+      spyOn(component, <any>'onRemove');
+
+      component.onClose();
+
+      expect(component.click.emit).toHaveBeenCalledWith(null);
+    });
+
+    it('onRemove: Should remove the element if not disabled', () => {
+      const mockElementRef = {
+        nativeElement: {
+          remove: jasmine.createSpy('remove')
+        }
+      };
+      component['el'] = mockElementRef;
+      component.disabled = false;
+
+      component['onRemove']();
+
+      expect(mockElementRef.nativeElement.remove).toHaveBeenCalled();
+    });
+
+    it('should set aria-label', () => {
+      component.label = 'Label';
+      expect(component.setAriaLabel()).toContain('Label Remove');
+    });
+
+    it('should set aria-label', () => {
+      component.value = 'Label';
+      expect(component.setAriaLabel()).toContain('Label Remove');
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.ts
@@ -1,9 +1,11 @@
+import { PoLanguageService } from './../../services/po-language/po-language.service';
 import { ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 
 import { PoTagBaseComponent } from './po-tag-base.component';
 import { PoTagIcon } from './enums/po-tag-icon.enum';
 import { PoTagItem } from './interfaces/po-tag-item.interface';
 import { PoTagType } from './enums/po-tag-type.enum';
+import { PoTagLiterals } from './po-tag.literals';
 
 const poTagTypeDefault = 'po-tag-' + PoTagType.Info;
 
@@ -36,6 +38,15 @@ export class PoTagComponent extends PoTagBaseComponent implements OnInit {
   @ViewChild('tagContainer', { static: true }) tagContainer: ElementRef;
 
   isClickable: boolean;
+  literals: any;
+
+  constructor(private el: ElementRef, private languageService: PoLanguageService) {
+    super();
+    const language = this.languageService.getShortLanguage();
+    this.literals = {
+      ...PoTagLiterals[language]
+    };
+  }
 
   ngOnInit() {
     this.isClickable = this.click.observers.length > 0;
@@ -58,15 +69,15 @@ export class PoTagComponent extends PoTagBaseComponent implements OnInit {
   }
 
   get tagColor() {
-    if (this.type) {
+    if (this.type && !this.removable) {
       return this.inverse ? `po-tag-${this.type}-inverse` : `po-tag-${this.type}`;
     }
 
-    if (this.color) {
+    if (this.color && !this.removable) {
       return this.inverse ? `po-text-${this.color}` : `po-${this.color}`;
     }
 
-    if (!this.customColor) {
+    if (!this.customColor && !this.removable) {
       return this.inverse ? `${poTagTypeDefault}-inverse` : poTagTypeDefault;
     }
   }
@@ -76,8 +87,17 @@ export class PoTagComponent extends PoTagBaseComponent implements OnInit {
   }
 
   onClick() {
-    const submittedTagItem: PoTagItem = { value: this.value, type: this.type };
-    this.click.emit(submittedTagItem);
+    if (!this.removable && !this.disabled) {
+      const submittedTagItem: PoTagItem = { value: this.value, type: this.type };
+      this.click.emit(submittedTagItem);
+    }
+  }
+
+  onClose() {
+    if (!this.disabled) {
+      this.click.emit(null);
+      this.onRemove();
+    }
   }
 
   onKeyPressed(event) {
@@ -87,7 +107,7 @@ export class PoTagComponent extends PoTagBaseComponent implements OnInit {
   }
 
   styleTag() {
-    if (!this.tagColor && !this.inverse) {
+    if (!this.tagColor && !this.inverse && !this.removable) {
       return { 'background-color': this.customColor, 'color': 'white' };
     } else if (!this.tagColor && this.inverse && !this.customTextColor) {
       return { 'border': '1px solid ' + this.customColor };
@@ -100,5 +120,15 @@ export class PoTagComponent extends PoTagBaseComponent implements OnInit {
 
   getWidthTag() {
     return this.tagContainer.nativeElement.offsetWidth > 155;
+  }
+
+  setAriaLabel() {
+    return this.label ? this.label + ' ' + this.literals.remove : this.value + ' ' + this.literals.remove;
+  }
+
+  private onRemove() {
+    if (!this.disabled) {
+      this.el.nativeElement.remove();
+    }
   }
 }

--- a/projects/ui/src/lib/components/po-tag/po-tag.literals.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.literals.ts
@@ -1,0 +1,14 @@
+export const PoTagLiterals = {
+  en: {
+    remove: 'Remove'
+  },
+  es: {
+    remove: 'Eliminar'
+  },
+  pt: {
+    remove: 'Remover'
+  },
+  ru: {
+    remove: 'удалять'
+  }
+};

--- a/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.html
+++ b/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.html
@@ -1,5 +1,7 @@
 <po-tag
   [p-color]="color"
+  [p-disabled]="properties.includes('disabled')"
+  [p-removable]="properties.includes('removable')"
   [p-icon]="icon"
   [p-text-color]="textColor"
   [p-label]="label"
@@ -55,6 +57,16 @@
       [p-options]="iconList"
     >
     </po-select>
+
+    <po-checkbox-group
+      class="po-md-6 po-mt-2"
+      name="properties"
+      [(ngModel)]="properties"
+      p-label="Properties"
+      [p-options]="propertiesOptions"
+      (p-change)="propertiesChange($event)"
+    >
+    </po-checkbox-group>
 
     <po-switch *ngIf="type" class="po-md-6" name="icon" [(ngModel)]="icon" p-label="Icon"> </po-switch>
   </div>

--- a/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.ts
+++ b/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.ts
@@ -1,6 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoRadioGroupOption, PoSelectOption, PoTagOrientation, PoTagType } from '@po-ui/ng-components';
+import {
+  PoRadioGroupOption,
+  PoSelectOption,
+  PoTagOrientation,
+  PoTagType,
+  PoCheckboxGroupOption
+} from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-tag-labs',
@@ -27,6 +33,12 @@ export class SamplePoTagLabsComponent implements OnInit {
   orientation: PoTagOrientation;
   type: PoTagType;
   value: string;
+  properties: Array<string>;
+
+  propertiesOptions: Array<PoCheckboxGroupOption> = [
+    { value: 'disabled', label: 'Disabled' },
+    { value: 'removable', label: 'Removable' }
+  ];
 
   public readonly iconList: Array<PoSelectOption> = [
     { label: 'po-icon-bluetooth', value: 'po-icon-bluetooth' },
@@ -60,6 +72,18 @@ export class SamplePoTagLabsComponent implements OnInit {
     this.event = event;
   }
 
+  propertiesChange(event) {
+    const value = [...this.propertiesOptions];
+
+    if (event.includes('removable')) {
+      value[0] = { value: 'disabled', label: 'Disabled', disabled: false };
+      this.propertiesOptions = value;
+    } else {
+      value[0] = { value: 'disabled', label: 'Disabled', disabled: true };
+      this.propertiesOptions = value;
+    }
+  }
+
   restore() {
     this.color = undefined;
     this.icon = undefined;
@@ -69,5 +93,6 @@ export class SamplePoTagLabsComponent implements OnInit {
     this.type = undefined;
     this.event = '';
     this.textColor = undefined;
+    this.properties = [];
   }
 }


### PR DESCRIPTION
**tag**

**DTHFUI-6870**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente PoTag foi reescrito seguindo as definições do Animalia DS, porém sua variação de remoção não foi implementada.

**Qual o novo comportamento?**
O componente PoTag agora tem a variação de remoção e pode ser utilizado no PoDisclaimer

**Simulação**
[app.zip](https://github.com/po-ui/po-style/files/11452888/app.zip)
**Style**
[style.zip](https://github.com/po-ui/po-angular/files/11531528/style.zip)
**Themes**
[theme.zip](https://github.com/po-ui/po-angular/files/11531547/theme.zip)