### PR TITLE
feat(loading): ajusta redimensionamento do loading

### DIFF
--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
@@ -80,17 +80,9 @@
     </ul>
   </ng-container>
 
-  <div *ngIf="isServerSearching && type !== 'action'" class="po-text-center">
-    <ng-container *ngIf="infiniteLoading; then scrollLoadingTemplate; else defaultLoadingTemplate"></ng-container>
+  <div *ngIf="isServerSearching && type !== 'action'" [class.po-listbox-container-loading-default]="!infiniteLoading">
+    <po-loading-overlay p-size="md"></po-loading-overlay>
   </div>
-
-  <ng-template #scrollLoadingTemplate>
-    <po-loading-overlay class="po-listbox-container-loading-scroll"></po-loading-overlay>
-  </ng-template>
-
-  <ng-template #defaultLoadingTemplate>
-    <po-loading class="po-listbox-container-loading-default"></po-loading>
-  </ng-template>
 
   <ng-template #noDataTemplate>
     <div

--- a/projects/ui/src/lib/components/po-loading/po-loading-base.component.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading-base.component.ts
@@ -1,6 +1,7 @@
 import { Input, Directive } from '@angular/core';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { PoLoadingLiterals } from './interfaces/po-loading-literals.interface';
+import { PoLoadingIconSize } from './po-loading-icon/po-loading-icon-size-enum';
 export const poLoadingLiteralsDefault = {
   en: <PoLoadingLiterals>{
     loading: 'Loading'
@@ -27,6 +28,7 @@ export const poLoadingLiteralsDefault = {
 @Directive()
 export class PoLoadingBaseComponent {
   private _text?: string;
+  private _size?: PoLoadingIconSize;
 
   /**
    * Texto a ser exibido no componente.
@@ -38,6 +40,26 @@ export class PoLoadingBaseComponent {
   get text(): string {
     return this._text;
   }
+
+  /**
+   * Define o tamanho do ícone.
+   *
+   * @default `lg`
+   *
+   * Valores válidos:
+   *  - `xs`: tamanho `extra small`
+   *  - `sm`: tamanho `small`
+   *  - `md`: tamanho `medium`
+   *  - `lg`: tamanho `large`
+   */
+  @Input('p-size') set size(value: string) {
+    this._size = PoLoadingIconSize[value] ? PoLoadingIconSize[value] : PoLoadingIconSize.lg;
+  }
+
+  get size(): string {
+    return this._size;
+  }
+
   constructor(private languageService: PoLanguageService) {
     this.text = this.getTextDefault();
   }

--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.spec.ts
@@ -42,6 +42,30 @@ describe('PoLoadingOverlayBaseComponent:', () => {
       spyOn(component, <any>'getTextDefault');
       expectPropertiesValues(component, 'text', textValidValues, textValidValues);
     });
+
+    it('p-size: set size with `lg', () => {
+      component.size = null;
+
+      expect(component.size).toBe('lg');
+    });
+
+    it('p-size: set size with `sm', () => {
+      component.size = 'sm';
+
+      expect(component.size).toBe('sm');
+    });
+
+    it('p-size: set size with `xs', () => {
+      component.size = 'xs';
+
+      expect(component.size).toBe('xs');
+    });
+
+    it('p-size: set size with `md', () => {
+      component.size = 'md';
+
+      expect(component.size).toBe('md');
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.ts
@@ -32,6 +32,7 @@ export const poLoadingOverlayLiteralsDefault = {
 export class PoLoadingOverlayBaseComponent {
   private _screenLock?: boolean = false;
   private _text?: string;
+  private _size?: string;
 
   /**
    * @optional
@@ -80,6 +81,23 @@ export class PoLoadingOverlayBaseComponent {
 
   get text(): string {
     return this._text;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o tamnho do componente.
+   *
+   * @default `lg`
+   */
+  @Input('p-size') set size(value: string | null) {
+    this._size = value === '' || !value ? 'lg' : value;
+  }
+
+  get size(): string {
+    return this._size;
   }
 
   constructor(private languageService: PoLanguageService) {

--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay.component.html
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay.component.html
@@ -1,3 +1,3 @@
 <po-overlay [p-screen-lock]="screenLock">
-  <po-loading [p-text]="text"></po-loading>
+  <po-loading [p-text]="text" [p-size]="size"></po-loading>
 </po-overlay>

--- a/projects/ui/src/lib/components/po-loading/po-loading.component.html
+++ b/projects/ui/src/lib/components/po-loading/po-loading.component.html
@@ -1,11 +1,10 @@
-<div class="po-loading">
-  <po-loading-icon p-size="lg"></po-loading-icon>
-  <ng-template [ngIf]="text">
-    <span class="po-loading-label po-text-ellipsis"
-      >{{ text }}
-      <div class="po-loading-dot" aria-hidden="true">.</div>
-      <div class="po-loading-dot" aria-hidden="true">.</div>
-      <div class="po-loading-dot" aria-hidden="true">.</div>
-    </span>
-  </ng-template>
+<div class="po-loading po-loading-{{ size }}">
+  <po-loading-icon [p-size]="size"></po-loading-icon>
+
+  <span *ngIf="text" class="po-loading-label po-text-ellipsis"
+    >{{ text }}
+    <div class="po-loading-dot" aria-hidden="true">.</div>
+    <div class="po-loading-dot" aria-hidden="true">.</div>
+    <div class="po-loading-dot" aria-hidden="true">.</div>
+  </span>
 </div>

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -20,6 +20,8 @@ import { PoTableService } from './services/po-table.service';
 class PoTableComponent extends PoTableBaseComponent {
   checkInfiniteScroll() {}
   calculateHeightTableContainer(height) {}
+  changeSizeLoading() {}
+  changeHeaderWidth() {}
 }
 
 describe('PoTableBaseComponent:', () => {
@@ -530,6 +532,39 @@ describe('PoTableBaseComponent:', () => {
       component.ngOnChanges(changes);
 
       expect(component.calculateHeightTableContainer).not.toHaveBeenCalled();
+    });
+
+    it('ngOnChanges: should call `changeSizeLoading` if height is changed', () => {
+      spyOn(component, 'changeSizeLoading');
+      const height = 400;
+      const changes = <any>{ height };
+      component.height = height;
+
+      component.ngOnChanges(changes);
+
+      expect(component['changeSizeLoading']).toHaveBeenCalled();
+    });
+
+    it('ngOnChanges: should call `changeSizeLoading` if there is items', () => {
+      spyOn(component, 'changeSizeLoading');
+      items = component.items;
+      const changes = <any>{ items };
+      component.items = items;
+
+      component.ngOnChanges(changes);
+
+      expect(component['changeSizeLoading']).toHaveBeenCalled();
+    });
+
+    it('ngOnChanges: should´n call `changeSizeLoading` if there is no items', () => {
+      spyOn(component, 'changeSizeLoading');
+      items = null;
+      const changes = <any>{ items };
+      component.items = null;
+
+      component.ngOnChanges(changes);
+
+      expect(component['changeSizeLoading']).toHaveBeenCalled();
     });
 
     describe('isEverySelected:', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -451,6 +451,7 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   itemsSelected: Array<any> = [];
   paramsFilter: {};
   filteredItems: Array<any> = [];
+  initialized = false;
   private initialVisibleColumns: boolean = false;
   private _spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
   private _filteredColumns: Array<string>;
@@ -963,6 +964,11 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     if (changes.height) {
       this.calculateHeightTableContainer(this.height);
     }
+
+    if ((changes.height || changes.items) && this.initialized) {
+      this.changeHeaderWidth();
+    }
+    this.changeSizeLoading();
   }
 
   selectAllRows() {
@@ -1277,4 +1283,8 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   protected abstract calculateHeightTableContainer(height);
 
   protected abstract checkInfiniteScroll();
+
+  protected abstract changeSizeLoading();
+
+  protected abstract changeHeaderWidth();
 }

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -50,11 +50,8 @@
 </po-container>
 
 <ng-template #tableContainerTemplate>
-  <div [class.po-table-container-relative]="loading">
-    <div *ngIf="loading" class="po-table-overlay">
-      <po-loading class="po-table-overlay-content" [p-text]="literals.loadingData"></po-loading>
-    </div>
-
+  <div [class.po-table-container-sticky]="loading">
+    <po-loading-overlay *ngIf="loading" [p-text]="literals.loadingData" [p-size]="sizeLoading"></po-loading-overlay>
     <div class="po-table-main-container">
       <div
         #tableWrapper
@@ -865,7 +862,7 @@
 </ng-template>
 
 <ng-template #noColumnsWithHeight>
-  <div class="po-table-header-fixed-inner" [style.width.px]="noColumnsHeader?.nativeElement.offsetWidth">
+  <div class="po-table-header-fixed-inner" [style.width.px]="headerWidth">
     {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
   </div>
 </ng-template>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -2156,9 +2156,8 @@ describe('PoTableComponent:', () => {
 
       fixture.detectChanges();
 
-      expect(nativeElement.querySelector('div.po-table-container-relative')).toBeTruthy();
-      expect(nativeElement.querySelector('div.po-table-overlay')).toBeTruthy();
-      expect(nativeElement.querySelector('po-loading.po-table-overlay-content')).toBeTruthy();
+      expect(nativeElement.querySelector('div.po-table-container-sticky')).toBeTruthy();
+      expect(nativeElement.querySelector('po-loading-overlay')).toBeTruthy();
     });
 
     it('shouldn`t show loading on table', () => {
@@ -2166,9 +2165,8 @@ describe('PoTableComponent:', () => {
 
       fixture.detectChanges();
 
-      expect(nativeElement.querySelector('div.po-table-container-relative')).toBeFalsy();
-      expect(nativeElement.querySelector('div.po-table-overlay')).toBeFalsy();
-      expect(nativeElement.querySelector('po-loading.po-table-overlay-content')).toBeFalsy();
+      expect(nativeElement.querySelector('div.po-table-container-sticky')).toBeFalsy();
+      expect(nativeElement.querySelector('po-loading-overlay')).toBeFalsy();
     });
 
     it('should show td with `po-table-column-actions` class if has more than 1 action', () => {
@@ -3194,5 +3192,83 @@ describe('PoTableComponent:', () => {
     component.draggable = false;
 
     expect(component['isDraggable']).toBeFalse();
+  });
+
+  it('changeSizeLoading: should set sm  if height of parent element is smaller or equal 150px', () => {
+    const fakeTable = {
+      sizeLoading: 'sm',
+      tableWrapperElement: {
+        nativeElement: {
+          offsetHeight: 150
+        }
+      }
+    };
+
+    component['changeSizeLoading'].call(fakeTable);
+
+    expect(fakeTable.sizeLoading).toBe('sm');
+  });
+
+  it('changeSizeLoading: should set lg if height of parent element is higher or equal 260px', () => {
+    const fakeTable = {
+      sizeLoading: 'sm',
+      tableWrapperElement: {
+        nativeElement: {
+          offsetHeight: 260
+        }
+      }
+    };
+
+    component['changeSizeLoading'].call(fakeTable);
+
+    expect(fakeTable.sizeLoading).toBe('lg');
+  });
+
+  it('changeSizeLoading: should set md  if height of parent element is between 150px and 260px', () => {
+    const fakeTable = {
+      sizeLoading: 'sm',
+      tableWrapperElement: {
+        nativeElement: {
+          offsetHeight: 200
+        }
+      }
+    };
+
+    component['changeSizeLoading'].call(fakeTable);
+
+    expect(fakeTable.sizeLoading).toBe('md');
+  });
+
+  it('changeSizeLoading: should set lg if there is no height in parentElement', () => {
+    const fakeTable = {
+      sizeLoading: 'sm',
+      tableTemplate: {
+        nativeElement: {
+          parentElement: {
+            anotherProperty: null
+          }
+        }
+      }
+    };
+
+    component['changeSizeLoading'].call(fakeTable);
+
+    expect(fakeTable.sizeLoading).toBe('lg');
+  });
+
+  it('changeHeaderWidth: should set width if noColumnsHeader ', () => {
+    const fakeTable = {
+      headerWidth: null,
+      noColumnsHeader: {
+        nativeElement: {
+          offsetWidth: 300
+        }
+      },
+      changeDetector: { detectChanges: () => {} }
+    };
+
+    component['changeHeaderWidth'].call(fakeTable);
+
+    expect(fakeTable.headerWidth).toBe(300);
   });
 });

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -141,6 +141,8 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   inputFieldValue = '';
   JSON: JSON;
   newOrderColumns: Array<PoTableColumn>;
+  sizeLoading: string = 'sm';
+  headerWidth: number;
 
   close: PoModalAction = {
     action: () => {
@@ -162,7 +164,6 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   private differ;
   private footerHeight;
   private headerHeight;
-  private initialized = false;
   private timeoutResize;
   private visibleElement = false;
   private scrollEvent$: Observable<any>;
@@ -295,8 +296,17 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.idRadio = `po-radio-${uuid()}`;
   }
 
+  changeHeaderWidth() {
+    if (this.noColumnsHeader) {
+      this.headerWidth = this.noColumnsHeader?.nativeElement.offsetWidth;
+    }
+    this.changeDetector.detectChanges();
+  }
+
   ngAfterViewInit() {
     this.initialized = true;
+    this.changeHeaderWidth();
+    this.changeSizeLoading();
   }
 
   showMoreInfiniteScroll({ target }): void {
@@ -309,6 +319,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   ngDoCheck() {
     this.checkChangesItems();
     this.verifyCalculateHeightTableContainer();
+
     // Permite que os cabeçalhos sejam calculados na primeira vez que o componente torna-se visível,
     // evitando com isso, problemas com Tabs ou Divs que iniciem escondidas.
     if (this.tableWrapperElement?.nativeElement.offsetWidth && !this.visibleElement && this.initialized) {
@@ -723,6 +734,18 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.modalDelete.close();
     this.poNotification.success(this.literals.deleteSuccessful);
     this.eventDelete.emit(newItemsFiltered);
+  }
+
+  protected changeSizeLoading() {
+    const tableHeight = this.tableWrapperElement?.nativeElement?.offsetHeight;
+
+    if (tableHeight <= 150) {
+      this.sizeLoading = 'sm';
+    } else if (tableHeight > 150 && tableHeight < 260) {
+      this.sizeLoading = 'md';
+    } else {
+      this.sizeLoading = 'lg';
+    }
   }
 
   private checkChangesItems() {


### PR DESCRIPTION
**loading-overlay**

**DTHFUI-8010**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componentes listbox e table apresentam o loading desposicionado.

**Qual o novo comportamento?**
Adicionado propriedade p-size e ajustado posicionamento do loading

**Simulação**
Uso dos samples do po-combo e po-table no App em anexo
[app.zip](https://github.com/po-ui/po-angular/files/13530195/app.zip)

[po-style](https://github.com/po-ui/po-style/pull/476)


