### PR TITLE
fix(multiselect): corrige comportamento ao utilizar a tecla Tab

### DIFF
--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
@@ -24,6 +24,7 @@
         [attr.aria-checked]="checkboxAllValue === null ? 'mixed' : checkboxAllValue"
         (click)="changeAll.emit()"
         (keydown)="changeAllEmit($event)"
+        (keydown)="onSelectAllCheckboxKeyDown($event)"
       >
         <po-item-list
           [p-selected]="checkboxAllValue"

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
@@ -664,6 +664,15 @@ describe('PoListBoxComponent', () => {
 
         expect(component.closeEvent.emit).toHaveBeenCalled();
       });
+
+      it('should emit closeEvent on Tab keydown', () => {
+        const mockEvent = new KeyboardEvent('keydown', { code: 'Tab' });
+
+        spyOn(component.closeEvent, 'emit');
+
+        component.onSelectAllCheckboxKeyDown(mockEvent);
+        expect(component.closeEvent.emit).toHaveBeenCalled();
+      });
     });
   });
 

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
@@ -88,6 +88,12 @@ export class PoListBoxComponent extends PoListBoxBaseComponent implements AfterV
     }
   }
 
+  onSelectAllCheckboxKeyDown(event: KeyboardEvent) {
+    if (event.code === 'Tab') {
+      this.closeEvent.emit();
+    }
+  }
+
   onKeyDown(itemListAction: PoItemListOption | PoItemListOptionGroup | any, event?: KeyboardEvent) {
     event.preventDefault();
 


### PR DESCRIPTION
**MULTISELECT**

**DTHFUI-7981**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao pressionar a tecla tab no checkbox de selecionar todos do multiselect o listbox se mantém aberto

**Qual o novo comportamento?**
Ao pressionar a tecla tab no checkbox de selecionar todos do multiselect o listbox fecha normalmente

**Simulação**
Portal