### PR TITLE
fix(dynamic-search): limpa campo de busca rápida

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.html
@@ -1,4 +1,5 @@
 <po-page-list
+  #poPageList
   [p-actions]="actions"
   [p-breadcrumb]="breadcrumb"
   [p-disclaimer-group]="disclaimerGroup"
@@ -10,7 +11,7 @@
     [p-filters]="filters"
     [p-keep-filters]="keepFilters"
     [p-literals]="advancedFilterLiterals"
-    (p-search-event)="onAdvancedSearch($event)"
+    (p-search-event)="onAdvancedSearch($event, true)"
   >
   </po-advanced-filter>
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -246,6 +246,30 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(component['convertToFilters']).toHaveBeenCalledWith(filters);
     });
 
+    it(`onAdvancedSearch: should call 'clearInputSearch' if isAdvancedSearch is true`, () => {
+      const fakeThis = {
+        setDisclaimers: () => ['test'],
+        _disclaimerGroup: {
+          disclaimers: ['test']
+        },
+        setFilters: () => {},
+        advancedSearch: {
+          emit: () => {}
+        },
+        poPageList: {
+          clearInputSearch: () => {}
+        }
+      };
+      const filteredItems = { filter: 'fakeFilter', optionsService: 'fakeOptionsService' };
+      const isAdvancedSearch = true;
+
+      spyOn(fakeThis.poPageList, 'clearInputSearch');
+
+      component.onAdvancedSearch.call(fakeThis, filteredItems, isAdvancedSearch);
+
+      expect(fakeThis.poPageList.clearInputSearch).toHaveBeenCalled();
+    });
+
     it(`setFilters: should update filters value if the objects are compatible`, () => {
       const filterThatWillBeApplied = { city: 'Ontario' };
       const formattedFilters = [{ property: 'city', value: 'Ontario' }];

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -8,7 +8,8 @@ import {
   PoLanguageService,
   PoPageFilter,
   PoDisclaimerGroupRemoveAction,
-  PoComboOption
+  PoComboOption,
+  PoPageListComponent
 } from '@po-ui/ng-components';
 
 import { capitalizeFirstLetter, getBrowserLanguage } from '../../utils/util';
@@ -44,6 +45,7 @@ type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicSearchOptions);
 })
 export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseComponent implements OnInit, OnDestroy {
   @ViewChild(PoAdvancedFilterComponent, { static: true }) poAdvancedFilter: PoAdvancedFilterComponent;
+  @ViewChild(PoPageListComponent, { static: true }) poPageList: PoPageListComponent;
 
   private loadSubscription: Subscription;
 
@@ -147,7 +149,7 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
     this.poAdvancedFilter.open();
   }
 
-  onAdvancedSearch(filteredItems) {
+  onAdvancedSearch(filteredItems, isAdvancedSearch?) {
     const { filter, optionsService } = filteredItems;
 
     this._disclaimerGroup.disclaimers = this.setDisclaimers(filter, optionsService);
@@ -155,6 +157,10 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
     this.setFilters(filter);
 
     this.advancedSearch.emit(filter);
+
+    if (isAdvancedSearch) {
+      this.poPageList.clearInputSearch();
+    }
   }
 
   private getDisclaimersWithoutQuickSearch() {


### PR DESCRIPTION
**dynamic-page**

**DTHFUI-6660**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não apaga input de busca rapida após realizar busca avançada

**Qual o novo comportamento?**
Apaga input de busca rapida após realizar busca avançada


**Simulação**
buildar antes de testar o app
[app.zip](https://github.com/po-ui/po-angular/files/13715709/app.zip)
