### PR TITLE
fix(table): torna variação striped padrão

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -239,9 +239,9 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * Habilita ou desabilita o estilo listrado da tabela (`striped`).
    * > Recomendado para tabelas com maior número de dados, facilitando a sua visualização na tabela.
    *
-   * @default `false`
+   * @default `true`
    */
-  @Input({ alias: 'p-striped', transform: convertToBoolean }) striped: boolean = false;
+  @Input({ alias: 'p-striped', transform: convertToBoolean }) striped: boolean = true;
 
   /**
    * @description

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -21,7 +21,7 @@
   [p-show-more-disabled]="properties.includes('showMoreDisabled')"
   [p-single-select]="selection.includes('singleSelect')"
   [p-sort]="properties.includes('sort')"
-  [p-striped]="properties.includes('striped')"
+  [p-striped]="!properties.includes('unstriped')"
   (p-all-selected)="changeEvent('p-all-selected')"
   (p-all-unselected)="changeEvent('p-all-unselected')"
   (p-collapsed)="changeEvent('p-collapsed')"

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -85,7 +85,7 @@ export class SamplePoTableLabsComponent implements OnInit {
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { label: 'Sort', value: 'sort' },
-    { label: 'Striped', value: 'striped' },
+    { label: 'Unstriped', value: 'unstriped' },
     { label: 'Show more disabled', value: 'showMoreDisabled' },
     { label: 'Loading show more', value: 'loadingShowMore' },
     { label: 'Hide detail', value: 'hideDetail' },


### PR DESCRIPTION
**table**

**DTHFUI-7464**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
variação striped padrão false

**Qual o novo comportamento?**
variação striped padrão true

**Simulação**
Sample portal