### PR TITLE
feat(theme-builder): implementa novos componentes animalizados

### DIFF
--- a/projects/portal/src/app/theme-builder/theme-builder.component.css
+++ b/projects/portal/src/app/theme-builder/theme-builder.component.css
@@ -456,6 +456,89 @@ p {
   }
 }
 
+.multiselect-hover .po-multiselect-input {
+  border-color: var(--color-hover);
+  background-color: var(--background-hover);
+  cursor: pointer;
+}
+
+.multiselect-focus .po-multiselect-input {
+  outline-color: var(--outline-color-focused);
+  outline-width: var(--outline-width);
+  border: 1px solid var(--color-focused);
+  outline-style: solid;
+  outline-offset: 2px;
+}
+
+.multiselect-focus .po-multiselect-input .po-field-icon-container-right .po-icon-input {
+  color: var(--color-focused);
+}
+
+.combo-hover .po-combo-input {
+  border-color: var(--color-hover);
+  background-color: var(--background-hover);
+}
+
+.combo-hover .po-combo-container-content span.po-field-icon.po-icon.po-icon-arrow-down.po-icon-input {
+  border-color: var(--color-hover);
+  background: var(--background-hover);
+}
+
+.combo-focus .po-combo-input {
+  border-color: var(--color-focused);
+  outline-color: var(--outline-color-focused);
+  outline-width: var(--outline-width);
+  outline-style: solid;
+  outline-offset: 2px;
+}
+
+.combo-focus .po-combo-input ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-down,
+.combo-focus .po-combo-input ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-up {
+  border-color: var(--color-focused);
+}
+
+.accordion-hover .po-accordion-item-header-button {
+  color: var(--color-hover);
+  background-color: var(--background-hover);
+}
+
+.accordion-hover .po-accordion-item-header-button .po-accordion-item-header-icon {
+  color: var(--color-hover);
+}
+
+.accordion-focus .po-accordion-item-header-button {
+  color: var(--color-focus);
+  position: relative;
+  outline-color: var(--outline-color-focused);
+  outline-width: var(--outline-width);
+  outline-style: solid;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.accordion-focus .po-accordion-item-header-button .po-accordion-item-header-icon {
+  color: var(--color-focus);
+}
+
+.accordion-pressed .po-accordion-item-header-button {
+  background-color: var(--background-pressed);
+  color: var(--color-pressed);
+  outline: none;
+}
+
+.accordion-pressed .po-accordion-item-header-button .po-accordion-item-header-icon {
+  color: var(--color-pressed);
+}
+
+.breadcrumb-default ul,
+.breadcrumb-default li {
+  margin-bottom: 0 !important;
+}
+
+.tag-hover .po-tag-remove {
+  background-color: var(--color-hover);
+}
+
 .menu-item {
   height: 80%;
   display: flex;

--- a/projects/portal/src/app/theme-builder/theme-builder.component.html
+++ b/projects/portal/src/app/theme-builder/theme-builder.component.html
@@ -709,6 +709,234 @@
             </div>
           </div>
         </po-widget>
+        <po-widget [class.hide]="!multiselectView" class="widget-items po-sm-12 po-md-6 po-lg-4 po-xl-3 po-pl-0">
+          <po-widget class="widget-menu">
+            <div class="po-row row-menu">
+              <div class="po-md-12 po-p-0 col-widget">
+                <po-tag
+                  [p-color]="ratioMultiselect > 7 ? '#c3ffc3b3' : '#ffd3d3'"
+                  [p-icon]="ratioMultiselect > 7 ? 'po-icon-ok' : 'po-icon-close'"
+                  [p-text-color]="ratioMultiselect > 7 ? 'green' : 'red'"
+                  p-value="AAA"
+                  class="po-pr-1 po-pt-1 container-widget"
+                ></po-tag>
+                <po-tag
+                  [p-color]="ratioMultiselect > 4.5 ? '#c3ffc3b3' : '#ffd3d3'"
+                  [p-icon]="ratioMultiselect > 4.5 ? 'po-icon-ok' : 'po-icon-close'"
+                  [p-text-color]="ratioMultiselect > 4.5 ? 'green' : 'red'"
+                  p-value="AA"
+                  class="po-pr-1 po-pt-1 container-widget"
+                >
+                </po-tag>
+              </div>
+              <div class="po-md-12 po-p-0">
+                <div class="menu-with-constrast">
+                  <po-multiselect
+                    #multiselect
+                    p-placeholder="Customize seu multiselect"
+                    class="po-pr-1 po-pl-1 po-pt-1"
+                    [p-options]="[
+                      { label: 'Item 1', value: 1 },
+                      { label: 'Item 2', value: 2 },
+                      { label: 'Item 3', value: 3 }
+                    ]"
+                  ></po-multiselect>
+                </div>
+                <p class="po-pl-1"><strong>Live demo</strong></p>
+              </div>
+            </div>
+          </po-widget>
+          <div class="po-row">
+            <div class="po-md-12 description-widget">
+              <p><strong>Multiselect</strong></p>
+              <po-tag class="po-pl-2" p-color="#efefef" p-text-color="#000" p-value="AnimaliaDS"> </po-tag>
+            </div>
+            <div class="po-md-12 po-pt-1 description-widget">
+              <po-button
+                p-icon="po-icon-settings"
+                p-kind="tertiary"
+                p-label="Personalizar"
+                (click)="customizeComponent.open(); openPageSlide('Multiselect', 'multiselect')"
+              ></po-button>
+            </div>
+          </div>
+        </po-widget>
+        <po-widget [class.hide]="!comboView" class="widget-items po-sm-12 po-md-6 po-lg-4 po-xl-3 po-pl-0">
+          <po-widget class="widget-menu">
+            <div class="po-row row-menu">
+              <div class="po-md-12 po-p-0 col-widget">
+                <po-tag
+                  [p-color]="ratioCombo > 7 ? '#c3ffc3b3' : '#ffd3d3'"
+                  [p-icon]="ratioCombo > 7 ? 'po-icon-ok' : 'po-icon-close'"
+                  [p-text-color]="ratioCombo > 7 ? 'green' : 'red'"
+                  p-value="AAA"
+                  class="po-pr-1 po-pt-1 container-widget"
+                ></po-tag>
+                <po-tag
+                  [p-color]="ratioCombo > 4.5 ? '#c3ffc3b3' : '#ffd3d3'"
+                  [p-icon]="ratioCombo > 4.5 ? 'po-icon-ok' : 'po-icon-close'"
+                  [p-text-color]="ratioCombo > 4.5 ? 'green' : 'red'"
+                  p-value="AA"
+                  class="po-pr-1 po-pt-1 container-widget"
+                >
+                </po-tag>
+              </div>
+              <div class="po-md-12 po-p-0">
+                <div class="menu-with-constrast">
+                  <po-combo
+                    #combo
+                    p-placeholder="Customize seu combo"
+                    class="po-pr-1 po-pl-1 po-pt-1"
+                    [p-options]="[
+                      { label: 'Item 1', value: 1 },
+                      { label: 'Item 2', value: 2 },
+                      { label: 'Item 3', value: 3 }
+                    ]"
+                  ></po-combo>
+                </div>
+                <p class="po-pl-1"><strong>Live demo</strong></p>
+              </div>
+            </div>
+          </po-widget>
+          <div class="po-row">
+            <div class="po-md-12 description-widget">
+              <p><strong>Combo</strong></p>
+              <po-tag class="po-pl-2" p-color="#efefef" p-text-color="#000" p-value="AnimaliaDS"> </po-tag>
+            </div>
+            <div class="po-md-12 po-pt-1 description-widget">
+              <po-button
+                p-icon="po-icon-settings"
+                p-kind="tertiary"
+                p-label="Personalizar"
+                (click)="customizeComponent.open(); openPageSlide('Combo', 'combo')"
+              ></po-button>
+            </div>
+          </div>
+        </po-widget>
+        <po-widget [class.hide]="!accordionView" class="widget-items po-sm-12 po-md-6 po-lg-4 po-xl-3 po-pl-0">
+          <po-widget class="widget-menu">
+            <div class="po-row row-menu">
+              <div class="po-md-12 po-p-0 col-widget">
+                <po-tag
+                  [p-color]="ratioAccordion > 7 ? '#c3ffc3b3' : '#ffd3d3'"
+                  [p-icon]="ratioAccordion > 7 ? 'po-icon-ok' : 'po-icon-close'"
+                  [p-text-color]="ratioAccordion > 7 ? 'green' : 'red'"
+                  p-value="AAA"
+                  class="po-pr-1 po-pt-1 container-widget"
+                ></po-tag>
+                <po-tag
+                  [p-color]="ratioAccordion > 4.5 ? '#c3ffc3b3' : '#ffd3d3'"
+                  [p-icon]="ratioAccordion > 4.5 ? 'po-icon-ok' : 'po-icon-close'"
+                  [p-text-color]="ratioAccordion > 4.5 ? 'green' : 'red'"
+                  p-value="AA"
+                  class="po-pr-1 po-pt-1 container-widget"
+                >
+                </po-tag>
+              </div>
+              <div class="po-md-12 po-p-0">
+                <div class="menu-with-constrast">
+                  <po-accordion #accordion class="po-pr-1 po-pl-1 po-pt-2">
+                    <po-accordion-item p-label="PO Accordion 1">
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    </po-accordion-item>
+                  </po-accordion>
+                </div>
+                <p class="po-pl-1"><strong>Live demo</strong></p>
+              </div>
+            </div>
+          </po-widget>
+          <div class="po-row">
+            <div class="po-md-12 description-widget">
+              <p><strong>Accordion</strong></p>
+              <po-tag class="po-pl-2" p-color="#efefef" p-text-color="#000" p-value="AnimaliaDS"> </po-tag>
+            </div>
+            <div class="po-md-12 po-pt-1 description-widget">
+              <po-button
+                p-icon="po-icon-settings"
+                p-kind="tertiary"
+                p-label="Personalizar"
+                (click)="customizeComponent.open(); openPageSlide('Accordion', 'accordion')"
+              ></po-button>
+            </div>
+          </div>
+        </po-widget>
+        <po-widget [class.hide]="!breadcrumbView" class="widget-items po-sm-12 po-md-6 po-lg-4 po-xl-3 po-pl-0">
+          <po-widget class="widget-menu">
+            <div class="po-row row-menu">
+              <div class="po-md-12 po-p-0">
+                <div class="menu-item">
+                  <po-breadcrumb
+                    class="po-pt-5"
+                    #breadcrumb
+                    [p-items]="[
+                      { label: 'Po Portal', link: 'portal' },
+                      { label: 'Po Breadcrumb', link: 'breadcrumb' }
+                    ]"
+                  >
+                  </po-breadcrumb>
+                </div>
+                <p class="po-pl-1"><strong>Live demo</strong></p>
+              </div>
+            </div>
+          </po-widget>
+          <div class="po-row">
+            <div class="po-md-12 description-widget">
+              <p><strong>Breadcrumb</strong></p>
+              <po-tag class="po-pl-2" p-color="#efefef" p-text-color="#000" p-value="AnimaliaDS"> </po-tag>
+            </div>
+            <div class="po-md-12 po-pt-1 description-widget">
+              <po-button
+                p-icon="po-icon-settings"
+                p-kind="tertiary"
+                p-label="Personalizar"
+                (click)="customizeComponent.open(); openPageSlide('Breadcrumb', 'breadcrumb')"
+              ></po-button>
+            </div>
+          </div>
+        </po-widget>
+        <po-widget [class.hide]="!tagView" class="widget-items po-sm-12 po-md-6 po-lg-4 po-xl-3 po-pl-0">
+          <po-widget class="widget-menu">
+            <div class="po-row row-menu">
+              <div class="po-md-12 po-p-0 col-widget">
+                <po-tag
+                  [p-color]="ratioTagDefault > 7 ? '#c3ffc3b3' : '#ffd3d3'"
+                  [p-icon]="ratioTagDefault > 7 ? 'po-icon-ok' : 'po-icon-close'"
+                  [p-text-color]="ratioTagDefault > 7 ? 'green' : 'red'"
+                  p-value="AAA"
+                  class="po-pr-1 po-pt-1 container-widget"
+                ></po-tag>
+                <po-tag
+                  [p-color]="ratioTagDefault > 4.5 ? '#c3ffc3b3' : '#ffd3d3'"
+                  [p-icon]="ratioTagDefault > 4.5 ? 'po-icon-ok' : 'po-icon-close'"
+                  [p-text-color]="ratioTagDefault > 4.5 ? 'green' : 'red'"
+                  p-value="AA"
+                  class="po-pr-1 po-pt-1 container-widget"
+                >
+                </po-tag>
+              </div>
+              <div class="po-md-12 po-p-0">
+                <div class="menu-with-constrast">
+                  <po-tag #tag p-value="PO Tag" class="po-pr-1 po-pl-1 po-pt-1"></po-tag>
+                </div>
+                <p class="po-pl-1"><strong>Live demo</strong></p>
+              </div>
+            </div>
+          </po-widget>
+          <div class="po-row">
+            <div class="po-md-12 description-widget">
+              <p><strong>Tag</strong></p>
+              <po-tag class="po-pl-2" p-color="#efefef" p-text-color="#000" p-value="AnimaliaDS"> </po-tag>
+            </div>
+            <div class="po-md-12 po-pt-1 description-widget">
+              <po-button
+                p-icon="po-icon-settings"
+                p-kind="tertiary"
+                p-label="Personalizar"
+                (click)="customizeComponent.open(); openPageSlide('Tag', 'tag')"
+              ></po-button>
+            </div>
+          </div>
+        </po-widget>
       </div>
       <po-widget class="po-lg-12 po-pr-0 po-pl-0 po-pb-2" *ngIf="!verifyIfItemVisibility()">
         <div class="container widget-align">
@@ -2374,6 +2602,698 @@
         </div>
       </section>
     </ng-template>
+    <ng-template [ngSwitchCase]="'multiselect'">
+      <div class="container-item">
+        <p class="color-title-p"><strong>Estados</strong></p>
+      </div>
+      <po-widget class="widget-color">
+        <div class="container content-page-slide po-pl-2 po-pr-2 po-pt-1">
+          <div class="container-item">
+            <p><strong>Live demo</strong></p>
+          </div>
+        </div>
+        <div class="po-row po-mt-2 po-pl-2 po-pr-2">
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-multiselect
+              class="po-pb-1"
+              #multiselectDefault
+              name="multiselect"
+              [p-options]="[
+                { label: 'Option 1', value: '1' },
+                { label: 'Option 2', value: '2' },
+                { label: 'Option 3', value: '3' },
+              ]"
+              p-placeholder="Customize seu po-multiselect"
+            ></po-multiselect>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Padrão"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-multiselect
+              class="po-pb-1 multiselect-hover"
+              #multiselectHover
+              name="multiselect"
+              [p-options]="[
+                { label: 'Option 1', value: '1' },
+                { label: 'Option 2', value: '2' },
+                { label: 'Option 3', value: '3' },
+              ]"
+              p-placeholder="Customize seu po-multiselect"
+            ></po-multiselect>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Hover"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-multiselect
+              class="po-pb-1 multiselect-focus"
+              #multiselectFocus
+              name="multiselect"
+              [p-options]="[
+                { label: 'Option 1', value: '1' },
+                { label: 'Option 2', value: '2' }
+              ]"
+              p-placeholder="Customize seu po-multiselect"
+            ></po-multiselect>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Focus"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-multiselect
+              class="po-pb-1"
+              #multiselectDisabled
+              [p-disabled]="true"
+              [ngModel]="[1, 2]"
+              name="multiselect"
+              [p-options]="[
+                { label: 'Option 1', value: 1 },
+                { label: 'Option 2', value: 2 }
+              ]"
+              p-placeholder="Customize seu po-multiselect"
+            ></po-multiselect>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Disabled"> </po-tag>
+          </div>
+        </div>
+      </po-widget>
+      <div class="container-item po-mt-2 po-mb-2">
+        <p class="color-title-p"><strong>Acessibilidade</strong></p>
+      </div>
+      <ng-container *ngTemplateOutlet="acessibility"></ng-container>
+      <section>
+        <div class="container-item po-mt-2 po-mb-2">
+          <p class="color-title-p"><strong>Personalizar</strong></p>
+        </div>
+
+        <div class="po-row">
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="fontSizeMultiselect"><strong>Tamanho da fonte: </strong></label>
+            <input
+              type="range"
+              id="fontSizeMultiselect"
+              min="10"
+              max="32"
+              [formControl]="multiselectForm.get('fontSize')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorMultiselect"><strong>Cor da borda: </strong></label>
+            <input
+              type="color"
+              id="colorMultiselect"
+              class="style-inputColor"
+              [formControl]="multiselectForm.get('borderColor')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorHoverMultiselect"><strong>Cor da borda Hover: </strong></label>
+            <input
+              type="color"
+              id="colorHoverMultiselect"
+              class="style-inputColor"
+              [formControl]="multiselectForm.get('borderColorHover')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorBackgroundMultiselect"><strong>Cor do background: </strong></label>
+            <input
+              type="color"
+              id="colorBackgroundMultiselect"
+              class="style-inputColor"
+              [formControl]="multiselectForm.get('colorBackground')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorBackgroundHoverMultiselect"><strong>Cor do background Hover: </strong></label>
+            <input
+              type="color"
+              id="colorBackgroundHoverMultiselect"
+              class="style-inputColor"
+              [formControl]="multiselectForm.get('colorBackgroundHover')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorTextMultiselect"><strong>Cor do texto do placeholder: </strong></label>
+            <input
+              type="color"
+              id="colorTextMultiselect"
+              class="style-inputColor"
+              [formControl]="multiselectForm.get('textColor')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorFocusMultiselect"><strong>Cor Focus: </strong></label>
+            <input
+              type="color"
+              id="colorFocusMultiselect"
+              class="style-inputColor"
+              [formControl]="multiselectForm.get('colorFocus')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorDisabledMultiselect"><strong>Cor Disabled: </strong></label>
+            <input
+              type="color"
+              id="colorDisabledMultiselect"
+              class="style-inputColor"
+              [formControl]="multiselectForm.get('colorDisabled')"
+            />
+          </div>
+        </div>
+      </section>
+    </ng-template>
+    <ng-template [ngSwitchCase]="'combo'">
+      <div class="container-item">
+        <p class="color-title-p"><strong>Estados</strong></p>
+      </div>
+      <po-widget class="widget-color">
+        <div class="container content-page-slide po-pl-2 po-pr-2 po-pt-1">
+          <div class="container-item">
+            <p><strong>Live demo</strong></p>
+          </div>
+        </div>
+        <div class="po-row po-mt-2 widget-align">
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-combo
+              class="po-pb-1"
+              #comboDefault
+              name="combo"
+              [p-options]="[
+                { label: 'Option 1', value: '1' },
+                { label: 'Option 2', value: '2' },
+                { label: 'Option 3', value: '3' },
+              ]"
+              p-placeholder="Customize seu po-combo"
+            ></po-combo>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Padrão"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-combo
+              class="po-pb-1 combo-hover"
+              #comboHover
+              name="combo"
+              [p-options]="[
+                { label: 'Option 1', value: '1' },
+                { label: 'Option 2', value: '2' },
+                { label: 'Option 3', value: '3' },
+              ]"
+              p-placeholder="Customize seu po-combo"
+            ></po-combo>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Hover"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-combo
+              class="po-pb-1 combo-focus"
+              #comboFocus
+              name="combo"
+              [p-options]="[
+                { label: 'Option 1', value: '1' },
+                { label: 'Option 2', value: '2' }
+              ]"
+              p-placeholder="Customize seu po-combo"
+            ></po-combo>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Focus"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-combo
+              class="po-pb-1"
+              #comboDisabled
+              [p-disabled]="true"
+              [ngModel]="1"
+              name="combo"
+              [p-options]="[
+                { label: 'Option 1', value: 1 },
+                { label: 'Option 2', value: 2 }
+              ]"
+              p-placeholder="Customize seu po-combo"
+            ></po-combo>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Disabled"> </po-tag>
+          </div>
+        </div>
+      </po-widget>
+      <div class="container-item po-mt-2 po-mb-2">
+        <p class="color-title-p"><strong>Acessibilidade</strong></p>
+      </div>
+      <ng-container *ngTemplateOutlet="acessibility"></ng-container>
+      <section>
+        <div class="container-item po-mt-2 po-mb-2">
+          <p class="color-title-p"><strong>Personalizar</strong></p>
+        </div>
+
+        <div class="po-row">
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="fontSizeCombo"><strong>Tamanho da fonte: </strong></label>
+            <input type="range" id="fontSizeCombo" min="10" max="32" [formControl]="comboForm.get('fontSize')" />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorCombo"><strong>Cor da borda: </strong></label>
+            <input type="color" id="colorCombo" class="style-inputColor" [formControl]="comboForm.get('borderColor')" />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorHoverCombo"><strong>Cor da borda Hover: </strong></label>
+            <input
+              type="color"
+              id="colorHoverCombo"
+              class="style-inputColor"
+              [formControl]="comboForm.get('borderColorHover')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorBackgroundCombo"><strong>Cor do background: </strong></label>
+            <input
+              type="color"
+              id="colorBackgroundCombo"
+              class="style-inputColor"
+              [formControl]="comboForm.get('colorBackground')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorBackgroundHoverCombo"><strong>Cor do background Hover: </strong></label>
+            <input
+              type="color"
+              id="colorBackgroundHoverCombo"
+              class="style-inputColor"
+              [formControl]="comboForm.get('colorBackgroundHover')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorTextCombo"><strong>Cor do texto: </strong></label>
+            <input
+              type="color"
+              id="colorTextCombo"
+              class="style-inputColor"
+              [formControl]="comboForm.get('textColor')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorTextPlaceCombo"><strong>Cor do texto do placeholder: </strong></label>
+            <input
+              type="color"
+              id="colorTextPlaceCombo"
+              class="style-inputColor"
+              [formControl]="comboForm.get('textColorPlaceholder')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorFocusCombo"><strong>Cor Focus: </strong></label>
+            <input
+              type="color"
+              id="colorFocusCombo"
+              class="style-inputColor"
+              [formControl]="comboForm.get('colorFocus')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorDisabledCombo"><strong>Cor Disabled: </strong></label>
+            <input
+              type="color"
+              id="colorDisabledCombo"
+              class="style-inputColor"
+              [formControl]="comboForm.get('colorDisabled')"
+            />
+          </div>
+        </div>
+      </section>
+    </ng-template>
+    <ng-template [ngSwitchCase]="'accordion'">
+      <div class="container-item">
+        <p class="color-title-p"><strong>Estados</strong></p>
+      </div>
+      <po-widget class="widget-color">
+        <div class="container content-page-slide po-pl-2 po-pr-2 po-pt-1">
+          <div class="container-item">
+            <p><strong>Live demo</strong></p>
+          </div>
+        </div>
+        <div class="po-row po-mt-2 widget-align">
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-accordion #accordionDefault class="po-pb-1">
+              <po-accordion-item p-label="PO Accordion 1">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </po-accordion-item>
+            </po-accordion>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Padrão"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-accordion #accordionHover class="po-pb-1 accordion-hover">
+              <po-accordion-item p-label="PO Accordion 1">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </po-accordion-item>
+            </po-accordion>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Hover"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-accordion #accordionFocus class="po-pb-1 accordion-focus">
+              <po-accordion-item p-label="PO Accordion 1">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </po-accordion-item>
+            </po-accordion>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Focus"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-accordion #accordionPressed class="po-pb-1 accordion-pressed">
+              <po-accordion-item p-label="PO Accordion 1">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </po-accordion-item>
+            </po-accordion>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Pressed"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-accordion #accordionDisabled class="po-pb-1 accordion-disabled">
+              <po-accordion-item p-label="PO Accordion 1" [p-disabled]="true">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </po-accordion-item>
+            </po-accordion>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Disabled"> </po-tag>
+          </div>
+        </div>
+      </po-widget>
+      <div class="container-item po-mt-2 po-mb-2">
+        <p class="color-title-p"><strong>Acessibilidade</strong></p>
+      </div>
+      <ng-container *ngTemplateOutlet="acessibility"></ng-container>
+      <section>
+        <div class="container-item po-mt-2 po-mb-2">
+          <p class="color-title-p"><strong>Personalizar</strong></p>
+        </div>
+
+        <div class="po-row">
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="fontSizeAccordion"><strong>Tamanho da fonte: </strong></label>
+            <input
+              type="range"
+              id="fontSizeAccordion"
+              min="10"
+              max="32"
+              [formControl]="accordionForm.get('fontSize')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorBackgroundAccordion"><strong>Cor do background: </strong></label>
+            <input
+              type="color"
+              id="colorBackgroundAccordion"
+              class="style-inputColor"
+              [formControl]="accordionForm.get('colorBackground')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorBackgroundHoverAccordion"><strong>Cor do background Hover: </strong></label>
+            <input
+              type="color"
+              id="colorBackgroundHoverAccordion"
+              class="style-inputColor"
+              [formControl]="accordionForm.get('colorHover')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorBackgroundPressedAccordion"><strong>Cor do background Pressed: </strong></label>
+            <input
+              type="color"
+              id="colorBackgroundPressedAccordion"
+              class="style-inputColor"
+              [formControl]="accordionForm.get('colorPressed')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorTextAccordion"><strong>Cor do texto: </strong></label>
+            <input
+              type="color"
+              id="colorTextAccordion"
+              class="style-inputColor"
+              [formControl]="accordionForm.get('textColor')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorTextHoverAccordion"><strong>Cor do texto Hover: </strong></label>
+            <input
+              type="color"
+              id="colorTextHoverAccordion"
+              class="style-inputColor"
+              [formControl]="accordionForm.get('textColorHover')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorTextPressedAccordion"><strong>Cor do texto Pressed: </strong></label>
+            <input
+              type="color"
+              id="colorTextPressedAccordion"
+              class="style-inputColor"
+              [formControl]="accordionForm.get('textColorPressed')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorFocusAccordion"><strong>Cor do texto Focus: </strong></label>
+            <input
+              type="color"
+              id="colorFocusAccordion"
+              class="style-inputColor"
+              [formControl]="accordionForm.get('textColorFocus')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorDisabledAccordion"><strong>Cor Disabled: </strong></label>
+            <input
+              type="color"
+              id="colorDisabledAccordion"
+              class="style-inputColor"
+              [formControl]="accordionForm.get('colorDisabled')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="textColorDisabledAccordion"><strong>Cor do texto Disabled: </strong></label>
+            <input
+              type="color"
+              id="textColorDisabledAccordion"
+              class="style-inputColor"
+              [formControl]="accordionForm.get('textColorDisabled')"
+            />
+          </div>
+        </div>
+      </section>
+    </ng-template>
+    <ng-template [ngSwitchCase]="'breadcrumb'">
+      <div class="container-item">
+        <p class="color-title-p"><strong>Estados</strong></p>
+      </div>
+      <po-widget class="widget-color">
+        <div class="container content-page-slide po-pl-2 po-pr-2 po-pt-1">
+          <div class="container-item">
+            <p><strong>Live demo</strong></p>
+          </div>
+        </div>
+        <div class="po-row po-mt-2 widget-align">
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-breadcrumb
+              #breadcrumbDefault
+              class="breadcrumb-default po-pb-2"
+              [p-items]="[
+                { label: 'Po Portal', link: 'portal' },
+                { label: 'Po Breadcrumb', link: 'breadcrumb' },
+                { label: 'Po Breadcrumb 2', link: 'breadcrumb2' },
+                { label: 'Po Breadcrumb 3', link: 'breadcrumb3' },
+                { label: 'Po Breadcrumb 4', link: 'breadcrumb4' }
+              ]"
+            >
+            </po-breadcrumb>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Padrão"> </po-tag>
+          </div>
+        </div>
+      </po-widget>
+      <div class="container-item po-mt-2 po-mb-2">
+        <p class="color-title-p"><strong>Acessibilidade</strong></p>
+      </div>
+      <div class="container widget-align">
+        <p><strong>É necessário cor do background e cor do texto para funcionamento da acessibilidade</strong></p>
+      </div>
+      <div class="container-item po-mt-2 po-mb-2">
+        <p class="color-title-p"><strong>Personalizar</strong></p>
+      </div>
+      <section>
+        <div class="po-row">
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorCurrentPageBreadcrumb"><strong>Cor página atual: </strong></label>
+            <input
+              type="color"
+              id="colorCurrentPageBreadcrumb"
+              class="style-inputColor"
+              [formControl]="breadcrumbForm.get('colorCurrentPage')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorIconBreadcrumb"><strong>Cor do ícone de separação dos links: </strong></label>
+            <input
+              type="color"
+              id="colorIconBreadcrumb"
+              class="style-inputColor"
+              [formControl]="breadcrumbForm.get('colorIcon')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorBreadcrumb"><strong>Cor do ícone de agrupamento dos links: </strong></label>
+            <input
+              type="color"
+              id="colorBreadcrumb"
+              class="style-inputColor"
+              [formControl]="breadcrumbForm.get('color')"
+            />
+          </div>
+        </div>
+      </section>
+    </ng-template>
+    <ng-template [ngSwitchCase]="'tag'">
+      <div class="container-item">
+        <p class="color-title-p"><strong>Estados</strong></p>
+      </div>
+      <po-widget class="widget-color">
+        <div class="container content-page-slide po-pl-2 po-pr-2">
+          <div class="container-item">
+            <p><strong>Live demo</strong></p>
+          </div>
+          <div class="container-item">
+            <po-select
+              name="select"
+              [p-options]="[
+                { label: 'None/Info', value: 1 },
+                { label: 'Danger', value: 2 },
+                { label: 'Success', value: 3 },
+                { label: 'Warning', value: 4 },
+                { label: 'Neutral', value: 5 },
+                { label: 'Removable', value: 6 },
+              ]"
+              [ngModel]="tagSelected"
+              (p-change)="changeTag($event)"
+              p-placeholder="Selecione sua tag"
+            >
+            </po-select>
+          </div>
+        </div>
+        <div class="po-row po-mt-2 widget-align">
+          <div class="po-md-6 po-lg-6 po-xl-6 item-align po-pb-2">
+            <po-tag [class.hide]="tagSelected !== 1" #tagDefault class="po-pb-2" p-value="PO Tag"></po-tag>
+            <po-tag
+              [class.hide]="tagSelected !== 2"
+              #tagDanger
+              class="po-pb-2"
+              p-value="PO Tag"
+              p-type="danger"
+            ></po-tag>
+            <po-tag
+              [class.hide]="tagSelected !== 3"
+              #tagSuccess
+              class="po-pb-2"
+              p-value="PO Tag"
+              p-type="success"
+            ></po-tag>
+            <po-tag
+              [class.hide]="tagSelected !== 4"
+              #tagWarning
+              class="po-pb-2"
+              p-value="PO Tag"
+              p-type="warning"
+            ></po-tag>
+            <po-tag
+              [class.hide]="tagSelected !== 5"
+              #tagNeutral
+              class="po-pb-2"
+              p-value="PO Tag"
+              p-type="neutral"
+            ></po-tag>
+            <po-tag
+              [class.hide]="tagSelected !== 6"
+              #tagRemovable
+              class="po-pb-2"
+              p-value="PO Tag"
+              [p-removable]="true"
+            ></po-tag>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Padrão"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 po-pb-2" [ngClass]="tagSelected === 6 ? 'item-align' : 'hide'">
+            <po-tag [p-removable]="true" #tagHover class="po-pb-2 tag-hover" p-value="PO Tag"></po-tag>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Hover"> </po-tag>
+          </div>
+          <div class="po-md-6 po-lg-6 po-xl-6 po-pb-2" [ngClass]="tagSelected === 6 ? 'item-align' : 'hide'">
+            <po-tag [p-removable]="true" [p-disabled]="true" #tagDisabled class="po-pb-2" p-value="PO Tag"></po-tag>
+            <po-tag p-color="#efefef" p-text-color="#000" p-value="Disabled"> </po-tag>
+          </div>
+        </div>
+      </po-widget>
+      <div class="container-item po-mt-2 po-mb-2">
+        <p class="color-title-p"><strong>Acessibilidade</strong></p>
+      </div>
+      <ng-container *ngTemplateOutlet="acessibility"></ng-container>
+      <section>
+        <div class="container-item po-mt-2 po-mb-2">
+          <p class="color-title-p"><strong>Personalizar</strong></p>
+        </div>
+
+        <div class="po-row">
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="borderRadiusTag"><strong>Border radius: </strong></label>
+            <input
+              type="range"
+              id="borderRadiusTag"
+              min="0"
+              max="32"
+              [formControl]="tagsFormGlobal.get('borderRadius')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="fontSizeTag"><strong>Tamanho da fonte: </strong></label>
+            <input type="range" id="fontSizeTag" min="10" max="32" [formControl]="tagsFormGlobal.get('fontSize')" />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="lineHeightTag"><strong>Line height: </strong></label>
+            <input type="range" id="lineHeightTag" min="15" max="45" [formControl]="tagsFormGlobal.get('lineHeight')" />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorTag"><strong>Cor da tag: </strong></label>
+            <input type="color" id="colorTag" class="style-inputColor" [formControl]="tagForm.get('backgroundColor')" />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="textColorTag"><strong>Cor do texto da tag: </strong></label>
+            <input type="color" id="textColorTag" class="style-inputColor" [formControl]="tagForm.get('textColor')" />
+          </div>
+          <div *ngIf="tagSelected === 6" class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="borderColorTag"><strong>Cor da borda: </strong></label>
+            <input
+              type="color"
+              id="borderColorTag"
+              class="style-inputColor"
+              [formControl]="tagForm.get('borderColor')"
+            />
+          </div>
+        </div>
+        <div class="po-row" *ngIf="tagSelected === 6">
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorHoverTag"><strong>Cor Hover: </strong></label>
+            <input type="color" id="colorHoverTag" class="style-inputColor" [formControl]="tagForm.get('colorHover')" />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="colorDisabledTag"><strong>Cor Disabled: </strong></label>
+            <input
+              type="color"
+              id="colorDisabledTag"
+              class="style-inputColor"
+              [formControl]="tagForm.get('colorDisabled')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="textColorDisabledTag"><strong>Cor do texto Disabled: </strong></label>
+            <input
+              type="color"
+              id="textColorDisabledTag"
+              class="style-inputColor"
+              [formControl]="tagForm.get('textColorDisabled')"
+            />
+          </div>
+          <div class="po-md-12 po-lg-6 customize-item po-mb-1 po-pl-0">
+            <label for="borderColorDisabledTag"><strong>Cor da borda Disabled: </strong></label>
+            <input
+              type="color"
+              id="borderColorDisabledTag"
+              class="style-inputColor"
+              [formControl]="tagForm.get('borderColorDisabled')"
+            />
+          </div>
+        </div>
+      </section>
+    </ng-template>
   </po-page-slide>
 
   <ng-template #acessibility>
@@ -2476,6 +3396,12 @@
           #resultPopupContainer
         ></pre>
         <pre [ngClass]="resultCheckbox?.innerText.length ? '' : 'pre-none'" class="teste" #resultCheckbox></pre>
+        <pre [ngClass]="resultMultiselect?.innerText.length ? '' : 'pre-none'" class="teste" #resultMultiselect></pre>
+        <pre [ngClass]="resultCombo?.innerText.length ? '' : 'pre-none'" class="teste" #resultCombo></pre>
+        <pre [ngClass]="resultAccordion?.innerText.length ? '' : 'pre-none'" class="teste" #resultAccordion></pre>
+        <pre [ngClass]="resultBreadcrumb?.innerText.length ? '' : 'pre-none'" class="teste" #resultBreadcrumb></pre>
+        <pre [ngClass]="resultTag?.innerText.length ? '' : 'pre-none'" class="teste" #resultTag></pre>
+        <pre [ngClass]="resultTagsGlobal?.innerText.length ? '' : 'pre-none'" class="teste" #resultTagsGlobal></pre>
       </div>
     </div>
 
@@ -2632,6 +3558,42 @@
         p-label="Disclaimer"
         name="Disclaimer"
         [(ngModel)]="disclaimerView"
+        (p-change)="switchIndividual()"
+      ></po-switch>
+      <po-switch
+        class="po-sm-6"
+        p-label-off="Escondido"
+        p-label-on="Visível"
+        p-label="Multiselect"
+        name="Multiselect"
+        [(ngModel)]="multiselectView"
+        (p-change)="switchIndividual()"
+      ></po-switch>
+      <po-switch
+        class="po-sm-6"
+        p-label-off="Escondido"
+        p-label-on="Visível"
+        p-label="Combo"
+        name="Combo"
+        [(ngModel)]="comboView"
+        (p-change)="switchIndividual()"
+      ></po-switch>
+      <po-switch
+        class="po-sm-6"
+        p-label-off="Escondido"
+        p-label-on="Visível"
+        p-label="Accordion"
+        name="accordion"
+        [(ngModel)]="accordionView"
+        (p-change)="switchIndividual()"
+      ></po-switch>
+      <po-switch
+        class="po-sm-6"
+        p-label-off="Escondido"
+        p-label-on="Visível"
+        p-label="Breadcrumb"
+        name="breadcrumb"
+        [(ngModel)]="breadcrumbView"
         (p-change)="switchIndividual()"
       ></po-switch>
     </div>

--- a/projects/portal/src/app/theme-builder/theme-builder.component.ts
+++ b/projects/portal/src/app/theme-builder/theme-builder.component.ts
@@ -3,15 +3,17 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  Renderer2,
-  ViewChild,
   OnInit,
+  ViewChild,
   ViewEncapsulation
 } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
 import {
+  PoAccordionComponent,
+  PoBreadcrumbComponent,
   PoButtonComponent,
+  PoComboComponent,
   PoDatepickerComponent,
   PoDisclaimerComponent,
   PoDropdownComponent,
@@ -19,10 +21,12 @@ import {
   PoListViewAction,
   PoListViewLiterals,
   PoModalComponent,
+  PoMultiselectComponent,
   PoPageSlideComponent,
   PoPopupComponent,
   PoSelectComponent,
   PoSwitchComponent,
+  PoTagComponent,
   PoTextareaComponent
 } from '../../../../ui/src/lib';
 
@@ -108,6 +112,34 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
   @ViewChild('checkboxChecked', { read: ElementRef }) checkboxChecked: ElementRef;
   @ViewChild('checkboxUnchecked', { read: ElementRef }) checkboxUnchecked: ElementRef;
   @ViewChild('checkboxHover', { read: ElementRef }) checkboxHover: ElementRef;
+  @ViewChild('multiselect') multiselectComponent: PoMultiselectComponent;
+  @ViewChild('multiselectDefault', { read: ElementRef }) multiselectDefault: ElementRef;
+  @ViewChild('multiselectHover') multiselectHover: PoMultiselectComponent;
+  @ViewChild('multiselectFocus') multiselectFocus: PoMultiselectComponent;
+  @ViewChild('multiselectDisabled') multiselectDisabled: PoMultiselectComponent;
+  @ViewChild('combo') comboComponent: PoComboComponent;
+  @ViewChild('comboDefault', { read: ElementRef }) comboDefault: ElementRef;
+  @ViewChild('comboHover') comboHover: PoComboComponent;
+  @ViewChild('comboFocus') comboFocus: PoComboComponent;
+  @ViewChild('comboDisabled') comboDisabled: PoComboComponent;
+  @ViewChild('accordion') accordionComponent: PoAccordionComponent;
+  @ViewChild('accordionDefault', { read: ElementRef }) accordionDefault: ElementRef;
+  @ViewChild('accordionHover') accordionHover: PoAccordionComponent;
+  @ViewChild('accordionFocus') accordionFocus: PoAccordionComponent;
+  @ViewChild('accordionPressed') accordionPressed: PoAccordionComponent;
+  @ViewChild('accordionDisabled') accordionDisabled: PoAccordionComponent;
+  @ViewChild('breadcrumb') breadcrumbComponent: PoBreadcrumbComponent;
+  @ViewChild('breadcrumbDefault', { read: ElementRef }) breadcrumbDefault: ElementRef;
+  @ViewChild('tag') tagComponent: PoTagComponent;
+  @ViewChild('tagDefault', { read: ElementRef }) tagDefault: ElementRef;
+  @ViewChild('tagDanger', { read: ElementRef }) tagDanger: ElementRef;
+  @ViewChild('tagSuccess', { read: ElementRef }) tagSuccess: ElementRef;
+  @ViewChild('tagWarning', { read: ElementRef }) tagWarning: ElementRef;
+  @ViewChild('tagNeutral', { read: ElementRef }) tagNeutral: ElementRef;
+  @ViewChild('tagRemovable', { read: ElementRef }) tagRemovable: ElementRef;
+  @ViewChild('tagHover', { read: ElementRef }) tagHover: ElementRef;
+  @ViewChild('tagDisabled', { read: ElementRef }) tagDisabled: ElementRef;
+
   @ViewChild('resultButtonD') resultButtonD: HTMLElement;
   @ViewChild('resultButtonP') resultButtonP: HTMLElement;
   @ViewChild('resultButtonL') resultButtonL: HTMLElement;
@@ -126,6 +158,12 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
   @ViewChild('resultPopup') resultPopup: HTMLElement;
   @ViewChild('resultPopupContainer') resultPopupContainer: HTMLElement;
   @ViewChild('resultCheckbox') resultCheckbox: HTMLElement;
+  @ViewChild('resultMultiselect') resultMultiselect: HTMLElement;
+  @ViewChild('resultCombo') resultCombo: HTMLElement;
+  @ViewChild('resultAccordion') resultAccordion: HTMLElement;
+  @ViewChild('resultBreadcrumb') resultBreadcrumb: HTMLElement;
+  @ViewChild('resultTag') resultTag: HTMLElement;
+  @ViewChild('resultTagsGlobal') resultTagsGlobal: HTMLElement;
 
   botaoPrimaryView = true;
   switchView = true;
@@ -141,26 +179,52 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
   dropdownView = true;
   popupView = true;
   checkboxView = true;
+  multiselectView = true;
+  comboView = true;
+  accordionView = true;
+  breadcrumbView = true;
+  tagView = true;
   switchSampleBuilder = true;
+
+  resultTagI = '';
+  resultTagD = '';
+  resultTagS = '';
+  resultTagW = '';
+  resultTagN = '';
+  resultTagR = '';
 
   switchAllComponentes = true;
 
-  colorBack!: string;
   colorText = '#ffffff';
   changedColorButton = false;
   changedColorPopup = false;
-  itemSelected!: string;
+  changedColorAccordion = false;
   kindButton = 1;
+  tagSelected = 1;
+
+  colorBack!: string;
+  itemSelected!: string;
   nameItem!: string;
   ratio!: number;
   ratioButton!: number;
   ratioDisclaimer!: number;
   ratioInput!: number;
   ratioSelect!: number;
+  ratioMultiselect!: number;
+  ratioCombo!: number;
+  ratioAccordion!: number;
+  ratioTag!: number;
+  ratioTagDefault!: number;
+  ratioTagDanger!: number;
+  ratioTagSuccess!: number;
+  ratioTagWarning!: number;
+  ratioTagNeutral!: number;
+  ratioTagRemovable!: number;
   ratioTextarea!: number;
   ratioDatepicker!: number;
   ratioTooltip!: number;
   ratioPopup!: number;
+  tagActive;
 
   // Cor primária
   brandFormP: FormGroup;
@@ -224,6 +288,28 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
 
   //checkbox
   checkboxForm: FormGroup;
+
+  //multiselect
+  multiselectForm: FormGroup;
+
+  //combo
+  comboForm: FormGroup;
+
+  //accordion
+  accordionForm: FormGroup;
+
+  //breadcrumb
+  breadcrumbForm: FormGroup;
+
+  //tag
+  tagForm;
+  tagsFormGlobal: FormGroup;
+  tagFormI: FormGroup;
+  tagFormD: FormGroup;
+  tagFormS: FormGroup;
+  tagFormW: FormGroup;
+  tagFormN: FormGroup;
+  tagFormR: FormGroup;
 
   private readonly formPropertyP = {
     colorAction: '--color-primary'
@@ -388,6 +474,90 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
     borderColor: '--border-color'
   };
 
+  private readonly formPropertyDictMultiselect = {
+    borderColor: '--color',
+    borderColorHover: '--color-hover',
+    colorBackground: '--background',
+    colorBackgroundHover: '--background-hover',
+    textColor: '--text-color-placeholder',
+    fontSize: '--font-size',
+    colorFocus: '--color-focused',
+    colorDisabled: '--background-disabled'
+  };
+
+  private readonly formPropertyDictCombo = {
+    borderColor: '--color',
+    borderColorHover: '--color-hover',
+    colorBackground: '--background',
+    colorBackgroundHover: '--background-hover',
+    colorFocus: '--color-focused',
+    colorDisabled: '--background-disabled',
+    fontSize: '--font-size',
+    textColor: '--text-color',
+    textColorPlaceholder: '--text-color-placeholder'
+  };
+
+  private readonly formPropertyDictAccordion = {
+    colorBackground: '--background-color',
+    colorHover: '--background-hover',
+    colorPressed: '--background-pressed',
+    colorDisabled: '--background-disabled',
+    textColor: '--color',
+    textColorDisabled: '--color-disabled',
+    textColorHover: '--color-hover',
+    textColorPressed: '--color-pressed',
+    textColorFocus: '--color-focus',
+    fontSize: '--font-size'
+  };
+
+  private readonly formPropertyDictBreadcrumb = {
+    colorIcon: '--color-icon',
+    colorCurrentPage: '--color-current-page',
+    color: '--color'
+  };
+
+  private formPropertyDictTag;
+  private readonly formPropertyDictTagI = {
+    backgroundColor: '--color-info',
+    textColor: '--text-color-info'
+  };
+
+  private readonly formPropertyDictTagD = {
+    backgroundColor: '--color-negative',
+    textColor: '--text-color-negative'
+  };
+
+  private readonly formPropertyDictTagS = {
+    backgroundColor: '--color-positive',
+    textColor: '--text-color-positive'
+  };
+
+  private readonly formPropertyDictTagW = {
+    backgroundColor: '--color-tag-warning',
+    textColor: '--text-color-warning'
+  };
+
+  private readonly formPropertyDictTagN = {
+    backgroundColor: '--color-neutral',
+    textColor: '--text-color-neutral'
+  };
+
+  private readonly formPropertyDictTagR = {
+    backgroundColor: '--color',
+    textColor: '--text-color',
+    borderColor: '--border-color',
+    colorHover: '--color-hover',
+    colorDisabled: '--color-disabled',
+    textColorDisabled: '--text-color-disabled',
+    borderColorDisabled: '--border-color-disabled'
+  };
+
+  private readonly formPropertyDictTagsGlobal = {
+    borderRadius: '--border-radius',
+    fontSize: '--font-size',
+    lineHeight: '--line-height'
+  };
+
   listViewLiterals: PoListViewLiterals = {
     showDetails: 'Mais Detalhes',
     hideDetails: 'Menos Detalhes'
@@ -401,7 +571,7 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
     }
   ];
 
-  constructor(private formBuilder: FormBuilder, private renderer: Renderer2, private cdr: ChangeDetectorRef) {}
+  constructor(private formBuilder: FormBuilder, private cdr: ChangeDetectorRef) {}
 
   ngOnInit(): void {
     this.brandFormP = this.formBuilder.group({
@@ -566,6 +736,90 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       colorHover: [null],
       borderColor: [null]
     });
+
+    this.multiselectForm = this.formBuilder.group({
+      borderColor: [null],
+      borderColorHover: [null],
+      colorBackground: [null],
+      colorBackgroundHover: [null],
+      textColor: [null],
+      fontSize: [null],
+      colorFocus: [null],
+      colorDisabled: [null]
+    });
+
+    this.comboForm = this.formBuilder.group({
+      borderColor: [null],
+      borderColorHover: [null],
+      colorBackground: [null],
+      colorBackgroundHover: [null],
+      textColor: [null],
+      textColorPlaceholder: [null],
+      fontSize: [null],
+      colorFocus: [null],
+      colorDisabled: [null]
+    });
+
+    this.accordionForm = this.formBuilder.group({
+      fontSize: [null],
+      colorBackground: [null],
+      colorHover: [null],
+      colorPressed: [null],
+      textColor: [null],
+      textColorHover: [null],
+      textColorPressed: [null],
+      textColorFocus: [null],
+      colorDisabled: [null],
+      textColorDisabled: [null]
+    });
+
+    this.breadcrumbForm = this.formBuilder.group({
+      colorIcon: [null],
+      colorCurrentPage: [null],
+      color: [null]
+    });
+
+    this.tagFormI = this.formBuilder.group({
+      backgroundColor: [null],
+      textColor: [null]
+    });
+
+    this.tagFormD = this.formBuilder.group({
+      backgroundColor: [null],
+      textColor: [null]
+    });
+
+    this.tagFormS = this.formBuilder.group({
+      backgroundColor: [null],
+      textColor: [null]
+    });
+
+    this.tagFormW = this.formBuilder.group({
+      backgroundColor: [null],
+      textColor: [null]
+    });
+
+    this.tagFormN = this.formBuilder.group({
+      backgroundColor: [null],
+      textColor: [null]
+    });
+
+    this.tagFormR = this.formBuilder.group({
+      backgroundColor: [null],
+      textColor: [null],
+      borderColor: [null],
+      colorHover: [null],
+      colorDisabled: [null],
+      textColorDisabled: [null],
+      borderColorDisabled: [null]
+    });
+
+    this.tagsFormGlobal = this.formBuilder.group({
+      borderRadius: [null],
+      fontSize: [null],
+      lineHeight: [null]
+    });
+    this.tagForm = this.tagFormI;
   }
 
   openGetcss() {
@@ -872,13 +1126,185 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       }
     }
 
+    this.multiselectForm.reset();
+    Object.keys(this.formPropertyDictMultiselect).forEach((fieldName: string) => {
+      this.multiselectComponent.inputElement.nativeElement.style.setProperty(
+        this.formPropertyDictMultiselect[fieldName],
+        null
+      );
+      if (this.itemSelected === 'multiselect') {
+        this.multiselectDefault.nativeElement.style.setProperty(this.formPropertyDictMultiselect[fieldName], null);
+        this.multiselectHover.inputElement.nativeElement.style.setProperty(
+          this.formPropertyDictMultiselect[fieldName],
+          null
+        );
+        this.multiselectFocus.inputElement.nativeElement.style.setProperty(
+          this.formPropertyDictMultiselect[fieldName],
+          null
+        );
+        this.multiselectDisabled.inputElement.nativeElement.style.setProperty(
+          this.formPropertyDictMultiselect[fieldName],
+          null
+        );
+      }
+    });
+
+    this.comboForm.reset();
+    Object.keys(this.formPropertyDictCombo).forEach((fieldName: string) => {
+      this.comboComponent.inputEl.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], null);
+      if (this.itemSelected === 'combo') {
+        this.comboDefault.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], null);
+        this.comboHover.inputEl.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], null);
+        this.comboFocus.inputEl.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], null);
+        this.comboDisabled.inputEl.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], null);
+        this.comboHover.iconElement.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], null);
+        this.comboFocus.iconElement.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], null);
+      }
+    });
+
+    this.accordionForm.reset();
+    Object.keys(this.formPropertyDictAccordion).forEach((fieldName: string) => {
+      const accordionList = this.accordionComponent.accordionsHeader.toArray();
+      accordionList[0].accordionElement.nativeElement.style.setProperty(
+        this.formPropertyDictAccordion[fieldName],
+        null
+      );
+      if (this.itemSelected === 'accordion') {
+        this.accordionDefault.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], null);
+        this.accordionHover.accordionsHeader
+          .toArray()[0]
+          .accordionElement.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], null);
+        this.accordionFocus.accordionsHeader
+          .toArray()[0]
+          .accordionElement.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], null);
+        this.accordionPressed.accordionsHeader
+          .toArray()[0]
+          .accordionElement.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], null);
+        this.accordionDisabled.accordionsHeader
+          .toArray()[0]
+          .accordionElement.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], null);
+      }
+    });
+
+    this.breadcrumbForm.reset();
+    Object.keys(this.formPropertyDictBreadcrumb).forEach((fieldName: string) => {
+      this.breadcrumbComponent.breadcrumbElement.nativeElement.style.setProperty(
+        this.formPropertyDictBreadcrumb[fieldName],
+        null
+      );
+      if (this.itemSelected === 'breadcrumb') {
+        this.breadcrumbDefault.nativeElement.style.setProperty(this.formPropertyDictBreadcrumb[fieldName], null);
+      }
+    });
+
+    this.tagsFormGlobal.reset();
+    this.tagFormI.reset();
+    Object.keys(this.formPropertyDictTagI).forEach((fieldName: string) => {
+      this.tagComponent.poTag.nativeElement.style.setProperty(this.formPropertyDictTagI[fieldName], null);
+      if (this.itemSelected === 'tag') {
+        this.tagDefault.nativeElement.style.setProperty(this.formPropertyDictTagI[fieldName], null);
+        this.tagDefault.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], null);
+      }
+    });
+
+    this.tagFormD.reset();
+    Object.keys(this.formPropertyDictTagD).forEach((fieldName: string) => {
+      if (this.itemSelected === 'tag') {
+        this.tagDanger.nativeElement.style.setProperty(this.formPropertyDictTagD[fieldName], null);
+        this.tagDanger.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], null);
+      }
+    });
+
+    this.tagFormS.reset();
+    Object.keys(this.formPropertyDictTagS).forEach((fieldName: string) => {
+      if (this.itemSelected === 'tag') {
+        this.tagSuccess.nativeElement.style.setProperty(this.formPropertyDictTagS[fieldName], null);
+        this.tagSuccess.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], null);
+      }
+    });
+
+    this.tagFormW.reset();
+    Object.keys(this.formPropertyDictTagW).forEach((fieldName: string) => {
+      if (this.itemSelected === 'tag') {
+        this.tagWarning.nativeElement.style.setProperty(this.formPropertyDictTagW[fieldName], null);
+        this.tagWarning.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], null);
+      }
+    });
+
+    this.tagFormN.reset();
+    Object.keys(this.formPropertyDictTagN).forEach((fieldName: string) => {
+      if (this.itemSelected === 'tag') {
+        this.tagNeutral.nativeElement.style.setProperty(this.formPropertyDictTagN[fieldName], null);
+        this.tagNeutral.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], null);
+      }
+    });
+
+    this.tagFormR.reset();
+    Object.keys(this.formPropertyDictTagR).forEach((fieldName: string) => {
+      if (this.itemSelected === 'tag') {
+        this.tagRemovable.nativeElement.style.setProperty(this.formPropertyDictTagR[fieldName], null);
+        this.tagHover.nativeElement.style.setProperty(this.formPropertyDictTagR[fieldName], null);
+        this.tagDisabled.nativeElement.style.setProperty(this.formPropertyDictTagR[fieldName], null);
+        this.tagRemovable.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], null);
+        this.tagHover.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], null);
+        this.tagDisabled.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], null);
+      }
+    });
+
     this.setRatioDefault();
     this.changedColorButton = false;
     this.changedColorPopup = false;
+    this.changedColorAccordion = false;
   }
 
   changeKindButton(kindValue: number): void {
     this.kindButton = kindValue;
+  }
+
+  changeTag(tagValue: number): void {
+    this.tagSelected = tagValue;
+    if (tagValue === 1) {
+      this.formPropertyDictTag = this.formPropertyDictTagI;
+      this.ratio = this.ratioTagDefault;
+      this.ratioTag = this.ratioTagDefault;
+      this.tagActive = this.tagDefault;
+      this.tagForm = this.tagFormI;
+    }
+    if (tagValue === 2) {
+      this.formPropertyDictTag = this.formPropertyDictTagD;
+      this.ratio = this.ratioTagDanger;
+      this.ratioTag = this.ratioTagDanger;
+      this.tagActive = this.tagDanger;
+      this.tagForm = this.tagFormD;
+    }
+    if (tagValue === 3) {
+      this.formPropertyDictTag = this.formPropertyDictTagS;
+      this.ratio = this.ratioTagSuccess;
+      this.ratioTag = this.ratioTagSuccess;
+      this.tagActive = this.tagSuccess;
+      this.tagForm = this.tagFormS;
+    }
+    if (tagValue === 4) {
+      this.formPropertyDictTag = this.formPropertyDictTagW;
+      this.ratio = this.ratioTagWarning;
+      this.ratioTag = this.ratioTagWarning;
+      this.tagActive = this.tagWarning;
+      this.tagForm = this.tagFormW;
+    }
+    if (tagValue === 5) {
+      this.formPropertyDictTag = this.formPropertyDictTagN;
+      this.ratio = this.ratioTagNeutral;
+      this.ratioTag = this.ratioTagNeutral;
+      this.tagActive = this.tagNeutral;
+      this.tagForm = this.tagFormN;
+    }
+    if (tagValue === 6) {
+      this.formPropertyDictTag = this.formPropertyDictTagR;
+      this.ratio = this.ratioTagRemovable;
+      this.ratioTag = this.ratioTagRemovable;
+      this.tagActive = this.tagRemovable;
+      this.tagForm = this.tagFormR;
+    }
   }
 
   copyToClipboard() {
@@ -920,6 +1346,35 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
     this.popupForm.valueChanges.subscribe(changes => this.checkChangesPopup(changes));
     this.popupContainerForm.valueChanges.subscribe(changes => this.checkChangesPopupContainer(changes));
     this.checkboxForm.valueChanges.subscribe(changes => this.checkChangesCheckbox(changes));
+    this.multiselectForm.valueChanges.subscribe(changes => this.checkChangesMultiselect(changes));
+    this.comboForm.valueChanges.subscribe(changes => this.checkChangesCombo(changes));
+    this.accordionForm.valueChanges.subscribe(changes => this.checkChangesAccordion(changes));
+    this.breadcrumbForm.valueChanges.subscribe(changes => this.checkChangesBreadcrumb(changes));
+    this.tagFormI.valueChanges.subscribe(changes => {
+      this.resultTagI = '';
+      this.checkChangesTag(changes);
+    });
+    this.tagFormD.valueChanges.subscribe(changes => {
+      this.resultTagD = '';
+      this.checkChangesTag(changes);
+    });
+    this.tagFormS.valueChanges.subscribe(changes => {
+      this.resultTagS = '';
+      this.checkChangesTag(changes);
+    });
+    this.tagFormW.valueChanges.subscribe(changes => {
+      this.resultTagW = '';
+      this.checkChangesTag(changes);
+    });
+    this.tagFormN.valueChanges.subscribe(changes => {
+      this.resultTagN = '';
+      this.checkChangesTag(changes);
+    });
+    this.tagFormR.valueChanges.subscribe(changes => {
+      this.resultTagR = '';
+      this.checkChangesTag(changes);
+    });
+    this.tagsFormGlobal.valueChanges.subscribe(changes => this.checkChangesTagsGlobal(changes));
 
     this.setRatioDefault();
   }
@@ -955,6 +1410,37 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       const popup = this.popupBuilder.poListBoxRef.listboxItemList.nativeElement.children[0].children[0];
       this.setColorsBackAndText(popup, this.ratioPopup, '--background', '--color');
     }
+    if (item === 'multiselect') {
+      this.setColorsBackAndText(
+        this.multiselectDefault.nativeElement,
+        this.ratioMultiselect,
+        '--background',
+        '--text-color-placeholder'
+      );
+    }
+    if (item === 'combo') {
+      this.setColorsBackAndText(this.comboDefault.nativeElement, this.ratioCombo);
+    }
+    if (item === 'accordion') {
+      this.setColorsBackAndText(
+        this.accordionDefault.nativeElement,
+        this.ratioAccordion,
+        '--background-color',
+        '--color'
+      );
+    }
+    if (item === 'tag') {
+      this.tagSelected = 1;
+      this.tagActive = this.tagDefault;
+      this.formPropertyDictTag = this.formPropertyDictTagI;
+      this.tagForm = this.tagFormI;
+      this.setColorsBackAndText(
+        this.tagDefault.nativeElement,
+        this.ratioTagDefault,
+        '--color-info',
+        '--text-color-info'
+      );
+    }
   }
 
   switchIndividual() {
@@ -983,6 +1469,11 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       this.tooltipView = true;
       this.popupView = true;
       this.checkboxView = true;
+      this.multiselectView = true;
+      this.accordionView = true;
+      this.breadcrumbView = true;
+      this.comboView = true;
+      this.tagView = true;
     } else {
       this.botaoPrimaryView = false;
       this.switchView = false;
@@ -998,6 +1489,11 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       this.tooltipView = false;
       this.popupView = false;
       this.checkboxView = false;
+      this.multiselectView = false;
+      this.accordionView = false;
+      this.breadcrumbView = false;
+      this.comboView = false;
+      this.tagView = false;
     }
   }
 
@@ -1016,7 +1512,12 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       this.linkView ||
       this.tooltipView ||
       this.popupView ||
-      this.checkboxView
+      this.checkboxView ||
+      this.multiselectView ||
+      this.comboView ||
+      this.accordionView ||
+      this.breadcrumbView ||
+      this.tagView
     );
   }
 
@@ -1092,6 +1593,9 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
         }
         if (!this.changedColorPopup) {
           this.ratioPopup = this.setRatioComponent(this.changedColorPopup, colorBack, '#ffffff');
+        }
+        if (!this.changedColorAccordion) {
+          this.ratioAccordion = this.setRatioComponent(this.changedColorAccordion, '#ffffff', colorBack);
         }
       }
     });
@@ -1806,6 +2310,252 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
     }
   }
 
+  private checkChangesMultiselect(changes: { [key: string]: string }): void {
+    if (!this.isEmpty(changes)) {
+      this.resultMultiselect['nativeElement'].innerHTML = 'po-multiselect {<br>';
+
+      Object.keys(changes).forEach((fieldName: string) => {
+        let value;
+        if (typeof changes[fieldName] === 'number') {
+          value = `${changes[fieldName]}px`;
+        } else {
+          value = /color/i.test(fieldName) ? changes[fieldName] : `var(--${changes[fieldName]})`;
+        }
+        if (changes[fieldName]) {
+          this.multiselectComponent.inputElement.nativeElement.style.setProperty(
+            this.formPropertyDictMultiselect[fieldName],
+            value
+          );
+          this.multiselectDefault.nativeElement.style.setProperty(this.formPropertyDictMultiselect[fieldName], value);
+          this.multiselectHover.inputElement.nativeElement.style.setProperty(
+            this.formPropertyDictMultiselect[fieldName],
+            value
+          );
+          this.multiselectFocus.inputElement.nativeElement.style.setProperty(
+            this.formPropertyDictMultiselect[fieldName],
+            value
+          );
+          this.multiselectDisabled.inputElement.nativeElement.style.setProperty(
+            this.formPropertyDictMultiselect[fieldName],
+            value
+          );
+
+          this.resultMultiselect[
+            'nativeElement'
+          ].innerHTML += `${this.formPropertyDictMultiselect[fieldName]}: ${value};<br>`;
+          this.ratio = this.ratioMultiselect = this.checkChangesContrast(
+            changes,
+            fieldName,
+            this.ratioMultiselect,
+            'colorBackground'
+          );
+        }
+      });
+
+      this.resultMultiselect['nativeElement'].innerHTML += '}';
+    } else {
+      this.resultMultiselect['nativeElement'].innerHTML = '';
+    }
+  }
+
+  private checkChangesCombo(changes: { [key: string]: string }): void {
+    if (!this.isEmpty(changes)) {
+      this.resultCombo['nativeElement'].innerHTML = 'po-combo {<br>';
+
+      Object.keys(changes).forEach((fieldName: string) => {
+        let value;
+        if (typeof changes[fieldName] === 'number') {
+          value = `${changes[fieldName]}px`;
+        } else {
+          value = /color/i.test(fieldName) ? changes[fieldName] : `var(--${changes[fieldName]})`;
+        }
+        if (changes[fieldName]) {
+          this.comboComponent.inputEl.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], value);
+          this.comboDefault.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], value);
+          this.comboHover.inputEl.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], value);
+          this.comboHover.iconElement.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], value);
+          this.comboFocus.inputEl.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], value);
+          this.comboFocus.iconElement.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], value);
+          this.comboDisabled.inputEl.nativeElement.style.setProperty(this.formPropertyDictCombo[fieldName], value);
+
+          this.resultCombo['nativeElement'].innerHTML += `${this.formPropertyDictCombo[fieldName]}: ${value};<br>`;
+          this.ratio = this.ratioCombo = this.checkChangesContrast(
+            changes,
+            fieldName,
+            this.ratioCombo,
+            'colorBackground'
+          );
+        }
+      });
+
+      this.resultCombo['nativeElement'].innerHTML += '}';
+    } else {
+      this.resultCombo['nativeElement'].innerHTML = '';
+    }
+  }
+
+  private checkChangesAccordion(changes: { [key: string]: string }): void {
+    if (!this.isEmpty(changes)) {
+      this.resultAccordion['nativeElement'].innerHTML = 'po-accordion {<br>';
+
+      Object.keys(changes).forEach((fieldName: string) => {
+        let value;
+        if (typeof changes[fieldName] === 'number') {
+          value = `${changes[fieldName]}px`;
+        } else {
+          value = /color/i.test(fieldName) ? changes[fieldName] : `var(--${changes[fieldName]})`;
+        }
+        if (changes[fieldName]) {
+          this.accordionComponent.accordionsHeader
+            .toArray()[0]
+            .accordionElement.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], value);
+          this.accordionDefault.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], value);
+          this.accordionHover.accordionsHeader
+            .toArray()[0]
+            .accordionElement.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], value);
+          this.accordionFocus.accordionsHeader
+            .toArray()[0]
+            .accordionElement.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], value);
+          this.accordionPressed.accordionsHeader
+            .toArray()[0]
+            .accordionElement.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], value);
+          this.accordionDisabled.accordionsHeader
+            .toArray()[0]
+            .accordionElement.nativeElement.style.setProperty(this.formPropertyDictAccordion[fieldName], value);
+
+          this.resultAccordion[
+            'nativeElement'
+          ].innerHTML += `${this.formPropertyDictAccordion[fieldName]}: ${value};<br>`;
+          this.ratio = this.ratioAccordion = this.checkChangesContrast(
+            changes,
+            fieldName,
+            this.ratioAccordion,
+            'colorBackground'
+          );
+          if (fieldName === 'textColor') {
+            this.changedColorAccordion = true;
+          }
+        }
+      });
+
+      this.resultAccordion['nativeElement'].innerHTML += '}';
+    } else {
+      this.resultAccordion['nativeElement'].innerHTML = '';
+    }
+  }
+
+  private checkChangesBreadcrumb(changes: { [key: string]: string }): void {
+    if (!this.isEmpty(changes)) {
+      this.resultBreadcrumb['nativeElement'].innerHTML = 'po-breadcrumb {<br>';
+
+      Object.keys(changes).forEach((fieldName: string) => {
+        let value;
+        if (typeof changes[fieldName] === 'number') {
+          value = `${changes[fieldName]}px`;
+        } else {
+          value = /color/i.test(fieldName) ? changes[fieldName] : `var(--${changes[fieldName]})`;
+        }
+        if (changes[fieldName]) {
+          this.breadcrumbComponent.breadcrumbElement.nativeElement.style.setProperty(
+            this.formPropertyDictBreadcrumb[fieldName],
+            value
+          );
+          this.breadcrumbDefault.nativeElement.style.setProperty(this.formPropertyDictBreadcrumb[fieldName], value);
+
+          this.resultBreadcrumb[
+            'nativeElement'
+          ].innerHTML += `${this.formPropertyDictBreadcrumb[fieldName]}: ${value};<br>`;
+        }
+      });
+
+      this.resultBreadcrumb['nativeElement'].innerHTML += '}';
+    } else {
+      this.resultBreadcrumb['nativeElement'].innerHTML = '';
+    }
+  }
+
+  private checkChangesTag(changes: { [key: string]: string }): void {
+    if (!this.isEmpty(changes)) {
+      this.resultTag['nativeElement'].innerHTML = 'po-tag {<br>';
+      Object.keys(changes).forEach((fieldName: string) => {
+        let value;
+        if (typeof changes[fieldName] === 'number') {
+          value = `${changes[fieldName]}px`;
+        } else {
+          value = /color/i.test(fieldName) ? changes[fieldName] : `var(--${changes[fieldName]})`;
+        }
+        if (changes[fieldName]) {
+          this.tagActive.nativeElement.style.setProperty(this.formPropertyDictTag[fieldName], value);
+
+          this.ratio = this.ratioTag = this.checkChangesContrast(changes, fieldName, this.ratioTag, 'backgroundColor');
+          if (this.tagSelected === 1) {
+            this.tagComponent.poTag.nativeElement.style.setProperty(this.formPropertyDictTag[fieldName], value);
+            this.ratioTagDefault = this.ratioTag;
+            this.resultTagI += `${this.formPropertyDictTag[fieldName]}: ${value};<br>`;
+          } else if (this.tagSelected === 2) {
+            this.ratioTagDanger = this.ratioTag;
+            this.resultTagD += `${this.formPropertyDictTag[fieldName]}: ${value};<br>`;
+          } else if (this.tagSelected === 3) {
+            this.ratioTagSuccess = this.ratioTag;
+            this.resultTagS += `${this.formPropertyDictTag[fieldName]}: ${value};<br>`;
+          } else if (this.tagSelected === 4) {
+            this.ratioTagWarning = this.ratioTag;
+            this.resultTagW += `${this.formPropertyDictTag[fieldName]}: ${value};<br>`;
+          } else if (this.tagSelected === 5) {
+            this.ratioTagNeutral = this.ratioTag;
+            this.resultTagN += `${this.formPropertyDictTag[fieldName]}: ${value};<br>`;
+          } else if (this.tagSelected === 6) {
+            this.ratioTagRemovable = this.ratioTag;
+            this.resultTagR += `${this.formPropertyDictTag[fieldName]}: ${value};<br>`;
+            this.tagHover.nativeElement.style.setProperty(this.formPropertyDictTag[fieldName], value);
+            this.tagDisabled.nativeElement.style.setProperty(this.formPropertyDictTag[fieldName], value);
+          }
+          this.resultTag['nativeElement'].innerHTML = `po-tag {<br>${this.resultTagI || ''}${this.resultTagD || ''}${
+            this.resultTagS || ''
+          }${this.resultTagW || ''}${this.resultTagN || ''}${this.resultTagR || ''}`;
+        }
+      });
+
+      this.resultTag['nativeElement'].innerHTML += '}';
+    } else {
+      this.resultTag['nativeElement'].innerHTML = '';
+    }
+  }
+
+  private checkChangesTagsGlobal(changes: { [key: string]: string }): void {
+    if (!this.isEmpty(changes)) {
+      this.resultTagsGlobal['nativeElement'].innerHTML = 'po-tag {<br>';
+
+      Object.keys(changes).forEach((fieldName: string) => {
+        let value;
+        if (typeof changes[fieldName] === 'number') {
+          value = `${changes[fieldName]}px`;
+        } else {
+          value = /color/i.test(fieldName) ? changes[fieldName] : `var(--${changes[fieldName]})`;
+        }
+        if (changes[fieldName]) {
+          this.tagComponent.poTag.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], value);
+          this.tagDefault.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], value);
+          this.tagSuccess.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], value);
+          this.tagDanger.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], value);
+          this.tagWarning.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], value);
+          this.tagNeutral.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], value);
+          this.tagRemovable.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], value);
+          this.tagHover.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], value);
+          this.tagDisabled.nativeElement.style.setProperty(this.formPropertyDictTagsGlobal[fieldName], value);
+
+          this.resultTagsGlobal[
+            'nativeElement'
+          ].innerHTML += `${this.formPropertyDictTagsGlobal[fieldName]}: ${value};<br>`;
+        }
+      });
+
+      this.resultTagsGlobal['nativeElement'].innerHTML += '}';
+    } else {
+      this.resultTagsGlobal['nativeElement'].innerHTML = '';
+    }
+  }
+
   private checkChanges() {
     return (
       !!this.resultButtonD?.['nativeElement']?.innerHTML ||
@@ -1815,6 +2565,11 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       !!this.resultDisclaimer?.['nativeElement']?.innerHTML ||
       !!this.resultSwitch?.['nativeElement']?.innerHTML ||
       !!this.resultSelect?.['nativeElement']?.innerHTML ||
+      !!this.resultMultiselect?.['nativeElement']?.innerHTML ||
+      !!this.resultCombo?.['nativeElement']?.innerHTML ||
+      !!this.resultAccordion?.['nativeElement']?.innerHTML ||
+      !!this.resultTag?.['nativeElement']?.innerHTML ||
+      !!this.resultTagsGlobal?.['nativeElement']?.innerHTML ||
       !!this.resultTextarea?.['nativeElement']?.innerHTML ||
       !!this.resultDropdown?.['nativeElement']?.innerHTML ||
       !!this.resultDatepicker?.['nativeElement']?.innerHTML ||
@@ -1851,13 +2606,20 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
   private setRatioDefault() {
     this.ratioButton = this.setRatioComponent(false, '#2c3739', '#ffffff');
     this.ratioDisclaimer = this.setRatioComponent(false, '#f2eaf6', '#2c3739');
-    this.ratioDatepicker = this.ratioTextarea = this.ratioInput = this.ratioSelect = this.setRatioComponent(
+    this.ratioDatepicker = this.ratioTextarea = this.ratioInput = this.ratioSelect = this.ratioMultiselect = this.ratioCombo = this.setRatioComponent(
       false,
       '#fbfbfb',
       '#1d2426'
     );
     this.ratioTooltip = this.setRatioComponent(false, '#2c3739', '#ffffff');
     this.ratioPopup = this.setRatioComponent(false, '#ffffff', '#753399');
+    this.ratioAccordion = this.setRatioComponent(false, '#753399', '#ffffff');
+    this.ratioTagDefault = this.setRatioComponent(false, '#e3e9f7', '#173782');
+    this.ratioTagDanger = this.setRatioComponent(false, '#f6e6e5', '#72211d');
+    this.ratioTagSuccess = this.setRatioComponent(false, '#def7ed', '#0f5236');
+    this.ratioTagWarning = this.setRatioComponent(false, '#fcf6e3', '#473400');
+    this.ratioTagNeutral = this.setRatioComponent(false, '#eceeee', '#2c3739');
+    this.ratioTagRemovable = this.setRatioComponent(false, '#f2eaf6', '#2c3739');
     this.cdr.detectChanges();
   }
 
@@ -1876,7 +2638,12 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       !this.linkView ||
       !this.tooltipView ||
       !this.popupView ||
-      !this.checkboxView
+      !this.checkboxView ||
+      !this.multiselectView ||
+      !this.comboView ||
+      !this.accordionView ||
+      !this.breadcrumbView ||
+      !this.tagView
     );
   }
 
@@ -1895,7 +2662,12 @@ export class ThemeBuilderComponent implements AfterViewInit, OnInit {
       this.linkView &&
       this.tooltipView &&
       this.popupView &&
-      this.checkboxView
+      this.checkboxView &&
+      this.multiselectView &&
+      this.comboView &&
+      this.accordionView &&
+      this.breadcrumbView &&
+      this.tagView
     );
   }
 

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.html
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.html
@@ -1,5 +1,6 @@
 <div class="po-accordion-item-header">
   <button
+    #accordionElement
     [disabled]="disabledItem"
     [attr.aria-label]="label"
     [attr.aria-expanded]="expanded || false"

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { PoLanguageService } from '../../../services/po-language';
 import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
@@ -9,6 +9,8 @@ import { poLocaleDefault } from '../../../services/po-language/po-language.const
 })
 export class PoAccordionItemHeaderComponent {
   private language: string = poLocaleDefault;
+
+  @ViewChild('accordionElement', { read: ElementRef, static: true }) accordionElement: ElementRef;
 
   @Input('p-expanded') expanded: boolean = false;
 

--- a/projects/ui/src/lib/components/po-accordion/po-accordion.component.html
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion.component.html
@@ -1,4 +1,4 @@
-<div class="po-accordion po-container po-container-no-padding">
+<div class="po-accordion">
   <div *ngIf="showManagerAccordion && poAccordionItems.length > 1" class="po-accordion-manager">
     <po-accordion-manager
       [p-expanded-all-items]="expandedAllItems"

--- a/projects/ui/src/lib/components/po-accordion/po-accordion.component.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion.component.ts
@@ -1,11 +1,12 @@
-import { Component, ContentChildren, QueryList, OnDestroy } from '@angular/core';
+import { Component, ContentChildren, OnDestroy, QueryList, ViewChildren } from '@angular/core';
 
 import { Subscription } from 'rxjs';
 
+import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { PoAccordionBaseComponent } from './po-accordion-base.component';
+import { PoAccordionItemHeaderComponent } from './po-accordion-item-header/po-accordion-item-header.component';
 import { PoAccordionItemComponent } from './po-accordion-item/po-accordion-item.component';
 import { PoAccordionService } from './services/po-accordion.service';
-import { PoLanguageService } from '../../services/po-language/po-language.service';
 
 /**
  * @docsExtends PoAccordionBaseComponent
@@ -35,6 +36,7 @@ import { PoLanguageService } from '../../services/po-language/po-language.servic
   providers: [PoAccordionService]
 })
 export class PoAccordionComponent extends PoAccordionBaseComponent implements OnDestroy {
+  @ViewChildren(PoAccordionItemHeaderComponent) accordionsHeader: QueryList<PoAccordionItemHeaderComponent>;
   @ContentChildren(PoAccordionItemComponent) poAccordionItems: QueryList<PoAccordionItemComponent>;
 
   expandedAllItems = false;


### PR DESCRIPTION
Construtor de temas e Accordion

DTHFUI-7944
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Accordion não customiza o icone da seta nos estados de hover e pressed e não existe os componentes de multiselect, combo, accordion, breadcrumb e tag no construtor de temas.

**Qual o novo comportamento?**
Accordion customiza o icone da seta nos estados de hover e pressed e é implementado os componentes de multiselect, combo, accordion, breadcrumb e tag no construtor de temas.

PR Style: https://github.com/po-ui/po-style/pull/473

**Simulação**
Validar os novos componentes no construtor de temas e verificar sample do accordion