### PR TITLE
feat(table): cria propriedade p-spacing para a tabela

### DIFF
--- a/projects/ui/src/lib/components/po-table/enums/po-table-spacing.enum.ts
+++ b/projects/ui/src/lib/components/po-table/enums/po-table-spacing.enum.ts
@@ -1,0 +1,16 @@
+/**
+ * @usedBy PoTableComponent
+ *
+ * @description
+ * Tipos de espaçamento das colunas da tabela.
+ */
+export enum PoTableColumnSpacing {
+  /** Espaçamento pequeno, só funciona em colunas não interativas */
+  Small = 'small',
+
+  /** Espaçamento médio */
+  Medium = 'medium',
+
+  /** Espaçamento grande */
+  Large = 'large'
+}

--- a/projects/ui/src/lib/components/po-table/index.ts
+++ b/projects/ui/src/lib/components/po-table/index.ts
@@ -1,5 +1,6 @@
 export * from './enums/po-table-column-sort-type.enum';
 export * from './enums/po-table-row-template-arrow-direction.enum';
+export * from './enums/po-table-spacing.enum';
 export * from './interfaces/po-table-action.interface';
 export * from './interfaces/po-table-boolean.interface';
 export * from './interfaces/po-table-column.interface';

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -1,19 +1,20 @@
 import { Directive } from '@angular/core';
 
-import * as utilsFunctions from '../../utils/util';
-import { expectPropertiesValues, expectSettersMethod } from '../../util-test/util-expect.spec';
 import { PoDateService } from '../../services/po-date/po-date.service';
-import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { poLocaleDefault } from '../../services/po-language/po-language.constant';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { expectPropertiesValues, expectSettersMethod } from '../../util-test/util-expect.spec';
+import * as utilsFunctions from '../../utils/util';
 
-import { PoTableAction } from './interfaces/po-table-action.interface';
-import { PoTableBaseComponent, poTableLiteralsDefault } from './po-table-base.component';
-import { PoTableColumn } from './interfaces/po-table-column.interface';
-import { PoTableColumnSortType } from './enums/po-table-column-sort-type.enum';
-import { PoTableService } from './services/po-table.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Observable, of } from 'rxjs';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PoTableColumnSortType } from './enums/po-table-column-sort-type.enum';
+import { PoTableColumnSpacing } from './enums/po-table-spacing.enum';
+import { PoTableAction } from './interfaces/po-table-action.interface';
+import { PoTableColumn } from './interfaces/po-table-column.interface';
+import { PoTableBaseComponent, poTableLiteralsDefault } from './po-table-base.component';
+import { PoTableService } from './services/po-table.service';
 
 @Directive()
 class PoTableComponent extends PoTableBaseComponent {
@@ -597,6 +598,47 @@ describe('PoTableBaseComponent:', () => {
 
         expect(component['unselectOtherRows']).not.toHaveBeenCalled();
         expect(component['isEverySelected']).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('verifyInteractiveColumns: ', () => {
+      it('should call spacing `large`', () => {
+        component.columns = [
+          { label: 'Table', property: 'table', visible: true },
+          { label: 'Angular', property: 'angular', visible: true }
+        ];
+        component.spacing = PoTableColumnSpacing.Large;
+
+        component['verifyInteractiveColumns']();
+
+        expect(component.spacing).toBe('large');
+      });
+
+      it('should call spacing `small` when row is not interactive', () => {
+        component.columns = [
+          { label: 'Table', property: 'table', visible: true },
+          { label: 'Angular', property: 'angular', visible: true }
+        ];
+        component.selectable = false;
+        component.actions = [];
+        component.spacing = PoTableColumnSpacing.Small;
+
+        component['verifyInteractiveColumns']();
+
+        expect(component.spacing).toBe('small');
+      });
+
+      it('should call spacing `medium` when row is interactive and set spacing `small`', () => {
+        component.columns = [
+          { label: 'Table', property: 'table', visible: true },
+          { label: 'Angular', property: 'angular', visible: true, type: 'link' }
+        ];
+        component.selectable = true;
+        component.spacing = PoTableColumnSpacing.Small;
+
+        component['verifyInteractiveColumns']();
+
+        expect(component.spacing).toBe('medium');
       });
     });
 
@@ -1471,6 +1513,19 @@ describe('PoTableBaseComponent:', () => {
       expect(component['getDefaultColumns']).not.toHaveBeenCalled();
     });
 
+    it('p-columns: should call `verifyInteractiveColumns` if have a column if visible propertie', () => {
+      spyOn(component, <any>'verifyInteractiveColumns');
+
+      component['initialVisibleColumns'] = false;
+      component.columns = [
+        { label: 'Table', property: 'table', visible: true },
+        { label: 'Angular', property: 'angular', visible: true }
+      ];
+
+      expect(component['initialVisibleColumns']).toBe(true);
+      expect(component['verifyInteractiveColumns']).toHaveBeenCalled();
+    });
+
     it('p-container: should update property with valid values', () => {
       const validValues = ['border', 'shadow'];
 
@@ -1503,6 +1558,42 @@ describe('PoTableBaseComponent:', () => {
 
     it('p-service-delete: should update property with valid values', () => {
       expectPropertiesValues(component, 'serviceDeleteApi', 'https://po-ui.io', 'https://po-ui.io');
+    });
+
+    it('p-spacing: should update property with valid values', () => {
+      expectPropertiesValues(component, 'spacing', 'small', 'small');
+    });
+
+    it('p-spacing: should update property with `Medium` if values are invalid', () => {
+      const invalidValues = [undefined, null, true, false, 'qdqdsa', [], {}];
+      expectPropertiesValues(component, 'spacing', invalidValues, 'medium');
+    });
+
+    it('visibleActions: should be `false` if doesn`t have action.', () => {
+      component.actions = undefined;
+
+      expect(component.visibleActions).toBeFalsy();
+    });
+
+    it('visibleActions: shouldn`t return action if visible is `false`.', () => {
+      component.actions = [
+        { label: 'PO1', visible: false },
+        { label: 'PO2', visible: true }
+      ];
+
+      expect(component.visibleActions).toEqual([{ label: 'PO2', visible: true }]);
+    });
+
+    it('visibleActions: should return only valid values', () => {
+      component.actions = [{ label: 'PO1' }, undefined, null];
+
+      expect(component.visibleActions).toEqual([{ label: 'PO1' }]);
+    });
+
+    it('visibleActions: should be `true` if has action.', () => {
+      component.actions = actions;
+
+      expect(component.visibleActions).toBeTruthy();
     });
 
     it('sortType: should return `ascending` if `sortedColumn.ascending` is `true`.', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -99,6 +99,7 @@
       'po-table-selectable': selectable,
       'po-table-striped': striped
     }"
+    [attr.p-spacing]="spacing"
   >
     <thead>
       <tr
@@ -428,6 +429,7 @@
         'po-table-striped': striped
       }"
       [ngStyle]="{ 'table-layout': !hasItems ? 'fixed' : 'auto' }"
+      [attr.p-spacing]="spacing"
     >
       <thead class="po-table-header-sticky" [style.top]="inverseOfTranslation">
         <tr

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -15,6 +15,7 @@ import { PoColorPaletteService } from './../../services/po-color-palette/po-colo
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-arrow-direction.enum';
+import { PoTableColumnSpacing } from './enums/po-table-spacing.enum';
 import { PoTableAction } from './interfaces/po-table-action.interface';
 import { PoTableColumn } from './interfaces/po-table-column.interface';
 import { PoTableBaseComponent } from './po-table-base.component';
@@ -1410,33 +1411,6 @@ describe('PoTableComponent:', () => {
       expect(component.hasRowTemplate).toBeTruthy();
     });
 
-    it('visibleActions: should be `false` if doesn`t have action.', () => {
-      component.actions = undefined;
-
-      expect(component.visibleActions).toBeFalsy();
-    });
-
-    it('visibleActions: shouldn`t return action if visible is `false`.', () => {
-      component.actions = [
-        { label: 'PO1', visible: false },
-        { label: 'PO2', visible: true }
-      ];
-
-      expect(component.visibleActions).toEqual([{ label: 'PO2', visible: true }]);
-    });
-
-    it('visibleActions: should return only valid values', () => {
-      component.actions = [{ label: 'PO1' }, undefined, null];
-
-      expect(component.visibleActions).toEqual([{ label: 'PO1' }]);
-    });
-
-    it('visibleActions: should be `true` if has action.', () => {
-      component.actions = actions;
-
-      expect(component.visibleActions).toBeTruthy();
-    });
-
     it('detailHideSelect: should return `false` if doesn`t have MasterDetail', () => {
       component.columns = columns;
 
@@ -2337,6 +2311,35 @@ describe('PoTableComponent:', () => {
       fixture.detectChanges();
 
       expect(nativeElement.querySelector(`po-table-column-manager`)).toBe(null);
+    });
+
+    it('should call attr-p-spacing `medium` if p-spacing not set', () => {
+      component.columns = [...columnsWithDetail];
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('[p-spacing="medium"]')).toBeTruthy();
+    });
+
+    it('should call attr-p-spacing `small` if p-spacing is `small` and row is not interactive', () => {
+      component.columns = [{ property: 'name' }, { property: 'age' }];
+      component.spacing = PoTableColumnSpacing.Small;
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('[p-spacing="small"]')).toBeTruthy();
+    });
+
+    it('should call attr-p-spacing `medium` if p-spacing is `small` and row is interactive', () => {
+      component.spacing = PoTableColumnSpacing.Small;
+      component['initialVisibleColumns'] = false;
+      component.columns = [
+        { property: 'name', type: 'link', visible: true },
+        { property: 'age', visible: true }
+      ];
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('[p-spacing="small"]')).toBeNull();
+      expect(nativeElement.querySelector('[p-spacing="medium"]')).toBeTruthy();
     });
 
     it('should display .po-table-header-master-detail if columns contains detail and rowTemplate is undefined', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -275,12 +275,6 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return this.visibleActions.length === 1;
   }
 
-  get visibleActions() {
-    return (
-      this.actions !== undefined && this.actions && this.actions.filter(action => action && action.visible !== false)
-    );
-  }
-
   get isDraggable(): boolean {
     return this.draggable;
   }

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -13,6 +13,7 @@
   [p-loading]="properties.includes('loading')"
   [p-max-columns]="maxColumns"
   [p-selectable]="selection.includes('selectable')"
+  [p-spacing]="spacing"
   [p-loading-show-more]="properties.includes('loadingShowMore')"
   [p-show-more-disabled]="properties.includes('showMoreDisabled')"
   [p-single-select]="selection.includes('singleSelect')"
@@ -126,6 +127,11 @@
       (p-change)="changeActionOptions()"
     >
     </po-checkbox-group>
+  </div>
+
+  <div class="po-row">
+    <po-radio-group class="po-lg-6" name="spacing" [(ngModel)]="spacing" p-label="Spacing" [p-options]="typeSpacing">
+    </po-radio-group>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -1,11 +1,12 @@
-import { Component, ViewChild, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 
 import {
   PoCheckboxGroupOption,
-  PoRadioGroupOption,
   PoModalComponent,
+  PoRadioGroupOption,
   PoTableAction,
   PoTableColumn,
+  PoTableColumnSpacing,
   PoTableLiterals
 } from '@po-ui/ng-components';
 
@@ -41,6 +42,7 @@ export class SamplePoTableLabsComponent implements OnInit {
   maxColumns: number;
   properties: Array<string>;
   selection: Array<string>;
+  spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
 
   actionsDefinitionOptions: Array<PoCheckboxGroupOption> = [
     { label: 'Actions', value: 'actions' },
@@ -93,6 +95,12 @@ export class SamplePoTableLabsComponent implements OnInit {
     { label: 'Top', value: 'top' }
   ];
 
+  public readonly typeSpacing: Array<PoRadioGroupOption> = [
+    { label: 'Small', value: 'small', disabled: false },
+    { label: 'Medium', value: 'medium' },
+    { label: 'Large', value: 'large' }
+  ];
+
   constructor(private samplePoTableLabsService: SamplePoTableLabsService) {}
 
   ngOnInit() {
@@ -119,6 +127,7 @@ export class SamplePoTableLabsComponent implements OnInit {
         : [this.actionTableFirst, this.actionTableSecond]
       : [];
     this.actionTableFirst.visible = this.actionsDefinition.visibleAction;
+    this.spacingSelectOrAction();
   }
 
   changeEvent(event: string) {
@@ -141,6 +150,7 @@ export class SamplePoTableLabsComponent implements OnInit {
     this.selectionOptions[2].disabled = !selectable;
 
     this.selectionOptions = [].concat(this.selectionOptions);
+    this.spacingSelectOrAction();
   }
 
   deleteItems(items: Array<any>) {
@@ -172,6 +182,7 @@ export class SamplePoTableLabsComponent implements OnInit {
     this.maxColumns = undefined;
     this.properties = [];
     this.selection = [];
+    this.spacing = PoTableColumnSpacing.Medium;
 
     this.updateColumns();
     this.changeActionOptions();
@@ -183,6 +194,30 @@ export class SamplePoTableLabsComponent implements OnInit {
 
   updateColumns() {
     this.columns = [];
-    this.columnsName.forEach(column => this.columns.push(this.columnsDefinition[column]));
+    this.typeSpacing[0].disabled = false;
+    this.columnsName.forEach(column => {
+      this.columns.push(this.columnsDefinition[column]);
+      this.verifySpacing(column);
+    });
+  }
+
+  private spacingSelectOrAction() {
+    if (this.columnsName.length > 0) {
+      this.updateColumns();
+    } else {
+      this.verifySpacing();
+      if (this.actions.length === 0 && this.selection[0] !== 'selectable') {
+        this.typeSpacing[0].disabled = false;
+      }
+    }
+  }
+
+  private verifySpacing(column?: string) {
+    if (column === 'link' || column === 'detail' || this.selection[0] === 'selectable' || this.actions.length > 0) {
+      this.typeSpacing[0].disabled = true;
+      if (this.spacing === 'small') {
+        this.spacing = PoTableColumnSpacing.Medium;
+      }
+    }
   }
 }

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-transport/sample-po-table-transport.component.html
@@ -5,6 +5,7 @@
   [p-items]="items"
   [p-sort]="true"
   [p-striped]="true"
+  p-spacing="large"
 >
   <ng-template
     p-table-row-template


### PR DESCRIPTION
Cria nova propriedade para customizar o tamanho da row da tabela

fixes DTHFUI-7432

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O espaçamento das colunas não são customizáveis

**Qual o novo comportamento?**
O espaçamento das colunas possuem 3 tamanhos diferentes, sendo alteranado através da nova propriedade p-spacing

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/12216693/app.zip)

style:
https://github.com/po-ui/po-style/pull/436
