### PR TITLE
fix(lookup): resolve disclaimer do lookup para o filtro booleano

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
@@ -514,10 +514,15 @@ describe('PoLookupModalBaseComponent:', () => {
     });
 
     it('addDisclaimer: should create disclaimer and disclaimerGroup.disclaimer with parameters', () => {
-      const expectedValueDisclaimer = { property: 'propertyTest', value: 'valueTest' };
+      component.advancedFilters = [{ property: 'propertyTest' }];
+      const expectedValueDisclaimer = {
+        property: 'propertyTest',
+        value: 'valueTest',
+        label: 'PropertyTest: valueTest'
+      };
       const expectedValueDisclaimerGroup = {
         title: 'titleTest',
-        disclaimers: [{ property: 'propertyTest', value: 'valueTest' }]
+        disclaimers: [{ property: 'propertyTest', value: 'valueTest', label: 'PropertyTest: valueTest' }]
       };
 
       component.addDisclaimer('valueTest', 'propertyTest');
@@ -529,10 +534,10 @@ describe('PoLookupModalBaseComponent:', () => {
     it("addDisclaimer: should return formated currency in locale default if field type is 'currency'", () => {
       component['language'] = 'pt';
       component.advancedFilters = [{ property: 'value', type: 'currency' }];
-      const expectedValueDisclaimer = { property: 'value', value: 321, label: '321,00' };
+      const expectedValueDisclaimer = { property: 'value', value: 321, label: 'Value: 321,00' };
       const expectedValueDisclaimerGroup = {
         title: 'titleTest',
-        disclaimers: [{ property: 'value', value: 321, label: '321,00' }]
+        disclaimers: [{ property: 'value', value: 321, label: 'Value: 321,00' }]
       };
 
       component.addDisclaimer(321, 'value');
@@ -543,10 +548,10 @@ describe('PoLookupModalBaseComponent:', () => {
 
     it("addDisclaimer: should return formated currency in locale 'En' if field type is 'currency' and locale is 'en'", () => {
       component.advancedFilters = [{ property: 'value', type: 'currency', locale: 'en' }];
-      const expectedValueDisclaimer = { property: 'value', value: 321, label: '321.00' };
+      const expectedValueDisclaimer = { property: 'value', value: 321, label: 'Value: 321.00' };
       const expectedValueDisclaimerGroup = {
         title: 'titleTest',
-        disclaimers: [{ property: 'value', value: 321, label: '321.00' }]
+        disclaimers: [{ property: 'value', value: 321, label: 'Value: 321.00' }]
       };
 
       component.addDisclaimer(321, 'value');
@@ -565,10 +570,10 @@ describe('PoLookupModalBaseComponent:', () => {
           ]
         }
       ];
-      const expectedValueDisclaimer = { property: 'company', value: 1, label: 'Totvs' };
+      const expectedValueDisclaimer = { property: 'company', value: 1, label: 'Company: Totvs' };
       const expectedValueDisclaimerGroup = {
         title: 'titleTest',
-        disclaimers: [{ property: 'company', value: 1, label: 'Totvs' }]
+        disclaimers: [{ property: 'company', value: 1, label: 'Company: Totvs' }]
       };
 
       component.addDisclaimer(1, 'company');
@@ -584,10 +589,10 @@ describe('PoLookupModalBaseComponent:', () => {
           options: [{ value: 1 }, { value: 2 }]
         }
       ];
-      const expectedValueDisclaimer = { property: 'company', value: 1 };
+      const expectedValueDisclaimer = { property: 'company', value: 1, label: 'Company: 1' };
       const expectedValueDisclaimerGroup = {
         title: 'titleTest',
-        disclaimers: [{ property: 'company', value: 1 }]
+        disclaimers: [{ property: 'company', value: 1, label: 'Company: 1' }]
       };
 
       component.addDisclaimer(1, 'company');
@@ -600,6 +605,7 @@ describe('PoLookupModalBaseComponent:', () => {
       component.advancedFilters = [
         {
           property: 'company',
+          label: 'The company',
           optionsMulti: true,
           options: [
             { label: 'Totvs', value: 1 },
@@ -607,16 +613,69 @@ describe('PoLookupModalBaseComponent:', () => {
           ]
         }
       ];
-      const expectedValueDisclaimer = { property: 'company', value: [1, 2], label: 'Totvs, PO UI' };
+      const expectedValueDisclaimer = { property: 'company', value: [1, 2], label: 'The company: Totvs, PO UI' };
       const expectedValueDisclaimerGroup = {
         title: 'titleTest',
-        disclaimers: [{ property: 'company', value: [1, 2], label: 'Totvs, PO UI' }]
+        disclaimers: [{ property: 'company', value: [1, 2], label: 'The company: Totvs, PO UI' }]
       };
 
       component.addDisclaimer([1, 2], 'company');
 
       expect(component.disclaimer).toEqual(expectedValueDisclaimer);
       expect(component.disclaimerGroup.disclaimers).toEqual(expectedValueDisclaimerGroup.disclaimers);
+    });
+
+    it('addDisclaimer: should add disclaimer for boolean property when value is true', () => {
+      component.advancedFilters = [{ property: 'isApproved', type: 'boolean', label: 'Is Approved' }];
+
+      component.addDisclaimer(true, 'isApproved');
+
+      expect(component.disclaimer.label).toBe('Is Approved: true');
+    });
+
+    it('addDisclaimer: should add disclaimer for boolean property when value is false', () => {
+      component.advancedFilters = [{ property: 'isActive', type: 'boolean', label: 'Is Active' }];
+
+      component.addDisclaimer(false, 'isActive');
+
+      expect(component.disclaimer.label).toBe('Is Active: false');
+    });
+
+    it('formatValueToBoolean: should format value to boolean when filterValue is truthy', () => {
+      const filterValue = true;
+      const field = {
+        label: 'Field Label',
+        booleanTrue: 'Yes',
+        property: 'fieldProperty'
+      };
+
+      component['formatValueToBoolean'](field, filterValue);
+
+      expect(component['disclaimerLabel']).toBe('Yes');
+    });
+
+    it('formatValueToBoolean: should format value to boolean when filterValue is falsy', () => {
+      const filterValue = false;
+      const field = {
+        label: 'Field Label',
+        booleanFalse: 'No',
+        property: 'fieldProperty'
+      };
+
+      component['formatValueToBoolean'](field, filterValue);
+
+      expect(component['disclaimerLabel']).toBe('No');
+    });
+
+    it('formatValueToBoolean: should format value to property when label is not provided', () => {
+      const filterValue = true;
+      const field = {
+        property: 'fieldProperty'
+      };
+
+      component['formatValueToBoolean'](field, filterValue);
+
+      expect(component['disclaimerLabel']).toBe('true');
     });
 
     xit('p-infinite-scroll: should update property `p-infinite-scroll`', () => {


### PR DESCRIPTION
PO-LOOKUP-MODAL

fixes DTHFUI-7511

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Após realizar algum filtro na busca avançada do lookup, o resultado no disclaimer é apenas o valor e se for do tipo booleano aparece o valor true ou false ao invés das propriedades 'booleanTrue' ou 'booleanFalse'. Exemplo: O campo do tipo booleano com o nome de 'Tem carro' com os valores do switch sendo 'Sim' para true e 'Não' para false aparece no disclaimer quando filtrado somente 'true'

**Qual o novo comportamento?**
Após realizar algum filtro na busca avançada do lookup, o resultado no disclaimer é a label concatenada com o valor e se for do tipo booleano aparece o valor das propriedades 'booleanTrue' ou 'booleanFalse'. Exemplo: O campo do tipo booleano com o nome de 'Tem carro' com os valores do switch sendo 'Sim' para true e 'Não' para false aparece no disclaimer quando filtrado 'Tem carro: Sim'.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/12433012/app.zip)
