### PR TITLE
feat(input): adiciona evento tecla enter

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -119,6 +119,15 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    *
    * @description
    *
+   * Evento disparado ao pressionar tecla enter.
+   */
+  @Output('p-enter-click') enterClick: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Evento disparado ao entrar do campo.
    */
   @Output('p-enter') enter: EventEmitter<any> = new EventEmitter();

--- a/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
@@ -32,6 +32,7 @@
       (click)="eventOnClick($event)"
       (focus)="eventOnFocus($event)"
       (input)="eventOnInput($event)"
+      (keyup.enter)="enterClick.emit($event.target)"
     />
 
     <div class="po-field-icon-container-right">

--- a/projects/ui/src/lib/components/po-field/po-input/po-input.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input.component.spec.ts
@@ -51,9 +51,11 @@ describe('PoInputComponent: ', () => {
   describe('Methods:', () => {
     describe('ngAfterViewInit:', () => {
       let inputFocus: jasmine.Spy;
+      let inputkeyup: jasmine.Spy;
 
       beforeEach(() => {
         inputFocus = spyOn(component, 'focus');
+        inputkeyup = spyOn(component.enterClick, 'emit');
       });
 
       it('should call `focus` if autoFocus is true.', () => {
@@ -66,6 +68,13 @@ describe('PoInputComponent: ', () => {
         component.autoFocus = false;
         component.ngAfterViewInit();
         expect(inputFocus).not.toHaveBeenCalled();
+      });
+
+      it('should emit "keyup.enter" event when an Enter key is pressed', () => {
+        const enterEvent = new KeyboardEvent('keyup', { key: 'Enter' });
+        component.enterClick.emit(enterEvent);
+        component.ngAfterViewInit();
+        expect(inputkeyup).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
O componente não escutava  evento keyup.enter. Este commit implementa evento tecla enter.

Fixes #1765, DTHFUI-7528

**< PoInputComponent>**

**< Fixes #1765, DTHFUI-7528 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o componente não possui escuta para EMITIR evento do (keyup.enter) a tecla ENTER. 

**Qual o novo comportamento?**
Adicionando escuta para EMITIR evento (keyup.enter) a tecla enter.

**Simulação**
npm run build:portal && ng serve portal
Testar no **PO Input Labs**