### PR TITLE
fix(table): mantém ordenação dos itens após uma pesquisa

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -385,6 +385,21 @@ describe('PoTableBaseComponent:', () => {
     expect(component.items).toEqual(sortedItemsDesc);
   });
 
+  it('should sort values descending with item as param', () => {
+    const column = component.columns[1];
+    const sortedItemsDesc = items.slice().sort((a, b) => b.numberData - a.numberData);
+    component['sortArray'](column, false, items);
+    expect(component.filteredItems).toEqual(sortedItemsDesc);
+  });
+
+  it('should sort values descending with item as param and height', () => {
+    const column = component.columns[1];
+    component.height = 600;
+    const sortedItemsDesc = items.slice().sort((a, b) => b.numberData - a.numberData);
+    component['sortArray'](column, false, items);
+    expect(component.filteredItems).toEqual(sortedItemsDesc);
+  });
+
   it('should sort values ascending', () => {
     const column = component.columns[1];
     const sortedItemsAsc = items.slice().sort((a, b) => a.numberData - b.numberData);

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -6,7 +6,6 @@ import { poLocaleDefault } from '../../services/po-language/po-language.constant
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { capitalizeFirstLetter, convertToBoolean, isTypeof, sortValues } from '../../utils/util';
 
-import { InputBoolean } from '../../decorators';
 import { PoFilterMode } from '../po-search/po-search-filter-mode.enum';
 import { PoTableColumnSortType } from './enums/po-table-column-sort-type.enum';
 import { PoTableColumnSpacing } from './enums/po-table-spacing.enum';
@@ -1087,6 +1086,19 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     }
   }
 
+  sortArray(column: PoTableColumn, ascending: boolean, item?: Array<any>) {
+    let itemsList;
+    if (item) {
+      itemsList = this.height ? [...item] : item;
+    } else {
+      itemsList = this.height ? [...this.filteredItems] : this.filteredItems;
+    }
+    itemsList.sort((leftSide, rightSide): number =>
+      sortValues(leftSide[column.property], rightSide[column.property], ascending)
+    );
+    this.filteredItems = itemsList;
+  }
+
   protected getDefaultColumns(item: any) {
     const keys = Object.keys(item);
 
@@ -1197,16 +1209,6 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
 
   private setSubtitleColumns() {
     this.subtitleColumns = this.getSubtitleColumns();
-  }
-
-  private sortArray(column: PoTableColumn, ascending: boolean) {
-    const itemsList = this.height ? [...this.filteredItems] : this.filteredItems;
-    itemsList.sort((leftSide, rightSide): number =>
-      sortValues(leftSide[column.property], rightSide[column.property], ascending)
-    );
-    if (this.height) {
-      this.filteredItems = itemsList;
-    }
   }
 
   private unselectOtherRows(rows: Array<any>, row) {

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -2090,6 +2090,22 @@ describe('PoTableComponent:', () => {
 
         expect(component.filteredItems).toBe(items);
       });
+
+      it('onFilteredItemsChange should call `sortArray` if exist sortedColumn', () => {
+        component.sortedColumn = {
+          property: { property: 'name' },
+          ascending: true
+        };
+        component.items = [
+          { id: 2, name: 'item2' },
+          { id: 1, name: 'item1' }
+        ];
+
+        spyOn(component, 'sortArray');
+        component.onFilteredItemsChange(items);
+
+        expect(component.sortArray).toHaveBeenCalled();
+      });
     });
   });
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -603,7 +603,11 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   onFilteredItemsChange(items: Array<any>): void {
-    this.filteredItems = items;
+    if (this.sortedColumn.property) {
+      this.sortArray(this.sortedColumn.property, this.sortedColumn.ascending, items);
+    } else {
+      this.filteredItems = items;
+    }
   }
 
   /**


### PR DESCRIPTION
Corrige ordenação após pesquisa de um item na tabela mantendo a ordenação atual



**table**

**fixes DTHFUI-7716**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não mantém a ordenação dos itens após realizar uma pesquisa

**Qual o novo comportamento?**
Mantém a ordenação dos itens após realizar uma pesquisa


**Simulação**
testar app com a tabela utilizando altura e sem altura:

app: 
[app.zip](https://github.com/po-ui/po-angular/files/12861188/app.zip)
