### PR TITLE
fix(page-slide): ajusta largura do `po-page-slide`

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-base.component.ts
@@ -61,6 +61,17 @@ export class PoPageSlideBaseComponent {
    * @optional
    *
    * @description
+   *
+   * Permite a expansão dinâmica da largura do `po-page-slide` quando `p-size` for `auto` (automático).
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-flexible-width', transform: convertToBoolean }) flexibleWidth: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
    * Evento executado ao fechar o page slide.
    */
   @Output('p-close') closePageSlide: EventEmitter<any> = new EventEmitter<any>();
@@ -84,7 +95,7 @@ export class PoPageSlideBaseComponent {
    *  - `xl` (extra-grande)
    *  - `auto` (automático)
    *
-   * > Todas as opções de tamanho possuem uma largura máxima de **768px**.
+   * > Todas as opções de tamanho, exceto `auto`, possuem uma largura máxima de **768px**.
    *
    * @default `md`
    */

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.html
@@ -1,6 +1,10 @@
 <div class="po-page-slide" tabindex="0" *ngIf="!hidden" [@fade]>
   <div class="po-page-slide-overlay" (mousedown)="onClickOut($event)"></div>
-  <div class="po-page-slide-container po-page-slide-right po-page-slide-{{ size }}" [@slide]>
+  <div
+    class="po-page-slide-container po-page-slide-right po-page-slide-{{ size }}"
+    [@slide]
+    [ngStyle]="{ 'width': flexibleWidth ? '' : size === 'auto' ? 'auto' : '' }"
+  >
     <div class="po-page-slide-content" tabindex="-1" #pageContent>
       <div class="po-page-slide-header">
         <div class="po-page-slide-title">


### PR DESCRIPTION
Ajusta largura do `po-page-slide` concedendo mais flexibilidade

**page-slide**

**DTHFUI-8038**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao utilizar componentes grandes dentro do `po-page-slide` sua largura não era flexível e não calculava automaticamente

**Qual o novo comportamento?**
Ao utilizar componentes grandes dentro do `po-page-slide` sua largura e flexível é calcula automaticamente

**Simulação**
[Style](https://github.com/po-ui/po-style/pull/488)
[app.zip](https://github.com/po-ui/po-angular/files/14088214/app.zip)

