### PR TITLE
fix(page-edit): valida campos obrigatórios

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.spec.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectorRef, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PoCheckboxGroupComponent } from './po-checkbox-group.component';
@@ -22,7 +22,8 @@ describe('PoCheckboxGroupComponent:', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PoCheckboxGroupComponent, PoFieldContainerComponent, PoFieldContainerBottomComponent]
+      declarations: [PoCheckboxGroupComponent, PoFieldContainerComponent, PoFieldContainerBottomComponent],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(PoCheckboxGroupComponent);
@@ -85,19 +86,35 @@ describe('PoCheckboxGroupComponent:', () => {
     });
 
     describe('focus:', () => {
+      const checkbox1 = document.createElement('po-checkbox');
+      const checkbox2 = document.createElement('po-checkbox');
+      const checkboxLabel = [
+        {
+          checkboxLabel: {
+            nativeElement: checkbox1
+          }
+        },
+        {
+          checkboxLabel: {
+            nativeElement: checkbox2
+          }
+        }
+      ] as any;
+
       it('should call `focus` of checkbox.', () => {
         component.options = [
           { label: 'teste1', value: 'teste1' },
           { label: 'teste2', value: 'teste2' }
         ];
 
+        component.checkboxLabels = checkboxLabel;
         changeDetector.detectChanges();
 
-        spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
+        spyOn(component.checkboxLabels[0].checkboxLabel.nativeElement, 'focus');
 
         component.focus();
 
-        expect(component.checkboxLabels.toArray()[0].nativeElement.focus).toHaveBeenCalled();
+        expect(component.checkboxLabels[0].checkboxLabel.nativeElement.focus).toHaveBeenCalled();
       });
 
       it('shouldn`t call `focus` of checkbox if option is `disabled`.', () => {
@@ -106,15 +123,16 @@ describe('PoCheckboxGroupComponent:', () => {
           { label: 'teste2', value: 'teste2' }
         ];
 
+        component.checkboxLabels = checkboxLabel;
         changeDetector.detectChanges();
 
-        spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
-        spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+        spyOn(component.checkboxLabels[0].checkboxLabel.nativeElement, 'focus');
+        spyOn(component.checkboxLabels[1].checkboxLabel.nativeElement, 'focus');
 
         component.focus();
 
-        expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
-        expect(component.checkboxLabels.toArray()[1].nativeElement.focus).toHaveBeenCalled();
+        expect(component.checkboxLabels[0].checkboxLabel.nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.checkboxLabels[1].checkboxLabel.nativeElement.focus).toHaveBeenCalled();
       });
 
       it('shouldn`t call `focus` if component is `disabled`.', () => {
@@ -124,15 +142,16 @@ describe('PoCheckboxGroupComponent:', () => {
         ];
         component.disabled = true;
 
+        component.checkboxLabels = checkboxLabel;
         changeDetector.detectChanges();
 
-        spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
-        spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+        spyOn(component.checkboxLabels[0].checkboxLabel.nativeElement, 'focus');
+        spyOn(component.checkboxLabels[1].checkboxLabel.nativeElement, 'focus');
 
         component.focus();
 
-        expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
-        expect(component.checkboxLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.checkboxLabels[0].checkboxLabel.nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.checkboxLabels[1].checkboxLabel.nativeElement.focus).not.toHaveBeenCalled();
       });
 
       it('shouldn`t call `focus` if all checkboxes are `disabled`.', () => {
@@ -141,15 +160,16 @@ describe('PoCheckboxGroupComponent:', () => {
           { label: 'teste2', value: 'teste2', disabled: true }
         ];
 
+        component.checkboxLabels = checkboxLabel;
         changeDetector.detectChanges();
 
-        spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
-        spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+        spyOn(component.checkboxLabels[0].checkboxLabel.nativeElement, 'focus');
+        spyOn(component.checkboxLabels[1].checkboxLabel.nativeElement, 'focus');
 
         component.focus();
 
-        expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
-        expect(component.checkboxLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.checkboxLabels[0].checkboxLabel.nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.checkboxLabels[1].checkboxLabel.nativeElement.focus).not.toHaveBeenCalled();
       });
     });
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
@@ -4,15 +4,15 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  ElementRef,
   forwardRef,
   QueryList,
   ViewChildren
 } from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { PoCheckboxGroupBaseComponent } from './po-checkbox-group-base.component';
+import { PoCheckboxComponent } from '../po-checkbox/po-checkbox.component';
 import { PoCheckboxGroupOption } from './interfaces/po-checkbox-group-option.interface';
+import { PoCheckboxGroupBaseComponent } from './po-checkbox-group-base.component';
 
 /**
  * @docsExtends PoCheckboxGroupBaseComponent
@@ -52,7 +52,7 @@ import { PoCheckboxGroupOption } from './interfaces/po-checkbox-group-option.int
   ]
 })
 export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent implements AfterViewChecked, AfterViewInit {
-  @ViewChildren('checkboxLabel') checkboxLabels: QueryList<ElementRef>;
+  @ViewChildren('checkboxLabel') checkboxLabels: QueryList<PoCheckboxComponent>;
 
   constructor(private changeDetector: ChangeDetectorRef) {
     super();
@@ -90,7 +90,7 @@ export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent imple
       const checkboxLabel = this.checkboxLabels.find((_, index) => !this.options[index].disabled);
 
       if (checkboxLabel) {
-        checkboxLabel.nativeElement.focus();
+        checkboxLabel.checkboxLabel.nativeElement.focus();
       }
     }
   }

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
@@ -5,6 +5,7 @@
   (keydown)="onKeyDown($event, checkboxValue)"
 >
   <div
+    #checkboxLabel
     role="checkbox"
     class="po-checkbox-outline"
     [attr.p-size]="size"
@@ -22,7 +23,6 @@
     </span>
 
     <po-label
-      #checkboxLabel
       *ngIf="label"
       class="po-checkbox-label"
       tabindex="-1"


### PR DESCRIPTION
Page-Dynamic-Edit e Checkbox

[DTHFUI-7478]
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não existe nenhum comportamento visual além de um alert quando submete o formulário com campos obrigatórios faltantes, além de não funcionar a propriedade p-auto-focus no checkbox e checkbox-group

**Qual o novo comportamento?**
É colocado uma borda vermelha em todos os campos vazios obrigatórios ao clicar no botão de submeter o formulário do Po-Page-Dynamic-Edit, além de realizar o foco no primeiro campo inválido. Propriedade p-auto-focus corrigida no checkbox e checkbox-group

**Simulação**
Rodar npm run build ; npm run build:portal para funcionamento do PoTemplatesModule
[app.zip](https://github.com/po-ui/po-angular/files/12613980/app.zip)

Além da pasta style ser alterada na node_modules:
[style.zip](https://github.com/po-ui/po-angular/files/12613982/style.zip)

