### PR TITLE
feat(disclaimer-group): reutiliza `po-tag` no componente

### DIFF
--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.spec.ts
@@ -225,32 +225,6 @@ describe('PoDisclaimerGroupBaseComponent:', () => {
       expect(component.removeAll.emit).toHaveBeenCalledWith(validDisclaimers);
     });
 
-    it('onCloseAction: should remove disclaimer and emit current disclaimers', fakeAsync(() => {
-      spyOn(component.change, <any>'emit');
-
-      const disclaimerToRemove = { value: 'north', label: 'Region', property: 'region', hideClose: false };
-      const currentDisclaimers = [component.disclaimers[0], component.disclaimers[1]];
-
-      component.onCloseAction(disclaimerToRemove);
-
-      tick();
-
-      expect(component.disclaimers).toEqual(currentDisclaimers);
-      expect(component.change.emit).toHaveBeenCalledWith(component.disclaimers);
-    }));
-
-    it('onCloseAction: should emit removedDisclaimer and currentDisclaimers in remove action', () => {
-      spyOn(component.remove, <any>'emit');
-
-      const removedDisclaimer = { value: 'north', label: 'Region', property: 'region', hideClose: false };
-      const currentDisclaimers = [component.disclaimers[0], component.disclaimers[1]];
-
-      component.onCloseAction(removedDisclaimer);
-
-      expect(component.disclaimers).toEqual(currentDisclaimers);
-      expect(component.remove.emit).toHaveBeenCalledWith({ currentDisclaimers, removedDisclaimer });
-    });
-
     it('checkDisclaimers: should return only valid disclaimers.', () => {
       const checkedDisclaimers = component['checkDisclaimers']([...validDisclaimers]);
 

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group-base.component.ts
@@ -1,8 +1,8 @@
-import { DoCheck, EventEmitter, Input, IterableDiffers, Output, Directive, ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectorRef, Directive, DoCheck, EventEmitter, Input, IterableDiffers, Output } from '@angular/core';
 
-import { convertToBoolean, isKeyCodeEnter, uuid } from '../../utils/util';
-import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { poLocaleDefault } from '../../services/po-language/po-language.constant';
+import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { convertToBoolean, isKeyCodeEnter, uuid } from '../../utils/util';
 
 import { PoDisclaimer } from '../po-disclaimer/po-disclaimer.interface';
 
@@ -140,16 +140,6 @@ export class PoDisclaimerGroupBaseComponent implements DoCheck {
     this.checkChanges();
   }
 
-  onCloseAction(disclaimer) {
-    this.removeDisclaimer(disclaimer);
-
-    this.emitChangeDisclaimers();
-    this.remove.emit({
-      removedDisclaimer: { ...disclaimer },
-      currentDisclaimers: [...this.disclaimers]
-    });
-  }
-
   isRemoveAll() {
     return !this.hideRemoveAll && this.disclaimers.filter(c => !c.hideClose).length > 1;
   }
@@ -175,9 +165,17 @@ export class PoDisclaimerGroupBaseComponent implements DoCheck {
     this.removeAll.emit([...removeItems]);
   }
 
-  private removeDisclaimer(disclaimer: any) {
+  protected removeDisclaimer(disclaimer: any) {
     const itemIndex = this.disclaimers.findIndex(d => d['$id'] === disclaimer['$id']);
     this.disclaimers.splice(itemIndex, 1);
+  }
+
+  protected emitChangeDisclaimers() {
+    setTimeout(() => {
+      this.change.emit(this.disclaimers);
+    });
+    this.previousDisclaimers = [...this._disclaimers];
+    this.changeDetector?.detectChanges();
   }
 
   private checkChanges() {
@@ -223,13 +221,5 @@ export class PoDisclaimerGroupBaseComponent implements DoCheck {
         disclaimer.value !== this.previousDisclaimers[index].value ||
         disclaimer.property !== this.previousDisclaimers[index].property
     );
-  }
-
-  private emitChangeDisclaimers() {
-    setTimeout(() => {
-      this.change.emit(this.disclaimers);
-    });
-    this.previousDisclaimers = [...this._disclaimers];
-    this.changeDetector?.detectChanges();
   }
 }

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.html
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.html
@@ -10,14 +10,12 @@
   >
   </po-disclaimer-remove>
 
-  <po-disclaimer
+  <po-tag
     *ngFor="let disclaimer of disclaimers"
     class="po-disclaimer-group-disclaimer-align"
-    [p-hide-close]="disclaimer.hideClose"
-    [p-label]="disclaimer.label"
-    [p-property]="disclaimer.property"
-    [p-value]="disclaimer.value"
-    (p-close-action)="onCloseAction(disclaimer)"
+    [p-value]="disclaimer.label || disclaimer.value"
+    [p-removable]="!disclaimer.hideClose"
+    (p-close)="onCloseAction(disclaimer, $event)"
   >
-  </po-disclaimer>
+  </po-tag>
 </div>

--- a/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer-group/po-disclaimer-group.component.ts
@@ -1,8 +1,20 @@
-import { Component, IterableDiffers, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  IterableDiffers,
+  OnChanges,
+  SimpleChanges,
+  inject
+} from '@angular/core';
 
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 
+import { Subscription, fromEvent } from 'rxjs';
 import { PoDisclaimerGroupBaseComponent } from './po-disclaimer-group-base.component';
+import { PoDisclaimer } from '../po-disclaimer/po-disclaimer.interface';
 
 /**
  * @docsExtends PoDisclaimerGroupBaseComponent
@@ -31,12 +43,134 @@ import { PoDisclaimerGroupBaseComponent } from './po-disclaimer-group-base.compo
   templateUrl: './po-disclaimer-group.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PoDisclaimerGroupComponent extends PoDisclaimerGroupBaseComponent {
+export class PoDisclaimerGroupComponent extends PoDisclaimerGroupBaseComponent implements AfterViewInit, OnChanges {
+  private subscription: Subscription = new Subscription();
+
+  private el = inject(ElementRef);
+
   constructor(
     differs: IterableDiffers,
     languageService: PoLanguageService,
     protected changeDetector: ChangeDetectorRef
   ) {
     super(differs, languageService, changeDetector);
+  }
+
+  ngAfterViewInit(): void {
+    this.handleKeyboardNavigationTag();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.disclaimers) {
+      setTimeout(() => {
+        this.handleKeyboardNavigationTag();
+      });
+    }
+  }
+
+  onCloseAction(disclaimer: PoDisclaimer, event?) {
+    const index = this.disclaimers.findIndex(option => option.value === disclaimer.value);
+
+    this.removeDisclaimer(disclaimer);
+
+    this.emitChangeDisclaimers();
+    this.remove.emit({
+      removedDisclaimer: { ...disclaimer },
+      currentDisclaimers: [...this.disclaimers]
+    });
+
+    setTimeout(() => {
+      this.focusOnNextTag(index, event);
+    }, 300);
+  }
+
+  focusOnNextTag(indexClosed: number, clickOrEnter: string) {
+    if (clickOrEnter === 'enter') {
+      const tagRemoveElements: NodeListOf<Element> = this.el.nativeElement.querySelectorAll('.po-tag-remove');
+      indexClosed = indexClosed || indexClosed === 0 ? indexClosed : tagRemoveElements.length;
+      this.focusOnRemoveTag(tagRemoveElements, indexClosed);
+    } else {
+      indexClosed = 0;
+    }
+    this.handleKeyboardNavigationTag(indexClosed);
+  }
+
+  handleKeyboardNavigationTag(initialIndex = 0) {
+    this.subscription.unsubscribe();
+    this.subscription = new Subscription();
+    const tagRemoveElements: NodeListOf<Element> = this.el.nativeElement.querySelectorAll('.po-tag-remove');
+    this.initializeTagRemoveElements(tagRemoveElements, initialIndex);
+  }
+
+  private handleArrowLeft(tagRemoveElements, index) {
+    if (index > 0) {
+      this.setTabIndex(tagRemoveElements[index], -1);
+      tagRemoveElements[index - 1].focus();
+      this.setTabIndex(tagRemoveElements[index - 1], 0);
+    }
+  }
+
+  private handleArrowRight(tagRemoveElements, index) {
+    if (index < tagRemoveElements.length - 1) {
+      this.setTabIndex(tagRemoveElements[index], -1);
+      tagRemoveElements[index + 1].focus();
+      this.setTabIndex(tagRemoveElements[index + 1], 0);
+    }
+  }
+
+  private setTabIndex(element, tabIndex) {
+    element.setAttribute('tabindex', tabIndex);
+  }
+
+  private initializeTagRemoveElements(tagRemoveElements, initialIndex) {
+    tagRemoveElements.forEach((tagRemoveElement, index) => {
+      if (index === initialIndex) {
+        this.setTabIndex(tagRemoveElements[initialIndex], 0);
+      } else if (tagRemoveElements.length === initialIndex) {
+        this.setTabIndex(tagRemoveElements[initialIndex - 1], 0);
+      } else {
+        this.setTabIndex(tagRemoveElement, -1);
+      }
+
+      this.subscription.add(
+        fromEvent(tagRemoveElement, 'keydown').subscribe((event: KeyboardEvent) => {
+          this.handleKeyDown(event, tagRemoveElements, index);
+        })
+      );
+
+      if (index !== 0) {
+        this.subscription.add(
+          fromEvent(tagRemoveElements, 'blur').subscribe(() => {
+            this.setTabIndex(tagRemoveElements[index], -1);
+            this.setTabIndex(tagRemoveElements[0], 0);
+          })
+        );
+      }
+    });
+  }
+
+  private handleKeyDown(event: KeyboardEvent, tagRemoveElements, index: number) {
+    const KEY_SPACE = 'Space';
+    const KEY_ARROW_LEFT = 'ArrowLeft';
+    const KEY_ARROW_RIGHT = 'ArrowRight';
+
+    if (event.code === KEY_SPACE) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    if (event.key === KEY_ARROW_LEFT) {
+      this.handleArrowLeft(tagRemoveElements, index);
+    } else if (event.key === KEY_ARROW_RIGHT) {
+      this.handleArrowRight(tagRemoveElements, index);
+    }
+  }
+
+  private focusOnRemoveTag(tag: any, indexClosed: number) {
+    if (tag.length === indexClosed) {
+      tag[indexClosed - 1]?.focus();
+    } else {
+      tag[indexClosed]?.focus();
+    }
   }
 }


### PR DESCRIPTION
Reutiliza `po-tag` no componente `disclaimer-group` com nova definição de acessibilidade

fixes DTHFUI-7945

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**
Reutiliza o po-tag dentro do disclaimer-group

**Simulação**
testar portal e app
app: 
[app.zip](https://github.com/po-ui/po-angular/files/13904516/app.zip)
