### PR TITLE
fix(datepicker): corrige exibição de horário em formatação extendida

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -123,7 +123,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   @Output('p-change') onchange: EventEmitter<any> = new EventEmitter<any>();
 
   protected firstStart = true;
-  protected hour: string = 'T00:00:01-00:00';
+  protected hour: string = 'T00:00:00-00:00';
   protected isExtendedISO: boolean = false;
   protected objMask: any;
   protected onChangeModel: any = null;

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -1001,7 +1001,7 @@ describe('PoDatepickerComponent:', () => {
     it('writeValue: should keep `hour` with it`s default value if date isn`t an extended iso format', () => {
       component.writeValue('2019-11-21');
 
-      expect(component.hour).toBe('T00:00:01-00:00');
+      expect(component.hour).toBe('T00:00:00-00:00');
     });
 
     it('onKeyup: should change value of the mask when typing', () => {


### PR DESCRIPTION
DATEPICKER

#1725, DTHFUI-7389

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Horário da data é exibido como T00:00:01-00:00

**Qual o novo comportamento?**
Horário da data é exibido como T00:00:00-00:00

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11747771/app.zip)
