### PR TITLE
fix(table): corrige exibição de colunas do tipo label

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.html
@@ -1,4 +1,5 @@
 <po-tag
+  *ngIf="hasLabel"
   [p-color]="value?.color"
   [p-value]="value?.label"
   [p-text-color]="value?.textColor"

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
@@ -24,7 +24,9 @@ describe('PoTableColumnLabelComponent:', () => {
     labels = [
       { value: 'success', label: 'Success', color: 'color-11' },
       { value: 'warning', label: 'Warning', color: 'color-08' },
-      { value: 1, label: 'Danger', color: 'color-07' }
+      { value: 1, label: 'Danger', color: 'color-07' },
+      { value: 2, label: undefined, color: 'color-07' },
+      { value: 5, label: ' ', color: 'color-07' }
     ];
   });
 
@@ -32,11 +34,30 @@ describe('PoTableColumnLabelComponent:', () => {
     expect(component instanceof PoTableColumnLabelComponent).toBeTruthy();
   });
 
+  describe('Methods: ', () => {
+    it('should return false if value property contains a label with only whitespace', () => {
+      component.value = labels[4];
+      component.checkValueHasLabel();
+      expect(component.hasLabel).toBeFalse();
+    });
+
+    it('should return true if value property contains a label', () => {
+      component.value = labels[1];
+      component.checkValueHasLabel();
+      expect(component.hasLabel).toBeTrue();
+    });
+
+    it('should returns false if value is undefined', () => {
+      component.value = undefined;
+      component.checkValueHasLabel();
+      expect(component.hasLabel).toBeFalse();
+    });
+  });
+
   describe('Templates:', () => {
     it('should show "Warning" text', () => {
       component.value = labels[1];
       fixture.detectChanges();
-
       const warningContent = fixture.debugElement.nativeElement.querySelector(`.po-${PoColorPaletteEnum.Color08}`);
       expect(warningContent.innerHTML).toContain('Warning');
     });
@@ -57,6 +78,12 @@ describe('PoTableColumnLabelComponent:', () => {
       component.value = labels[2];
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.querySelector(`.po-${PoColorPaletteEnum.Color07}`)).toBeTruthy();
+    });
+
+    it('should not render a tag component if the value property has not a label', () => {
+      component.value = labels[3];
+      fixture.detectChanges();
+      expect(fixture.debugElement.nativeElement.querySelector(`.po-tag`)).toBeFalsy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 
 import { PoTableColumnLabel } from './po-table-column-label.interface';
 
@@ -15,6 +15,16 @@ import { PoTableColumnLabel } from './po-table-column-label.interface';
   templateUrl: './po-table-column-label.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PoTableColumnLabelComponent {
+export class PoTableColumnLabelComponent implements OnInit {
+  hasLabel: boolean = false;
+
   @Input('p-value') value: PoTableColumnLabel;
+
+  ngOnInit(): void {
+    this.checkValueHasLabel();
+  }
+
+  checkValueHasLabel(): void {
+    this.hasLabel = this.value?.label?.trim() ? true : false;
+  }
 }


### PR DESCRIPTION
PO-TABLE

DTHFUI-7227
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Colunas do tipo label da tabela estão sendo exibidas mesmo sem nenhum valor


**Qual o novo comportamento?**
Colunas do tipo label da tabela devem ser exibidas apenas quando houver valor

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11509215/app.zip)
