### PR TITLE
feat(po-dynamic-view): adicionado a propriedade params

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -249,7 +249,7 @@ export class PoDynamicViewBaseComponent {
 
     if (value !== '') {
       return this.service
-        .getObjectByValue(value)
+        .getObjectByValue(value, field.params)
         .pipe(map(res => this.transformArrayValue(res, field)))
         .pipe(catchError(() => of(null)));
     } else {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
@@ -236,4 +236,16 @@ export interface PoDynamicViewField extends PoDynamicField {
 
   /** Texto exibido quando o valor do componente for *false*. */
   booleanFalse?: string;
+
+  /**
+   * Objeto que será enviado como parâmetro nas requisições de busca `searchService`
+   * utilizadas pelos campos que dependem de serviços para carregar seus dados.
+   *
+   * Por exemplo, para o parâmetro `{ age: 23 }` a URL da requisição ficaria:
+   *
+   * ``
+   * url + /1?age=23
+   * ``
+   */
+  params?: any;
 }


### PR DESCRIPTION
**< po-dynamic-view>**

**< #1933 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente, o po-dynamic-view não suporta a passagem de parâmetros adicionais para as requisições de serviços, limitando a contextualização dos dados apresentados.

**Qual o novo comportamento?**
Com a proposta de melhoria, o po-dynamic-view incluiria a nova propriedade params, permitindo a adição de parâmetros extras nas requisições de serviços de maneira dinâmica, similar aos componentes lookup e combo usados no po-dynamic-edit. Isso expandiria a funcionalidade para casos de uso que requerem contexto adicional, como filtrar dados baseados em parâmetros específicos do usuário ou da sessão.

**Simulação**
Considere um formulário que exibe informações de um pedido que faz parte de um conjunto de dados relacionados a um cliente e um produto específicos. A chave composta para cada pedido poderia ser o ID do cliente e o ID do produto. Com a nova propriedade params, poderíamos passar o ID do cliente como um parâmetro fixo, enquanto o componente po-dynamic-view faria a requisição de serviço para buscar detalhes do pedido usando essa parte da chave composta. Por exemplo:

```
{
    searchService: 'https://exemplo.com/products',
    fieldLabel: 'name',
    fieldValue: 'id',
    property: 'produtc',
    params: {clientId: '10'},
    label: 'Product'
}
```
Ao configurar o po-dynamic-view, o campo `produtc` que carrega seu dado utilizando `searchService` utilizaria do `params` requisição:
![image](https://github.com/po-ui/po-angular/assets/12103080/f4b8e830-682e-4a78-acc3-5a2b2e4a4fc9)

Assim cada vez que o po-dynamic-view fizesse uma requisição para buscar os dados dos pedidos, ele incluiria o clienteId nos parâmetros da requisição, permitindo que a API retornasse apenas os pedidos relacionados a esse cliente específico.
