### PR TITLE
fix(listview): propriedade p-danger no botão de ação

### DIFF
--- a/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
+++ b/projects/ui/src/lib/components/po-list-view/po-list-view.component.html
@@ -70,7 +70,7 @@
                 [p-disabled]="returnBooleanValue(action, item, 'disabled')"
                 [p-icon]="action.icon"
                 [p-label]="action.label"
-                [p-kind]="action.type"
+                [p-danger]="action.type === 'danger'"
                 (p-click)="onClickAction(action, item)"
               >
               </po-button>


### PR DESCRIPTION
**list-view**

**7641**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Botao de ação não obedece interface danger

**Qual o novo comportamento?**
Botao de ação agora pode ser utilizar `p-danger`

**Simulação**
Samples do portal
