### PR TITLE
 fix(input): adiciona onTouched ao método clear para disparar validação

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
@@ -407,6 +407,28 @@ describe('PoInputGeneric:', () => {
     expect(component.controlChangeEmitter).toHaveBeenCalled();
   });
 
+  it('should call onTouched when input is cleaned', () => {
+    component['onTouched'] = jasmine.createSpy('onTouched');
+
+    component.clear('');
+
+    expect(component['onTouched']).toHaveBeenCalled();
+  });
+
+  it('should set valueBeforeChange to undefined when input is cleaned', () => {
+    component.valueBeforeChange = 'previous value';
+
+    component.clear('');
+
+    expect(component.valueBeforeChange).toBeUndefined();
+  });
+
+  it('should not throw error when onTouched is null and input is cleaned', () => {
+    component['onTouched'] = null;
+
+    expect(() => component.clear('')).not.toThrow();
+  });
+
   it('should clean input when "value" to be null', () => {
     const fakeThis = {
       inputEl: component.inputEl,

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -232,7 +232,9 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
   }
 
   clear(value) {
+    this.onTouched?.();
     this.callOnChange(value);
+    this.valueBeforeChange = undefined;
     this.controlChangeEmitter();
     if (this.errorAsyncProperties?.triggerMode === 'changeModel') {
       this.verifyErrorAsync();


### PR DESCRIPTION
O evento de validação apenas é disparado se o usuário tocar no campo antes de clicar no `X` do `clean`.

Foi feito um ajuste para que o evento de validação seja disparado mesmo se o usuário clicar diretamente no `X` do `clean` sem tocar no campo.

Fixes https://github.com/po-ui/po-angular/issues/1837

**Input**

**1837**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O evento `validate` apenas é disparado se o usuário tocar no campo antes de clicar no `X` do `clean`.

**Qual o novo comportamento?**
Foi feito um ajuste para que o evento `validate` seja disparado mesmo o usuário clicar diretamente no `X` do `clean` sem tocar no campo.

**Simulação**

A simulação pode ser feita pelo [APP](https://github.com/po-ui/po-angular/files/13178997/app.zip)
