### PR TITLE
feat(loading-overlay): novo componente interno e implementações do AnimaliaDS

### DIFF
--- a/projects/ui/src/lib/components/components.module.ts
+++ b/projects/ui/src/lib/components/components.module.ts
@@ -29,6 +29,7 @@ import { PoMenuPanelModule } from './po-menu-panel/po-menu-panel.module';
 import { PoMenuModule } from './po-menu/po-menu.module';
 import { PoModalModule } from './po-modal/po-modal.module';
 import { PoNavbarModule } from './po-navbar/po-navbar.module';
+import { PoOverlayModule } from './po-overlay/po-overlay.module';
 import { PoPageModule } from './po-page/po-page.module';
 import { PoPageSlideModule } from './po-page/po-page-slide/po-page-slide.module';
 import { PoSwitchModule } from './po-field/po-switch/po-switch.module';
@@ -73,6 +74,7 @@ import { PoSearchModule } from './po-search';
     PoMenuPanelModule,
     PoModalModule,
     PoNavbarModule,
+    PoOverlayModule,
     PoPageModule,
     PoPopoverModule,
     PoPopupModule,
@@ -119,6 +121,7 @@ import { PoSearchModule } from './po-search';
     PoMenuPanelModule,
     PoModalModule,
     PoNavbarModule,
+    PoOverlayModule,
     PoPageModule,
     PoPopoverModule,
     PoPopupModule,

--- a/projects/ui/src/lib/components/index.ts
+++ b/projects/ui/src/lib/components/index.ts
@@ -29,6 +29,7 @@ export * from './po-menu-panel/index';
 export * from './po-menu/index';
 export * from './po-modal/index';
 export * from './po-navbar/index';
+export * from './po-overlay/index';
 export * from './po-page/index';
 export * from './po-page/po-page-slide/index';
 export * from './po-popover/index';

--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay.component.html
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay.component.html
@@ -1,3 +1,3 @@
-<div [class.po-overlay-absolute]="!screenLock" [class.po-overlay-fixed]="screenLock">
-  <po-loading class="po-loading-overlay-content" [p-text]="text"></po-loading>
-</div>
+<po-overlay [p-screen-lock]="screenLock">
+  <po-loading [p-text]="text"></po-loading>
+</po-overlay>

--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay.component.spec.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay.component.spec.ts
@@ -32,21 +32,18 @@ describe('PoLoadingOverlayComponent', () => {
       component.screenLock = true;
       fixture.detectChanges();
       expect(nativeElement.querySelector('.po-overlay-fixed')).toBeTruthy();
-      expect(nativeElement.querySelector('.po-overlay-overlay-absolute')).toBeFalsy();
     });
 
     it('should set class `po-loading-absolute` when p-screen-locked is true', () => {
       component.screenLock = false;
       fixture.detectChanges();
       expect(nativeElement.querySelector('.po-overlay-fixed')).toBeFalsy();
-      expect(nativeElement.querySelector('.po-overlay-absolute')).toBeTruthy();
     });
 
     it('should set class `po-loading-overlay-absolute` when p-screen-locked is not defined', () => {
       component.screenLock = undefined;
       fixture.detectChanges();
       expect(nativeElement.querySelector('.po-overlay-fixed')).toBeFalsy();
-      expect(nativeElement.querySelector('.po-overlay-absolute')).toBeTruthy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-loading/po-loading.component.html
+++ b/projects/ui/src/lib/components/po-loading/po-loading.component.html
@@ -1,4 +1,11 @@
 <div class="po-loading">
   <po-loading-icon></po-loading-icon>
-  <span class="po-loading-label po-text-ellipsis" *ngIf="text">{{ text }}</span>
+  <ng-template [ngIf]="text">
+    <span class="po-loading-label po-text-ellipsis"
+      >{{ text }}
+      <div class="po-loading-dot" aria-hidden="true">.</div>
+      <div class="po-loading-dot" aria-hidden="true">.</div>
+      <div class="po-loading-dot" aria-hidden="true">.</div>
+    </span>
+  </ng-template>
 </div>

--- a/projects/ui/src/lib/components/po-loading/po-loading.component.spec.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading.component.spec.ts
@@ -33,7 +33,9 @@ describe('PoLoadingComponent', () => {
     component.text = expectedContent;
     fixture.detectChanges();
 
-    const contentComponent = nativeElement.querySelector('.po-loading-label').innerHTML;
+    const contentComponent = nativeElement
+      .querySelector('.po-loading-label')
+      .innerHTML.substr(0, expectedContent.length);
 
     expect(contentComponent).toBe(expectedContent);
   });

--- a/projects/ui/src/lib/components/po-loading/po-loading.module.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading.module.ts
@@ -6,6 +6,7 @@ import { PoLanguageModule } from './../../services/po-language/po-language.modul
 import { PoLoadingComponent } from './po-loading.component';
 import { PoLoadingIconComponent } from './po-loading-icon/po-loading-icon.component';
 import { PoLoadingOverlayComponent } from './po-loading-overlay/po-loading-overlay.component';
+import { PoOverlayModule } from '../po-overlay/po-overlay.module';
 
 /**
  *
@@ -14,8 +15,8 @@ import { PoLoadingOverlayComponent } from './po-loading-overlay/po-loading-overl
  * Módulo do componente po-loading-overlay.
  */
 @NgModule({
-  imports: [CommonModule, PoLanguageModule],
   declarations: [PoLoadingComponent, PoLoadingIconComponent, PoLoadingOverlayComponent],
-  exports: [PoLoadingComponent, PoLoadingIconComponent, PoLoadingOverlayComponent]
+  exports: [PoLoadingComponent, PoLoadingIconComponent, PoLoadingOverlayComponent],
+  imports: [CommonModule, PoLanguageModule, PoOverlayModule]
 })
 export class PoLoadingModule {}

--- a/projects/ui/src/lib/components/po-overlay/index.ts
+++ b/projects/ui/src/lib/components/po-overlay/index.ts
@@ -1,0 +1,3 @@
+export * from './po-overlay.component';
+
+export * from './po-overlay.module';

--- a/projects/ui/src/lib/components/po-overlay/po-overlay-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-overlay/po-overlay-base.component.spec.ts
@@ -1,0 +1,24 @@
+import { PoOverlayBaseComponent } from './po-overlay-base.component';
+import * as utilsFunctions from '../../utils/util';
+
+describe('PoOverlayBaseComponent', () => {
+  const component = new PoOverlayBaseComponent();
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+    it('p-screen-lock: should update property `p-screen-lock` with valid values.', () => {
+      component.screenLock = utilsFunctions.convertToBoolean(1);
+
+      expect(component.screenLock).toBe(true);
+    });
+
+    it('p-screen-lock: should update property `p-screen-lock` with invalid values.', () => {
+      component.screenLock = utilsFunctions.convertToBoolean(3);
+
+      expect(component.screenLock).toBe(false);
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-overlay/po-overlay-base.component.ts
+++ b/projects/ui/src/lib/components/po-overlay/po-overlay-base.component.ts
@@ -1,0 +1,29 @@
+import { Directive, Input } from '@angular/core';
+import { convertToBoolean } from './../../utils/util';
+
+@Directive()
+export class PoOverlayBaseComponent {
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define se o *overlay* será aplicado a um *container* ou a página inteira.
+   *
+   * Para utilizar o componente como um *container*, o elemento pai deverá receber uma posição relativa, por exemplo:
+   *
+   * ```
+   * <div style="position: relative">
+   *
+   *  <po-chart [p-series]="[{ value: 10, category: 'Example' }]">
+   *  </po-chart>
+   *
+   *  <po-overlay>
+   *  </po-overlay>
+   * </div>
+   * ```
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-screen-lock', transform: convertToBoolean }) screenLock: boolean = false;
+}

--- a/projects/ui/src/lib/components/po-overlay/po-overlay.component.html
+++ b/projects/ui/src/lib/components/po-overlay/po-overlay.component.html
@@ -1,0 +1,5 @@
+<div class="po-overlay" [class.po-overlay-fixed]="screenLock" role="alert" aria-busy="true">
+  <div class="po-overlay-content">
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/projects/ui/src/lib/components/po-overlay/po-overlay.component.spec.ts
+++ b/projects/ui/src/lib/components/po-overlay/po-overlay.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { configureTestSuite } from './../../util-test/util-expect.spec';
+import { PoOverlayComponent } from './po-overlay.component';
+
+describe('PoOverlayComponent', () => {
+  let component: PoOverlayComponent;
+  let fixture: ComponentFixture<PoOverlayComponent>;
+  let nativeElement: any;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoOverlayComponent);
+    component = fixture.componentInstance;
+
+    nativeElement = fixture.debugElement.nativeElement;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Template:', () => {
+    it('should set class `po-overlay-fixed` when p-screen-locked is true', () => {
+      component.screenLock = true;
+      fixture.detectChanges();
+      expect(nativeElement.querySelector('.po-overlay-fixed')).toBeTruthy();
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-overlay/po-overlay.component.ts
+++ b/projects/ui/src/lib/components/po-overlay/po-overlay.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+import { PoOverlayBaseComponent } from './po-overlay-base.component';
+
+@Component({
+  selector: 'po-overlay',
+  templateUrl: './po-overlay.component.html'
+})
+export class PoOverlayComponent extends PoOverlayBaseComponent {}

--- a/projects/ui/src/lib/components/po-overlay/po-overlay.module.ts
+++ b/projects/ui/src/lib/components/po-overlay/po-overlay.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PoOverlayComponent } from './po-overlay.component';
+
+@NgModule({
+  declarations: [PoOverlayComponent],
+  imports: [CommonModule],
+  exports: [PoOverlayComponent]
+})
+export class PoOverlayModule {}


### PR DESCRIPTION
**overlay**
**loading overlay**
**DTHFUI-7502**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente Loading Overlay traz na sua composição, uma camada pai fazendo o papel de overlay com fundo composto por rgb e alpha, e uma camada filho que carrega o po-loading, que é a caixa mais clara exibindo conteúdo. Por conta das definições do AnimaliaDS, a forma como está estruturado não atende as especificações de tokens. 

**Qual o novo comportamento?**
Desmembrado a camada pai que era uma div, transformando-a em um componente po-overlay. 
Com essa forma é possível atender às especificações do AnimaliaDS e reaproveitá-lo em outros componentes que atualmente se utilizam do efeito de overlay como é o caso da modal, tabela, datepicker e o próprio loading overlay.
Também está implementado os requisitos de acessibilidade conforme o AnimaliaDS.

https://github.com/po-ui/po-style/pull/469
https://github.com/totvs/po-theme-totvs/pull/272

**Simulação**
No App é possível simular o uso dos dois componentes utilizando dos switchs para habilitar o p-screen-lock de cada um.
1-No primeiro caso é possível ver apenas a implementação do po-overlay carregando um conteúdo qualquer;
2-No segundo caso é possível ver o loading overlay abrindo, porém agora com o uso do po-overlay em sua composição.

[app.zip](https://github.com/po-ui/po-angular/files/13299342/app.zip)
[styles.zip](https://github.com/po-ui/po-angular/files/13299334/styles.zip)
