### PR TITLE
feat(table): implementa recurso `drag and drop` nas colunas da tabela

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -30,6 +30,7 @@
     (p-change-visible-columns)="onChangeVisibleColumns($event)"
     (p-restore-column-manager)="onColumnRestoreManager($event)"
     (p-sort-by)="onSortBy($event)"
+    [p-draggable]="draggable"
   >
   </po-table>
 </po-page-dynamic-search>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -2770,4 +2770,9 @@ describe('PoPageDynamicTableComponent:', () => {
       ]);
     });
   });
+  it('draggable: should return false if draggable is false', () => {
+    component.draggable = false;
+
+    expect(component.draggable).toBeFalse();
+  });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -128,6 +128,11 @@ type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicTableOptions);
  *  <file name="sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.html"> </file>
  *  <file name="sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.ts"> </file>
  * </example>
+ *
+ * <example name="po-page-dynamic-table-drag-and-drop" title="PO Page Dynamic Table - Drag and Drop">
+ *  <file name="sample-po-page-dynamic-table-drag-and-drop/sample-po-page-dynamic-table-drag-and-drop.component.html"> </file>
+ *  <file name="sample-po-page-dynamic-table-drag-and-drop/sample-po-page-dynamic-table-drag-and-drop.component.ts"> </file>
+ * </example>
  */
 @Component({
   selector: 'po-page-dynamic-table',
@@ -278,6 +283,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   private _defaultPageActions: Array<PoPageAction> = [];
   private _defaultTableActions: Array<PoTableAction> = [];
   private _hideCloseDisclaimers: Array<string> = [];
+  private _draggable = false;
 
   private set defaultPageActions(value: Array<PoPageAction>) {
     this._defaultPageActions = value;
@@ -500,6 +506,22 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
    * > O valor padrão será traduzido de acordo com o idioma configurado no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
    */
   @Input('p-literals') searchLiterals: PoPageDynamicSearchLiterals;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Habilita o modo drag and drop para as colunas da tabela.
+   *
+   */
+  @Input('p-draggable') set draggable(value: boolean) {
+    this._draggable = value;
+  }
+
+  get draggable(): boolean {
+    return this._draggable;
+  }
 
   constructor(
     private router: Router,

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-drag-and-drop/sample-po-page-dynamic-table-drag-and-drop.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-drag-and-drop/sample-po-page-dynamic-table-drag-and-drop.component.html
@@ -1,0 +1,12 @@
+<po-page-dynamic-table
+  p-auto-router
+  p-concat-filters
+  p-keep-filters
+  p-title="Po Page Dynamic Table - Drag and Drop"
+  [p-draggable]="true"
+  [p-height]="300"
+  [p-infinite-scroll]="true"
+  [p-fields]="fields"
+  [p-service-api]="serviceApi"
+>
+</po-page-dynamic-table>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-drag-and-drop/sample-po-page-dynamic-table-drag-and-drop.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-drag-and-drop/sample-po-page-dynamic-table-drag-and-drop.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sample-po-page-dynamic-table-drag-and-drop',
+  templateUrl: './sample-po-page-dynamic-table-drag-and-drop.component.html'
+})
+export class SamplePoPageDynamicTableDragAndDropComponent {
+  readonly serviceApi = 'https://po-sample-api.fly.dev/v1/people';
+
+  readonly fields: Array<any> = [
+    { property: 'id', key: true, visible: false },
+    { property: 'name', label: 'Name' },
+    { property: 'genre', label: 'Genre', sortable: false },
+    { property: 'city', label: 'City' }
+  ];
+
+  constructor() {}
+}

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -423,6 +423,7 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   private sortStore: PoTableColumnSort;
   private _infiniteScrollDistance?: number = 100;
   private _infiniteScroll?: boolean = false;
+  private _draggable?: boolean = false;
 
   /**
    * @description
@@ -812,6 +813,23 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
 
   private get sortType(): PoTableColumnSortType {
     return this.sortedColumn.ascending ? PoTableColumnSortType.Ascending : PoTableColumnSortType.Descending;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Habilita o modo drag and drop para as colunas da tabela.
+   *
+   * @default `false`
+   */
+  @Input('p-draggable') set draggable(draggable: boolean) {
+    this._draggable = draggable || false;
+  }
+
+  get draggable() {
+    return this._draggable;
   }
 
   constructor(

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -101,7 +101,13 @@
     }"
   >
     <thead>
-      <tr [ngClass]="{ 'no-hover': hideSelectAll }" [class.po-table-header]="!height">
+      <tr
+        [ngClass]="{ 'no-hover': hideSelectAll, 'po-table-column-drag': this.isDraggable }"
+        [class.po-table-header]="!height"
+        cdkDropList
+        cdkDropListOrientation="horizontal"
+        (cdkDropListDropped)="drop($event)"
+      >
         <th
           *ngIf="hasSelectableColumn"
           [style.pointer-events]="hideSelectAll ? 'none' : 'auto'"
@@ -134,32 +140,83 @@
           <ng-container *ngIf="height; then noColumnsWithHeight; else noColumnsWithoutHeight"> </ng-container>
         </th>
 
-        <th
-          *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
-          class="po-table-header-ellipsis"
-          [style.width]="column.width"
-          [style.max-width]="column.width"
-          [style.min-width]="column.width"
-          [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
-          [class.po-clickable]="(sort && column.sortable !== false) || hasService"
-          [ngClass]="{
-            'po-table-header-sorted':
-              sort &&
-              JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
-              (sortedColumn.ascending || !sortedColumn.ascending)
-          }"
-          [class.po-table-header-subtitle]="column.type === 'subtitle'"
-          (click)="sortColumn(column)"
-        >
-          <div
-            class="po-table-header-flex"
-            [class.po-table-header-fixed-inner]="height"
-            [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
-            [class.po-table-header-flex-center]="column.type === 'subtitle'"
+        <ng-container *ngIf="this.isDraggable; then tableDefaultThDragDrop; else tableDefaultThDefault"> </ng-container>
+        <ng-template #tableDefaultThDragDrop>
+          <th
+            *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
+            class="po-table-header-ellipsis"
+            [style.width]="column.width"
+            [style.max-width]="column.width"
+            [style.min-width]="column.width"
+            [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
+            [class.po-clickable]="(sort && column.sortable !== false) || hasService"
+            [ngClass]="{
+              'po-table-header-sorted':
+                sort &&
+                JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
+                (sortedColumn.ascending || !sortedColumn.ascending)
+            }"
+            [class.po-table-header-subtitle]="column.type === 'subtitle'"
+            [class.po-table-column-drag-box]="this.isDraggable"
+            (click)="sortColumn(column)"
+            cdkDrag
+            cdkDragLockAxis="x"
           >
-            <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }"> </ng-container>
-          </div>
-        </th>
+            <div
+              class="po-table-header-flex"
+              [class.po-table-header-fixed-inner]="height"
+              [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
+              [class.po-table-header-flex-center]="column.type === 'subtitle'"
+            >
+              <ng-container *ngIf="this.isDraggable">
+                <svg
+                  cdkDragHandle
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle cx="9" cy="6" r="2" fill="black" />
+                  <circle cx="15" cy="6" r="2" fill="black" />
+                  <circle cx="9" cy="12" r="2" fill="black" />
+                  <circle cx="15" cy="12" r="2" fill="black" />
+                  <circle cx="9" cy="18" r="2" fill="black" />
+                  <circle cx="15" cy="18" r="2" fill="black" />
+                </svg>
+              </ng-container>
+              <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }"> </ng-container>
+            </div>
+          </th>
+        </ng-template>
+        <ng-template #tableDefaultThDefault>
+          <th
+            *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
+            class="po-table-header-ellipsis"
+            [style.width]="column.width"
+            [style.max-width]="column.width"
+            [style.min-width]="column.width"
+            [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
+            [class.po-clickable]="(sort && column.sortable !== false) || hasService"
+            [ngClass]="{
+              'po-table-header-sorted':
+                sort &&
+                JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
+                (sortedColumn.ascending || !sortedColumn.ascending)
+            }"
+            [class.po-table-header-subtitle]="column.type === 'subtitle'"
+            (click)="sortColumn(column)"
+          >
+            <div
+              class="po-table-header-flex"
+              [class.po-table-header-fixed-inner]="height"
+              [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
+              [class.po-table-header-flex-center]="column.type === 'subtitle'"
+            >
+              <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }"> </ng-container>
+            </div>
+          </th>
+        </ng-template>
 
         <th
           *ngIf="hasRowTemplateWithArrowDirectionRight && (hasVisibleActions || hideColumnsManager)"
@@ -373,7 +430,12 @@
       [ngStyle]="{ 'table-layout': !hasItems ? 'fixed' : 'auto' }"
     >
       <thead class="po-table-header-sticky" [style.top]="inverseOfTranslation">
-        <tr [class.po-table-header]="!height">
+        <tr
+          [class.po-table-header]="!height"
+          cdkDropList
+          cdkDropListOrientation="horizontal"
+          (cdkDropListDropped)="drop($event)"
+        >
           <th
             *ngIf="hasSelectableColumn"
             [style.pointer-events]="hideSelectAll ? 'none' : 'auto'"
@@ -406,33 +468,87 @@
             <ng-container *ngIf="height; then noColumnsWithHeight; else noColumnsWithoutHeight"> </ng-container>
           </th>
 
-          <th
-            *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
-            class="po-table-header-ellipsis"
-            [style.width]="column.width"
-            [style.max-width]="column.width"
-            [style.min-width]="column.width"
-            [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
-            [class.po-clickable]="(sort && column.sortable !== false) || hasService"
-            [ngClass]="{
-              'po-table-header-sorted':
-                sort &&
-                JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
-                (sortedColumn.ascending || !sortedColumn.ascending)
-            }"
-            [ngStyle]="{ 'width': !hasItems ? '100%' : 'auto' }"
-            [class.po-table-header-subtitle]="column.type === 'subtitle'"
-            (click)="sortColumn(column)"
-          >
-            <div
-              class="po-table-header-flex"
-              [class.po-table-header-fixed-inner]="height"
-              [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
-              [class.po-table-header-flex-center]="column.type === 'subtitle'"
+          <ng-container *ngIf="this.isDraggable; then tableVirtualScrollThDragDrop; else tableVirtualScrollThDefault">
+          </ng-container>
+          <ng-template #tableVirtualScrollThDragDrop>
+            <th
+              *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
+              class="po-table-header-ellipsis"
+              [style.width]="column.width"
+              [style.max-width]="column.width"
+              [style.min-width]="column.width"
+              [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
+              [class.po-clickable]="(sort && column.sortable !== false) || hasService"
+              [ngClass]="{
+                'po-table-header-sorted':
+                  sort &&
+                  JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
+                  (sortedColumn.ascending || !sortedColumn.ascending)
+              }"
+              [ngStyle]="{ 'width': !hasItems ? '100%' : 'auto' }"
+              [class.po-table-header-subtitle]="column.type === 'subtitle'"
+              [class.po-table-column-drag-box]="this.isDraggable"
+              (click)="sortColumn(column)"
+              cdkDrag
+              cdkDragLockAxis="x"
             >
-              <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }"> </ng-container>
-            </div>
-          </th>
+              <div
+                class="po-table-header-flex"
+                [class.po-table-header-fixed-inner]="height"
+                [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
+                [class.po-table-header-flex-center]="column.type === 'subtitle'"
+              >
+                <ng-container *ngIf="this.isDraggable">
+                  <svg
+                    cdkDragHandle
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle cx="9" cy="6" r="2" fill="black" />
+                    <circle cx="15" cy="6" r="2" fill="black" />
+                    <circle cx="9" cy="12" r="2" fill="black" />
+                    <circle cx="15" cy="12" r="2" fill="black" />
+                    <circle cx="9" cy="18" r="2" fill="black" />
+                    <circle cx="15" cy="18" r="2" fill="black" />
+                  </svg>
+                </ng-container>
+
+                <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }"> </ng-container>
+              </div>
+            </th>
+          </ng-template>
+          <ng-template #tableVirtualScrollThDefault>
+            <th
+              *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
+              class="po-table-header-ellipsis"
+              [style.width]="column.width"
+              [style.max-width]="column.width"
+              [style.min-width]="column.width"
+              [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
+              [class.po-clickable]="(sort && column.sortable !== false) || hasService"
+              [ngClass]="{
+                'po-table-header-sorted':
+                  sort &&
+                  JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
+                  (sortedColumn.ascending || !sortedColumn.ascending)
+              }"
+              [ngStyle]="{ 'width': !hasItems ? '100%' : 'auto' }"
+              [class.po-table-header-subtitle]="column.type === 'subtitle'"
+              (click)="sortColumn(column)"
+            >
+              <div
+                class="po-table-header-flex"
+                [class.po-table-header-fixed-inner]="height"
+                [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
+                [class.po-table-header-flex-center]="column.type === 'subtitle'"
+              >
+                <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }"> </ng-container>
+              </div>
+            </th>
+          </ng-template>
 
           <th
             *ngIf="hasRowTemplateWithArrowDirectionRight && (hasVisibleActions || hideColumnsManager)"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -901,6 +901,46 @@ describe('PoTableComponent:', () => {
       });
     });
 
+    it('drop: should update columns and call onVisibleColumnsChange when `hideColumnsManager` is false', () => {
+      const previousIndex = 0;
+      const currentIndex = 1;
+      const event = {
+        previousIndex: previousIndex,
+        currentIndex: currentIndex
+      };
+
+      const mockColumns = [{ property: 'column1' }, { property: 'column2' }, { property: 'detail' }];
+
+      component.columns = mockColumns;
+      component.mainColumns = mockColumns;
+      spyOn(component, 'onVisibleColumnsChange');
+
+      component.drop(event as any);
+
+      expect(component.newOrderColumns[previousIndex]).toEqual(mockColumns[currentIndex]);
+      expect(component.newOrderColumns[currentIndex]).toEqual(mockColumns[previousIndex]);
+      expect(component.newOrderColumns[2]).toEqual(mockColumns[2]);
+      expect(component.onVisibleColumnsChange).toHaveBeenCalledWith(component.newOrderColumns);
+    });
+
+    it('drop: should update mainColumns when `hideColumnsManager` is true', () => {
+      const previousIndex = 0;
+      const currentIndex = 1;
+      const event = {
+        previousIndex: previousIndex,
+        currentIndex: currentIndex
+      };
+      const mockColumns = [{ property: 'column1' }, { property: 'column2' }, { property: 'detail' }];
+
+      component.hideColumnsManager = true;
+      component.mainColumns = [{ property: 'column1' }, { property: 'column2' }, { property: 'detail' }];
+      component.drop(event as any);
+
+      expect(component.mainColumns[currentIndex]).toEqual(mockColumns[previousIndex]);
+      expect(component.mainColumns[previousIndex]).toEqual(mockColumns[currentIndex]);
+      expect(component.mainColumns[2]).toEqual(mockColumns[2]);
+    });
+
     describe('getBooleanLabel:', () => {
       const simpleColumnBoolean: PoTableColumn = { property: 'boolean', label: 'Boolean', type: 'boolean' };
 
@@ -3133,5 +3173,11 @@ describe('PoTableComponent:', () => {
     component.height = 200;
 
     expect(component['hasInfiniteScroll']()).toBeFalse();
+  });
+
+  it('draggable: should return false if draggable is false', () => {
+    component.draggable = false;
+
+    expect(component['isDraggable']).toBeFalse();
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -1,4 +1,6 @@
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+
 import { DecimalPipe } from '@angular/common';
 import {
   AfterViewInit,
@@ -90,6 +92,10 @@ import { PoTableService } from './services/po-table.service';
  *  <file name="sample-po-table-heroes/sample-po-table-heroes.service.ts"> </file>
  * </example>
  *
+ * <example name="po-table-draggable" title="PO Table Drag and Drop">
+ *  <file name="sample-po-table-draggable/sample-po-table-draggable.component.html"> </file>
+ *  <file name="sample-po-table-draggable/sample-po-table-draggable.component.ts"> </file>
+ * </example>
  */
 @Component({
   selector: 'po-table',
@@ -132,6 +138,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   tagColor: string;
   idRadio: string;
   JSON: JSON;
+  newOrderColumns: Array<PoTableColumn>;
 
   close: PoModalAction = {
     action: () => {
@@ -272,6 +279,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return (
       this.actions !== undefined && this.actions && this.actions.filter(action => action && action.visible !== false)
     );
+  }
+
+  get isDraggable(): boolean {
+    return this.draggable;
   }
 
   public get inverseOfTranslation(): string {
@@ -555,7 +566,6 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   onVisibleColumnsChange(columns: Array<PoTableColumn>) {
     this.columns = columns;
-
     this.changeDetector.detectChanges();
   }
 
@@ -626,6 +636,28 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     } else {
       const index = this.items.findIndex(indexItem => indexItem === item);
       this.items.splice(index, 1, updatedItem);
+    }
+  }
+
+  drop(event: CdkDragDrop<Array<string>>) {
+    moveItemInArray(this.mainColumns, event.previousIndex, event.currentIndex);
+
+    if (this.hideColumnsManager === false) {
+      this.newOrderColumns = this.mainColumns;
+      const detail = this.columns.filter(item => item.property === 'detail')[0];
+
+      if (detail !== undefined) {
+        this.newOrderColumns.push(detail);
+      }
+
+      this.columns.map((item, index) => {
+        if (!item.visible) {
+          this.newOrderColumns.splice(index, 0, item);
+        }
+      });
+      this.columns = this.newOrderColumns;
+
+      this.onVisibleColumnsChange(this.newOrderColumns);
     }
   }
 

--- a/projects/ui/src/lib/components/po-table/po-table.module.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.module.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { ScrollingModule } from '@angular/cdk/scrolling';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 
 import { PoButtonModule } from './../po-button/po-button.module';
 import { PoCheckboxGroupModule } from '../po-field/po-checkbox-group/po-checkbox-group.module';
@@ -45,6 +46,7 @@ import { PoSwitchModule } from './../po-field/po-switch/po-switch.module';
     CommonModule,
     FormsModule,
     ScrollingModule,
+    DragDropModule,
     RouterModule,
     PoButtonModule,
     PoCheckboxGroupModule,

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-draggable/sample-po-table-draggable.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-draggable/sample-po-table-draggable.component.html
@@ -1,0 +1,10 @@
+<div class="po-font-text-bold">Choose one column and drag to another horizontal position in the table and drop</div>
+
+<po-divider></po-divider>
+
+<po-table
+  [p-items]="[{ code: '001', table: 'PO Table', angular: 'PO-UI' }]"
+  [p-draggable]="true"
+  [p-hide-columns-manager]="true"
+>
+</po-table>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-draggable/sample-po-table-draggable.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-draggable/sample-po-table-draggable.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sample-po-table-draggable',
+  templateUrl: './sample-po-table-draggable.component.html'
+})
+export class SamplePoTableDraggableComponent {}

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.e2e-spec.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.e2e-spec.ts
@@ -85,4 +85,8 @@ describe('Po-Table-Labs E2E', () => {
     table.poCheckboxShowActions.click();
     expect(table.poTableActions.isPresent()).toBeTruthy();
   });
+
+  it('Checks if checkbox ´Habilitar recurso de drag and drop (draggable)´ exist', () => {
+    expect(table.poCheckboxDraggableTable.isPresent()).toBeTruthy();
+  });
 });

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -27,6 +27,7 @@
   (p-unselected)="changeEvent('p-unselected')"
   [p-auto-collapse]="properties.includes('autoCollapse')"
   (p-delete-items)="deleteItems($event)"
+  [p-draggable]="properties.includes('draggable')"
 >
 </po-table>
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.po.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.po.ts
@@ -61,6 +61,10 @@ export class PoTableLabsPage {
     return this.getPoCheckbox('actionOptions', 'showSingleAction');
   }
 
+  get poCheckboxDraggableTable() {
+    return this.getPoCheckbox('options', 'draggable');
+  }
+
   get poTableColumnDestiny() {
     return this.getPoTableColumn('Destino');
   }

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -83,7 +83,8 @@ export class SamplePoTableLabsComponent implements OnInit {
     { label: 'Auto collapse', value: 'autoCollapse' },
     { label: 'Hide columns manager', value: 'hideColumnsManager' },
     { label: 'Hide batch actions', value: 'hideBatchActions' },
-    { label: 'Actions Right', value: 'actionsRight' }
+    { label: 'Actions Right', value: 'actionsRight' },
+    { label: 'Draggable', value: 'draggable' }
   ];
 
   public readonly typeHeaderOptions: Array<PoRadioGroupOption> = [


### PR DESCRIPTION
**TABLE**

**DTHFUI-7315**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente não possui recurso de drag and drop nas colunas.

**Qual o novo comportamento?**
Implementado recurso de drag and drop no componente com parâmetro p-draggable opcional tendo valor padrão falso. Caso seja passado como verdadeiro, o recurso de drag and drop estará disponível.

**Simulação**
Samples: [/portal (po-table e po-page-dynamic-table)](Portal)
App: [app.zip](https://github.com/po-ui/po-angular/files/12018446/app.zip)
