### PR TITLE
feat(menu): adiciona propriedade `action`

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
@@ -214,7 +214,7 @@ describe('PoMenuBaseComponent:', () => {
     it(`configService: shouldn't call 'menuService.configProperties' and should set 'filterService' if service parameter
       is a custom service`, () => {
       const service: PoMenuFilter = {
-        getFilteredData: (search, params) => of([{ label: 'Menu', link: '/' }])
+        getFilteredData: (search, params) => of([{ label: 'Menu', link: '/', action: () => {} }])
       };
 
       const spyConfigPropeties = spyOn(component.menuService, <any>'configProperties');

--- a/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item-filtered.interface.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item-filtered.interface.ts
@@ -11,4 +11,7 @@ export interface PoMenuItemFiltered {
 
   /** *Link* para redirecionamento no clique do item do menu, podendo ser um *link* interno ou externo. */
   link: string;
+
+  /** Ação a ser executada quando o item de menu for clicado. */
+  action: () => void;
 }

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.spec.ts
@@ -1534,9 +1534,9 @@ describe('PoMenuComponent:', () => {
       });
     });
 
-    it('convertToMenuItemFiltered: should return only { link, label } if `menuItem` is an object with others properties', () => {
-      const expectedValue = { label: 'Menu 1', link: 'menu1' };
-      const menuItem = { icon: 'copy', label: 'Menu 1', link: 'menu1' };
+    it('convertToMenuItemFiltered: should return only { link, label, action } if `menuItem` is an object with others properties', () => {
+      const expectedValue = { label: 'Menu 1', link: 'menu1', action: jasmine.any(Function) };
+      const menuItem = { icon: 'copy', label: 'Menu 1', link: 'menu1', action: () => {} };
 
       const spySetMenuItemProperties = spyOn(component, <any>'setMenuItemProperties');
 
@@ -1546,15 +1546,18 @@ describe('PoMenuComponent:', () => {
       expect(spySetMenuItemProperties).toHaveBeenCalled();
     });
 
-    it('convertToMenuItemFiltered: should return { link: ``, label: `` } if `menuItem` is undefined', () => {
+    it('convertToMenuItemFiltered: should return { link: ``, label: ``, action } if `menuItem` is undefined', () => {
       const menuItem = undefined;
 
       const spySetMenuItemProperties = spyOn(component, <any>'setMenuItemProperties');
 
       const menuItemFiltered = component['convertToMenuItemFiltered'](menuItem);
 
-      expect(menuItemFiltered).toEqual(<any>{ label: '', link: '' });
+      expect(menuItemFiltered).toEqual(<any>{ label: '', link: '', action: jasmine.any(Function) });
       expect(spySetMenuItemProperties).toHaveBeenCalled();
+
+      expect(menuItemFiltered.action).toEqual(jasmine.any(Function));
+      expect(menuItemFiltered.action()).toBeUndefined();
     });
 
     it('filterLocalItems: should call `findItems` and return filtered items', () => {
@@ -1579,7 +1582,7 @@ describe('PoMenuComponent:', () => {
     });
 
     it('filterOnService: should call `getFilteredData` and return filtered menu itens from service', async () => {
-      const menuItems = [{ label: 'Menu', link: '/menu' }];
+      const menuItems = [{ label: 'Menu', link: '/menu', action: () => {} }];
       const search = 'menu';
 
       component.service = 'http://po.com.br/api';

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.ts
@@ -363,10 +363,10 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
     }
   }
 
-  private convertToMenuItemFiltered(menuItem: any = { label: '', link: '' }): PoMenuItemFiltered {
-    const { label, link } = menuItem;
+  private convertToMenuItemFiltered(menuItem: any = { label: '', link: '', action: () => {} }): PoMenuItemFiltered {
+    const { label, link, action } = menuItem;
 
-    const menuItemFiltered: PoMenuItemFiltered = { label, link };
+    const menuItemFiltered: PoMenuItemFiltered = { label, link, action };
 
     this.setMenuItemProperties(menuItemFiltered);
 

--- a/projects/ui/src/lib/components/po-menu/services/po-menu.service.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/services/po-menu.service.spec.ts
@@ -27,7 +27,7 @@ describe('PoMenuService:', () => {
   });
 
   describe('Methods:', () => {
-    const itemsFiltered = [{ label: 'Menu', link: '/menu' }];
+    const itemsFiltered = [{ label: 'Menu', link: '/menu', action: () => {} }];
     const expectedResponse = {
       items: itemsFiltered
     };


### PR DESCRIPTION
**MENU**

**DTHFUI-6636**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
`po-menu` em sua interface `po-menu-item-filtered.interface` não possui propriedade `action`.

**Qual o novo comportamento?**
`po-menu` em sua interface `po-menu-item-filtered.interface` passa possuir propriedade `action`.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/11952015/app.zip)