### PR TITLE
fix(theme-builder): ajusta estilização para o angular 16

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -341,12 +341,12 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "2mb",
+                  "maximumWarning": "2.1mb",
                   "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
+                  "maximumWarning": "8kb",
                   "maximumError": "10kb"
                 }
               ]

--- a/projects/portal/src/app/theme-builder/theme-builder.component.css
+++ b/projects/portal/src/app/theme-builder/theme-builder.component.css
@@ -111,10 +111,10 @@ p {
 
 .container-widget {
   float: right;
+}
 
-  .button-clone {
-    margin-right: 0;
-  }
+.container-widget > .container-item > .button-clone {
+  margin-right: 0;
 }
 
 .constructor-title {
@@ -194,276 +194,265 @@ p {
   padding-right: 8px;
 }
 
-:host ::ng-deep {
-  .list-container {
-    .po-list-view-main-container {
-      padding-right: 8px;
-    }
-
-    .po-list-view-title {
-      color: #00000094;
-      font-size: 18px;
-    }
-
-    .po-list-view-detail-button > po-button > button {
-      color: #00000094;
-      font-size: 14px;
-    }
-
-    .po-list-view-detail-button > po-button > button:hover {
-      background-color: transparent;
-    }
-
-    .po-list-view-detail-button > po-button > button:enabled:active {
-      background-color: transparent;
-    }
+.list-container {
+  .po-list-view-main-container {
+    padding-right: 8px;
   }
 
-  .list-container > div > div > po-container > .po-container {
-    padding: 5px;
+  .po-list-view-title {
+    color: #00000094;
+    font-size: 18px;
   }
 
-  .menu-filter {
-    .po-menu-filter-icon {
-      color: black;
-    }
-
-    .po-menu-filter {
-      border-radius: 0;
-      border: 1px solid #0000008c;
-    }
-
-    .po-menu-filter-container {
-      padding-right: 0;
-    }
+  .po-list-view-detail-button > po-button > button {
+    color: #00000094;
+    font-size: 14px;
   }
 
-  .widget-items > .po-widget {
-    height: 250px;
+  .po-list-view-detail-button > po-button > button:hover {
+    background-color: transparent;
   }
 
-  .widget-color > .po-widget {
-    background: #d7d7d7;
+  .po-list-view-detail-button > po-button > button:enabled:active {
+    background-color: transparent;
+  }
+}
+
+.list-container > div > div > po-container > .po-container {
+  padding: 5px;
+}
+
+.menu-filter {
+  .po-menu-filter-icon {
+    color: black;
   }
 
-  .widget-menu {
-    .po-widget {
-      background: #efefef;
-    }
-
-    .po-container {
-      padding: 0;
-    }
-
-    .po-widget-body {
-      height: 140px;
-    }
+  .po-menu-filter {
+    border-radius: 0;
+    border: 1px solid #0000008c;
   }
 
-  .section-textarea {
-    height: 74% !important;
-    .section-textarea {
-      padding-top: 5px;
-      padding-bottom: 5px;
-    }
+  .po-menu-filter-container {
+    padding-right: 0;
+  }
+}
 
-    .po-textarea {
-      height: 65px;
-    }
+.widget-items > .po-widget {
+  height: 255px;
+}
+
+.widget-color > .po-widget {
+  background: #d7d7d7;
+}
+
+.widget-menu {
+  .po-widget {
+    background: #efefef;
   }
 
-  .widget-color > .po-widget > po-container > .po-container {
+  .po-container {
     padding: 0;
   }
 
-  .page-slide-item {
-    .po-page-slide-header {
-      height: 50px;
-    }
+  .po-widget-body {
+    height: 140px;
+  }
+}
+
+.section-textarea {
+  height: 74% !important;
+  .po-field-container-content {
+    padding: 13px 0 0 0;
   }
 
-  .button-p-hover > .po-button {
-    color: var(--text-color);
+  .po-textarea {
+    height: 65px;
+  }
+}
+
+.widget-color > .po-widget > po-container > .po-container {
+  padding: 0;
+}
+
+.page-slide-item {
+  .po-page-slide-header {
+    height: 50px;
+  }
+}
+
+.button-p-hover > .po-button {
+  color: var(--text-color);
+  background-color: var(--color-hover);
+}
+
+.button-s-hover > .po-button {
+  background-color: var(--background-hover);
+  border-color: var(--border-color-hover);
+  color: var(--border-color-hover);
+}
+
+.button-t-hover > .po-button {
+  color: var(--border-color-hover);
+  background-color: var(--background-hover);
+}
+
+.button-focus,
+.button-p-pressed,
+.button-s-pressed,
+.button-t-pressed {
+  .po-button {
+    outline-color: var(--outline-color-focused);
+    outline-width: var(--border-width-lg);
+    outline-style: solid;
+    outline-offset: 2px;
+  }
+}
+
+.button-p-pressed > .po-button {
+  background-color: var(--color-pressed);
+  color: var(--text-color);
+}
+
+.button-s-pressed > .po-button {
+  background-color: var(--background-pressed);
+  border-color: var(--border-color-hover);
+  color: var(--border-color-hover);
+}
+
+.button-t-pressed > .po-button {
+  background-color: var(--background-pressed);
+  color: var(--color-pressed);
+}
+
+.switch-checked {
+  .po-switch-track {
+    background-color: var(--track-checked);
+  }
+}
+
+.switch-unchecked {
+  .po-switch-track {
+    background-color: var(--track-unchecked);
+  }
+}
+
+.disclaimer-hover {
+  .po-disclaimer-remove {
     background-color: var(--color-hover);
   }
+}
 
-  .button-s-hover > .po-button {
-    background-color: var(--background-hover);
-    border-color: var(--border-color-hover);
-    color: var(--border-color-hover);
-  }
-
-  .button-t-hover > .po-button {
-    color: var(--border-color-hover);
-    background-color: var(--background-hover);
-  }
-
-  .button-focus,
-  .button-p-pressed,
-  .button-s-pressed,
-  .button-t-pressed {
-    .po-button {
-      outline-color: var(--outline-color-focused);
-      outline-width: var(--border-width-lg);
-      outline-style: solid;
-      outline-offset: 2px;
-    }
-  }
-
-  .button-p-pressed > .po-button {
-    background-color: var(--color-pressed);
-    color: var(--text-color);
-  }
-
-  .button-s-pressed > .po-button {
-    background-color: var(--background-pressed);
-    border-color: var(--border-color-hover);
-    color: var(--border-color-hover);
-  }
-
-  .button-t-pressed > .po-button {
-    background-color: var(--background-pressed);
-    color: var(--color-pressed);
-  }
-
-  .switch-checked {
-    .po-switch-track {
-      background-color: var(--track-checked);
-    }
-  }
-
-  .switch-unchecked {
-    .po-switch-track {
-      background-color: var(--track-unchecked);
-    }
-  }
-
-  .disclaimer-hover {
-    .po-disclaimer-remove {
-      background-color: var(--color-hover);
-    }
-  }
-
-  .input-hover {
-    .po-input {
-      border-color: var(--color-hover);
-      background-color: var(--background-hover);
-    }
-  }
-
-  .input-focus {
-    .po-input {
-      border-color: var(--color-input-border-text-focusable, var(--color-focused));
-      outline-color: var(--outline-color-focused);
-      outline-width: 4px;
-      outline-style: solid;
-      outline-offset: 2px;
-    }
-  }
-
-  .select-hover > po-field-container > div > .po-field-container-content > select {
+.input-hover {
+  .po-input {
     border-color: var(--color-hover);
     background-color: var(--background-hover);
-    cursor: pointer;
   }
+}
 
-  .select-focus > po-field-container > div > .po-field-container-content > select {
-    border-color: var(--color-select-border-button-focus, var(--color-focused));
-    outline-color: var(--color-select-button-focus, var(--outline-color-focused));
+.input-focus {
+  .po-input {
+    border-color: var(--color-input-border-text-focusable, var(--color-focused));
+    outline-color: var(--outline-color-focused);
+    outline-width: 4px;
+    outline-style: solid;
+    outline-offset: 2px;
+  }
+}
+
+.select-hover > po-field-container > div > .po-field-container-content > select {
+  border-color: var(--color-hover);
+  background-color: var(--background-hover);
+  cursor: pointer;
+}
+
+.select-focus > po-field-container > div > .po-field-container-content > select {
+  border-color: var(--color-select-border-button-focus, var(--color-focused));
+  outline-color: var(--color-select-button-focus, var(--outline-color-focused));
+  outline-width: var(--border-width-lg);
+  outline-style: solid;
+  outline-offset: 2px;
+}
+
+.textarea-hover {
+  .po-textarea {
+    border-color: var(--color-hover);
+    background: var(--background-hover);
+  }
+}
+
+.textarea-focus {
+  .po-textarea {
+    border-color: var(--color-focused);
+    outline-color: var(--outline-color-focused);
     outline-width: var(--border-width-lg);
     outline-style: solid;
     outline-offset: 2px;
   }
+}
 
-  .select-focus > po-field-container > div > .po-field-container-content > select {
-    border-color: var(--color-select-border-button-focus, var(--color-focused));
-    outline-color: var(--color-select-button-focus, var(--outline-color-focused));
+.dropdown-hover {
+  .po-dropdown-button {
+    border: solid var(--border-width) var(--color-hover);
+    color: var(--color-hover);
+    background-color: var(--background-hover);
+  }
+}
+
+.dropdown-focus {
+  .po-dropdown {
+    outline-color: var(--outline-color-focused);
     outline-width: var(--border-width-lg);
     outline-style: solid;
     outline-offset: 2px;
   }
+}
 
-  .textarea-hover {
-    .po-textarea {
-      border-color: var(--color-hover);
-      background: var(--background-hover);
-    }
+.datepicker-hover {
+  .po-button {
+    color: var(--border-color-hover);
+    background-color: var(--background-hover);
   }
 
-  .textarea-focus {
-    .po-textarea {
-      border-color: var(--color-focused);
-      outline-color: var(--outline-color-focused);
-      outline-width: var(--border-width-lg);
-      outline-style: solid;
-      outline-offset: 2px;
-    }
+  .po-input {
+    color: var(--border-color-hover);
+    background-color: var(--background-hover);
   }
+}
 
-  .dropdown-hover {
-    .po-dropdown-button {
-      border: solid var(--border-width) var(--color-hover);
-      color: var(--color-hover);
-      background-color: var(--background-hover);
-    }
+.link-visited {
+  .po-link {
+    color: var(--text-color-visited);
   }
+}
 
-  .dropdown-focus {
-    .po-dropdown {
-      outline-color: var(--outline-color-focused);
-      outline-width: var(--border-width-lg);
-      outline-style: solid;
-      outline-offset: 2px;
-    }
+.popup-hover {
+  .po-item-list {
+    background-color: var(--background-hover);
+    color: var(--color-hover);
   }
+}
 
-  .datepicker-hover {
-    .po-button {
-      color: var(--border-color-hover);
-      background-color: var(--background-hover);
-    }
+.radio-hover > div > label > input {
+  box-shadow: 0 0 0 var(--border-width-lg) var(--shadow-color-hover);
+}
 
-    .po-input {
-      color: var(--border-color-hover);
-      background-color: var(--background-hover);
-    }
+.checkbox-checked {
+  .po-checkbox {
+    background-color: var(--color-checked);
   }
+}
 
-  .link-visited {
-    .po-link {
-      color: var(--text-color-visited);
-    }
+.checkbox-unchecked {
+  .po-checkbox {
+    background-color: var(--color-unchecked);
+    border: 2px solid var(--border-color);
   }
+}
 
-  .popup-hover {
-    .po-item-list {
-      background-color: var(--background-hover);
-      color: var(--color-hover);
-    }
-  }
-
-  .radio-hover > div > label > input {
-    box-shadow: 0 0 0 var(--border-width-lg) var(--shadow-color-hover);
-  }
-
-  .checkbox-checked {
-    .po-checkbox {
-      background-color: var(--color-checked);
-    }
-  }
-
-  .checkbox-unchecked {
-    .po-checkbox {
-      background-color: var(--color-unchecked);
-      border: 2px solid var(--border-color);
-    }
-  }
-
-  .checkbox-hover {
-    .po-checkbox {
-      border-color: var(--color-hover);
-      box-shadow: 0 0 0 4px var(--shadow-color-hover);
-    }
+.checkbox-hover {
+  .po-checkbox {
+    border-color: var(--color-hover);
+    box-shadow: 0 0 0 4px var(--shadow-color-hover);
   }
 }
 

--- a/projects/portal/src/app/theme-builder/theme-builder.component.ts
+++ b/projects/portal/src/app/theme-builder/theme-builder.component.ts
@@ -1,4 +1,13 @@
-import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, Renderer2, ViewChild, OnInit } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Renderer2,
+  ViewChild,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
 import {
@@ -20,7 +29,8 @@ import {
 @Component({
   selector: 'app-theme-builder',
   templateUrl: './theme-builder.component.html',
-  styleUrls: ['theme-builder.component.css']
+  styleUrls: ['theme-builder.component.css'],
+  encapsulation: ViewEncapsulation.None
 })
 export class ThemeBuilderComponent implements AfterViewInit, OnInit {
   @ViewChild('viewCSSModal') viewCSSModal: PoModalComponent;
@@ -796,20 +806,6 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       }
     });
 
-    const tooltipElement = this.renderer.selectRootElement('.po-tooltip', true);
-    if (tooltipElement) {
-      this.tooltipForm.reset();
-      Object.keys(this.formPropertyDictTooltip).forEach((fieldName: string) => {
-        tooltipElement.style.setProperty(this.formPropertyDictTooltip[fieldName], null);
-      });
-      if (this.itemSelected === 'tooltip') {
-        const tooltipDefault = this.tooltipDefault.buttonElement.nativeElement.nextElementSibling;
-        Object.keys(this.formPropertyDictTooltip).forEach((fieldName: string) => {
-          tooltipDefault.style.setProperty(this.formPropertyDictTooltip[fieldName], null);
-        });
-      }
-    }
-
     this.popupForm.reset();
     Object.keys(this.formPropertyDictModal).forEach((fieldName: string) => {
       this.popupBuilder.poListBoxRef.listboxItemList.nativeElement.children[0].children[0].style.setProperty(
@@ -858,6 +854,27 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
         this.checkboxHover.nativeElement.style.setProperty(this.formPropertyDictCheckbox[fieldName], null);
       }
     });
+
+    const tooltipElement = document.querySelector('.po-tooltip');
+    if (tooltipElement) {
+      this.tooltipForm.reset();
+      Object.keys(this.formPropertyDictTooltip).forEach((fieldName: string) => {
+        this.tooltip.buttonElement.nativeElement.nextElementSibling.style.setProperty(
+          this.formPropertyDictTooltip[fieldName],
+          null
+        );
+      });
+      if (this.itemSelected === 'tooltip') {
+        const tooltipDefault = this.tooltipDefault.buttonElement.nativeElement.nextElementSibling;
+        Object.keys(this.formPropertyDictTooltip).forEach((fieldName: string) => {
+          tooltipDefault.style.setProperty(this.formPropertyDictTooltip[fieldName], null);
+        });
+      }
+    }
+
+    this.setRatioDefault();
+    this.changedColorButton = false;
+    this.changedColorPopup = false;
   }
 
   changeKindButton(kindValue: number): void {
@@ -904,19 +921,7 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
     this.popupContainerForm.valueChanges.subscribe(changes => this.checkChangesPopupContainer(changes));
     this.checkboxForm.valueChanges.subscribe(changes => this.checkChangesCheckbox(changes));
 
-    const backButton = getComputedStyle(document.querySelector('po-page-default')).getPropertyValue(
-      '--color-secondary'
-    );
-    this.ratioButton = this.setRatioComponent(this.changedColorButton, backButton);
-    this.ratioDisclaimer = this.setRatioComponent(false, '#f2eaf6', '#2c3739');
-    this.ratioDatepicker = this.ratioTextarea = this.ratioInput = this.ratioSelect = this.setRatioComponent(
-      false,
-      '#fbfbfb',
-      '#1d2426'
-    );
-    this.ratioTooltip = this.setRatioComponent(false, '#2c3739', '#ffffff');
-    this.ratioPopup = this.setRatioComponent(this.changedColorPopup, '#ffffff', '#753399');
-    this.cdr.detectChanges();
+    this.setRatioDefault();
   }
 
   openPageSlide(itemLabel: string, item: string) {
@@ -1650,7 +1655,7 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
   }
 
   private checkChangesTooltip(changes: { [key: string]: string }): void {
-    const tooltipElement = this.renderer.selectRootElement('.po-tooltip', true);
+    const tooltipElement = document.querySelector('.po-tooltip');
     if (tooltipElement) {
       if (!this.isEmpty(changes)) {
         this.resultTooltip['nativeElement'].innerHTML = '.po-tooltip {<br>';
@@ -1664,7 +1669,10 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
           }
           if (changes[fieldName]) {
             const tooltipDefault = this.tooltipDefault.buttonElement.nativeElement.nextElementSibling;
-            tooltipElement.style.setProperty(this.formPropertyDictTooltip[fieldName], value);
+            this.tooltip.buttonElement.nativeElement.nextElementSibling.style.setProperty(
+              this.formPropertyDictTooltip[fieldName],
+              value
+            );
             tooltipDefault.style.setProperty(this.formPropertyDictTooltip[fieldName], value);
 
             this.resultTooltip[
@@ -1838,6 +1846,19 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       this.colorText = colorText ? colorText : this.colorText;
       return this.calculateRatio(this.colorBack, this.colorText);
     }
+  }
+
+  private setRatioDefault() {
+    this.ratioButton = this.setRatioComponent(false, '#2c3739', '#ffffff');
+    this.ratioDisclaimer = this.setRatioComponent(false, '#f2eaf6', '#2c3739');
+    this.ratioDatepicker = this.ratioTextarea = this.ratioInput = this.ratioSelect = this.setRatioComponent(
+      false,
+      '#fbfbfb',
+      '#1d2426'
+    );
+    this.ratioTooltip = this.setRatioComponent(false, '#2c3739', '#ffffff');
+    this.ratioPopup = this.setRatioComponent(false, '#ffffff', '#753399');
+    this.cdr.detectChanges();
   }
 
   private verifyIfAllNotVisibility() {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-template/sample-po-multiselect-template.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-template/sample-po-multiselect-template.component.ts
@@ -19,7 +19,7 @@ import { PoSelectOption } from '@po-ui/ng-components';
 
       .containerButton {
         display: flex;
-        align-items: end;
+        align-items: flex-end;
         padding: 8px;
       }
     `


### PR DESCRIPTION
THEME-BUILDER

fixes #DTHFUI-7601

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Construtor de temas está com a estilização incorreta quando executamos os comandos npm run build:portal e npm run build:portal:prod e rodamos live-server na pasta dist/portal na versão do Angular 16

**Qual o novo comportamento?**
Construtor de temas está com a estilização correta quando executamos os comandos npm run build:portal e npm run build:portal:prod e rodamos live-server na pasta dist/portal na versão do Angular 16

**Simulação**
Executar os comandos npm run build:portal e npm run build:portal:prod -> entrar pelo terminal na pasta dist/portal e rodar live-server e verificar se o construtor de temas está correto