### PR TITLE
feat(tree-view): adiciona propriedade p-max-level

### DIFF
--- a/projects/ui/src/lib/components/po-tree-view/po-tree-view-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tree-view/po-tree-view-base.component.spec.ts
@@ -41,6 +41,18 @@ describe('PoTreeViewBaseComponent:', () => {
 
       expectPropertiesValues(component, 'selectable', invalidValues, false);
     });
+
+    it('p-max-level: should update property with value if valid', () => {
+      const validValues = [12, 10.6];
+
+      expectPropertiesValues(component, 'maxLevel', validValues, [12, 10]);
+    });
+
+    it('p-max-level: should update property with `4` if invalid values', () => {
+      const invalidValues = ['test', undefined];
+
+      expectPropertiesValues(component, 'maxLevel', invalidValues, 4);
+    });
   });
 
   describe('Methods: ', () => {
@@ -114,6 +126,7 @@ describe('PoTreeViewBaseComponent:', () => {
     });
 
     it('getItemsByMaxLevel: should return items up to 4 levels', () => {
+      component.maxLevel = 4;
       const unlimitedItems = [
         {
           label: 'Nivel 01',

--- a/projects/ui/src/lib/components/po-tree-view/po-tree-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-tree-view/po-tree-view-base.component.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
 
-import { convertToBoolean } from '../../utils/util';
+import { convertToBoolean, convertToInt } from '../../utils/util';
 
 import { PoTreeViewItem } from './po-tree-view-item/po-tree-view-item.interface';
 
@@ -67,11 +67,14 @@ export class PoTreeViewBaseComponent {
 
   private _items: Array<PoTreeViewItem> = [];
   private _selectable: boolean = false;
+  private _maxLevel = poTreeViewMaxLevel;
 
   /**
    * Lista de itens do tipo `PoTreeViewItem` que será renderizada pelo componente.
    */
-  @Input('p-items') set items(value: Array<PoTreeViewItem>) {
+  @Input('p-items') inputedItems: Array<PoTreeViewItem>;
+
+  set items(value: Array<PoTreeViewItem>) {
     this._items = Array.isArray(value) ? this.getItemsByMaxLevel(value) : [];
   }
 
@@ -94,6 +97,25 @@ export class PoTreeViewBaseComponent {
 
   get selectable() {
     return this._selectable;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o máximo de níveis para o tree-view.
+   *
+   * > O valor padrão é 4
+   *
+   * @default 4
+   */
+  @Input('p-max-level') set maxLevel(value: number) {
+    this._maxLevel = convertToInt(value, poTreeViewMaxLevel);
+  }
+
+  get maxLevel() {
+    return this._maxLevel;
   }
 
   protected emitExpanded(treeViewItem: PoTreeViewItem) {
@@ -189,7 +211,7 @@ export class PoTreeViewBaseComponent {
     items.forEach(item => {
       const { subItems, ...currentItem } = item;
 
-      if (level === poTreeViewMaxLevel) {
+      if (level === this.maxLevel) {
         return;
       }
 

--- a/projects/ui/src/lib/components/po-tree-view/po-tree-view.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tree-view/po-tree-view.component.spec.ts
@@ -5,6 +5,7 @@ import { of } from 'rxjs';
 import { PoTreeViewComponent } from './po-tree-view.component';
 import { PoTreeViewItem } from './po-tree-view-item/po-tree-view-item.interface';
 import { PoTreeViewModule } from './po-tree-view.module';
+import { SimpleChanges } from '@angular/core';
 
 describe('PoTreeViewComponent:', () => {
   let component: PoTreeViewComponent;
@@ -73,6 +74,23 @@ describe('PoTreeViewComponent:', () => {
 
     it('trackByFunction: should return index param', () => {
       expect(component.trackByFunction(1)).toBe(1);
+    });
+
+    it('ngOnChanges: should update items when inputedItems changes', () => {
+      const changes: SimpleChanges = {
+        inputedItems: {
+          currentValue: [{ label: 'example', value: 1 }],
+          firstChange: true,
+          isFirstChange: () => true,
+          previousValue: undefined
+        }
+      };
+
+      component.items = undefined;
+
+      component.ngOnChanges(changes);
+
+      expect(component.items).toBeDefined();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-tree-view/po-tree-view.component.ts
+++ b/projects/ui/src/lib/components/po-tree-view/po-tree-view.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
 import { PoTreeViewBaseComponent } from './po-tree-view-base.component';
 import { PoTreeViewItem } from './po-tree-view-item/po-tree-view-item.interface';
@@ -35,7 +35,7 @@ import { PoTreeViewService } from './services/po-tree-view.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [PoTreeViewService]
 })
-export class PoTreeViewComponent extends PoTreeViewBaseComponent implements OnInit {
+export class PoTreeViewComponent extends PoTreeViewBaseComponent implements OnInit, OnChanges {
   get hasItems() {
     return !!(this.items && this.items.length);
   }
@@ -52,6 +52,12 @@ export class PoTreeViewComponent extends PoTreeViewBaseComponent implements OnIn
     this.treeViewService.onSelect().subscribe((treeViewItem: PoTreeViewItem) => {
       this.emitSelected(treeViewItem);
     });
+  }
+
+  ngOnChanges(changes?: SimpleChanges) {
+    if (changes?.['inputedItems']) {
+      this.items = this.inputedItems;
+    }
   }
 
   trackByFunction(index: number) {

--- a/projects/ui/src/lib/components/po-tree-view/samples/sample-po-tree-view-labs/sample-po-tree-view-labs.component.html
+++ b/projects/ui/src/lib/components/po-tree-view/samples/sample-po-tree-view-labs/sample-po-tree-view-labs.component.html
@@ -5,6 +5,7 @@
   (p-expanded)="changeEvent('p-expanded', $event)"
   (p-selected)="changeEvent('p-selected', $event)"
   (p-unselected)="changeEvent('p-unselected', $event)"
+  [p-max-level]="maxLevel"
 >
 </po-tree-view>
 
@@ -16,6 +17,12 @@
 
 <div class="po-row">
   <po-switch class="po-md-2" name="selectable" [(ngModel)]="selectable" p-label="Selectable"> </po-switch>
+</div>
+
+<po-divider p-label="Po Tree View Config"></po-divider>
+
+<div class="po-row">
+  <po-input class="po-md-4" name="level" [(ngModel)]="maxLevel" p-label="Max Level"> </po-input>
 </div>
 
 <po-divider p-label="Po Tree View Item"></po-divider>

--- a/projects/ui/src/lib/components/po-tree-view/samples/sample-po-tree-view-labs/sample-po-tree-view-labs.component.ts
+++ b/projects/ui/src/lib/components/po-tree-view/samples/sample-po-tree-view-labs/sample-po-tree-view-labs.component.ts
@@ -14,6 +14,7 @@ export class SamplePoTreeViewLabsComponent implements OnInit {
   parentList: Array<PoSelectOption>;
   selectable: boolean;
   treeViewItem: PoTreeViewItem;
+  maxLevel: number = 4;
 
   readonly itemPropertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'selected', label: 'Selected' },
@@ -58,6 +59,7 @@ export class SamplePoTreeViewLabsComponent implements OnInit {
     this.itemProperties = [];
     this.selectable = undefined;
     this.treeViewItem = <any>{};
+    this.maxLevel = 4;
   }
 
   private getTreeViewItemNode(items: Array<PoTreeViewItem>, value: string) {


### PR DESCRIPTION
O componente de tree-view não permitia mais do que 4 subníveis.
Adiciona a propriedade p-max-level para permitir configurar o número máximo de subníveis.

Fixes DTHFUI-7556

**po-tree-view**

**DTHFUI-7556**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente de tree-view não permite mais do que 4 subníveis.

**Qual o novo comportamento?**
Com a propriedade p-max-level agora é possível configurar o número máximo de subníveis.


**Simulação**
Acessar o labs do componente po-tree-view