### PR TITLE
fix(page-login): centraliza propriedades p-environment e p-product-name

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
@@ -15,10 +15,13 @@
   (p-selected-language)="onSelectedLanguage($event)"
 >
   <header class="po-page-login-header">
-    <h1 class="po-mb-md-4 po-mb-sm-1">
-      <div class="po-page-login-header-product-name">{{ productName }}</div>
+    <div class="po-page-login-header-product-name">
+      <h1>{{ productName }}</h1>
+    </div>
+
+    <div class="po-page-login-header-product-environment po-mb-md-4 po-mb-sm-1">
       <po-tag *ngIf="environment" p-type="warning" [p-value]="environment"> </po-tag>
-    </h1>
+    </div>
     <div class="po-page-login-header-welcome po-mb-md-4 po-mb-sm-2">{{ pageLoginLiterals.welcome }}</div>
   </header>
 


### PR DESCRIPTION
PAGE-LOGIN

#1743, DTHFUI-7429

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Propriedades p-product-name e p-environment estão alinhado à esquerda.

**Qual o novo comportamento?**
Propriedades p-product-name e p-environment estão alinhado ao centro.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11909151/app.zip)
