### PR TITLE
fix(decimal): corrige o uso de hífens, pontos e espaços

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -249,6 +249,27 @@ describe('PoDecimalComponent:', () => {
     expect(component['callOnChange']).toHaveBeenCalled();
   });
 
+  it('blur event must be called if has only hyphen', () => {
+    const fakeEvent = {
+      target: {
+        value: '-'
+      }
+    };
+    component['onTouched'] = () => {};
+
+    spyOn(component, <any>'setViewValue');
+    spyOn(component, <any>'onTouched');
+    spyOn(component, <any>'callOnChange');
+    spyOn(component.blur, 'emit');
+
+    component.onBlur(fakeEvent);
+
+    expect(component['onTouched']).toHaveBeenCalled();
+    expect(component['setViewValue']).toHaveBeenCalled();
+    expect(component['callOnChange']).toHaveBeenCalled();
+    expect(component.blur.emit).not.toHaveBeenCalled();
+  });
+
   it('should have a call onInput method', () => {
     const fakeEvent = {
       target: {
@@ -1400,6 +1421,18 @@ describe('PoDecimalComponent:', () => {
 
     it('hasLetters: should return true with undefined value.', () => {
       expect(component.hasLetters(undefined)).toBeFalsy();
+    });
+
+    it('hasNotSpace: should return false with whitespace value.', () => {
+      expect(component.hasNotSpace(' ')).toBeFalsy();
+    });
+
+    it('hasNotSpace: should return true with number.', () => {
+      expect(component.hasNotSpace('211')).toBeTruthy();
+    });
+
+    it('hasNotSpace: should return true with undefined value.', () => {
+      expect(component.hasNotSpace(undefined)).toBeTruthy();
     });
 
     it('isGreaterThanTotalLengthLimit: should return `false` if total sum is 16.', () => {

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -327,12 +327,16 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
     return value.match(/[a-zA-Z:;+=_´`^~"'?!@#$%¨&*()><{}çÇ\[\]/\\|]+/);
   }
 
+  hasNotSpace(value: string = '') {
+    return value.match(/^\S*$/);
+  }
+
   isValidNumber(event: any): boolean {
     // - event.key não existia em alguns browsers, como Samsung browser e Firefox.
     const keyValue = <any>String.fromCharCode(event.which);
     const validKey = event.which !== 8 && event.which !== 0;
 
-    return !this.hasLetters(keyValue) && validKey;
+    return !this.hasLetters(keyValue) && this.hasNotSpace(keyValue) && validKey;
   }
 
   // função responsável por adicionar os zeroes com as casa decimais ao sair do campo.
@@ -348,7 +352,12 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
       }
 
       const valueWithoutThousandSeparator = this.formatValueWithoutThousandSeparator(value);
-      this.setViewValue(this.formatToViewValue(valueWithoutThousandSeparator));
+      const formatedViewValue = this.formatToViewValue(valueWithoutThousandSeparator);
+      this.setViewValue(formatedViewValue);
+      if (!formatedViewValue) {
+        this.callOnChange(undefined);
+        return;
+      }
     }
 
     this.blur.emit();
@@ -427,16 +436,17 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
   }
 
   writeValueModel(value) {
+    let formatedViewValue;
     if (this.inputEl) {
       if (value || value === 0) {
-        const formatedViewValue = this.formatToViewValue(value);
+        formatedViewValue = this.formatToViewValue(value);
         this.setViewValue(formatedViewValue);
       } else {
         this.setViewValue('');
       }
     }
 
-    if (value) {
+    if (formatedViewValue) {
       this.change.emit(value);
     }
   }
@@ -506,6 +516,10 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
     const valueAfterDot = this.getValueAfterSeparator(numberValue, '.');
 
     const formatedNumber = this.formatMask(valueBeforeDot);
+
+    if (formatedNumber === 'NaN') {
+      return '';
+    }
 
     if (this.decimalsLength === 0) {
       return formatedNumber;


### PR DESCRIPTION
DECIMAL

DTHFUI-6099

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Espaços em brancos são permitidos e caracteres como somente hífen ou diversos pontos e números com locale russo retorna o input como 'NaN'

**Qual o novo comportamento?**
Espaços são bloqueados e caracteres que resultam o retorno do input como 'NaN' são limpos.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11626468/app.zip)

