### PR TITLE
build(cd): adiciona caminho do diretório de trabalho

### DIFF
--- a/.github/workflows/publish_po_angular_ci.yml
+++ b/.github/workflows/publish_po_angular_ci.yml
@@ -37,11 +37,6 @@ jobs:
         repository: po-ui/po-tslint
         path: po-tslint
 
-    # - uses: actions/setup-node@v4
-    #   with:
-    #     node-version: latest
-    #     registry-url: 'https://registry.npmjs.org'
-
     - name: Install and Build
       run: npm install && npm run build
       working-directory: ${{env.WORKING_DIR}}
@@ -64,125 +59,132 @@ jobs:
     # PUBLISH NG-SCHEMATICS
     - name: ng-schematics - publish
       # Se a versão remota for igual à versão que será publicada então ele pula o publish deste pacote e tenta publicar os demais pacotes
-      # if: (!contains(env.PACKAGE_VERSION, env.SCHEMATICS_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v4
+      #if: (!contains(env.PACKAGE_VERSION, env.SCHEMATICS_LAST_PUBLISHED_VERSION))
+      uses: actions/setup-node@v3
       with:
-        node-version: 'latest'
+        node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
-      run: npm publish dist/ng-schematics --ignore-scripts
-      working-directory: ${{env.WORKING_DIR}}
+    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-schematics --ignore-scripts
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-      # run: npm publish dist/ng-schematics --ignore-scripts
-      # working-directory: ${{env.WORKING_DIR}}
-      # env:
-      #   PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-      #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}  
 
     - name: ng-schematics - add "latest" tag
-
-      # if: (!contains(env.PACKAGE_VERSION, env.SCHEMATICS_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      if: (!contains(env.PACKAGE_VERSION, env.SCHEMATICS_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
       run: npm dist-tags add @${{ env.SCHEMATICS_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
       working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # # PUBLISH NG-STORAGE
-    # - name: ng-storage - publish
-    #   if: (!contains(env.PACKAGE_VERSION, env.STORAGE_LAST_PUBLISHED_VERSION))
-    #   run: npm publish dist/ng-storage --ignore-scripts
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # PUBLISH NG-STORAGE
+    - name: ng-storage - publish
+      if: (!contains(env.PACKAGE_VERSION, env.STORAGE_LAST_PUBLISHED_VERSION))
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-storage --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # - name: ng-storage - add "latest" tag
-    #   if: (!contains(env.PACKAGE_VERSION, env.STORAGE_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
-    #   run: npm dist-tags add @${{ env.STORAGE_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: ng-storage - add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.STORAGE_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.STORAGE_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      working-directory: ${{env.WORKING_DIR}}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # # PUBLISH NG-SYNC
-    # - name: ng-sync - publish
-    #   if: (!contains(env.PACKAGE_VERSION, env.SYNC_LAST_PUBLISHED_VERSION))
-    #   run: npm publish dist/ng-sync --ignore-scripts
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # PUBLISH NG-SYNC
+    - name: ng-sync - publish
+      if: (!contains(env.PACKAGE_VERSION, env.SYNC_LAST_PUBLISHED_VERSION))
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-sync --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # - name: ng-sync - add "latest" tag
-    #   if: (!contains(env.PACKAGE_VERSION, env.SYNC_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
-    #   run: npm dist-tags add @${{ env.SYNC_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: ng-sync - add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.SYNC_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.SYNC_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      working-directory: ${{env.WORKING_DIR}}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # # PUBLISH NG-COMPONENTS
-    # - name: ng-components - publish
-    #   if: (!contains(env.PACKAGE_VERSION, env.COMPONENTS_LAST_PUBLISHED_VERSION))
-    #   run: npm publish dist/ng-components --ignore-scripts
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # PUBLISH NG-COMPONENTS
+    - name: ng-components - publish
+      if: (!contains(env.PACKAGE_VERSION, env.COMPONENTS_LAST_PUBLISHED_VERSION))
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-components --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # - name: ng-components - add "latest" tag
-    #   if: (!contains(env.PACKAGE_VERSION, env.COMPONENTS_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
-    #   run: npm dist-tags add @${{ env.COMPONENTS_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: ng-components - add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.COMPONENTS_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.COMPONENTS_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      working-directory: ${{env.WORKING_DIR}}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    
+    # PUBLISH NG-TEMPLATES
+    - name: ng-templates - publish
+      if: (!contains(env.PACKAGE_VERSION, env.TEMPLATES_LAST_PUBLISHED_VERSION))
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-templates --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # # PUBLISH NG-TEMPLATES
-    # - name: ng-templates - publish
-    #   if: (!contains(env.PACKAGE_VERSION, env.TEMPLATES_LAST_PUBLISHED_VERSION))
-    #   run: npm publish dist/ng-templates --ignore-scripts
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: ng-templates - add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.TEMPLATES_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.TEMPLATES_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      working-directory: ${{env.WORKING_DIR}}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    
+    # PUBLISH NG-CODE-EDITOR
+    - name: ng-code-editor - publish
+      if: (!contains(env.PACKAGE_VERSION, env.CODE_EDITOR_LAST_PUBLISHED_VERSION))
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-code-editor --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # - name: ng-templates - add "latest" tag
-    #   if: (!contains(env.PACKAGE_VERSION, env.TEMPLATES_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
-    #   run: npm dist-tags add @${{ env.TEMPLATES_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: ng-code-editor - add "latest" tag
+      if: (!contains(env.PACKAGE_VERSION, env.CODE_EDITOR_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
+      run: npm dist-tags add @${{ env.CODE_EDITOR_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
+      working-directory: ${{env.WORKING_DIR}}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # # PUBLISH NG-CODE-EDITOR
-    # - name: ng-code-editor publish
-    #   if: (!contains(env.PACKAGE_VERSION, env.CODE_EDITOR_LAST_PUBLISHED_VERSION))
-    #   run: npm publish dist/ng-code-editor --ignore-scripts
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # PUBLISH PORTAL
+    - name: portal build
+      run: npm run build:portal:docs && npm run build:portal:prod
+      working-directory: ${{env.WORKING_DIR}}
 
-    # - name: ng-code-editor add "latest" tag
-    #   if: (!contains(env.PACKAGE_VERSION, env.CODE_EDITOR_LAST_PUBLISHED_VERSION) && !contains(env.PACKAGE_VERSION, '-next') && !contains(env.PACKAGE_VERSION, '-rc'))
-    #   run: npm dist-tags add @${{ env.CODE_EDITOR_NPM_PATH }}@${{ env.PACKAGE_VERSION }}
-    #   working-directory: ${{env.WORKING_DIR}}
-    #   env:
-    #     PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-    # # PUBLISH PORTAL
-    # - name: portal build
-    #   run: npm run build:portal:docs && npm run build:portal:prod
-    #   working-directory: ${{env.WORKING_DIR}}
-
-    # - name: 'Deploy to Azure Web App'
-    #   uses: azure/webapps-deploy@v2
-    #   with:
-    #     app-name: ${{ env.AZURE_WEBAPP_NAME }}
-    #     package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-    #     publish-profile: ${{ secrets.AZURE_TOKEN }}
-
+    - name: 'Deploy to Azure Web App'
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: ${{ env.AZURE_WEBAPP_NAME }}
+        package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+        publish-profile: ${{ secrets.AZURE_TOKEN }}


### PR DESCRIPTION
Adiciona o caminho do diretorio de trabalho {{working_dir}} no endereco do publish npm. Adiciona action de setup-node@v3 para cada deploy de acordo com as boas práticas do githubactions

**< publish_po_angular >**

**< DTHFUI-7679 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O pipeline de deploy apresenta erro ao realizar o NPM Publish de cada pacote. 

**Qual o novo comportamento?**
O pipeline de deploy deve encontrar os arquivos de cada pacote buildado e realizar o npm publish com sucesso.

**Simulação**
Disparar o workflow publish_po_angular