### PR TITLE
test(i18n): ajusta os testes do i18n

### DIFF
--- a/projects/ui/karma.conf.js
+++ b/projects/ui/karma.conf.js
@@ -27,35 +27,16 @@ module.exports = function (config) {
       reporters: [{ type: 'html' }, { type: 'lcovonly' }, { type: 'text-summary' }, { type: 'cobertura' }],
       check: {
         global: {
-          statements: 98,
-          branches: 98,
+          statements: 99,
+          branches: 99,
           functions: 99,
-          lines: 98
+          lines: 99
         },
         each: {
           branches: 99,
           statements: 99,
           lines: 99,
-          functions: 99,
-          overrides: {
-            'src/lib/services/po-i18n/po-i18n.service.ts': {
-              statements: 83,
-              lines: 80,
-              functions: 0
-            },
-            'src/lib/services/po-i18n/po-i18n-base.service.ts': {
-              statements: 6,
-              lines: 5,
-              branches: 0,
-              functions: 0
-            },
-            'src/lib/services/po-i18n/po-i18n.module.ts': {
-              statements: 61,
-              lines: 58,
-              branches: 0,
-              functions: 0
-            }
-          }
+          functions: 99
         }
       }
     },

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
@@ -9,7 +9,7 @@ import * as utils from '../../utils/util';
 import { PoI18nModule, PoI18nService } from '../po-i18n';
 import { PoLanguageModule } from '../po-language';
 
-xdescribe('PoI18nService:', () => {
+describe('PoI18nService:', () => {
   describe('without Service:', () => {
     let service: PoI18nService;
 

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
@@ -183,7 +183,7 @@ export class PoI18nBaseService {
    * @returns {string} sigla do idioma padrão.
    */
   getLanguage(): string {
-    return this.languageService?.getLanguage();
+    return this.languageService.getLanguage();
   }
 
   getLiterals(options: PoI18nLiterals = {}): Observable<object> {
@@ -211,7 +211,7 @@ export class PoI18nBaseService {
    * @returns {string} sigla do idioma padrão.
    */
   getShortLanguage(): string {
-    return this.languageService?.getShortLanguage();
+    return this.languageService.getShortLanguage();
   }
 
   /**
@@ -238,7 +238,7 @@ export class PoI18nBaseService {
       return;
     }
 
-    this.languageService?.setLanguage(language);
+    this.languageService.setLanguage(language);
 
     if (reload) {
       reloadCurrentPage();
@@ -248,7 +248,7 @@ export class PoI18nBaseService {
   private setConfig(config: PoI18nConfig) {
     // Seta as configurações padrões definidas no importação do módulo
     if (config['default']) {
-      this.languageService?.setLanguageDefault(config['default']['language']);
+      this.languageService.setLanguageDefault(config['default']['language']);
 
       this.contextDefault = config['default']['context'] ? config['default']['context'] : '';
       this.useCache = config['default']['cache'] ? config['default']['cache'] : false;


### PR DESCRIPTION
Corrige serviço de tradução no i18n

Fixes DTHFUI-7282

*po-i18n*

*DTHFUI-7282*
___________________________

*PR Checklist [Revisor]*

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

*Qual o comportamento atual?*
A técnica de Tradução parou de funcionar

*Qual o novo comportamento?*
Tradução e Testes agora funcionam

*Simulação*
Pelo portal através do `po-page-login`