### PR TITLE
feat(page-slide): adiciona evento p-close

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-base.component.spec.ts
@@ -55,4 +55,12 @@ describe('PoPageSlideBaseComponent', () => {
     component.close();
     expect(component.hidden).toBe(true);
   });
+
+  it('should emit `closeSlide` when close the slide', () => {
+    spyOn(component.closeSlide, 'emit');
+
+    component.close();
+
+    expect(component.closeSlide.emit).toHaveBeenCalled();
+  });
 });

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-base.component.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, EventEmitter, Input, Output } from '@angular/core';
 
 import { InputBoolean } from '../../../decorators';
 
@@ -90,6 +90,15 @@ export class PoPageSlideBaseComponent {
   }
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado quando o usuário fechar a página.
+   */
+  @Output('p-close') closeSlide: EventEmitter<void> = new EventEmitter<void>();
+
+  /**
    * Ativa a visualização da página.
    *
    * Para utilizá-la é necessário ter a instância do componente no DOM, podendo
@@ -136,5 +145,6 @@ export class PoPageSlideBaseComponent {
    */
   public close(): void {
     this.hidden = true;
+    this.closeSlide.emit();
   }
 }

--- a/projects/ui/src/lib/components/po-page/po-page-slide/samples/sample-po-page-slide-configuration/sample-po-page-slide-configuration.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/samples/sample-po-page-slide-configuration/sample-po-page-slide-configuration.component.html
@@ -1,4 +1,4 @@
-<po-page-slide p-title="Configuration" p-size="sm" #pageSlide>
+<po-page-slide p-title="Configuration" p-size="sm" #pageSlide (p-close)="alert()">
   <div class="po-row po-mb-2">
     <po-switch
       class="po-sm-6"

--- a/projects/ui/src/lib/components/po-page/po-page-slide/samples/sample-po-page-slide-configuration/sample-po-page-slide-configuration.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/samples/sample-po-page-slide-configuration/sample-po-page-slide-configuration.component.ts
@@ -11,4 +11,8 @@ export class SamplePoPageSlideConfigurationComponent {
   public notification = true;
   public favorited = false;
   public localization = true;
+
+  public alert() {
+    alert('Test of p-close');
+  }
 }


### PR DESCRIPTION
Adiciona evento `p-close` que é disparado quando a pagina é fechada pelo `X` ou clicando fora da pagina.

**page-slide**

**1750**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [X] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [X] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [X] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [X] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [X] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [X] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não sabemos quando a pagina foi fechada.

**Qual o novo comportamento?**
Quando a pagina é fechada, será disparado um evento para que o usuário possa executar alguma ação.

**Simulação**
Pode ser visto no exemplo "PO Page Slide - Configuration" (https://po-ui.io/documentation/po-page-slide).