### PR TITLE
feat(tag): ajusta area de click minima

### DIFF
--- a/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
@@ -77,18 +77,13 @@ export class PoTagBaseComponent {
   @Input('p-value') value: string;
 
   /**
-   * @deprecated 16.x.x
-   *
    * @optional
    *
    * @description
    *
-   * **Deprecated 16.x.x**.
-   *
-   * > Por regras de acessibilidade a tag não terá mais evento de click. Indicamos o uso do `Po-button` ou `Po-link`
-   * caso deseje esse comportamento.
-   *
    * Ação que será executada ao clicar sobre o `po-tag` e que receberá como parâmetro um objeto contendo o seu valor e tipo.
+   *
+   * O evento de click só funciona se a tag não for removível.
    */
   @Output('p-click') click: EventEmitter<any> = new EventEmitter<PoTagItem>();
 

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.html
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.html
@@ -5,62 +5,68 @@
 
   <div class="po-tag-sub-container">
     <div
-      #poTag
-      class="po-tag"
-      [attr.role]="isClickable && !disabled ? 'button' : ''"
+      #poTagWrapper
+      class="po-tag-wrapper"
       [class.po-clickable]="isClickable && !disabled && !removable"
-      [class.po-tag-inverse]="inverse && !type && !customTextColor && !removable"
-      [class.po-tag-removable]="removable"
-      [class.po-tag-disabled]="disabled && removable"
-      [ngClass]="tagColor"
-      [ngStyle]="styleTag()"
-      [tabindex]="isClickable && !removable ? 0 : -1"
-      (click)="onClick()"
+      [attr.role]="isClickable && !disabled && !removable ? 'button' : ''"
       (keydown.enter)="onKeyPressed($event)"
       (keydown.space)="$event.preventDefault()"
       (keyup.space)="onKeyPressed($event)"
+      (click)="onClick()"
+      [tabindex]="isClickable && !removable ? 0 : -1"
     >
-      <po-icon
-        *ngIf="icon && !removable"
-        class="po-tag-icon"
-        [p-icon]="!type ? icon : iconFromType"
-        [ngStyle]="
-          !tagColor && inverse && !customTextColor
-            ? { 'color': customColor }
-            : !type && customTextColor
-            ? { 'color': customTextColor }
-            : ''
-        "
+      <div
+        #poTag
+        class="po-tag"
+        [class.po-clickable]="isClickable && !disabled && !removable"
+        [class.po-tag-inverse]="inverse && !type && !customTextColor && !removable"
+        [class.po-tag-removable]="removable"
+        [class.po-tag-disabled]="disabled && removable"
+        [ngClass]="tagColor"
+        [ngStyle]="styleTag()"
       >
-      </po-icon>
-
-      <div #tagContainer class="po-tag-value" [p-tooltip]="getWidthTag() ? value : ''" p-tooltip-position="top">
-        <span
+        <po-icon
+          *ngIf="icon && !removable"
+          class="po-tag-icon"
+          [p-icon]="!type ? icon : iconFromType"
           [ngStyle]="
             !tagColor && inverse && !customTextColor
               ? { 'color': customColor }
-              : !type && customTextColor && !removable
+              : !type && customTextColor
               ? { 'color': customTextColor }
               : ''
           "
-          >{{ value }}</span
         >
-      </div>
+        </po-icon>
 
-      <span
-        #tagClose
-        *ngIf="removable"
-        p-tooltip-position="top"
-        [p-tooltip]="literals.remove"
-        [attr.aria-label]="setAriaLabel()"
-        class="po-tag-remove po-icon po-icon-close"
-        [class.po-clickable]="!disabled"
-        [tabindex]="!disabled ? 0 : -1"
-        [attr.role]="!disabled ? 'button' : ''"
-        (click)="onClose()"
-        (keydown.enter)="onClose('enter')"
-      >
-      </span>
+        <div #tagContainer class="po-tag-value" [p-tooltip]="getWidthTag() ? value : ''" p-tooltip-position="top">
+          <span
+            [ngStyle]="
+              !tagColor && inverse && !customTextColor
+                ? { 'color': customColor }
+                : !type && customTextColor && !removable
+                ? { 'color': customTextColor }
+                : ''
+            "
+            >{{ value }}</span
+          >
+        </div>
+
+        <span
+          #tagClose
+          *ngIf="removable"
+          p-tooltip-position="top"
+          [p-tooltip]="literals.remove"
+          [attr.aria-label]="setAriaLabel()"
+          class="po-tag-remove po-icon po-icon-close"
+          [class.po-clickable]="!disabled"
+          [tabindex]="!disabled ? 0 : -1"
+          [attr.role]="!disabled ? 'button' : ''"
+          (click)="onClose()"
+          (keydown.enter)="onClose('enter')"
+        >
+        </span>
+      </div>
     </div>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
@@ -149,7 +149,7 @@ describe('PoTagComponent:', () => {
     it('onKeyPressed: should call `onClick` if the event `keydown` is used with `enter` key.', () => {
       fixture.detectChanges();
 
-      const tagElement = fixture.debugElement.query(By.css('.po-tag'));
+      const tagElement = fixture.debugElement.query(By.css('.po-tag-wrapper'));
       const spyOnClick = spyOn(component, 'onClick');
 
       tagElement.triggerEventHandler('keydown.enter', fakeEvent);
@@ -171,7 +171,7 @@ describe('PoTagComponent:', () => {
     it('onKeyPressed: should call `onClick` if the event `keyup` is used with `space` key.', () => {
       fixture.detectChanges();
 
-      const tagElement = fixture.debugElement.query(By.css('.po-tag'));
+      const tagElement = fixture.debugElement.query(By.css('.po-tag-wrapper'));
       const spyOnClick = spyOn(component, 'onClick');
 
       tagElement.triggerEventHandler('keyup.space', fakeEvent);
@@ -191,12 +191,13 @@ describe('PoTagComponent:', () => {
     });
 
     it('onClose: Should have been called onClose', () => {
-      spyOn(component.click, <any>'emit');
       spyOn(component, <any>'onRemove');
+      spyOn(component.remove, 'emit');
 
       component.onClose();
 
-      expect(component.click.emit).toHaveBeenCalledWith('click');
+      expect(component['onRemove']).toHaveBeenCalled();
+      expect(component.remove.emit).toHaveBeenCalledWith('click');
     });
 
     it('onRemove: Should remove the element if not disabled', () => {

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.ts
@@ -86,12 +86,14 @@ export class PoTagComponent extends PoTagBaseComponent implements OnInit {
     if (!this.removable && !this.disabled) {
       const submittedTagItem = { value: this.value, type: this.type, event: event };
       this.click.emit(submittedTagItem);
+      if (this.poTag && this.poTag.nativeElement) {
+        this.poTag.nativeElement.focus();
+      }
     }
   }
 
   onClose(event = 'click') {
     if (!this.disabled) {
-      this.click.emit(event);
       this.onRemove();
       this.remove.emit(event);
     }


### PR DESCRIPTION
**TAG**

**DTHFUI-7938**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
`tag` não possuia área de click mínima de 44px

**Qual o novo comportamento?**
`tag` passa a ter área de click mínima de 44px

**Simulação**
HTML 

```
<po-tag p-value="PO Tag" (p-click)="changeEvent('p-click')"> </po-tag>
``` 
TS
 
```
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  event: string;
  changeEvent(event: string) {
    this.event = event;
  }
}
```
- Pr adicional
https://github.com/po-ui/po-style/pull/484/checks
