### PR TITLE
feat(po-dynamic-view): adiciona format aos valores

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
@@ -397,6 +397,39 @@ describe('PoDynamicViewBaseComponent:', () => {
       expect(newField.value).toEqual(listName);
     });
 
+    it('transformArrayValue: should return a concatenated string of multiple properties from an array of objects', () => {
+      const inputArray = [
+        { id: 1, name: 'Company1', ssn: '261-81-7609' },
+        { id: 2, name: 'Company2', ssn: '527-84-6773' }
+      ];
+      const field = {
+        property: 'company',
+        label: 'Company',
+        fieldLabel: 'name',
+        fieldValue: 'id',
+        format: ['id', 'name', 'ssn']
+      };
+
+      const result = component['transformArrayValue'](inputArray, field);
+
+      expect(result).toBe('1 - Company1 - 261-81-7609, 2 - Company2 - 527-84-6773');
+    });
+
+    it('transformArrayValue: should return a concatenated string of properties from a single object', () => {
+      const inputArray = [{ id: 1, name: 'Company1', ssn: '261-81-7609' }];
+      const field = {
+        property: 'company',
+        label: 'Company',
+        fieldLabel: 'name',
+        fieldValue: 'id',
+        format: ['id', 'name', 'ssn']
+      };
+
+      const result = component['transformArrayValue'](inputArray, field);
+
+      expect(result).toBe('1 - Company1 - 261-81-7609');
+    });
+
     it(`createField: should call 'transformFieldLabel' and return a fieldLabel property`, () => {
       const field = { property: 'name', label: 'Nome', fieldLabel: 'title', fieldValue: 'id' };
       component.value = { name: 'Test Name', title: 'Title Test', id: 123 };

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -259,21 +259,27 @@ export class PoDynamicViewBaseComponent {
 
   private transformArrayValue(valueProperty: any, field: PoDynamicViewField) {
     const valueArray = Array.isArray(valueProperty) ? valueProperty : [valueProperty];
-    const arrayWithLabel = valueArray.map(item => ({
-      value: item[field.fieldValue] || item.value,
-      label: item[field.fieldLabel] || item.label
-    }));
+    let labels: Array<string>;
 
-    const labels = arrayWithLabel.map(optionValue => {
-      if (optionValue.label) {
-        const labelTranformed = this.transformValue(field.type, optionValue.label, field.format);
-        if (field.concatLabelValue && optionValue.value) {
-          return `${labelTranformed} - ${optionValue.value}`;
-        } else {
-          return labelTranformed;
+    if (Array.isArray(field.format)) {
+      labels = valueArray.map(objectData => this.formatField(objectData, field.format));
+    } else {
+      const arrayWithLabel = valueArray.map(item => ({
+        value: item[field.fieldValue] || item.value,
+        label: item[field.fieldLabel] || item.label
+      }));
+
+      labels = arrayWithLabel.map(optionValue => {
+        if (optionValue.label) {
+          const labelTranformed = this.transformValue(field.type, optionValue.label, field.format);
+          if (field.concatLabelValue && optionValue.value) {
+            return `${labelTranformed} - ${optionValue.value}`;
+          } else {
+            return labelTranformed;
+          }
         }
-      }
-    });
+      });
+    }
 
     if (labels[0] !== undefined && labels.join()) {
       return labels.join(', ');
@@ -317,5 +323,21 @@ export class PoDynamicViewBaseComponent {
     }
 
     return transformedValue;
+  }
+
+  private formatField(objectSelected, properties) {
+    let formattedField;
+    if (Array.isArray(properties)) {
+      for (const property of properties) {
+        if (objectSelected && objectSelected[property]) {
+          if (!formattedField) {
+            formattedField = objectSelected[property];
+          } else {
+            formattedField += ' - ' + objectSelected[property];
+          }
+        }
+      }
+    }
+    return formattedField;
   }
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
@@ -96,26 +96,31 @@ export interface PoDynamicViewField extends PoDynamicField {
   isArrayOrObject?: boolean;
 
   /**
-   * Formato de exibição do valor do campo.
+   * Define o formato de exibição para o valor de um campo.
    *
-   * Aplicado para casos específicos de acordo com o tipo do campo.
+   * - Quando `format` é uma `string`, o formato aplicado depende da propriedade **type** segue como usar cada tipo:
+   *   - `currency`: Utiliza códigos de moeda definidos pelo [CurrencyPipe](https://angular.io/api/common/CurrencyPipe).
+   *     Exemplos: Use 'BRL' para Real Brasileiro e 'USD' para Dólar Americano.
+   *   - `date`: Adota formatos de data especificados pelo [DatePipe](https://angular.io/api/common/DatePipe).
+   *     Suporta formatos personalizados, como dia (dd), mês (MM) e ano (yyyy ou yy).
+   *     Formato padrão é 'dd/MM/yyyy'. Exemplos: 'dd/MM/yyyy', 'dd-MM-yy', 'mm/dd/yyyy'.
+   *   - `time`: Aceita formatos de tempo, incluindo hora (HH), minutos (mm), segundos (ss) e opcionalmente
+   *     milisegundos (f-ffffff). Formato padrão é 'HH:mm:ss'. Exemplos: 'HH:mm', 'HH:mm:ss.ffffff', 'HH:mm:ss.ff'.
+   *   - `number`: Usa especificações do [DecimalPipe](https://angular.io/api/common/DecimalPipe) para formatação numérica.
+   *     Na ausência de um formato específico, o número é exibido como fornecido.
+   *     Exemplo: Entrada `50`, formato `'1.2-5'`, resulta em `50.00`.
    *
-   * **types**:
-   * - `currency`: Aceita valores definidos para a propriedade `currencyCode` do
-   *  [**CurrencyPipe**](https://angular.io/api/common/CurrencyPipe)
-   * + Exemplos: 'BRL', 'USD'.
-   * - `date`: Aceita valores definidos para a propriedade `format` do [**DatePipe**](https://angular.io/api/common/DatePipe)
-   * e também aceita os caracteres de dia(dd), mês(MM) e ano (yyyy ou yy),
-   * caso não seja informado um formato o mesmo será 'dd/MM/yyyy'. Exemplos: 'dd/MM/yyyy', 'dd-MM-yy', 'mm/dd/yyyy'.
-   * - `time`: Aceita apenas os caracteres de hora(HH), minutos(mm), segundos(ss) e
-   *  milisegundos(f-ffffff), os milisegundos são opcionais, caso não seja informado um formato o mesmo será
-   * 'HH:mm:ss'. Exemplos: 'HH:mm', 'HH:mm:ss.ffffff', 'HH:mm:ss.ff', 'mm:ss.fff'.
-   * - `number`: Aceita valores definidos para a propriedade `digitsInfo` do [**DecimalPipe**](https://angular.io/api/common/DecimalPipe)
-   *  para formatação, e caso não seja informado, o número será exibido na sua forma original.
+   * - Quando `format` é um `Array<string>`:
+   *   - Cada elemento do array representa uma propriedade do objeto.
+   *   - Os valores dessas propriedades são concatenados, separados pelo padrão ' - '.
+   *   - Exemplo: Para `format: ["id", "name"]` e um objeto `{ id: 1, name: 'Carlos Diego' }`,
+   *     o resultado será `'1 - Carlos Diego'`.
    *
-   *  + Exemplo: com o valor de entrada: `50` e a valor para formatação: `'1.2-5'` o resultado será: `50.00`.
+   * @example Para formatar um campo de moeda, use format: "BRL".
+   *          Para um campo de data, use format: "dd/MM/yyyy".
+   *          Para combinar propriedades de um objeto em um campo, use format: ["id", "name"].
    */
-  format?: string;
+  format?: string | Array<string>;
 
   /**
    * Informa a ordem de exibição do campo.


### PR DESCRIPTION
Adiciona método formatFields e refatora transformArrayValue

- Criado método formatFields para concatenar propriedades do objeto.
- Refatorado transformArrayValue para usar formatFields.

Fixes: #1928

**< po-dynamic-view >**

**< #1928 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
No PoDynamicView, há uma limitação na forma como os campos que possuem um formato específico definido em suas propriedades são exibidos. Atualmente, apenas o label é apresentado, ignorando outros elementos formativos especificados. Por exemplo, em um campo configurado com o formato ["id", "nome"], somente o componente "nome" é visível na exibição, como "Carlos Diego", sem incorporar o "id" correspondente. Isso resulta em uma apresentação incompleta dos dados, onde elementos importantes para a identificação e contextualização, como o "id", são omitidos na visualização fornecida pelo componente.

**Qual o novo comportamento?**
O novo comportamento proposto para o PoDynamicView envolve uma apresentação mais completa e detalhada dos dados, respeitando a formatação definida em suas propriedades. No cenário onde um campo é configurado com um formato específico, como ["id", "nome"], o componente deverá exibir tanto o identificador quanto o nome. Por exemplo, um dado com formato ["id", "nome"] seria exibido como "1 - Carlos Diego", combinando o "id" e o "nome". Este ajuste proporcionará uma experiência de usuário mais consistente e intuitiva, alinhando a exibição de dados no PoDynamicView com o padrão já estabelecido no PoDynamicEdit, onde tal formatação integrada já é praticada.

**Simulação**
Para simular basta adcionar um po-dynamic-view no projeto app usando
Ex.:
**app.component.html**
```
<po-page-default p-title="Employee">
    <po-dynamic-view [p-fields]="fields" [p-value]="employee"> </po-dynamic-view>
</po-page-default>
```
**app.component.ts**
```
import { Component } from '@angular/core';
import { PoDynamicViewField } from '../../../ui/src/lib';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  fields: Array<PoDynamicViewField> = [
    { property: 'name', divider: 'Personal data', gridColumns: 4, order: 1 },
    { property: 'age', label: 'Age', gridColumns: 4 },
    { property: 'genre', gridColumns: 4 },
    { property: 'cpf', label: 'CPF', gridColumns: 4, order: 2 },
    { property: 'rg', label: 'RG', gridColumns: 4, order: 3 },
    { property: 'graduation', label: 'Graduation', gridColumns: 4 },
    { property: 'job', tag: true, icon: 'po-icon-copy' },
    { property: 'admissionDate', label: 'Admission date', type: 'date' },
    { property: 'hoursPerDay', label: 'Hours per day', type: 'time' },
    { property: 'availability', tag: true, color: '#C596E7', icon: 'po-icon-ok' },
    { property: 'city', label: 'City', divider: 'Address' },
    { property: 'addressStreet', label: 'Street' },
    { property: 'addressNumber', label: 'Number' },
    { property: 'zipCode', label: 'Zip Code' },
    {
      property: 'marriedStatus',
      options: [{ label: 'MARRIED', value: '1' }],
      label: 'Marital status',
      divider: 'ADDITIONAL DATA',
      tag: true,
      color: '#C596E7'
    },
    {
      property: 'children',
      options: [
        { label: 'yes ', value: '1' },
        { label: 'no', value: '2' }
      ]
    },
    {
      searchService: 'https://smart-ui-lab-back-end.fly.dev/company',
      fieldLabel: 'name',
      fieldValue: 'id',
      property: 'company',
      format: ['id', 'name'],
      label: 'Company'
    },
  ];

  employee = {
    name: 'Carlos Almeida',
    age: '20',
    rg: '9999999',
    email: 'carlos.almeida@smart-ui.com',
    cpf: '999.999.999-99',
    birthday: '1998-03-14T00:00:01-00:00',
    graduation: 'Bachelor Degree',
    genre: 'male',
    job: 'Software Engineer',
    addressStreet: 'Avenida Barão de Studart',
    addressNumber: '1000',
    zipCode: '60120-000',
    city: 'Fortaleza',
    availability: 'Available',
    admissionDate: '2014-10-14T13:45:00-00:00',
    hoursPerDay: '08:30:00',
    marriedStatus: '1',
    children: '1',
    company: 1
  };
}
```