### PR TITLE
feat(PoDynamicView): Melhoria no PoDynamicView para Exibição Personalizada de Valores Booleanos.

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
@@ -230,4 +230,10 @@ export interface PoDynamicViewField extends PoDynamicField {
    * [guia de API do PO UI](https://po-ui.io/guides/api).
    */
   searchService?: string | PoDynamicViewRequest;
+
+  /** Texto exibido quando o valor do componente for *true*. */
+  booleanTrue?: string;
+
+  /** Texto exibido quando o valor do componente for *false*. */
+  booleanFalse?: string;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
@@ -247,32 +247,75 @@ describe('PoDynamicViewComponent:', () => {
       expect(component['getVisibleFields']).toHaveBeenCalled();
     });
 
-    it(`setFieldValue: should return the label of the selected option if options exist and a match is found`, () => {
-      const field = {
-        value: 'value1',
-        options: [
-          { value: 'value1', label: 'label1' },
-          { value: 'value2', label: 'label2' },
-          { value: 'value3', label: 'label3' }
-        ]
-      };
+    describe('setFieldValue:', () => {
+      it(`should return the label of the selected option if options exist and a match is found`, () => {
+        const field = {
+          value: 'value1',
+          options: [
+            { value: 'value1', label: 'label1' },
+            { value: 'value2', label: 'label2' },
+            { value: 'value3', label: 'label3' }
+          ]
+        };
 
-      field.value = 'value2';
-      expect(component.setFieldValue(field)).toEqual('label2');
-    });
+        field.value = 'value2';
+        expect(component.setFieldValue(field)).toEqual('label2');
+      });
 
-    it(`setFieldValue: should return the field value if options exist but no match is found'`, () => {
-      const field = {
-        value: 'value1',
-        options: [
-          { value: 'value1', label: 'label1' },
-          { value: 'value2', label: 'label2' },
-          { value: 'value3', label: 'label3' }
-        ]
-      };
+      it(`should return the field value if options exist but no match is found'`, () => {
+        const field = {
+          value: 'value1',
+          options: [
+            { value: 'value1', label: 'label1' },
+            { value: 'value2', label: 'label2' },
+            { value: 'value3', label: 'label3' }
+          ]
+        };
 
-      field.value = 'value4';
-      expect(component.setFieldValue(field)).toEqual('value4');
+        field.value = 'value4';
+        expect(component.setFieldValue(field)).toEqual('value4');
+      });
+      it('should return the value of booleanTrue when the field value is true', () => {
+        const field = {
+          property: 'active',
+          type: 'boolean',
+          value: true,
+          booleanTrue: 'Ativo',
+          booleanFalse: 'Inativo'
+        };
+        expect(component.setFieldValue(field)).toEqual('Ativo');
+      });
+
+      it('should return the value of booleanFalse when the field value is false', () => {
+        const field = {
+          property: 'active',
+          type: 'boolean',
+          value: false,
+          booleanTrue: 'Ativo',
+          booleanFalse: 'Inativo'
+        };
+        expect(component.setFieldValue(field)).toEqual('Inativo');
+      });
+
+      it('should return "True" when the field value is true and booleanTrue is undefined', () => {
+        const field = {
+          property: 'active',
+          type: 'boolean',
+          value: true,
+          booleanFalse: 'Inativo'
+        };
+        expect(component.setFieldValue(field)).toEqual(true);
+      });
+
+      it('should return "False" when the field value is false and booleanFalse is undefined', () => {
+        const field = {
+          property: 'active',
+          type: 'boolean',
+          value: false,
+          booleanTrue: 'Ativo'
+        };
+        expect(component.setFieldValue(field)).toEqual(false);
+      });
     });
   });
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
@@ -66,6 +66,8 @@ export class PoDynamicViewComponent extends PoDynamicViewBaseComponent implement
     if (field.options) {
       const selectedOption = field.options.find(option => option.value === field.value);
       return selectedOption ? selectedOption.label : field.value;
+    } else if (field.type === 'boolean' && 'booleanTrue' in field && 'booleanFalse' in field) {
+      return field.value ? field.booleanTrue : field.booleanFalse;
     } else {
       return field.value;
     }


### PR DESCRIPTION
 Implementa exibição personalizada para campos booleanos no PoDynamicView, respeitando as propriedades booleanTrue e booleanFalse

**< PoDynamicView>**

**< #1913 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente, o PoDynamicView trata campos booleanos exibindo os valores padrão de true ou false. Isso pode não ser ideal para a experiência do usuário, pois esses valores são técnicos e podem não transmitir claramente o significado pretendido no contexto de negócios da aplicação.

**Qual o novo comportamento?**
Com a nova implementação, o PoDynamicView passará a exibir valores personalizados para campos booleanos, baseando-se nas propriedades booleanTrue e booleanFalse do campo. Isso permite que valores como 'Ativo'/'Inativo', 'Sim'/'Não', ou qualquer outro par de valores significativos sejam exibidos no lugar de true/false, melhorando a legibilidade e a experiência do usuário.

**Simulação**
Para simular o novo comportamento, defina um campo booleano em um PoDynamicView com as propriedades booleanTrue e booleanFalse. Por exemplo:

```const dynamicViewFields: PoDynamicViewField[] = [
  {
    property: 'status',
    type: 'boolean',
    booleanTrue: 'Ativo',
    booleanFalse: 'Inativo'
  }
];

// O PoDynamicView agora exibirá 'Ativo' se o valor for true, e 'Inativo' se for false.```