### PR TITLE
feat(number): adiciona evento para tecla enter

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.spec.ts
@@ -229,6 +229,15 @@ describe('PoNumberBaseComponent', () => {
     expect(result).toBeTrue();
   });
 
+  it('isControlKeys: should return true if the key is Enter', () => {
+    const fakeKeyboardEvent = {
+      key: 'Enter'
+    };
+
+    const result = component['isControlKeys'](fakeKeyboardEvent);
+    expect(result).toBeTrue();
+  });
+
   it('isControlKeys: should return false if isn`t a control key', () => {
     const fakeKeyboardEvent = {
       key: 'e'

--- a/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
@@ -127,7 +127,8 @@ export abstract class PoNumberBaseComponent extends PoInputGeneric {
       'Tab',
       'Delete',
       'Home',
-      'End'
+      'End',
+      'Enter'
     ];
 
     return controlKeys.indexOf(event.key) !== -1;


### PR DESCRIPTION
NUMBER

fixes DTHFUI-7431

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Tecla enter não disparava evento de keyup ao usuário

**Qual o novo comportamento?**
Tecla enter dispara evento de keyup ao usuário

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11909832/app.zip)
