### PR TITLE
fix(radio-group): corrige método focus

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
@@ -5,6 +5,7 @@ import { removeDuplicatedOptions } from '../../../utils/util';
 
 import { PoFieldContainerBottomComponent } from '../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
+import { PoRadioComponent } from '../po-radio/po-radio.component';
 import { PoRadioGroupBaseComponent } from './po-radio-group-base.component';
 import { PoRadioGroupComponent } from './po-radio-group.component';
 
@@ -16,7 +17,12 @@ describe('PoRadioGroupComponent:', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PoRadioGroupComponent, PoFieldContainerComponent, PoFieldContainerBottomComponent],
+      declarations: [
+        PoRadioGroupComponent,
+        PoFieldContainerComponent,
+        PoFieldContainerBottomComponent,
+        PoRadioComponent
+      ],
       providers: []
     }).compileComponents();
 
@@ -128,11 +134,11 @@ describe('PoRadioGroupComponent:', () => {
 
         fixture.detectChanges();
 
-        spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
+        spyOn(component.radioLabels.toArray()[0], 'focus');
 
         component.focus();
 
-        expect(component.radioLabels.toArray()[0].nativeElement.focus).toHaveBeenCalled();
+        expect(component.radioLabels.toArray()[0].focus).toHaveBeenCalled();
       });
 
       it('should call second radio option if the first option is disabled', () => {
@@ -144,13 +150,13 @@ describe('PoRadioGroupComponent:', () => {
 
         fixture.detectChanges();
 
-        spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
-        spyOn(component.radioLabels.toArray()[1].nativeElement, 'focus');
+        spyOn(component.radioLabels.toArray()[0], 'focus');
+        spyOn(component.radioLabels.toArray()[1], 'focus');
 
         component.focus();
 
-        expect(component.radioLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
-        expect(component.radioLabels.toArray()[1].nativeElement.focus).toHaveBeenCalled();
+        expect(component.radioLabels.toArray()[0].focus).not.toHaveBeenCalled();
+        expect(component.radioLabels.toArray()[1].focus).toHaveBeenCalled();
       });
 
       it('shouldn`t call `focus` of radio if `disabled` property of component is true', () => {
@@ -162,13 +168,13 @@ describe('PoRadioGroupComponent:', () => {
 
         fixture.detectChanges();
 
-        spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
-        spyOn(component.radioLabels.toArray()[1].nativeElement, 'focus');
+        spyOn(component.radioLabels.toArray()[0], 'focus');
+        spyOn(component.radioLabels.toArray()[1], 'focus');
 
         component.focus();
 
-        expect(component.radioLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
-        expect(component.radioLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.radioLabels.toArray()[0].focus).not.toHaveBeenCalled();
+        expect(component.radioLabels.toArray()[1].focus).not.toHaveBeenCalled();
       });
 
       it('shouldn`t call `focus` of radio if `undefined` property of component is true', () => {
@@ -177,7 +183,7 @@ describe('PoRadioGroupComponent:', () => {
 
         fixture.detectChanges();
 
-        const spy = spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
+        const spy = spyOn(component.radioLabels.toArray()[0], 'focus');
 
         component.focus();
 

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
@@ -16,6 +16,7 @@ import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { removeDuplicatedOptions } from '../../../utils/util';
 
+import { PoRadioComponent } from '../po-radio/po-radio.component';
 import { PoRadioGroupBaseComponent } from './po-radio-group-base.component';
 
 /**
@@ -71,7 +72,7 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
   @Input('p-help') help?: string;
 
   @ViewChild('inp', { read: ElementRef, static: true }) inputEl: ElementRef;
-  @ViewChildren('inputRadio') radioLabels: QueryList<ElementRef>;
+  @ViewChildren('inputRadio') radioLabels: QueryList<PoRadioComponent>;
 
   differ: any;
 
@@ -123,7 +124,7 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
       const radioLabel = this.radioLabels.find((_, index) => !this.options[index].disabled);
 
       if (radioLabel) {
-        radioLabel.nativeElement.focus();
+        radioLabel.focus();
       }
     }
   }

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
@@ -1,6 +1,7 @@
 <div #radio class="po-radio">
-  <label #radioLabel (click)="eventClick()" (keydown)="onKeyDown($event)">
+  <label (click)="eventClick()" (keydown)="onKeyDown($event)">
     <input
+      #radioInput
       type="radio"
       [attr.p-size]="size"
       [checked]="checked"

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { configureTestSuite, expectPropertiesValues, expectSettersMethod } from './../../../util-test/util-expect.spec';
+import { configureTestSuite, expectPropertiesValues } from './../../../util-test/util-expect.spec';
 
 import { PoRadioComponent } from './po-radio.component';
 
@@ -62,7 +62,12 @@ describe('PoRadioComponent', () => {
 
       component.focus();
 
+      spyOn(component, 'onKeyup');
+
+      component.onKeyup();
+
       expect(component.radioInput.nativeElement.focus).toHaveBeenCalled();
+      expect(component.onKeyup).toHaveBeenCalled();
     });
 
     it('focus: should`t call `focus` of radio if `disabled`', () => {

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.ts
@@ -92,6 +92,7 @@ export class PoRadioComponent extends PoFieldModel<boolean> {
   focus(): void {
     if (!this.disabled) {
       this.radioInput.nativeElement.focus();
+      this.onKeyup();
     }
   }
 


### PR DESCRIPTION
RADIO-GROUP

https://github.com/po-ui/po-angular/issues/1717, DTHFUI-7357
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
não é atríbuido foco utilizando a propriedade p-auto-focus ao radio group e método focus() gera erro no console

**Qual o novo comportamento?**
foco com a propriedade p-auto-focus ao radio group executa normalmente e método focus() não gera erro no console

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11739419/app.zip)
