### PR TITLE
fix(menu): corrige item seletor

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.html
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.html
@@ -39,7 +39,7 @@
     [style.maxHeight.px]="maxHeight"
   >
     <ul class="po-menu-sub-items-list">
-      <li class="po-menu-subm-items-list-item" *ngFor="let subItem of subItems" [attr.aria-level]="subItem.level">
+      <li class="po-menu-sub-items-list-item" *ngFor="let subItem of subItems" [attr.aria-level]="subItem.level">
         <po-menu-item
           p-is-sub-item
           [p-action]="subItem.action"


### PR DESCRIPTION
**MENU**

**DTHFUI-7743**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variáveis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e `COVERAGE` está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, Firefox, Edge)

**Qual o comportamento atual?**
Componente apresenta diferenças visuais entre os navegadores suportados,
- Safari apresenta os marcadores de itens na lista.
- Firefox apresenta espaçamento maior entre os itens na lista.

**Qual o novo comportamento?**
Componente apresenta o mesmo visual entre os navegadores suportados.

Corrige classe de item do menu:
| DE | PARA |
| - | - |
| po-menu-subm-items-list-item | po-menu-sub-items-list-item |

Fixes DTHFUI-7743



**Simulação**
Portal

** PR Complementar **
- https://github.com/po-ui/po-style/pull/459