### PR TITLE
feat(dynamicform): adiciona tipo `decimal`

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-type.enum.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-field-type.enum.ts
@@ -12,6 +12,9 @@ export enum PoDynamicFieldType {
   /** Valor numérico que contém casas decimais e milhar. */
   Currency = 'currency',
 
+  /** Valor numérico que contém casas decimais e milhar. */
+  Decimal = 'decimal',
+
   /** Valor para data. */
   Date = 'date',
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-field.interface.ts
@@ -177,6 +177,7 @@ export interface PoDynamicField {
    *
    * - `boolean`: Valores *booleanos*.
    * - `currency`: Valores monetários.
+   * - `decimal`: Valores decimais.
    * - `date`: Valores de datas.
    *  + Aceita os tipos **string** e **Date** padrão do Javascript,
    *  por exemplo: `'2017-11-28'` ou `new Date(2017, 10, 28)`.

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -120,13 +120,13 @@ export interface PoDynamicFormField extends PoDynamicField {
 
   /**  Quantidade máxima de casas decimais.
    *
-   * > Esta propriedade só pode ser utilizada quando o `type` for *currency*.
+   * > Esta propriedade só pode ser utilizada quando o `type` for *currency* ou *decimal*.
    */
   decimalsLength?: number;
 
   /** Quantidade máxima de dígitos antes do separador decimal. O valor máximo permitido é 13
    *
-   * > Esta propriedade só pode ser utilizada quando o `type` for *currency*.
+   * > Esta propriedade só pode ser utilizada quando o `type` for *currency* ou *decimal*.
    */
   thousandMaxlength?: number;
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -391,8 +391,28 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         expect(component['isCurrencyType']).toHaveBeenCalled();
       });
 
-      it('should return `input` if type is `decimal` and have a mask', () => {
+      it('should return `input` if type is `currency` and have a mask', () => {
         const expectedValue = 'input';
+        const field = { type: 'currency', property: 'code', mask: '99:99:99' };
+
+        spyOn(component, <any>'isCurrencyType').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isCurrencyType']).toHaveBeenCalled();
+      });
+
+      it('should return `decimal` if type is `decimal` and have a pattern', () => {
+        const expectedValue = 'decimal';
+        const field = { type: 'decimal', property: 'code', pattern: '99:99:99' };
+
+        spyOn(component, <any>'isCurrencyType').and.callThrough();
+
+        expect(component['getComponentControl'](field)).toBe(expectedValue);
+        expect(component['isCurrencyType']).toHaveBeenCalled();
+      });
+
+      it('should return `decimal` if type is `decimal` and have a mask', () => {
+        const expectedValue = 'decimal';
         const field = { type: 'decimal', property: 'code', mask: '99:99:99' };
 
         spyOn(component, <any>'isCurrencyType').and.callThrough();
@@ -401,9 +421,9 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
         expect(component['isCurrencyType']).toHaveBeenCalled();
       });
 
-      it('should return `input` if type is `decimal` and have a pattern', () => {
+      it('should return `input` if type is `currency` and have a pattern', () => {
         const expectedValue = 'input';
-        const field = { type: 'decimal', property: 'code', pattern: '99:99:99' };
+        const field = { type: 'currency', property: 'code', pattern: '99:99:99' };
 
         spyOn(component, <any>'isCurrencyType').and.callThrough();
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -158,7 +158,7 @@ export class PoDynamicFormFieldsBaseComponent {
 
     if (this.isNumberType(field, type)) {
       return 'number';
-    } else if (this.isCurrencyType(field, type)) {
+    } else if (this.isCurrencyType(field, type) || type === PoDynamicFieldType.Decimal) {
       return 'decimal';
     } else if (this.isSelect(field)) {
       return 'select';


### PR DESCRIPTION
**Dynamic-form**

**DTHFUI-7516*
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
caso seja passado currency com mask renderiza input

**Qual o novo comportamento?**
caso seja passado decimal com mask renderiza decimal


**Simulação**
```
//app.html
<po-dynamic-form [p-fields]="fields" [p-validate-on-input]="true"> </po-dynamic-form>

//app.ts
fields: Array<PoDynamicFormField> = [
    {
      property: 'exemple1',
      label: 'renderia decimal',
      placeholder: 'teste1',
      type: 'currency',
      decimalsLength: 0
    },
    {
      property: 'exemple2',
      label: 'renderiza input',
      placeholder: 'teste2 ',
      type: 'currency',
      decimalsLength: 0,
      mask: '999.999.999-99'
    },
    {
      property: 'exemple3',
      label: 'renderiza decimal',
      placeholder: 'teste3',
      type: 'decimal',
      decimalsLength: 0
    },
    {
      property: 'exemple4',
      label: 'renderiza decimal',
      placeholder: 'teste4',
      type: 'decimal',
      pattern: "^\\d*(\\,\\d{0,1})?$",
    }
  ];


```