### PR TITLE
feat(lookup): fazendo lookup cancelar requisiçoes ao fechar modal

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -265,7 +265,8 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
     this.language = languageService.getShortLanguage();
   }
 
-  ngOnDestroy() {
+  // Metodo responsavel por cancelar todas as requisiçoes pendentes
+  unsubscribeAllSubscriptions() {
     if (this.filterSubscription) {
       this.filterSubscription.unsubscribe();
     }
@@ -277,6 +278,10 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
     if (this.showMoreSubscription) {
       this.showMoreSubscription.unsubscribe();
     }
+  }
+
+  ngOnDestroy() {
+    this.unsubscribeAllSubscriptions();
   }
 
   ngOnInit() {
@@ -336,7 +341,7 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
 
   search(): void {
     this.page = 1;
-
+    this.unsubscribeAllSubscriptions();
     if (this.searchValue) {
       this.isLoading = true;
       this.disclaimerGroup.disclaimers = [];
@@ -348,6 +353,9 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
   }
 
   searchFilteredItems(): void {
+    if (this.isLoading) {
+      this.unsubscribeAllSubscriptions();
+    }
     this.searchSubscription = this.getFilteredItems(this.searchValue)
       .pipe(
         catchError(error => {
@@ -362,6 +370,10 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
   }
 
   showMoreEvent() {
+    if (this.isLoading) {
+      this.unsubscribeAllSubscriptions();
+    }
+
     this.page++;
     this.isLoading = true;
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -5,6 +5,7 @@
   [p-primary-action]="isAdvancedFilter ? primaryActionAdvancedFilter : primaryAction"
   [p-secondary-action]="isAdvancedFilter ? secondaryActionAdvancedFilter : secondaryAction"
   [p-title]="isAdvancedFilter ? advancedFilterModalTitle : title"
+  (p-close)="unsubscribeAllSubscriptions()"
 >
   <div [hidden]="isAdvancedFilter">
     <po-field-container class="po-lookup-header po-pull-right" [p-optional]="false">


### PR DESCRIPTION
**< po-lookup >**

**DTHFUI-8000**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Na modal do lookup pode ser feita múltiplas requisições podendo gerar estranhezas caso não haja uma demora considerável no lookup, e no pior dos casos pode uma requisição sobrepor uma requisição.

**Qual o novo comportamento?**
Caso o usuário tente fazer uma nova requisição ( dentro da modal do lookup ) e caso já tenha uma requisição pendente essa requisição pendente será cancelada e só logo após de ser cancelada será iniciada a nova e caso o usuário saia da modal serão canceladas as requisições pendentes.

**Simulação**
Tela de carregamento sumindo sem a requisição ter terminado
https://app.screencast.com/nyLgG1K2tP6Mp
