### PR TITLE
fix(table): corrige ordenação após filtragem de itens

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -400,7 +400,7 @@ describe('PoTableBaseComponent:', () => {
     component.height = 300;
     component['sortArray'](column, true);
 
-    expect(component.items).toEqual(sortedItemsAsc);
+    expect(component.filteredItems).toEqual(sortedItemsAsc);
   });
   it(`should has service and sort set 'sortStore'`, () => {
     const column = component.columns[1];

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -1200,12 +1200,12 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   }
 
   private sortArray(column: PoTableColumn, ascending: boolean) {
-    const itemsList = this.height ? [...this.items] : this.items;
+    const itemsList = this.height ? [...this.filteredItems] : this.filteredItems;
     itemsList.sort((leftSide, rightSide): number =>
       sortValues(leftSide[column.property], rightSide[column.property], ascending)
     );
     if (this.height) {
-      this.items = itemsList;
+      this.filteredItems = itemsList;
     }
   }
 


### PR DESCRIPTION
Corrige ordenação após realizar filtragem na tabela com ou sem altura

**table**

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)


**Simulação**
Realizar testes no sample
