### PR TITLE
feat(combo): implementa definições do animaliaDS

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/interfaces/po-combo-literals-default.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/interfaces/po-combo-literals-default.interface.ts
@@ -3,18 +3,22 @@ import { PoComboLiterals } from './po-combo-literals.interface';
 export const poComboLiteralsDefault = {
   en: <PoComboLiterals>{
     noData: 'No data found',
-    chooseOption: 'Choose an option'
+    chooseOption: 'Choose an option',
+    clear: 'Clear'
   },
   es: <PoComboLiterals>{
     noData: 'Datos no encontrados',
-    chooseOption: 'Elija una opción'
+    chooseOption: 'Elija una opción',
+    clear: 'limpia'
   },
   pt: <PoComboLiterals>{
     noData: 'Nenhum dado encontrado',
-    chooseOption: 'Escolha uma opção'
+    chooseOption: 'Escolha uma opção',
+    clear: 'Apagar'
   },
   ru: <PoComboLiterals>{
     noData: 'Данные не найдены',
-    chooseOption: 'Выберите опцию'
+    chooseOption: 'Выберите опцию',
+    clear: 'чистый'
   }
 };

--- a/projects/ui/src/lib/components/po-field/po-combo/interfaces/po-combo-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/interfaces/po-combo-literals.interface.ts
@@ -11,4 +11,7 @@ export interface PoComboLiterals {
 
   /** Texto exibido quando o combo estiver vazio. */
   chooseOption?: string;
+
+  /** Texto do aria-label do botão de limpar */
+  clean?: string;
 }

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -1438,11 +1438,12 @@ describe('PoComboBaseComponent:', () => {
 
     it('clear: should call `callModelChange` and `updateSelectedValue` and `updateComboList` and `initInputObservable`', () => {
       component.clean = true;
-
+      component.keyupSubscribe = of('').subscribe();
       spyOn(component, 'callModelChange');
       spyOn(component, 'updateSelectedValue');
       spyOn(component, 'updateComboList');
       spyOn(component, 'initInputObservable');
+      spyOn(component.keyupSubscribe, 'unsubscribe');
 
       component.clear('');
 
@@ -1450,6 +1451,7 @@ describe('PoComboBaseComponent:', () => {
       expect(component.updateSelectedValue).toHaveBeenCalled();
       expect(component.updateComboList).toHaveBeenCalled();
       expect(component.initInputObservable).toHaveBeenCalled();
+      expect(component.keyupSubscribe['unsubscribe']).toHaveBeenCalled();
       expect(component.selectedValue).toEqual(undefined);
     });
 
@@ -1457,6 +1459,7 @@ describe('PoComboBaseComponent:', () => {
       component['defaultService'].hasNext = false;
       component.infiniteScroll = true;
       component.service = defaultService;
+      component.keyupSubscribe = of('').subscribe();
 
       component.clear('');
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -887,6 +887,9 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     this.updateComboList();
     this.initInputObservable();
     this.updateHasNext();
+    if (this.service || this.filterService) {
+      this.keyupSubscribe.unsubscribe();
+    }
   }
 
   protected configAfterSetFilterService(service: PoComboFilter | string) {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -6,14 +6,14 @@
   [p-required]="required"
   [p-show-required]="showRequired"
 >
-  <div cdkOverlayOrigin #trigger="cdkOverlayOrigin" class="po-field-container-content">
+  <div cdkOverlayOrigin #trigger="cdkOverlayOrigin" class="po-field-container-content po-combo-container-content">
     <div *ngIf="icon" class="po-field-icon-container-left">
       <po-icon class="po-field-icon po-icon-input" [class.po-field-icon-disabled]="disabled" [p-icon]="icon"></po-icon>
     </div>
 
     <input
       #inp
-      class="po-input po-combo-input"
+      class="po-combo-input"
       [ngClass]="clean && inp.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
       [class.po-input-icon-left]="icon"
       autocomplete="off"
@@ -26,24 +26,35 @@
       (click)="toggleComboVisibility()"
       (keyup)="onKeyUp($event)"
       (blur)="onBlur()"
-      (keyup.enter)="searchOnEnter($event.target.value)"
+      (keyup)="searchOnEnterOrArrow($event, $event.target.value)"
       (keydown)="onKeyDown($event)"
     />
 
     <div class="po-field-icon-container-right">
-      <po-clean
-        class="po-icon-input"
-        *ngIf="clean && !disabled"
-        (p-change-event)="clear($event)"
-        [p-element-ref]="inputEl"
+      <div
+        tabindex="0"
+        role="button"
+        [attr.aria-label]="literals.clean"
+        *ngIf="clean && !disabled && inp.value"
+        class="po-combo-clean"
+        (click)="clear(null); $event.preventDefault()"
+        (keydown.enter)="clearAndFocus(); $event.preventDefault()"
       >
-      </po-clean>
+        <span
+          [class.po-border-focused]="!disabled && comboOpen"
+          class="po-icon po-field-icon po-icon-clear-content"
+        ></span>
+      </div>
       <span
         #iconArrow
-        class="po-icon po-field-icon {{ comboIcon }} po-icon-input"
+        class="po-icon po-field-icon po-icon-input"
         [class.po-field-icon-disabled]="disabled"
+        [class.po-icon-arrow-up]="comboOpen"
+        [class.po-icon-arrow-down]="!comboOpen"
         [class.po-field-icon]="!disabled"
-        (click)="toggleComboVisibility()"
+        [class.po-combo-default-border]="!disabled && inp.value"
+        [class.po-combo-background-arrow-up]="!disabled && comboOpen"
+        (click)="toggleComboVisibility(true)"
       >
       </span>
     </div>

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
@@ -35,7 +35,7 @@
         </po-item-list>
       </li>
       <li
-        class="po-listbox-item"
+        [class.po-listbox-item]="visible"
         *ngFor="let item of items"
         [cdkOption]="item[fieldLabel]"
         [cdkOptionDisabled]="

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
@@ -676,7 +676,7 @@ describe('PoListBoxComponent', () => {
         { label: 'd', value: 'd' }
       ];
       component.items = items;
-
+      component.visible = true;
       fixture.detectChanges();
 
       expect(nativeElement.querySelector('.po-listbox-item')).toBeTruthy();


### PR DESCRIPTION
**combo**

**DTHFUI-7500**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)


**Simulação**
style: https://github.com/po-ui/po-style/pull/465/files
theme: https://github.com/totvs/po-theme-totvs/pull/267

tester app e portal
app: 
[app.zip](https://github.com/po-ui/po-angular/files/13217037/app.zip)

 customização:
 
 ```
 /* @import url('https://fonts.googleapis.com/css2?family=Lumanosimo&family=Playfair+Display+SC&display=swap');

po-combo {
  --border-radius: 20px;
  --font-family: 'Lumanosimo', cursive;
  --text-color-placeholder: red;
  --color: green;
  --text-color: blue;
  --color-hover: pink;
  --background-hover: yellow;
  --color-focused: rgb(168, 37, 37);
  --outline-color-focused: gold;
  --color-disabled: rgb(198, 231, 229);
  --background-disabled: brown;
  --text-color-disabled: rgb(130, 225, 240);
} */
 
 ```
