### PR TITLE
fix(listbox): corrige posicionamento

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -602,6 +602,20 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    */
   @Input({ alias: 'p-cache', transform: convertToBoolean }) cache: boolean = true;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o dropdown do combo será incluido no body da página e não suspenso com a caixa de texto do componente.
+   * Opção necessária para o caso de uso do componente em páginas que necessitam renderizar o combo fora do conteúdo principal.
+   *
+   * > Obs: O uso dessa propriedade pode acarretar na perda sequencial da tabulação da página
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();
   }

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -49,33 +49,46 @@
     </div>
   </div>
 
-  <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="true">
-    <div #containerElement class="po-combo-container" [hidden]="!comboOpen && !isServerSearching">
-      <po-listbox
-        #poListbox
-        #contentElement
-        p-type="option"
-        [p-items]="visibleOptions"
-        [p-field-value]="dynamicValue"
-        [p-field-label]="dynamicLabel"
-        [p-template]="comboOptionTemplate"
-        [p-search-value]="getInputValue()"
-        [p-infinite-loading]="infiniteLoading"
-        [p-infinite-scroll]="infiniteScroll"
-        [p-filtering]="isFiltering"
-        [p-cache]="cache"
-        (p-selectcombo-item)="onOptionClick($event, $event.event)"
-        [p-filter-mode]="filterMode"
-        [p-visible]="comboOpen"
-        [p-is-searching]="isServerSearching"
-        [p-should-mark-letter]="shouldMarkLetters"
-        [p-compare-cache]="compareObjects(cacheOptions, visibleOptions)"
-        [p-combo-service]="service"
-        [p-infinite-scroll-distance]="infiniteScrollDistance"
-        (p-update-infinite-scroll)="showMoreInfiniteScroll()"
-        (p-close)="onCloseCombo()"
-      ></po-listbox>
-    </div>
+  <ng-container *ngIf="appendBox; then dropdownCDK; else dropdownDefault"> </ng-container>
+
+  <ng-template #dropdownDefault>
+    <ng-container *ngTemplateOutlet="dropdownListbox"> </ng-container>
   </ng-template>
+
+  <ng-template #dropdownCDK>
+    <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="true">
+      <ng-container *ngTemplateOutlet="dropdownListbox"></ng-container>
+    </ng-template>
+  </ng-template>
+
   <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
 </po-field-container>
+
+<ng-template #dropdownListbox>
+  <div #containerElement class="po-combo-container" [hidden]="!comboOpen && !isServerSearching">
+    <po-listbox
+      #poListbox
+      #contentElement
+      p-type="option"
+      [p-items]="visibleOptions"
+      [p-field-value]="dynamicValue"
+      [p-field-label]="dynamicLabel"
+      [p-template]="comboOptionTemplate"
+      [p-search-value]="getInputValue()"
+      [p-infinite-loading]="infiniteLoading"
+      [p-infinite-scroll]="infiniteScroll"
+      [p-filtering]="isFiltering"
+      [p-cache]="cache"
+      (p-selectcombo-item)="onOptionClick($event, $event.event)"
+      [p-filter-mode]="filterMode"
+      [p-visible]="comboOpen"
+      [p-is-searching]="isServerSearching"
+      [p-should-mark-letter]="shouldMarkLetters"
+      [p-compare-cache]="compareObjects(cacheOptions, visibleOptions)"
+      [p-combo-service]="service"
+      [p-infinite-scroll-distance]="infiniteScrollDistance"
+      (p-update-infinite-scroll)="showMoreInfiniteScroll()"
+      (p-close)="onCloseCombo()"
+    ></po-listbox>
+  </div>
+</ng-template>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -135,6 +135,20 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    */
   @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o dropdown do multiselect será incluido no body da página e não suspenso com a caixa de texto do componente.
+   * Opção necessária para o caso de uso do componente em páginas que necessitam renderizar o multiselect fora do conteúdo principal.
+   *
+   * > Obs: O uso dessa propriedade pode acarretar na perda sequencial da tabulação da página
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
   selectedOptions: Array<PoMultiselectOption | any> = [];
   visibleOptionsDropdown: Array<PoMultiselectOption | any> = [];
   visibleDisclaimers = [];

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -5,7 +5,12 @@
   [p-required]="required"
   [p-show-required]="showRequired"
 >
-  <div class="po-field-container-content" [class.po-multiselect-show]="dropdownOpen">
+  <div
+    cdkOverlayOrigin
+    #trigger="cdkOverlayOrigin"
+    class="po-field-container-content"
+    [class.po-multiselect-show]="dropdownOpen"
+  >
     <div
       #inputElement
       [tabindex]="disabled ? -1 : 0"
@@ -47,6 +52,22 @@
     </div>
   </div>
 
+  <ng-container *ngIf="appendBox; then dropdownCDK; else dropdownDefault"> </ng-container>
+
+  <ng-template #dropdownDefault>
+    <ng-container *ngTemplateOutlet="dropdownListbox"> </ng-container>
+  </ng-template>
+
+  <ng-template #dropdownCDK>
+    <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="true">
+      <ng-container *ngTemplateOutlet="dropdownListbox"></ng-container>
+    </ng-template>
+  </ng-template>
+
+  <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
+</po-field-container>
+
+<ng-template #dropdownListbox>
   <po-multiselect-dropdown
     #dropdownElement
     [p-searching]="isServerSearching"
@@ -65,6 +86,4 @@
     (p-close-dropdown)="controlDropdownVisibility(false)"
   >
   </po-multiselect-dropdown>
-
-  <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
-</po-field-container>
+</ng-template>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testi
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { Observable, of, throwError } from 'rxjs';
+import { OverlayModule } from '@angular/cdk/overlay';
 
 import * as UtilsFunction from '../../../utils/util';
 
@@ -37,7 +38,7 @@ describe('PoMultiselectComponent:', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, OverlayModule],
       declarations: [
         PoDisclaimerComponent,
         PoFieldContainerComponent,
@@ -71,6 +72,7 @@ describe('PoMultiselectComponent:', () => {
   });
 
   it('should call function wasClickedOnToggle', () => {
+    fixture.detectChanges();
     component.openDropdown(true);
     const documentBody = document.body;
     const event = document.createEvent('MouseEvents');
@@ -232,7 +234,7 @@ describe('PoMultiselectComponent:', () => {
       { label: 'label2', value: 2 }
     ];
     component.selectedOptions = [{ label: 'label2', value: 2 }];
-
+    fixture.detectChanges();
     spyOn(component.dropdown, 'scrollTo');
     component.scrollToSelectedOptions();
     expect(component.dropdown.scrollTo).toHaveBeenCalledWith(1);
@@ -240,7 +242,7 @@ describe('PoMultiselectComponent:', () => {
 
   it('shouldn`t call dropdown.scrollTo', () => {
     component.selectedOptions = [];
-
+    fixture.detectChanges();
     spyOn(component.dropdown, 'scrollTo');
     component.scrollToSelectedOptions();
     expect(component.dropdown.scrollTo).not.toHaveBeenCalled();
@@ -268,7 +270,7 @@ describe('PoMultiselectComponent:', () => {
 
   it('should call controlDropdownVisibility in wasClickedOnToggle', () => {
     component.dropdownOpen = true;
-
+    fixture.detectChanges();
     const event = document.createEvent('MouseEvents');
     event.initEvent('click', false, true);
 
@@ -765,7 +767,7 @@ describe('PoMultiselectComponent:', () => {
       call 'dropdown.controlVisibility' with 'false', 'setVisibleOptionsDropdown' with 'options' and 'removeListeners'.`, () => {
       component.dropdownIcon = undefined;
       component.dropdownOpen = undefined;
-
+      fixture.detectChanges();
       const controlVisibilitySpy = spyOn(component.dropdown, 'controlVisibility');
       const setVisibleOptionsDropdownSpy = spyOn(component, 'setVisibleOptionsDropdown');
       const removeListenersSpy = spyOn(component, <any>'removeListeners');
@@ -834,7 +836,7 @@ describe('PoMultiselectComponent:', () => {
       'initializeListeners', 'scrollToSelectedOptions', 'changeDetector.detectChanges' and 'setPositionDropdown'.`, () => {
       component.dropdownIcon = undefined;
       component.dropdownOpen = undefined;
-
+      fixture.detectChanges();
       const controlVisibilitySpy = spyOn(component.dropdown, 'controlVisibility');
       const setVisibleOptionsDropdownSpy = spyOn(component, 'setVisibleOptionsDropdown');
       const initializeListenersSpy = spyOn(component, <any>'initializeListeners');
@@ -873,7 +875,7 @@ describe('PoMultiselectComponent:', () => {
       const customPositions = ['top', 'bottom'];
       const isSetElementWidth = true;
       const poMultiselectContainerOffset = 8;
-
+      fixture.detectChanges();
       const setElementsSpy = spyOn(component['controlPosition'], 'setElements');
       const adjustContainerPositionSpy = spyOn(component, <any>'adjustContainerPosition');
 
@@ -1025,7 +1027,7 @@ describe('PoMultiselectComponent:', () => {
       const wasClickedOnToggleSpy = spyOn(component, 'wasClickedOnToggle');
 
       clickOutEvent();
-
+      fixture.detectChanges();
       expect(wasClickedOnToggleSpy).not.toHaveBeenCalled();
 
       component['open']();
@@ -1052,6 +1054,7 @@ describe('PoMultiselectComponent:', () => {
     });
 
     it(`open: should call 'wasClickedOnToggle' if dropdown list is opened and click window.`, () => {
+      fixture.detectChanges();
       const wasClickedOnToggleSpy = spyOn(component, 'wasClickedOnToggle');
 
       component['open']();
@@ -1061,8 +1064,9 @@ describe('PoMultiselectComponent:', () => {
     });
 
     it(`open: should call 'updateVisibleItems' if dropdown list is opened and resize window.`, () => {
-      const updateVisibleItemsSpy = spyOn(component, 'updateVisibleItems');
+      fixture.detectChanges();
 
+      const updateVisibleItemsSpy = spyOn(component, 'updateVisibleItems');
       component['open']();
       newEvent('resize');
 
@@ -1070,6 +1074,7 @@ describe('PoMultiselectComponent:', () => {
     });
 
     it(`open: should call 'adjustContainerPosition' if dropdown list is opened and scroll window.`, () => {
+      fixture.detectChanges();
       const adjustContainerPositionSpy = spyOn(component, <any>'adjustContainerPosition');
 
       component['open']();

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -103,8 +103,8 @@ export class PoMultiselectComponent
   @ContentChild(PoMultiselectOptionTemplateDirective, { static: true })
   multiselectOptionTemplate: PoMultiselectOptionTemplateDirective;
 
-  @ViewChild('dropdownElement', { read: ElementRef, static: true }) dropdownElement: ElementRef;
-  @ViewChild('dropdownElement', { static: true }) dropdown;
+  @ViewChild('dropdownElement', { read: ElementRef }) dropdownElement: ElementRef;
+  @ViewChild('dropdownElement') dropdown;
   @ViewChild('iconElement', { read: ElementRef, static: true }) iconElement: ElementRef;
   @ViewChild('inputElement', { read: ElementRef, static: true }) inputElement: ElementRef;
 


### PR DESCRIPTION
Corrige posicionamento do multiselect quando colocado em uma tabela com altura

fixes DTHFUI-7742

**multiselect**

**DTHFUI-7742**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)




**Simulação**

testar app e samples do portal
[app.zip](https://github.com/po-ui/po-angular/files/12957128/app.zip)

