### PR TITLE
feat(rich-text): impede envio de dados ao escolher cor

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
@@ -6,6 +6,7 @@
   <div *ngIf="!isInternetExplorer" class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="color">
     <div class="po-rich-text-toolbar-color-picker-container">
       <button
+        type="button"
         class="po-button po-button-default po-rich-text-toolbar-color-picker-button"
         [disabled]="readonly"
         [p-tooltip]="literals.textColor"


### PR DESCRIPTION
**rich-text**

**DTHFUI-7755**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O formulário está sendo enviado ao escolher uma cor imediatamente.

**Qual o novo comportamento?**
O formulário não envia de imediato ao escolher uma cor.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/13057863/app.zip)
Obs: Clicar bem na borda do botão para escolher cor, pois somente assim para simular a ação.

