### PR TITLE
fix(i18n): Métodos do PoI18nService retornam nulo

### DIFF
--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
@@ -190,6 +190,24 @@ xdescribe('PoI18nService:', () => {
         expect(utils.reloadCurrentPage).not.toHaveBeenCalled();
       });
 
+      it('setLanguage: should call `languageService.setLanguage` with value language param and set this value in instance', () => {
+        const oldLanguage = service.getLanguage();
+
+        let valueParam = 'en';
+
+        service.setLanguage(valueParam, false);
+        expect(service.getLanguage()).toEqual(valueParam);
+        expect(service.getShortLanguage()).toEqual(valueParam);
+
+        valueParam = 'pt-br';
+
+        service.setLanguage(valueParam, false);
+        expect(service.getLanguage()).toEqual(valueParam);
+        expect(service.getShortLanguage()).toEqual('pt');
+
+        service.setLanguage(oldLanguage);
+      });
+
       describe('setConfig:', () => {
         it(`should call 'languageService.setLanguageDefault' with 'config.default.language' if 'config.default' is defined.`, () => {
           const configMock = {

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
@@ -1,4 +1,5 @@
 import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 
 import { PoLanguageService } from './../po-language/po-language.service';
 
@@ -172,7 +173,7 @@ export class PoI18nModule {
         {
           provide: PoI18nService,
           useFactory: returnPoI18nService,
-          deps: [I18N_CONFIG, PoLanguageService]
+          deps: [I18N_CONFIG, HttpClient, PoLanguageService]
         }
       ]
     };


### PR DESCRIPTION
**po-i18n**

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O serviço PoI18nService está retornando o idioma nulo.

**Qual o novo comportamento?**
O serviço PoI18nService está retornando uma string, contendo o idioma correto.

**Simulação**
Importar o serviço PoI18nService e utilizar o método getShortLanguage.