### PR TITLE
fix(table): alinhamento de colunas do tipo number, currency, subtitle

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -313,6 +313,7 @@
           >
             <div
               class="po-table-column-cell po-table-body-ellipsis notranslate"
+              [style.width]="['currency', 'number', 'subtitle'].includes(column.type) ? '' : 'max-content'"
               [ngSwitch]="column.type"
               [p-tooltip]="tooltipText"
               [p-append-in-body]="true"


### PR DESCRIPTION
**table**

**DTHFUI-7479**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente table não está aplicando o alinhamento correto em colunas dos tipos number, currency e subtitle.

**Qual o novo comportamento?**
Componente table está aplicando o alinhamento correto em colunas dos tipos number, currency e subtitle.

**Simulação**
Sample label portal
[Style](https://github.com/po-ui/po-style/pull/449)