### PR TITLE
feat(table): implementa fixador de colunas

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/interfaces/po-checkbox-group-option.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/interfaces/po-checkbox-group-option.interface.ts
@@ -23,4 +23,6 @@ export interface PoCheckboxGroupOption {
    * usuário alterar a condição do checkbox.
    */
   disabled?: boolean;
+
+  fixed?: boolean;
 }

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
@@ -245,7 +245,7 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
   }
 
   checkOption(value: PoCheckboxGroupOption) {
-    if (!this._disabled && !value.disabled) {
+    if (!this._disabled && !value.disabled && !value.fixed) {
       this.checkOptionModel(value);
       this.changeValue();
     }

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -52,6 +52,7 @@
         [p-selectable]="true"
         [p-hide-detail]="true"
         [p-single-select]="!multiple"
+        [p-hide-action-fixed-columns]="true"
         [p-sort]="true"
         [p-columns]="columns"
         [p-height]="tableHeight"

--- a/projects/ui/src/lib/components/po-table/index.ts
+++ b/projects/ui/src/lib/components/po-table/index.ts
@@ -13,6 +13,7 @@ export * from './po-table-row-template/po-table-row-template.directive';
 export * from './po-table-subtitle-footer/po-table-subtitle-column.interface';
 export * from './po-table-cell-template/po-table-cell-template.directive';
 export * from './po-table-column-template/po-table-column-template.directive';
+export * from './po-table-column-frozen/po-table-column-frozen.directive';
 export * from './po-table.component';
 
 export * from './po-table.module';

--- a/projects/ui/src/lib/components/po-table/interfaces/po-table-column.interface.ts
+++ b/projects/ui/src/lib/components/po-table/interfaces/po-table-column.interface.ts
@@ -261,4 +261,6 @@ export interface PoTableColumn {
    * > Exemplo: '100px' ou '20%'.
    */
   width?: string;
+
+  fixed?: boolean;
 }

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -1257,6 +1257,21 @@ describe('PoTableBaseComponent:', () => {
       });
     });
 
+    describe('hideActionFixedColumns:', () => {
+      it('should set hide Fixed', () => {
+        expectSettersMethod(component, 'hideActionFixedColumns', true, 'hideActionFixedColumns', true);
+        expectSettersMethod(component, 'hideActionFixedColumns', false, 'hideActionFixedColumns', false);
+      });
+    });
+
+    describe('removePropertyFixed:', () => {
+      it('should return change fixed to false', () => {
+        const result = component['removePropertyFixed']([{ value: 'test', fixed: true }]);
+
+        expect(result).toEqual([{ value: 'test', fixed: false }]);
+      });
+    });
+
     describe('getFilteredItems:', () => {
       beforeEach(() => {
         items = [

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -164,6 +164,26 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    *
    * @description
    *
+   * Permite que as ações para fixar uma coluna da tabela sejam escondidas.
+   *
+   * @default `false`
+   */
+  @Input('p-hide-action-fixed-columns') set hideActionFixedColumns(hide: boolean) {
+    if (hide) {
+      this.columns = this.removePropertyFixed(this.columns);
+    }
+    this._hideActionFixedColumns = hide;
+  }
+
+  get hideActionFixedColumns() {
+    return this._hideActionFixedColumns;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Permite fechar um detalhe ou row template automaticamente, ao abrir outro item.
    *
    * @default `false`
@@ -424,6 +444,7 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   private _infiniteScrollDistance?: number = 100;
   private _infiniteScroll?: boolean = false;
   private _draggable?: boolean = false;
+  private _hideActionFixedColumns?: boolean = false;
 
   /**
    * @description
@@ -1142,6 +1163,15 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     }
 
     return `${column.property}`;
+  }
+
+  private removePropertyFixed(arr: Array<any>) {
+    return arr.map(obj => {
+      if (obj.hasOwnProperty('fixed')) {
+        obj.fixed = false;
+      }
+      return obj;
+    });
   }
 
   protected abstract calculateHeightTableContainer(height);

--- a/projects/ui/src/lib/components/po-table/po-table-column-frozen/po-table-column-frozen.directive.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-frozen/po-table-column-frozen.directive.spec.ts
@@ -1,0 +1,154 @@
+import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
+import { Component, DebugElement, ElementRef, SimpleChanges } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
+import { PoTableColumnFrozenDirective } from './po-table-column-frozen.directive';
+
+@Component({
+  template: `
+    <div #parentElement>
+      <div pFrozenColumn [pFrozenColumn]="frozen" [alignFrozen]="alignFrozen"></div>
+    </div>
+  `
+})
+class TestHostComponent {
+  frozen: boolean;
+  alignFrozen: string;
+}
+
+const mockElementRef: any = {
+  nativeElement: {
+    offsetWidth: 100
+  }
+};
+
+describe('PoTableColumnFrozenDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let testHostComponent: TestHostComponent;
+  let directiveEl: DebugElement;
+
+  let directiveInstance: PoTableColumnFrozenDirective;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PoTableColumnFrozenDirective, TestHostComponent],
+      providers: [{ provide: ElementRef, useValue: mockElementRef }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    testHostComponent = fixture.componentInstance;
+    directiveEl = fixture.debugElement.query(By.directive(PoTableColumnFrozenDirective));
+    directiveInstance = directiveEl.injector.get(PoTableColumnFrozenDirective);
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(directiveEl).toBeTruthy();
+  });
+
+  it('should add class po-table-column-fixed when frozen is true and alignFrozen is left', () => {
+    testHostComponent.frozen = true;
+    testHostComponent.alignFrozen = 'left';
+    fixture.detectChanges();
+
+    expect(directiveEl.nativeElement.classList.contains('po-table-column-fixed')).toBeTruthy();
+  });
+
+  it('should not add class po-table-column-fixed when frozen is false', () => {
+    testHostComponent.frozen = false;
+    fixture.detectChanges();
+
+    expect(directiveEl.nativeElement.classList.contains('po-table-column-fixed')).toBeFalsy();
+  });
+
+  it('index: should return -1 for an element that is not a child of the parent', () => {
+    const element = {
+      parentNode: {
+        childNodes: [
+          { element: '<div></div>', nodeType: 1 },
+          { element: '<div></div>', nodeType: 2 }
+        ]
+      }
+    };
+
+    expect(directiveInstance.index(element)).toBe(-1);
+  });
+
+  it('index: shouldn`t return -1 for an element', () => {
+    const parentEl = document.createElement('div');
+    const el = document.createElement('div');
+
+    parentEl.appendChild(el);
+
+    const result = directiveInstance.index(el);
+
+    expect(result).toBe(0);
+  });
+
+  it('getOuterWidth: should return width with no margin', () => {
+    const element = {
+      offsetWidth: 300
+    };
+    const result = directiveInstance.getOuterWidth(element);
+
+    // reduz 1px
+    expect(result).toBe(299);
+  });
+
+  it('getOuterWidth: should call getComputedStyle', () => {
+    const el = document.createElement('div');
+    el.style.width = '300px';
+    el.style.margin = '10px';
+
+    spyOn(window, 'getComputedStyle').and.callThrough();
+
+    directiveInstance.getOuterWidth(el, true);
+
+    expect(window.getComputedStyle).toHaveBeenCalled();
+  });
+
+  it('should call resizeColumns when frozen changes from true to false', fakeAsync(() => {
+    const previousValue = true;
+    const currentValue = false;
+
+    const changes: SimpleChanges = {
+      frozen: {
+        previousValue,
+        currentValue,
+        firstChange: false,
+        isFirstChange: () => false
+      }
+    };
+
+    spyOn(directiveInstance, 'resizeColumns');
+
+    directiveInstance.ngOnChanges(changes);
+
+    tick(101);
+
+    expect(directiveInstance.resizeColumns).toHaveBeenCalled();
+  }));
+
+  it('should not call resizeColumns when frozen changes from false to true', fakeAsync(() => {
+    const previousValue = false;
+    const currentValue = true;
+
+    const changes: SimpleChanges = {
+      frozen: {
+        previousValue,
+        currentValue,
+        firstChange: false,
+        isFirstChange: () => false
+      }
+    };
+
+    spyOn(directiveInstance, 'resizeColumns');
+
+    directiveInstance.ngOnChanges(changes);
+
+    tick(101);
+
+    expect(directiveInstance.resizeColumns).not.toHaveBeenCalled();
+  }));
+});

--- a/projects/ui/src/lib/components/po-table/po-table-column-frozen/po-table-column-frozen.directive.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-frozen/po-table-column-frozen.directive.ts
@@ -1,0 +1,133 @@
+import { AfterViewInit, Directive, ElementRef, Input, Renderer2, OnChanges, SimpleChanges } from '@angular/core';
+
+@Directive({
+  selector: '[pFrozenColumn]',
+  host: {
+    class: 'p-element',
+    '[class.po-frozen-column]': 'frozen'
+  }
+})
+export class PoTableColumnFrozenDirective implements AfterViewInit, OnChanges {
+  _frozen: boolean = true;
+
+  get frozen(): boolean {
+    return this._frozen;
+  }
+
+  @Input('pFrozenColumn') set frozen(val: boolean) {
+    this._frozen = val;
+
+    if (!val) {
+      this.renderer.removeClass(this.el.nativeElement, 'po-table-column-fixed');
+    } else {
+      this.updateStickyPosition();
+    }
+  }
+
+  @Input() alignFrozen: string = 'left';
+
+  constructor(private el: ElementRef, private renderer: Renderer2) {}
+
+  ngAfterViewInit() {
+    setTimeout(() => {
+      this.updateStickyPosition();
+    }, 300);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.frozen.previousValue && !changes.frozen.currentValue) {
+      setTimeout(() => {
+        this.resizeColumns();
+      }, 100);
+    }
+  }
+
+  /* istanbul ignore next */
+  updateStickyPosition() {
+    if (this._frozen) {
+      if (this.alignFrozen === 'right') {
+        let right = 0;
+        const next = this.el.nativeElement.nextElementSibling;
+
+        if (next) {
+          right = this.getOuterWidth(next) + (parseFloat(next.style.right) || 0);
+        }
+        this.el.nativeElement.style.right = right + 'px';
+      } else {
+        let left = 0;
+        const prev = this.el.nativeElement.previousElementSibling;
+        if (
+          prev &&
+          !prev.classList.contains('po-table-column-selectable') &&
+          !prev.classList.contains('po-table-column-actions') &&
+          !prev.classList.contains('po-table-column-detail-toggle') &&
+          !prev.classList.contains('po-table-header-master-detail')
+        ) {
+          left = this.getOuterWidth(prev) + (parseFloat(prev.style.left) || 0);
+        }
+        this.el.nativeElement.style.left = left - 1 + 'px';
+        this.renderer.addClass(this.el.nativeElement, 'po-table-column-fixed');
+      }
+
+      const filterRow = this.el.nativeElement.parentElement.nextElementSibling;
+
+      if (filterRow) {
+        const index = this.index(this.el.nativeElement);
+        if (filterRow.children && filterRow.children[index]) {
+          filterRow.children[index].style.left = this.el.nativeElement.style.left;
+          filterRow.children[index].style.right = this.el.nativeElement.style.right;
+        }
+      }
+    }
+  }
+
+  /* istanbul ignore next */
+  resizeColumns() {
+    const currentElement = this.el.nativeElement;
+    const prevElements = [];
+    let prevElement = currentElement.previousElementSibling;
+
+    // Encontra todos os elementos anteriores com a classe 'po-table-column-fixed'
+    while (prevElement && prevElement.classList.contains('po-table-column-fixed')) {
+      prevElements.push(prevElement);
+      prevElement = prevElement.previousElementSibling;
+    }
+
+    // Verifica se há elementos suficientes para ajustar os widths
+    if (prevElements.length >= 2) {
+      let leftAccumulator = 0;
+
+      // Calcula o novo 'left' para cada elemento anterior e aplica
+      for (let i = prevElements.length - 1; i >= 0; i--) {
+        const prevWidth = this.getOuterWidth(prevElements[i], true);
+        prevElements[i].style.left = leftAccumulator - 1 + 'px';
+        leftAccumulator += prevWidth;
+      }
+    }
+  }
+
+  getOuterWidth(el, margin?) {
+    let width = el.offsetWidth;
+
+    if (margin) {
+      const style = getComputedStyle(el);
+      width += parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+    }
+
+    return width - 1;
+  }
+
+  index(element: any): number {
+    const children = element.parentNode.childNodes;
+    let num = 0;
+    for (let i = 0; i < children.length; i++) {
+      if (children[i] === element) {
+        return num;
+      }
+      if (children[i].nodeType === 1) {
+        num++;
+      }
+    }
+    return -1;
+  }
+}

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.html
@@ -12,8 +12,10 @@
         [(ngModel)]="visibleColumns"
         p-columns="1"
         [p-options]="columnsOptions"
+        [p-hide-action-fixed-columns]="hideActionFixedColumns"
         (p-change)="checkChanges($event, false)"
         (p-change-position)="changePosition($event)"
+        (p-change-fixed)="emitColumnFixed($event)"
         [p-columns-manager]="columns"
       >
       </po-table-list-manager>

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
@@ -226,6 +226,12 @@ describe('PoTableColumnManagerComponent:', () => {
 
         expect(component['emitChangesToSelectedColumns']).not.toHaveBeenCalledWith(fakeEvent);
       });
+
+      it('should return change fixed to false', () => {
+        const result = component['removePropertyFixed']([{ value: 'test', fixed: true }]);
+
+        expect(result).toEqual([{ value: 'test', fixed: false }]);
+      });
     });
 
     it('emitChangesToSelectedColumns: should update `visibleColumns` and call `getVisibleTableColumns` and `visibleColumnsChange.emit`', () => {
@@ -1143,6 +1149,91 @@ describe('PoTableColumnManagerComponent:', () => {
       component['removeListeners']();
 
       expect(component['resizeListener']).toHaveBeenCalled();
+    });
+
+    describe('emitColumnFixed', () => {
+      it(`should emit visibleColumnsChange with new column and add fixed to option`, () => {
+        component.columns = [
+          {
+            property: 'Name',
+            visible: true
+          },
+          {
+            property: 'City',
+            visible: true
+          }
+        ];
+        spyOn(component.visibleColumnsChange, 'emit');
+
+        component.emitColumnFixed({
+          property: 'City',
+          value: 'City',
+          visible: true,
+          fixed: true
+        });
+
+        expect(component.columns).toEqual([
+          {
+            property: 'City',
+            visible: true,
+            fixed: true
+          },
+          {
+            property: 'Name',
+            visible: true
+          }
+        ]);
+
+        expect(component.visibleColumnsChange.emit).toHaveBeenCalled();
+      });
+
+      it(`should emit visibleColumnsChange with new column and remove fixed option`, () => {
+        component.columns = [
+          {
+            property: 'Name',
+            visible: true,
+            fixed: true
+          },
+          {
+            property: 'Age',
+            visible: true,
+            fixed: true
+          },
+          {
+            property: 'City',
+            visible: true,
+            fixed: true
+          }
+        ];
+        spyOn(component.visibleColumnsChange, 'emit');
+
+        component.emitColumnFixed({
+          property: 'Age',
+          value: 'Age',
+          visible: true,
+          fixed: false
+        });
+
+        expect(component.columns).toEqual([
+          {
+            property: 'Name',
+            visible: true,
+            fixed: true
+          },
+          {
+            property: 'City',
+            visible: true,
+            fixed: true
+          },
+          {
+            property: 'Age',
+            visible: true,
+            fixed: false
+          }
+        ]);
+
+        expect(component.visibleColumnsChange.emit).toHaveBeenCalled();
+      });
     });
 
     describe('stringify', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-list-manager/po-table-list-manager.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-list-manager/po-table-list-manager.component.html
@@ -1,14 +1,25 @@
+<section class="po-table-list-manager-section" *ngIf="existedFixedItem()">
+  <p class="po-table-list-manager-title-group-items">{{ literals.fixedColumns }}</p>
+  <ng-container *ngFor="let option of checkboxGroupOptionsView; trackBy: trackByFn">
+    <ng-container *ngIf="isFixed(option)">
+      <li class="po-table-list-manager-container" [class.po-checkbox-group-item-disabled]="option.disabled || disabled">
+        <ng-container *ngTemplateOutlet="listItemsManagerDefault; context: { $implicit: option }"></ng-container>
+      </li>
+    </ng-container>
+  </ng-container>
+</section>
+
 <section class="po-table-list-manager-section">
   <p class="po-table-list-manager-title-group-items">{{ literals.otherColumns }}</p>
-  <div
-    class="po-table-list-manager-container-items"
-    *ngFor="let option of checkboxGroupOptionsView; trackBy: trackByFn"
-    [class.po-checkbox-group-item-disabled]="option.disabled || disabled"
-  >
-    <ng-container *ngIf="!option.fixed">
-      <ng-container *ngTemplateOutlet="listItemsManagerDefault; context: { $implicit: option }"></ng-container>
+  <ng-container *ngFor="let option of checkboxGroupOptionsView; trackBy: trackByFn">
+    <ng-container *ngIf="!isFixed(option)">
+      <li class="po-table-list-manager-container" [class.po-checkbox-group-item-disabled]="option.disabled || disabled">
+        <ng-container *ngIf="!isFixed(option)">
+          <ng-container *ngTemplateOutlet="listItemsManagerDefault; context: { $implicit: option }"></ng-container>
+        </ng-container>
+      </li>
     </ng-container>
-  </div>
+  </ng-container>
 </section>
 
 <ng-template #listItemsManagerDefault let-option>
@@ -16,9 +27,9 @@
     <div class="po-table-list-manager-item-switch">
       <po-switch
         name="switch"
-        (click)="checkOption(option)"
+        (p-change)="clickSwitch(option)"
         (keydown)="onKeyDown($event, option)"
-        [p-disabled]="option.disabled || disabled"
+        [p-disabled]="option.disabled || disabled || isFixed(option)"
         [p-value]="checkedOptions[option.value]"
         p-label-off=" "
         p-label-on=" "
@@ -31,11 +42,19 @@
 
     <div class="po-table-list-manager-item-buttons">
       <po-button
+        *ngIf="!hideActionFixedColumns"
+        [p-icon]="isFixed(option) ? templateIconFixed : templateIconNotFixed"
+        (p-click)="emitFixed(option)"
+        [p-disabled]="!option.visible || checksIfHasFiveFixed(option)"
+      >
+      </po-button>
+
+      <po-button
         [p-tooltip]="literals.up"
         p-tooltip-position="left"
         p-icon="po-icon po-icon-arrow-up"
-        [p-disabled]="verifyArrowDisabled(option, 'up')"
-        (click)="emitChangePosition(option, 'up'); $event.stopPropagation()"
+        [p-disabled]="verifyArrowDisabled(option, 'up') || isFixed(option)"
+        (p-click)="emitChangePosition(option, 'up')"
       >
       </po-button>
 
@@ -43,10 +62,42 @@
         [p-tooltip]="literals.down"
         p-tooltip-position="top"
         p-icon="po-icon po-icon-arrow-down"
-        [p-disabled]="verifyArrowDisabled(option, 'down')"
-        (click)="emitChangePosition(option, 'down'); $event.stopPropagation()"
+        [p-disabled]="verifyArrowDisabled(option, 'down') || isFixed(option)"
+        (p-click)="emitChangePosition(option, 'down')"
       >
       </po-button>
     </div>
   </div>
+</ng-template>
+
+<ng-template #templateIconNotFixed>
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <g clip-path="url(#clip0_12562_15948)">
+      <path
+        d="M13.7143 5.71429V10C13.7143 10.96 14.0314 11.8514 14.5714 12.5714H9.42857C9.98571 11.8343 10.2857 10.9429 10.2857 10V5.71429H13.7143ZM16.2857 4H7.71429C7.24286 4 6.85714 4.38571 6.85714 4.85714C6.85714 5.32857 7.24286 5.71429 7.71429 5.71429H8.57143V10C8.57143 11.4229 7.42286 12.5714 6 12.5714V14.2857H11.1171V20.2857L11.9743 21.1429L12.8314 20.2857V14.2857H18V12.5714C16.5771 12.5714 15.4286 11.4229 15.4286 10V5.71429H16.2857C16.7571 5.71429 17.1429 5.32857 17.1429 4.85714C17.1429 4.38571 16.7571 4 16.2857 4Z"
+        fill="black"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_12562_15948">
+        <rect width="24" height="24" fill="white" />
+      </clipPath>
+    </defs>
+  </svg>
+</ng-template>
+
+<ng-template #templateIconFixed>
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <g clip-path="url(#clip0_12562_17487)">
+      <path
+        d="M16.2857 4H7.71429C7.24286 4 6.85714 4.38571 6.85714 4.85714C6.85714 5.32857 7.24286 5.71429 7.71429 5.71429H8.57143V10C8.57143 11.4229 7.42286 12.5714 6 12.5714V14.2857H11.1171V20.2857L11.9743 21.1429L12.8314 20.2857V14.2857H18V12.5714C16.5771 12.5714 15.4286 11.4229 15.4286 10V5.71429H16.2857C16.7571 5.71429 17.1429 5.32857 17.1429 4.85714C17.1429 4.38571 16.7571 4 16.2857 4Z"
+        fill="#B4B4C0"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_12562_17487">
+        <rect width="24" height="24" fill="black" />
+      </clipPath>
+    </defs>
+  </svg>
 </ng-template>

--- a/projects/ui/src/lib/components/po-table/po-table-list-manager/po-table-list-manager.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-list-manager/po-table-list-manager.component.spec.ts
@@ -20,9 +20,9 @@ describe('PoTableListManagerComponent:', () => {
     fixture = TestBed.createComponent(PoTableListManagerComponent);
     component = fixture.componentInstance;
     fixture.debugElement.injector.get(NG_VALUE_ACCESSOR);
-    fixture.detectChanges();
 
     component.columnsManager = [{ property: 'column1' }, { property: 'column2' }, { property: 'detail' }];
+    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -49,6 +49,21 @@ describe('PoTableListManagerComponent:', () => {
     ];
 
     const arrowDisabled = component.verifyArrowDisabled({ property: 'name', label: 'Name', value: 'name' }, 'down');
+
+    expect(arrowDisabled).toEqual(true);
+  });
+
+  it(`verifyArrowDisabled: Should return true if it is the up arrow of the first column`, () => {
+    component.columnsManager = [
+      { property: 'id', label: 'Code', fixed: true },
+      { property: 'initial', label: 'initial' },
+      { property: 'name', label: 'Name' }
+    ];
+
+    const arrowDisabled = component.verifyArrowDisabled(
+      { property: 'initial', label: 'initial', value: 'initial' },
+      'up'
+    );
 
     expect(arrowDisabled).toEqual(true);
   });
@@ -136,5 +151,103 @@ describe('PoTableListManagerComponent:', () => {
     component.emitChangePosition({ property: 'name', label: 'name', value: 'name' }, 'down');
 
     expect(component['changePosition'].emit).not.toHaveBeenCalled();
+  });
+
+  it(`isFixed: should return true if option is fixed`, () => {
+    component.columnsManager = [
+      { property: 'id', label: 'Code', fixed: true },
+      { property: 'initial', label: 'initial' },
+      { property: 'name', label: 'Name' }
+    ];
+
+    const resultIsfixed = component.isFixed({ property: 'id', value: 'id' });
+
+    expect(resultIsfixed).toBeTrue();
+  });
+
+  it(`isFixed: should return false if option is not fixed`, () => {
+    component.columnsManager = [
+      { property: 'id', label: 'Code' },
+      { property: 'initial', label: 'initial' },
+      { property: 'name', label: 'Name' }
+    ];
+
+    const resultIsfixed = component.isFixed({ property: 'id', value: 'id' });
+
+    expect(resultIsfixed).toBeFalse();
+  });
+
+  it(`emitFixed: should emit option with fixed true`, () => {
+    component.columnsManager = [
+      { property: 'id', label: 'Id', fixed: false },
+      { property: 'initial', label: 'initial' },
+      { property: 'name', label: 'Name' }
+    ];
+    spyOn(component['changeColumnFixed'], 'emit');
+
+    component.emitFixed({ property: 'id', value: 'id', visible: true });
+
+    expect(component['changeColumnFixed'].emit).toHaveBeenCalledWith({
+      property: 'id',
+      value: 'id',
+      visible: true,
+      fixed: true
+    });
+  });
+
+  it(`emitFixed: should emit option with fixed false`, () => {
+    component.columnsManager = [
+      { property: 'id', label: 'Id', fixed: true },
+      { property: 'initial', label: 'initial' },
+      { property: 'name', label: 'Name' }
+    ];
+    spyOn(component['changeColumnFixed'], 'emit');
+
+    component.emitFixed({ property: 'id', value: 'id', visible: true });
+
+    expect(component['changeColumnFixed'].emit).toHaveBeenCalledWith({
+      property: 'id',
+      value: 'id',
+      visible: true,
+      fixed: false
+    });
+  });
+
+  it(`clickSwitch: should call checkOption`, () => {
+    spyOn(component, 'checkOption');
+
+    component.clickSwitch({ property: 'id', label: 'Id', fixed: true });
+
+    expect(component.checkOption).toHaveBeenCalled();
+  });
+
+  it(`checksIfHasFiveFixed: should return true if has more than 5 fixed and item is not fixed`, () => {
+    component.columnsManager = [
+      { property: 'id', label: 'Id', fixed: true },
+      { property: 'initial', label: 'initial', fixed: true },
+      { property: 'name', label: 'Name', fixed: true },
+      { property: 'city', label: 'City', fixed: true },
+      { property: 'lastName', label: 'LastName', fixed: true },
+      { property: 'test', label: 'Teste', fixed: false }
+    ];
+
+    const result = component.checksIfHasFiveFixed({ property: 'test', label: 'Teste', value: 'test', fixed: false });
+
+    expect(result).toBeTrue();
+  });
+
+  it(`checksIfHasFiveFixed: should return true if has less than 5 fixed and item is not fixed`, () => {
+    component.columnsManager = [
+      { property: 'id', label: 'Id', fixed: true },
+      { property: 'initial', label: 'initial', fixed: true },
+      { property: 'name', label: 'Name', fixed: true },
+      { property: 'city', label: 'City', fixed: true },
+      { property: 'lastName', label: 'LastName', fixed: false },
+      { property: 'test', label: 'Teste', fixed: false }
+    ];
+
+    const result = component.checksIfHasFiveFixed({ property: 'test', label: 'Teste', value: 'test', fixed: false });
+
+    expect(result).toBeFalse();
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table-list-manager/po-table-list-manager.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-list-manager/po-table-list-manager.component.ts
@@ -1,6 +1,7 @@
 import { Component, forwardRef, Output, EventEmitter, Input, ChangeDetectorRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
+import { InputBoolean } from '../../../decorators';
 import { PoTableColumn } from '../interfaces/po-table-column.interface';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
 import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
@@ -10,22 +11,26 @@ export const poTableListManagerLiterals = {
   en: {
     up: 'up',
     down: 'down',
-    otherColumns: 'Other columns'
+    otherColumns: 'Other columns',
+    fixedColumns: 'Fixed'
   },
   es: {
     up: 'arriba',
     down: 'abajo',
-    otherColumns: 'Otras columnas'
+    otherColumns: 'Otras columnas',
+    fixedColumns: 'Fijado'
   },
   pt: {
     up: 'acima',
     down: 'abaixo',
-    otherColumns: 'Outras colunas'
+    otherColumns: 'Outras colunas',
+    fixedColumns: 'Fixo'
   },
   ru: {
     up: 'вверх',
     down: 'вниз',
-    otherColumns: 'Другие столбцы'
+    otherColumns: 'Другие столбцы',
+    fixedColumns: 'зафиксированный'
   }
 };
 
@@ -46,7 +51,12 @@ export class PoTableListManagerComponent extends PoCheckboxGroupComponent {
   @Output('p-change-position')
   private changePosition = new EventEmitter<any>();
 
+  @Output('p-change-fixed')
+  private changeColumnFixed = new EventEmitter<any>();
+
   @Input('p-columns-manager') columnsManager: Array<PoTableColumn>;
+
+  @Input('p-hide-action-fixed-columns') @InputBoolean() hideActionFixedColumns?: boolean = false;
 
   literals;
 
@@ -62,10 +72,12 @@ export class PoTableListManagerComponent extends PoCheckboxGroupComponent {
   }
 
   emitChangePosition(option, direction: Direction) {
-    const infoPosition = { option, direction };
-    const hasDisabled: boolean = this.verifyArrowDisabled(option, direction);
-    if (!hasDisabled) {
-      this.changePosition.emit(infoPosition);
+    if (!this.isFixed(option)) {
+      const infoPosition = { option, direction };
+      const hasDisabled: boolean = this.verifyArrowDisabled(option, direction);
+      if (!hasDisabled) {
+        this.changePosition.emit(infoPosition);
+      }
     }
   }
 
@@ -80,10 +92,56 @@ export class PoTableListManagerComponent extends PoCheckboxGroupComponent {
       return true;
     }
 
+    if (index !== 0 && direction === 'up' && this.columnsManager[index - 1].fixed) {
+      return true;
+    }
+
     if (index === this.columnsManager.length - valueSubtraction && direction === 'down') {
       return true;
     }
 
     return false;
+  }
+
+  emitFixed(option) {
+    if (option.visible) {
+      const index = this.columnsManager.findIndex(el => el.property === option.value);
+
+      if (
+        this.columnsManager[index].fixed === null ||
+        this.columnsManager[index].fixed === undefined ||
+        this.columnsManager[index].fixed === false
+      ) {
+        this.columnsManager[index].fixed = true;
+        option.fixed = true;
+      } else {
+        this.columnsManager[index].fixed = false;
+        option.fixed = false;
+      }
+      this.changeColumnFixed.emit(option);
+    }
+  }
+
+  isFixed(option) {
+    const index = this.columnsManager.findIndex(el => el.property === option.value);
+    if (this.columnsManager[index].fixed === true) {
+      return true;
+    }
+    return false;
+  }
+
+  existedFixedItem() {
+    return this.columnsManager.some(option => option['fixed'] === true);
+  }
+
+  checksIfHasFiveFixed(option) {
+    const isMoreThanFive = this.columnsManager.filter(item => item.fixed === true).length > 4;
+    const isNotFixed = !this.isFixed(option);
+
+    return isMoreThanFive && isNotFixed;
+  }
+
+  clickSwitch(option) {
+    this.checkOption(option);
   }
 }

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -140,11 +140,14 @@
           <ng-container *ngIf="height; then noColumnsWithHeight; else noColumnsWithoutHeight"> </ng-container>
         </th>
 
-        <ng-container *ngIf="this.isDraggable; then tableDefaultThDragDrop; else tableDefaultThDefault"> </ng-container>
+        <ng-container
+          *ngIf="this.isDraggable || hasSomeFixed(); then tableDefaultThDragDrop; else tableDefaultThDefault"
+        >
+        </ng-container>
         <ng-template #tableDefaultThDragDrop>
           <th
             *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
-            class="po-table-header-ellipsis"
+            class="po-table-header-ellipsis p-element po-frozen-column"
             [style.width]="column.width"
             [style.max-width]="column.width"
             [style.min-width]="column.width"
@@ -161,6 +164,8 @@
             (click)="sortColumn(column)"
             cdkDrag
             cdkDragLockAxis="x"
+            [cdkDragDisabled]="column.fixed ? 'true' : 'false'"
+            [pFrozenColumn]="column.fixed"
           >
             <div
               class="po-table-header-flex"
@@ -168,7 +173,7 @@
               [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
               [class.po-table-header-flex-center]="column.type === 'subtitle'"
             >
-              <ng-container *ngIf="this.isDraggable">
+              <ng-container *ngIf="this.isDraggable && !column.fixed">
                 <svg
                   cdkDragHandle
                   width="24"
@@ -192,7 +197,7 @@
         <ng-template #tableDefaultThDefault>
           <th
             *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
-            class="po-table-header-ellipsis"
+            class="po-table-header-ellipsis p-element po-frozen-column"
             [style.width]="column.width"
             [style.max-width]="column.width"
             [style.min-width]="column.width"
@@ -206,6 +211,7 @@
             }"
             [class.po-table-header-subtitle]="column.type === 'subtitle'"
             (click)="sortColumn(column)"
+            [pFrozenColumn]="column.fixed"
           >
             <div
               class="po-table-header-flex"
@@ -290,6 +296,8 @@
             [class.po-table-column-right]="column.type === 'currency' || column.type === 'number'"
             [class.po-table-column-center]="column.type === 'subtitle'"
             [class.po-table-column-icons]="column.type === 'icon'"
+            [pFrozenColumn]="column.fixed"
+            class="p-element po-frozen-column"
             [ngClass]="getClassColor(row, column)"
             (click)="hasSelectableRow() ? selectRow(row) : 'javascript:;'"
           >
@@ -468,12 +476,18 @@
             <ng-container *ngIf="height; then noColumnsWithHeight; else noColumnsWithoutHeight"> </ng-container>
           </th>
 
-          <ng-container *ngIf="this.isDraggable; then tableVirtualScrollThDragDrop; else tableVirtualScrollThDefault">
+          <ng-container
+            *ngIf="
+              this.isDraggable || hasSomeFixed();
+              then tableVirtualScrollThDragDrop;
+              else tableVirtualScrollThDefault
+            "
+          >
           </ng-container>
           <ng-template #tableVirtualScrollThDragDrop>
             <th
               *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
-              class="po-table-header-ellipsis"
+              class="po-table-header-ellipsis p-element po-frozen-column"
               [style.width]="column.width"
               [style.max-width]="column.width"
               [style.min-width]="column.width"
@@ -491,6 +505,8 @@
               (click)="sortColumn(column)"
               cdkDrag
               cdkDragLockAxis="x"
+              [cdkDragDisabled]="column.fixed ? 'true' : 'false'"
+              [pFrozenColumn]="column.fixed"
             >
               <div
                 class="po-table-header-flex"
@@ -498,7 +514,7 @@
                 [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
                 [class.po-table-header-flex-center]="column.type === 'subtitle'"
               >
-                <ng-container *ngIf="this.isDraggable">
+                <ng-container *ngIf="this.isDraggable && !column.fixed">
                   <svg
                     cdkDragHandle
                     width="24"
@@ -515,7 +531,6 @@
                     <circle cx="15" cy="18" r="2" fill="black" />
                   </svg>
                 </ng-container>
-
                 <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }"> </ng-container>
               </div>
             </th>
@@ -523,7 +538,7 @@
           <ng-template #tableVirtualScrollThDefault>
             <th
               *ngFor="let column of mainColumns; let i = index; trackBy: trackBy"
-              class="po-table-header-ellipsis"
+              class="po-table-header-ellipsis p-element po-frozen-column example-box"
               [style.width]="column.width"
               [style.max-width]="column.width"
               [style.min-width]="column.width"
@@ -538,6 +553,7 @@
               [ngStyle]="{ 'width': !hasItems ? '100%' : 'auto' }"
               [class.po-table-header-subtitle]="column.type === 'subtitle'"
               (click)="sortColumn(column)"
+              [pFrozenColumn]="column.fixed"
             >
               <div
                 class="po-table-header-flex"
@@ -626,6 +642,8 @@
               [class.po-table-column-center]="column.type === 'subtitle'"
               [class.po-table-column-icons]="column.type === 'icon'"
               [ngClass]="getClassColor(row, column)"
+              [pFrozenColumn]="column.fixed"
+              class="p-element po-frozen-column"
               (click)="hasSelectableRow() ? selectRow(row) : 'javascript:;'"
             >
               <div
@@ -873,6 +891,7 @@
   [p-max-columns]="maxColumns"
   [p-target]="columnManagerTarget"
   [p-last-visible-columns-selected]="lastVisibleColumnsSelected"
+  [p-hide-action-fixed-columns]="hideActionFixedColumns"
   (p-visible-columns-change)="onVisibleColumnsChange($event)"
   (p-change-visible-columns)="onChangeVisibleColumns($event)"
   [p-columns-default]="initialColumns"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -2284,7 +2284,7 @@ describe('PoTableComponent:', () => {
       component.container = 'border';
       fixture.detectChanges();
 
-      tick();
+      tick(1200);
 
       expect(nativeElement.querySelector('.po-container')).toBeTruthy();
     }));
@@ -2293,7 +2293,8 @@ describe('PoTableComponent:', () => {
       component.container = 'shadow';
       fixture.detectChanges();
 
-      tick();
+      tick(1200);
+
       expect(nativeElement.querySelector('.po-container')).toBeTruthy();
     }));
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -640,24 +640,26 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   drop(event: CdkDragDrop<Array<string>>) {
-    moveItemInArray(this.mainColumns, event.previousIndex, event.currentIndex);
+    if (!this.mainColumns[event.currentIndex].fixed) {
+      moveItemInArray(this.mainColumns, event.previousIndex, event.currentIndex);
 
-    if (this.hideColumnsManager === false) {
-      this.newOrderColumns = this.mainColumns;
-      const detail = this.columns.filter(item => item.property === 'detail')[0];
+      if (this.hideColumnsManager === false) {
+        this.newOrderColumns = this.mainColumns;
+        const detail = this.columns.filter(item => item.property === 'detail')[0];
 
-      if (detail !== undefined) {
-        this.newOrderColumns.push(detail);
-      }
-
-      this.columns.map((item, index) => {
-        if (!item.visible) {
-          this.newOrderColumns.splice(index, 0, item);
+        if (detail !== undefined) {
+          this.newOrderColumns.push(detail);
         }
-      });
-      this.columns = this.newOrderColumns;
 
-      this.onVisibleColumnsChange(this.newOrderColumns);
+        this.columns.map((item, index) => {
+          if (!item.visible) {
+            this.newOrderColumns.splice(index, 0, item);
+          }
+        });
+        this.columns = this.newOrderColumns;
+
+        this.onVisibleColumnsChange(this.newOrderColumns);
+      }
     }
   }
 
@@ -680,6 +682,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   public getColumnWidthActionsLeft() {
     return this.columnActionLeft?.nativeElement.offsetWidth;
+  }
+
+  public hasSomeFixed() {
+    return this.columns.some(item => item.fixed === true);
   }
 
   protected calculateHeightTableContainer(height) {

--- a/projects/ui/src/lib/components/po-table/po-table.module.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.module.ts
@@ -36,6 +36,7 @@ import { PoTableCellTemplateDirective } from './po-table-cell-template/po-table-
 import { PoTableColumnTemplateDirective } from './po-table-column-template/po-table-column-template.directive';
 import { PoTableListManagerComponent } from './po-table-list-manager/po-table-list-manager.component';
 import { PoSwitchModule } from './../po-field/po-switch/po-switch.module';
+import { PoTableColumnFrozenDirective } from './po-table-column-frozen/po-table-column-frozen.directive';
 
 /**
  * @description
@@ -79,7 +80,8 @@ import { PoSwitchModule } from './../po-field/po-switch/po-switch.module';
     PoTableSubtitleCircleComponent,
     PoTableSubtitleFooterComponent,
     PoTableCellTemplateDirective,
-    PoTableColumnTemplateDirective
+    PoTableColumnTemplateDirective,
+    PoTableColumnFrozenDirective
   ],
   exports: [
     PoTableComponent,

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.html
@@ -13,6 +13,7 @@
       p-height="300"
       [p-items]="items"
       (p-delete-items)="deleteItems($event)"
+      [p-hide-action-fixed-columns]="true"
     >
     </po-table>
   </div>
@@ -25,6 +26,7 @@
       [p-infinite-scroll]="true"
       p-height="300"
       [p-items]="itemsSelected"
+      [p-hide-action-fixed-columns]="true"
     >
     </po-table>
   </div>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -28,6 +28,7 @@
   [p-auto-collapse]="properties.includes('autoCollapse')"
   (p-delete-items)="deleteItems($event)"
   [p-draggable]="properties.includes('draggable')"
+  [p-hide-action-fixed-columns]="properties.includes('fixed')"
 >
 </po-table>
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -84,7 +84,8 @@ export class SamplePoTableLabsComponent implements OnInit {
     { label: 'Hide columns manager', value: 'hideColumnsManager' },
     { label: 'Hide batch actions', value: 'hideBatchActions' },
     { label: 'Actions Right', value: 'actionsRight' },
-    { label: 'Draggable', value: 'draggable' }
+    { label: 'Draggable', value: 'draggable' },
+    { label: 'Hide action fixed columns', value: 'fixed' }
   ];
 
   public readonly typeHeaderOptions: Array<PoRadioGroupOption> = [


### PR DESCRIPTION
**Table**

** DTHFUI-7314**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Consigo fixar até 5 colunas da tabela


**Simulação**
Testar todos os samples do portal, testar o fixador (para testar o fixador de forma efetiva o ideal é testar em tabelas que tenham scroll horizontal) e todas as funcionalidades já existente da tabela.
Testar theme totvs se mantém o padrão do tema.
style: https://github.com/po-ui/po-style/pull/437