### PR TITLE
fix(table): alinha colunas do tipo number e currency à direita

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
@@ -4,7 +4,12 @@
       <th class="po-table-header po-table-column-selectable" *ngIf="isSelectable"></th>
       <th class="po-table-header po-table-header-column po-table-header-master-detail"></th>
       <th class="po-table-header po-table-header-ellipsis" *ngFor="let detail of detail.columns">
-        {{ getColumnTitleLabel(detail) }}
+        <div
+          class="po-table-header-flex"
+          [class.po-table-header-flex-right]="detail.type === 'currency' || detail.type === 'number'"
+        >
+          {{ getColumnTitleLabel(detail) }}
+        </div>
       </th>
     </tr>
   </thead>
@@ -34,6 +39,7 @@
         class="po-table-column-master-detail po-table-master-detail-label"
         (click)="isSelectable ? onSelectRow(item) : 'javascript:;'"
         *ngFor="let detail of detailColumns"
+        [class.po-table-column-right]="typeHeaderTop && (detail.type === 'currency' || detail.type === 'number')"
       >
         <strong *ngIf="typeHeaderInline"> {{ getColumnTitleLabel(detail) }}: </strong>
 

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.spec.ts
@@ -368,5 +368,23 @@ describe('PoTableDetailComponent', () => {
       const number = detailElement.querySelector(elementDetail).innerText;
       expect(number).toEqual(expectedReturn);
     });
+
+    it('should find .po-table-header-flex-right if columns has number type', () => {
+      component.detail = { columns: [{ property: 'number', label: 'Number', type: 'number' }] };
+      component.detail['typeHeader'] = 'top';
+      component.items = [{ number: 333 }];
+
+      fixture.detectChanges();
+      expect(detailElement.querySelector('.po-table-header-flex-right')).toBeTruthy();
+    });
+
+    it('should find .po-table-column-right if columns has currency type', () => {
+      component.detail = { columns: [{ property: 'currency', label: 'Currency', type: 'currency' }] };
+      component.detail['typeHeader'] = 'top';
+      component.items = [{ currency: 2000 }];
+
+      fixture.detectChanges();
+      expect(detailElement.querySelector('.po-table-column-right')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
TABLE

DTHFUI-6317
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Colunas de detalhe do tipo 'number' e 'currency' da tabela estão com os valores e títulos centralizados

**Qual o novo comportamento?**
Colunas de detalhe do tipo 'number' e 'currency' da tabela estão com os valores e títulos alinhados à direita

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11531000/app.zip)
