### PR TITLE
feat(table): implementa funcionalidade de ações em lote

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -22,6 +22,7 @@
     [p-columns]="columns"
     [p-items]="items"
     [p-height]="height"
+    [p-hide-batch-actions]="true"
     [p-infinite-scroll]="infiniteScroll"
     [p-show-more-disabled]="!hasNext"
     (p-show-more)="showMore()"

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -60,6 +60,7 @@
         [p-loading]="isLoading"
         [p-show-more-disabled]="!hasNext"
         [p-infinite-scroll]="infiniteScroll"
+        [p-hide-batch-actions]="true"
         (p-selected)="onSelect($event)"
         (p-unselected)="onUnselect($event)"
         (p-all-selected)="onAllSelected($event)"

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-multiple/sample-po-lookup-multiple.component.html
@@ -16,6 +16,7 @@
       [p-items]="heroes"
       [p-height]="220"
       [p-striped]="true"
+      [p-hide-batch-actions]="true"
       [p-hide-columns-manager]="true"
       [p-loading]="loading"
     ></po-table>

--- a/projects/ui/src/lib/components/po-table/interfaces/po-table-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-table/interfaces/po-table-literals.interface.ts
@@ -18,6 +18,15 @@ export interface PoTableLiterals {
   /** Texto exibido quando não existem itens para serem exibidos na tabela. */
   noData?: string;
 
+  /** Texto exibido quando nenhum item for selecionado no checkbox. */
+  noItem?: string;
+
+  /** Texto exibido quando apenas 1 item for selecionado no checkbox. */
+  oneItem?: string;
+
+  /** Texto exibido quando apenas 1 item for selecionado no checkbox. */
+  multipleItems?: string;
+
   /** Texto exibido quando não existem colunas visíveis para a tabela. */
   noVisibleColumn?: string;
 
@@ -29,4 +38,19 @@ export interface PoTableLiterals {
 
   /** Texto do botão **Ver legenda completa** que aparece quando o rodapé de legendas é maior que a tabela. */
   seeCompleteSubtitle?: string;
+
+  /** Texto no corpo do Modal de exclusão */
+  bodyDelete?: string;
+
+  /** Texto no Modal para cancelar a exclusão */
+  cancel?: string;
+
+  /** Texto no Modal para confirmar a exclusão */
+  delete?: string;
+
+  /** Texto de notificação de remoção com sucesso */
+  deleteSuccessful?: string;
+
+  /** Texto de notificação de erro na requisição Delete */
+  deleteApiError?: string;
 }

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -600,6 +600,48 @@ describe('PoTableBaseComponent:', () => {
       });
     });
 
+    describe('setSelectedList: ', () => {
+      const rows = [
+        {
+          id: 1,
+          name: 'John',
+          $selected: true
+        },
+        {
+          id: 2,
+          name: 'John'
+        },
+        {
+          id: 3,
+          name: 'John'
+        }
+      ];
+
+      it('should call itemsSelected with 1 item in Array', () => {
+        component.items = rows;
+
+        component.setSelectedList();
+
+        expect(component.itemsSelected).toEqual([rows[0]]);
+      });
+
+      it('should call items with 2 items and itemsSelected empty', () => {
+        component.items = [rows[1], rows[2]];
+
+        component.setSelectedList();
+
+        expect(component.itemsSelected).toEqual([]);
+      });
+
+      it('should call items and itemsSelected empty', () => {
+        component.items = [];
+
+        component.setSelectedList();
+
+        expect(component.itemsSelected).toEqual([]);
+      });
+    });
+
     it('unselectOtherRows: should unselect rows that are different from the current row and call selectAllDetails', () => {
       const rows: any = [
         {
@@ -1139,29 +1181,46 @@ describe('PoTableBaseComponent:', () => {
     });
 
     describe('setService', () => {
-      it('should be called with string url and set service url', () => {
+      it('should be called with string url and set service url and method is GET', () => {
         spyOn(component['poTableService'], 'setUrl');
         const url = 'https://po-ui.io';
 
-        component['setService'](url);
-        expect(component['poTableService'].setUrl).toHaveBeenCalledWith(url);
+        component['setService'](url, 'GET');
+        expect(component['poTableService'].setUrl).toHaveBeenCalledWith(url, 'GET');
       });
 
-      it("should be called with undefined and don't set url", () => {
+      it("should be called with undefined and don't set url and method is GET", () => {
         spyOn(component['poTableService'], 'setUrl');
         const url = undefined;
 
-        component['setService'](url);
+        component['setService'](url, 'GET');
 
         expect(component['poTableService'].setUrl).not.toHaveBeenCalled();
       });
 
-      it("should be called with empty string and don't set url", () => {
+      it("should be called with empty string and don't set url and method is GET", () => {
         spyOn(component['poTableService'], 'setUrl');
         const url = '';
 
-        component['setService'](url);
+        component['setService'](url, 'GET');
         expect(component.hasService).toBeFalsy();
+        expect(component['poTableService'].setUrl).not.toHaveBeenCalled();
+      });
+
+      it('should be called with string url and set service url and method is DELETE', () => {
+        spyOn(component['poTableService'], 'setUrl');
+        const url = 'https://po-ui.io';
+
+        component['setService'](url, 'DELETE');
+        expect(component['poTableService'].setUrl).toHaveBeenCalledWith(url, 'DELETE');
+      });
+
+      it("should be called with undefined and don't set url and method is DELETE", () => {
+        spyOn(component['poTableService'], 'setUrl');
+        const url = undefined;
+
+        component['setService'](url, 'DELETE');
+
         expect(component['poTableService'].setUrl).not.toHaveBeenCalled();
       });
     });
@@ -1422,6 +1481,28 @@ describe('PoTableBaseComponent:', () => {
       const invalidValues = [undefined, null, '', true, false, 0, 1, 'aa', [], {}];
 
       expectPropertiesValues(component, 'container', invalidValues, 'border');
+    });
+
+    it('p-param-delete-api: should update property with valid values', () => {
+      const validValue = 'value';
+
+      expectPropertiesValues(component, 'paramDeleteApi', validValue, validValue);
+    });
+
+    it('p-param-delete-api: should update property with `id` if values are invalid', () => {
+      const invalidValues = [undefined, null, true, false, 0, 1, [], {}];
+
+      expectPropertiesValues(component, 'paramDeleteApi', invalidValues, 'id');
+    });
+
+    it('p-param-delete-api: should update property with `id` if values are invalid', () => {
+      const invalidValues = [undefined, null, true, false, 0, 1, [], {}];
+
+      expectPropertiesValues(component, 'paramDeleteApi', invalidValues, 'id');
+    });
+
+    it('p-service-delete: should update property with valid values', () => {
+      expectPropertiesValues(component, 'serviceDeleteApi', 'https://po-ui.io', 'https://po-ui.io');
     });
 
     it('sortType: should return `ascending` if `sortedColumn.ascending` is `true`.', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -1,11 +1,35 @@
 <div class="po-table-actions">
-  <div #columnManager *ngIf="hasValidColumns && !hideColumnsManager" class="po-table-actions-column-manager flex-end">
+  <div
+    #columnBatchActions
+    *ngIf="hasValidColumns && itemsSelected.length > 0 && !hideBatchActions"
+    class="po-table-actions-batch-actions"
+  >
+    <div [ngPlural]="itemsSelected.length" class="po-table-actions-batch-actions__label">
+      <strong>
+        <ng-template ngPluralCase="=0">{{ literals.noItem }}</ng-template>
+        <ng-template ngPluralCase="=1">{{ literals.oneItem }}</ng-template>
+        <ng-template ngPluralCase="other">{{ itemsSelected.length }} {{ literals.multipleItems }}</ng-template>
+      </strong>
+    </div>
+
+    <div class="po-table-actions-batch-actions__buttons">
+      <po-button
+        p-icon="po-icon-delete"
+        [p-danger]="true"
+        [p-disabled]="itemsSelected.length > 1 && serviceDeleteApi !== undefined"
+        [p-label]="literals.delete"
+        (p-click)="modalDelete.open()"
+      ></po-button>
+    </div>
+  </div>
+
+  <div #columnManager *ngIf="hasValidColumns && !hideColumnsManager" class="po-table-actions-column-manager">
     <po-button
       #columnManagerTarget
       p-icon="po-icon-settings"
-      [p-aria-label]="literals.columnsManager"
       p-kind="tertiary"
       p-tooltip-position="left"
+      [p-aria-label]="literals.columnsManager"
       [p-tooltip]="literals.columnsManager"
       (p-click)="onOpenColumnManager()"
     ></po-button>
@@ -739,3 +763,13 @@
   (p-initial-columns)="onColumnRestoreManager($event)"
 >
 </po-table-column-manager>
+
+<po-modal
+  #modalDelete
+  [p-title]="literals.delete"
+  [p-primary-action]="confirm"
+  [p-secondary-action]="close"
+  [p-click-out]="true"
+>
+  <p class="po-font-text-large">{{ literals.bodyDelete }}</p>
+</po-modal>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
@@ -19,6 +19,7 @@
   (p-unselected)="decreaseTotal($event)"
   (p-change-visible-columns)="changeColumnVisible($event)"
   (p-restore-column-manager)="restoreColumn()"
+  (p-delete-items)="deleteItems($event)"
 >
 </po-table>
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
@@ -125,6 +125,10 @@ export class SamplePoTableAirfareComponent implements AfterViewInit {
     }
   }
 
+  deleteItems(items: Array<any>) {
+    this.items = items;
+  }
+
   details(item) {
     this.detail = item;
     this.poModal.open();

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.html
@@ -12,6 +12,7 @@
       (p-unselected)="changeOptions($event, 'change')"
       p-height="300"
       [p-items]="items"
+      (p-delete-items)="deleteItems($event)"
     >
     </po-table>
   </div>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.ts
@@ -48,4 +48,9 @@ export class SamplePoTableHeroesComponent implements OnInit {
       this.itemsSelected = [...this.poItemsSelected.items];
     }
   }
+
+  deleteItems(items: Array<any>) {
+    this.items = items;
+    this.itemsSelected = [];
+  }
 }

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -6,6 +6,7 @@
   [p-height]="height"
   [p-hide-detail]="properties.includes('hideDetail')"
   [p-hide-columns-manager]="properties.includes('hideColumnsManager')"
+  [p-hide-batch-actions]="properties.includes('hideBatchActions')"
   [p-hide-select-all]="selection.includes('hideSelectAll')"
   [p-items]="items"
   [p-literals]="customLiterals"
@@ -25,6 +26,7 @@
   (p-show-more)="showMore()"
   (p-unselected)="changeEvent('p-unselected')"
   [p-auto-collapse]="properties.includes('autoCollapse')"
+  (p-delete-items)="deleteItems($event)"
 >
 </po-table>
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -36,6 +36,7 @@ export class SamplePoTableLabsComponent implements OnInit {
   event: string;
   height: number;
   items: Array<any>;
+  itemIndex = 0;
   literals: string;
   maxColumns: number;
   properties: Array<string>;
@@ -81,6 +82,7 @@ export class SamplePoTableLabsComponent implements OnInit {
     { label: 'Loading', value: 'loading' },
     { label: 'Auto collapse', value: 'autoCollapse' },
     { label: 'Hide columns manager', value: 'hideColumnsManager' },
+    { label: 'Hide batch actions', value: 'hideBatchActions' },
     { label: 'Actions Right', value: 'actionsRight' }
   ];
 
@@ -97,7 +99,8 @@ export class SamplePoTableLabsComponent implements OnInit {
   }
 
   addItem() {
-    this.items = [...this.items, this.samplePoTableLabsService.generateNewItem(this.items.length + 1)];
+    this.items = [...this.items, this.samplePoTableLabsService.generateNewItem(this.itemIndex)];
+    this.itemIndex++;
   }
 
   changeActionOptions() {
@@ -139,6 +142,12 @@ export class SamplePoTableLabsComponent implements OnInit {
     this.selectionOptions = [].concat(this.selectionOptions);
   }
 
+  deleteItems(items: Array<any>) {
+    if (this.height) {
+      this.items = items;
+    }
+  }
+
   disableAction() {
     return this.actionsDefinition.disableAction;
   }
@@ -157,6 +166,7 @@ export class SamplePoTableLabsComponent implements OnInit {
     this.customLiterals = undefined;
     this.height = undefined;
     this.items = [];
+    this.itemIndex = 0;
     this.literals = '';
     this.maxColumns = undefined;
     this.properties = [];

--- a/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
+++ b/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
@@ -18,12 +18,20 @@ describe('PoTableService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('setUrl: should be called and set api url', () => {
+  it('setUrl: should be called and set api url to method GET', () => {
     const url = 'https://po-sample-api.fly.dev/v1/heroes';
 
-    service.setUrl(url);
+    service.setUrl(url, 'GET');
 
     expect(service['url']).toBe(url);
+  });
+
+  it('setUrl: should be called and set api url to method DELETE', () => {
+    const url = 'https://po-sample-api.fly.dev/v1/heroes';
+
+    service.setUrl(url, 'DELETE');
+
+    expect(service['urlDelete']).toBe(url);
   });
 
   it('validateParams: should be called with string and return undefined', () => {
@@ -56,6 +64,17 @@ describe('PoTableService', () => {
     };
 
     service.getFilteredItems(filteredParams).subscribe(response => {
+      expect(response).toBeDefined();
+    });
+  });
+
+  it('deleteItem: to have been called and call backend', () => {
+    service['urlDelete'] = 'https://po-sample-api.fly.dev/v1/heroes';
+
+    const paramDelete = 'id';
+    const paramResponse = 12345;
+
+    service.deleteItem(paramDelete, paramResponse).subscribe(response => {
       expect(response).toBeDefined();
     });
   });

--- a/projects/ui/src/lib/components/po-table/services/po-table.service.ts
+++ b/projects/ui/src/lib/components/po-table/services/po-table.service.ts
@@ -15,6 +15,7 @@ export class PoTableService implements PoTableFilter {
   });
 
   private url: string;
+  private urlDelete: string;
 
   constructor(private http: HttpClient) {}
 
@@ -24,8 +25,20 @@ export class PoTableService implements PoTableFilter {
     return this.http.get(this.url, { headers: this.headers, params });
   }
 
-  setUrl(url: string) {
-    this.url = url;
+  deleteItem(paramDelete: string, paramResponse: any): Observable<any> {
+    const params = {
+      [paramDelete]: paramResponse
+    };
+
+    return this.http.delete(this.urlDelete, { headers: this.headers, params });
+  }
+
+  setUrl(url: string, method: 'GET' | 'DELETE') {
+    if (method === 'GET') {
+      this.url = url;
+    } else {
+      this.urlDelete = url;
+    }
   }
 
   scrollListener(componentListner: HTMLElement): Observable<any> {


### PR DESCRIPTION
TABLE

fixes DTHFUI-7317
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
N/A

**Qual o novo comportamento?**
Quando a tabela possui a propriedade selectable = true, é permitido ao usuário a opção de realizar ações (exclusão) em lote. Utilizando serviço, é possível apenas 1 item por vez

**Simulação**
Necessário rodar o comando npm run build:portal para executar os samples
[app.zip](https://github.com/po-ui/po-angular/files/12006101/app.zip)


Pasta styles para substituir na node_modules:

[style.zip](https://github.com/po-ui/po-angular/files/11984505/style.zip)
