### PR TITLE
feat(tag): implementa variação de status neutral

### DIFF
--- a/projects/ui/src/lib/components/po-tag/enums/po-tag-type.enum.ts
+++ b/projects/ui/src/lib/components/po-tag/enums/po-tag-type.enum.ts
@@ -12,9 +12,12 @@ export enum PoTagType {
   /** Informativo ou explicativo. */
   Info = 'info',
 
-  /** Confirmação, resultados positivos ou êxito */
+  /** Confirmação, resultados positivos ou êxito. */
   Success = 'success',
 
   /** Aviso ou advertência. */
-  Warning = 'warning'
+  Warning = 'warning',
+
+  /** De uso geral, quando os tipos Info, Warning, Success e Danger não atendem a necessidade. */
+  Neutral = 'neutral'
 }

--- a/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
@@ -268,7 +268,8 @@ export class PoTagBaseComponent {
    *  - `success`: cor verde utilizada para simbolizar sucesso ou êxito.
    *  - `warning`: cor amarela que representa aviso ou advertência.
    *  - `danger`: cor vermelha para erro ou aviso crítico.
-   *  - `info`: cor cinza escuro que caracteriza conteúdo informativo.
+   *  - `info`: cor azul claro que caracteriza conteúdo informativo.
+   *  - `neutral`: cor cinza claro para uso geral.
    *
    * > Quando esta propriedade for definida, irá sobrepor a definição de `p-color` e `p-icon` somente será exibido caso seja `true`.
    *

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
@@ -326,6 +326,14 @@ describe('PoTagComponent:', () => {
       expect(nativeElement.querySelector('.po-tag-warning')).toBeTruthy();
     });
 
+    it('should add `po-tag-neutral` if type is `PoTagType.Neutral`.', () => {
+      component.type = PoTagType.Neutral;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-tag-neutral')).toBeTruthy();
+    });
+
     it('should add `PoTagIcon.Danger` if type is `PoTagType.Danger and `icon` is true`.', () => {
       component.type = PoTagType.Danger;
       component.icon = true;

--- a/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.ts
+++ b/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.ts
@@ -61,7 +61,8 @@ export class SamplePoTagLabsComponent implements OnInit {
     { label: 'Info', value: PoTagType.Info },
     { label: 'Danger', value: PoTagType.Danger },
     { label: 'Success', value: PoTagType.Success },
-    { label: 'Warning', value: PoTagType.Warning }
+    { label: 'Warning', value: PoTagType.Warning },
+    { label: 'Neutral', value: PoTagType.Neutral }
   ];
 
   ngOnInit() {


### PR DESCRIPTION
**TAG**

**DTHFUI-7639**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

Implementa variação de status neutral de acordo com definições do AnimaliaDS.

**Simulação**
A variável --color-neutral, que estava definida para fazer uso da variável --color-neutral-dark-70, passa a utilizar --color-neutral-light-10. Por esse motivo as classes .po-color-neutral e .po-modal-title receberam ajuste, sendo necessário o respectivo teste nos componentes.
- Testar Labs da Tag no portal;
- Testar o Modal para verificar que po-modal-title está com o novo color-neutral;



