### PR TITLE
feat(combo): cria nova propriedade `p-remove-initial-filter`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -428,6 +428,18 @@ describe('PoComboBaseComponent:', () => {
     expect(component.visibleOptions.length).toBe(3);
   });
 
+  it('should update with all list if removeInitialFilter is true', () => {
+    const options: Array<PoComboOption> = [
+      { label: 'Valor 1', value: '1' },
+      { label: '2', value: '2' },
+      { label: 'Valor 3', value: '3' }
+    ];
+
+    component.removeInitialFilter = true;
+    component.updateComboList(options);
+    expect(component.visibleOptions).toBe(options);
+  });
+
   it('should select a new item if no one are selected', () => {
     const options: Array<PoComboOption> = [
       { label: 'Valor 1', value: '1' },
@@ -502,9 +514,9 @@ describe('PoComboBaseComponent:', () => {
       expect(component['updateHasNext']).toHaveBeenCalled();
     });
 
-    it('should call `updateSelectedValue` when contains `options` and param is a `validValue`', () => {
+    it('should call `updateSelectedValue` when contains `options` and param is a `validValue` and set false in `removeInitialFilter`', () => {
       component.options = [{ label: '1', value: 'valor 1' }];
-
+      component.removeInitialFilter = true;
       spyOn(component, 'updateSelectedValue');
       spyOn(component, 'getOptionFromValue');
       spyOn(component, 'getObjectByValue');
@@ -514,6 +526,7 @@ describe('PoComboBaseComponent:', () => {
       expect(component.updateSelectedValue).toHaveBeenCalled();
       expect(component.getOptionFromValue).toHaveBeenCalled();
       expect(component.getObjectByValue).not.toHaveBeenCalled();
+      expect(component.removeInitialFilter).toBeFalsy();
     });
 
     it('should call `updateSelectedValue` if `changeOnEnter` is `false`', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -207,6 +207,20 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @description
    *
+   * Define que o filtro no primeiro clique será removido.
+   *
+   * > Caso o combo tenha um valor padrão de inicialização, o primeiro clique
+   * no componente retornará todos os itens da lista e não apenas o item inicialiazado.
+   *
+   * @default `false`
+   */
+  @Input('p-remove-initial-filter') removeInitialFilter: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Deve ser informada uma função que será disparada quando houver alterações no ngModel. A função receberá como argumento o model modificado.
    *
    * > Pode-se optar pelo recebimento do objeto selecionado ao invés do model através da propriedade `p-emit-object-value`.
@@ -742,8 +756,12 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   updateComboList(options?: Array<any>) {
     const copyOptions = options || [...this.comboOptionsList];
 
-    const newOptions =
-      !options && !this.infiniteScroll && this.selectedValue ? [{ ...this.selectedOption }] : copyOptions;
+    let newOptions;
+    if (this.removeInitialFilter) {
+      newOptions = copyOptions;
+    } else {
+      newOptions = !options && !this.infiniteScroll && this.selectedValue ? [{ ...this.selectedOption }] : copyOptions;
+    }
 
     this.visibleOptions = newOptions;
 
@@ -823,6 +841,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
       const option = this.getOptionFromValue(value, this.comboOptionsList);
       this.updateSelectedValue(option);
       this.updateComboList();
+      this.removeInitialFilter = false;
       return;
     }
 


### PR DESCRIPTION
**Combo**

**DTHFUI-7339**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)



**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11665530/app.zip)
