### PR TITLE
fix(listbox): ajusta checkbox e fechamento via navegação por teclado

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -634,6 +634,15 @@ describe('PoComboComponent:', () => {
         expect(component.isFiltering).toBe(false);
       });
 
+      it('should call controlComboVisibility(false) when keyCode tab is pressed and shiftKey is true', () => {
+        const event = { ...fakeEvent, keyCode: 9, shiftKey: true };
+        spyOn(component, 'controlComboVisibility');
+
+        component.onKeyDown(event);
+
+        expect(component.controlComboVisibility).toHaveBeenCalledWith(false);
+      });
+
       it(`should call 'controlComboVisibility', 'updateComboList' and 'updateSelectedValue' with 'selectedView' and 'true'
         if selectedView.label is not equal inputValue, typed 'enter', 'selectedView' is truthy and 'comboOpen' is true `, () => {
         const event = { ...fakeEvent, keyCode: 13, target: { value: 'lab' } };

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -227,6 +227,11 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     const key = event.keyCode;
     const inputValue = event.target.value;
 
+    if (event.shiftKey && key === PoKeyCodeEnum.tab) {
+      this.controlComboVisibility(false);
+      return;
+    }
+
     // busca um registro quando acionar o tab
     if (this.service && key === PoKeyCodeEnum.tab && inputValue && !this.disabledTabFilter) {
       this.controlComboVisibility(false);

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -241,7 +241,7 @@ describe('PoMultiselectComponent:', () => {
     expect(component.controlDropdownVisibility).not.toHaveBeenCalled();
   });
 
-  it('should return when event keyCode is PoKeyCodeEnum.tab and visibleTags.length > 1', () => {
+  it('should return when event keyCode is PoKeyCodeEnum.tab', () => {
     const event = new KeyboardEvent('keydown', { keyCode: PoKeyCodeEnum.tab });
     const tagRemovable = document.createElement('span');
     tagRemovable.setAttribute('class', 'po-tag-remove');
@@ -253,13 +253,13 @@ describe('PoMultiselectComponent:', () => {
     expect(component.visibleTags.length).toEqual(2);
   });
 
-  it('should return when event keyCode is PoKeyCodeEnum.tab and visibleTags.length < 1', () => {
-    const event = new KeyboardEvent('keydown', { keyCode: PoKeyCodeEnum.tab });
-    component.visibleTags = [];
+  it('should call controlDropdownVisibility(false) when keyCode tab is pressed and shiftKey is true', () => {
+    const event = { keyCode: PoKeyCodeEnum.tab, shiftKey: true };
+    spyOn(component, 'controlDropdownVisibility');
 
     component.onKeyDown(event);
 
-    expect(component.visibleTags.length).toEqual(0);
+    expect(component.controlDropdownVisibility).toHaveBeenCalledWith(false);
   });
 
   it('should call preventDefault and controlDropdownVisibility(true) when keyCode space is pressed', () => {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -138,6 +138,7 @@ export class PoMultiselectComponent
   private initCalculateItems = true;
   private isCalculateVisibleItems: boolean = true;
   private cacheOptions: Array<PoMultiselectOption | any>;
+  private focusOnTag = false;
 
   constructor(
     private renderer: Renderer2,
@@ -314,10 +315,12 @@ export class PoMultiselectComponent
   }
 
   onKeyDown(event?: any) {
-    if (
-      (event.keyCode === PoKeyCodeEnum.tab && this.visibleTags.length > 1) ||
-      (event.keyCode === PoKeyCodeEnum.tab && this.visibleTags.length < 1)
-    ) {
+    if (event.shiftKey && event.keyCode === PoKeyCodeEnum.tab && !this.focusOnTag) {
+      this.controlDropdownVisibility(false);
+    }
+    this.focusOnTag = false;
+
+    if (event.keyCode === PoKeyCodeEnum.tab) {
       return;
     }
 
@@ -553,6 +556,7 @@ export class PoMultiselectComponent
     const KEY_SPACE = 'Space';
     const KEY_ARROW_LEFT = 'ArrowLeft';
     const KEY_ARROW_RIGHT = 'ArrowRight';
+    this.focusOnTag = true;
 
     if (event.code === KEY_SPACE) {
       event.preventDefault();

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.html
@@ -46,6 +46,7 @@
       [p-disabled-tabindex]="true"
       [p-checkboxValue]="checkboxValue === null ? 'mixed' : checkboxValue"
       [p-disabled]="disabled"
+      (click)="onCheckboxItem()"
       (p-change)="onSelectItem({label})"
     ></po-checkbox>
 


### PR DESCRIPTION
LISTBOX, MULTISELECT E COMBO

DTHFUI-7931
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não funciona clique no checkbox do listbox.
Caso o listbox esteja aberto e o foco esteja na caixa de texto do multiselect ou combo e seja pressoniado shift + tab, o listbox permanece aberto

**Qual o novo comportamento?**
Funciona clique no checkbox do listbox.
Caso o listbox esteja aberto e o foco esteja na caixa de texto do multiselect ou combo e seja pressoniado shift + tab, o listbox é fechado

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/13288645/app.zip)
