### PR TITLE
feat(dynamic-view): adicionado optionsService e optionsMulti

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
@@ -11,6 +11,11 @@ import { PoDynamicViewRequest } from './interfaces/po-dynamic-view-request.inter
 import { PoDynamicViewBaseComponent } from './po-dynamic-view-base.component';
 import { PoDynamicViewField } from './po-dynamic-view-field.interface';
 import { PoDynamicViewService } from './services/po-dynamic-view.service';
+import { PoComboFilterService } from '../../po-field/po-combo/po-combo-filter.service';
+import { PoMultiselectFilterService } from '../../po-field/po-multiselect/po-multiselect-filter.service';
+import { PoComboFilter } from '../../po-field/po-combo/interfaces/po-combo-filter.interface';
+import { PoMultiselectFilter } from '../../po-field/po-multiselect/po-multiselect-filter.interface';
+import { PoComboOption } from '../../po-field';
 
 class DynamicViewService implements PoDynamicViewRequest {
   getObjectByValue(id: string): Observable<any> {
@@ -19,6 +24,34 @@ class DynamicViewService implements PoDynamicViewRequest {
 }
 
 class TestService implements PoDynamicViewRequest {
+  getObjectByValue(id: string): Observable<any> {
+    return of({ value: 123, label: 'teste' });
+  }
+}
+
+class TestComboService implements PoComboFilter {
+  getFilteredData(params: any, filterParams?: any): Observable<Array<PoComboOption>> {
+    return of([{ value: 123, label: 'Teste' }]);
+  }
+
+  getObjectByValue(value: string | number): Observable<PoComboOption> {
+    return of({ value: 123, label: 'Teste' });
+  }
+}
+
+class TestMultiselectService implements PoMultiselectFilter {
+  getFilteredData(params: { property: string; value: string }): Observable<Array<any>> {
+    return of([
+      { value: 123, label: 'teste' },
+      { value: 456, label: 'teste' }
+    ]);
+  }
+  getObjectsByValues(values: Array<string | number>): Observable<Array<any>> {
+    return of([
+      { value: 123, label: 'teste' },
+      { value: 456, label: 'teste' }
+    ]);
+  }
   getObjectByValue(id: string): Observable<any> {
     return of({ value: 123, label: 'teste' });
   }
@@ -33,6 +66,8 @@ describe('PoDynamicViewBaseComponent:', () => {
   let timePipe;
   let currencyPipe;
   let dynamicViewService;
+  let comboFilterService;
+  let multiselectFilterService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -45,7 +80,9 @@ describe('PoDynamicViewBaseComponent:', () => {
         PoDynamicViewService,
         HttpClient,
         HttpHandler,
-        DynamicViewService
+        DynamicViewService,
+        PoComboFilterService,
+        PoMultiselectFilterService
       ]
     });
 
@@ -55,6 +92,8 @@ describe('PoDynamicViewBaseComponent:', () => {
     timePipe = TestBed.inject(PoTimePipe);
     currencyPipe = TestBed.inject(CurrencyPipe);
     dynamicViewService = TestBed.inject(PoDynamicViewService);
+    comboFilterService = TestBed.inject(PoComboFilterService);
+    multiselectFilterService = TestBed.inject(PoMultiselectFilterService);
 
     component = new PoDynamicViewBaseComponent(
       titleCase,
@@ -62,7 +101,9 @@ describe('PoDynamicViewBaseComponent:', () => {
       currencyPipe,
       datePipe,
       timePipe,
-      dynamicViewService
+      dynamicViewService,
+      comboFilterService,
+      multiselectFilterService
     );
   });
 
@@ -274,6 +315,129 @@ describe('PoDynamicViewBaseComponent:', () => {
           expectArraysSameOrdering(newFields, expectedFields);
         })
       ));
+
+      it('should return ordering fields with property optionsService using service type', fakeAsync(
+        inject([PoComboFilterService], (comboService: PoComboFilterService) => {
+          component.service = comboService;
+          const fields: Array<PoDynamicViewField> = [
+            { property: 'test 1' },
+            { property: 'test 0', optionsService: new TestComboService(), fieldLabel: 'name', fieldValue: 'id' },
+            { property: 'test 2', optionsService: 'url.com' },
+            { property: 'test 3', optionsService: 'url.com' },
+            { property: 'test 4' },
+            { property: 'test 5' }
+          ];
+          component.value[fields[1].property] = '123';
+          component.value[fields[2].property] = [{ test: 123 }];
+          component.value[fields[3].property] = { test: 123 };
+
+          spyOn(component.service, 'getObjectByValue').and.returnValue(of([{ id: 1, name: 'po' }]));
+
+          const expectedFields = [
+            { property: 'test 1', value: undefined },
+            { property: 'test 0', value: 'teste' },
+            { property: 'test 2', value: null },
+            { property: 'test 3', value: null },
+            { property: 'test 4' },
+            { property: 'test 5' }
+          ];
+
+          component.fields = [...fields];
+
+          const newFields = component['getConfiguredFields']();
+          tick(500);
+          console.log(newFields);
+
+          expectArraysSameOrdering(newFields, expectedFields);
+        })
+      ));
+
+      it('should return ordering fields with property optionsService and optionsMulti using service type', fakeAsync(
+        inject([PoMultiselectFilterService], (multiselectService: PoMultiselectFilter) => {
+          component.service = multiselectService;
+          const fields: Array<PoDynamicViewField> = [
+            { property: 'test 1' },
+            {
+              property: 'test 0',
+              optionsService: new TestMultiselectService(),
+              fieldLabel: 'name',
+              fieldValue: 'id',
+              optionsMulti: true
+            },
+            { property: 'test 2', optionsService: 'url.com', optionsMulti: true },
+            { property: 'test 3', optionsService: 'url.com', optionsMulti: true },
+            { property: 'test 4' },
+            { property: 'test 5' }
+          ];
+          component.value[fields[1].property] = '123';
+          component.value[fields[2].property] = [{ test: 123 }];
+          component.value[fields[3].property] = { test: 123 };
+
+          spyOn(component.service, 'getObjectsByValues').and.returnValue(of([{ id: 1, name: 'po' }]));
+
+          const expectedFields = [
+            { property: 'test 1', value: undefined },
+            { property: 'test 0', value: 'teste' },
+            { property: 'test 2', value: null },
+            { property: 'test 3', value: null },
+            { property: 'test 4' },
+            { property: 'test 5' }
+          ];
+
+          component.fields = [...fields];
+
+          const newFields = component['getConfiguredFields']();
+          tick(500);
+          console.log(newFields);
+
+          expectArraysSameOrdering(newFields, expectedFields);
+        })
+      ));
+
+      it('should process fields with optionsService', () => {
+        component.fields = [{ property: 'category', optionsService: 'url.optionsService.com' }];
+        component.value = { 'category': '123' };
+        spyOn(component, <any>'createFieldWithService').and.callThrough();
+        const configuredFields = component['getConfiguredFields']();
+        expect(component['createFieldWithService']).toHaveBeenCalled();
+        expect(configuredFields.length).toBeGreaterThan(0);
+      });
+
+      it('should process fields with optionsMulti', () => {
+        component.fields = [{ property: 'tags', optionsMulti: true, optionsService: 'url.optionsMultiService.com' }];
+        component.value = { 'tags': ['tag1', 'tag2'] };
+        spyOn(component, <any>'createFieldWithService').and.callThrough();
+        const configuredFields = component['getConfiguredFields']();
+        expect(component['createFieldWithService']).toHaveBeenCalled();
+        expect(configuredFields.length).toBeGreaterThan(0);
+      });
+
+      it('should not process fields with optionsService when there is no value', () => {
+        component.fields = [{ property: 'category', optionsService: 'url.optionsService.com' }];
+        component.value = { 'category': null };
+        spyOn(component, <any>'createFieldWithService');
+        const configuredFields = component['getConfiguredFields']();
+        expect(component['createFieldWithService']).not.toHaveBeenCalled();
+        expect(configuredFields.length).toBe(0);
+      });
+
+      it('should handle fields with empty array values correctly', () => {
+        component.fields = [{ property: 'emptyArray', optionsMulti: true }];
+        component.value = { 'emptyArray': [] };
+        spyOn(component, <any>'createField');
+        const configuredFields = component['getConfiguredFields']();
+        expect(component['createField']).toHaveBeenCalled();
+        expect(configuredFields.length).toBeGreaterThan(0);
+      });
+
+      it('should handle fields without defined values correctly', () => {
+        component.fields = [{ property: 'undefinedValue' }];
+        component.value = {};
+        spyOn(component, <any>'createField');
+        const configuredFields = component['getConfiguredFields']();
+        expect(component['createField']).toHaveBeenCalled();
+        expect(configuredFields.length).toBeGreaterThan(0);
+      });
     });
 
     it('searchById: should return null if value is empty', done => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -8,6 +8,8 @@ import { Observable, catchError, map, of } from 'rxjs';
 import { getGridColumnsClasses, isVisibleField } from '../po-dynamic.util';
 import { PoDynamicViewField } from './po-dynamic-view-field.interface';
 import { PoDynamicViewService } from './services/po-dynamic-view.service';
+import { PoComboFilterService } from '../../po-field/po-combo/po-combo-filter.service';
+import { PoMultiselectFilterService } from '../../po-field/po-multiselect/po-multiselect-filter.service';
 
 /**
  *
@@ -131,32 +133,59 @@ export class PoDynamicViewBaseComponent {
     private decimalPipe: DecimalPipe,
     private timePipe: PoTimePipe,
     private titleCasePipe: TitleCasePipe,
-    protected dynamicViewService: PoDynamicViewService
+    protected dynamicViewService: PoDynamicViewService,
+    protected comboFilterService: PoComboFilterService,
+    protected multiselectFilterService: PoMultiselectFilterService
   ) {}
 
   protected getConfiguredFields(useSearchService = true) {
     const newFields = [];
 
     this.fields.forEach((field, index) => {
-      if (isVisibleField(field)) {
-        if (!field.searchService) {
-          newFields.splice(index, 0, this.createField(field));
-        } else if (
-          this.value[field.property]?.length ||
-          (!Array.isArray(this.value[field.property]) && this.value[field.property] && useSearchService)
-        ) {
-          if (isTypeof(field.searchService, 'object')) {
-            this.service = <PoDynamicViewService>field.searchService;
-          }
-          if (field.searchService && isTypeof(field.searchService, 'string')) {
+      if (!isVisibleField(field)) {
+        return;
+      }
+
+      if (!field.searchService && !field.optionsService) {
+        newFields.push(this.createField(field));
+        return;
+      }
+
+      const hasValue =
+        this.value[field.property]?.length ||
+        (!Array.isArray(this.value[field.property]) && this.value[field.property] && useSearchService);
+
+      if (hasValue) {
+        if (field.searchService) {
+          if (typeof field.searchService === 'object') {
+            this.service = field.searchService as PoDynamicViewService;
+          } else if (typeof field.searchService === 'string') {
             this.service = this.dynamicViewService;
-            this.service.setConfig(field.searchService as string);
+            this.service.setConfig(field.searchService);
           }
-          const indexUpdated = field.order ? field.order : index;
-          this.createFieldWithService(field, newFields, indexUpdated);
+        } else if (field.optionsService) {
+          if (field.optionsMulti) {
+            if (typeof field.optionsService === 'object') {
+              this.service = field.optionsService as PoMultiselectFilterService;
+            } else {
+              this.service = this.multiselectFilterService;
+              this.service.configProperties(field.optionsService, field.fieldLabel, field.fieldValue);
+            }
+          } else {
+            if (typeof field.optionsService === 'object') {
+              this.service = field.optionsService as PoComboFilterService;
+            } else {
+              this.service = this.comboFilterService;
+              this.service.configProperties(field.optionsService, field.fieldLabel, field.fieldValue);
+            }
+          }
         }
+
+        const indexUpdated = field.order || index;
+        this.createFieldWithService(field, newFields, indexUpdated);
       }
     });
+
     return sortFields(newFields);
   }
 
@@ -248,10 +277,17 @@ export class PoDynamicViewBaseComponent {
     }
 
     if (value !== '') {
-      return this.service
-        .getObjectByValue(value, field.params)
-        .pipe(map(res => this.transformArrayValue(res, field)))
-        .pipe(catchError(() => of(null)));
+      if (field.optionsMulti) {
+        return this.service
+          .getObjectsByValues(value, field.params)
+          .pipe(map(res => this.transformArrayValue(res, field)))
+          .pipe(catchError(() => of(null)));
+      } else {
+        return this.service
+          .getObjectByValue(value, field.params)
+          .pipe(map(res => this.transformArrayValue(res, field)))
+          .pipe(catchError(() => of(null)));
+      }
     } else {
       return of(null);
     }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
@@ -1,3 +1,4 @@
+import { PoComboFilter, PoMultiselectFilter } from '../../po-field';
 import { PoDynamicField } from '../po-dynamic-field.interface';
 import { PoDynamicViewRequest } from './interfaces/po-dynamic-view-request.interface';
 
@@ -226,6 +227,21 @@ export interface PoDynamicViewField extends PoDynamicField {
   options?: Array<{ label: string; value: string | number }>;
 
   /**
+   *  Serviço que será utilizado para buscar os itens e preencher a lista de opções dinamicamente.
+   *  Pode ser informada uma URL ou uma instancia do serviço baseado em PoComboFilter.
+   *  **Importante**
+   *  > Para que funcione corretamente, é importante que o serviço siga o
+   *  [guia de API do PO UI](https://po-ui.io/guides/api).
+   */
+  optionsService?: string | PoComboFilter | PoMultiselectFilter;
+
+  /**
+   * Habilita a visualização de múltiplas itens.
+   * Útil para exibir dados em formatos semelhantes aos componentes que suportam seleção múltipla.
+   */
+  optionsMulti?: boolean;
+
+  /**
    * Serviço customizado para um campo em específico.
    * Pode ser ser informada uma URL ou uma instancia do serviço baseado em PoDynamicViewRequest.
    * **Importante:**
@@ -243,7 +259,7 @@ export interface PoDynamicViewField extends PoDynamicField {
   booleanFalse?: string;
 
   /**
-   * Objeto que será enviado como parâmetro nas requisições de busca `searchService`
+   * Objeto que será enviado como parâmetro nas requisições de busca `searchService` ou `optionsService`
    * utilizadas pelos campos que dependem de serviços para carregar seus dados.
    *
    * Por exemplo, para o parâmetro `{ age: 23 }` a URL da requisição ficaria:

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
@@ -6,6 +6,8 @@ import { PoTimePipe } from '../../../pipes/po-time/po-time.pipe';
 import { PoDynamicViewField } from './../po-dynamic-view/po-dynamic-view-field.interface';
 import { PoDynamicViewBaseComponent } from './po-dynamic-view-base.component';
 import { PoDynamicViewService } from './services/po-dynamic-view.service';
+import { PoComboFilterService } from '../../po-field/po-combo/po-combo-filter.service';
+import { PoMultiselectFilterService } from '../../po-field/po-multiselect/po-multiselect-filter.service';
 
 /**
  * @docsExtends PoDynamicViewBaseComponent
@@ -40,9 +42,20 @@ export class PoDynamicViewComponent extends PoDynamicViewBaseComponent implement
     decimalPipe: DecimalPipe,
     timePipe: PoTimePipe,
     titleCasePipe: TitleCasePipe,
-    dynamicViewService: PoDynamicViewService
+    dynamicViewService: PoDynamicViewService,
+    comboFilterService: PoComboFilterService,
+    multiselectFilterService: PoMultiselectFilterService
   ) {
-    super(currencyPipe, datePipe, decimalPipe, timePipe, titleCasePipe, dynamicViewService);
+    super(
+      currencyPipe,
+      datePipe,
+      decimalPipe,
+      timePipe,
+      titleCasePipe,
+      dynamicViewService,
+      comboFilterService,
+      multiselectFilterService
+    );
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic.module.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic.module.ts
@@ -16,6 +16,8 @@ import { PoDynamicFormValidationService } from './po-dynamic-form/po-dynamic-for
 import { PoDynamicViewComponent } from './po-dynamic-view/po-dynamic-view.component';
 import { PoImageModule } from '../po-image';
 import { PoDynamicViewService } from './po-dynamic-view/services/po-dynamic-view.service';
+import { PoComboFilterService } from '../po-field/po-combo/po-combo-filter.service';
+import { PoMultiselectFilterService } from '../po-field/po-multiselect/po-multiselect-filter.service';
 
 @NgModule({
   imports: [
@@ -38,7 +40,9 @@ import { PoDynamicViewService } from './po-dynamic-view/services/po-dynamic-view
     TitleCasePipe,
     PoDynamicFormLoadService,
     PoDynamicFormValidationService,
-    PoDynamicViewService
+    PoDynamicViewService,
+    PoComboFilterService,
+    PoMultiselectFilterService
   ]
 })
 export class PoDynamicModule {}


### PR DESCRIPTION
**< po-dynamic-view >**

**< #1939 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente, o componente po-dynamic-view do PO UI suporta apenas a propriedade searchService para carregar dados dinamicamente. Isso limita sua funcionalidade a casos de uso onde a busca de dados é realizada através de um serviço de pesquisa, sem suportar outras formas de carregamento de dados como seleções de múltiplas opções ou combo, que são comuns no uso do po-dynamic-edit.

**Qual o novo comportamento?**
Com a implementação da melhoria proposta, o po-dynamic-view passará a suportar as propriedades **optionsService** e **optionsMulti**. Isso permitirá que o componente carregue automaticamente opções de dados para campos que utilizam seleções de múltiplas opções (multi-select) ou combo, alinhando-se com as funcionalidades já existentes no po-dynamic-edit. Essa mudança facilitará a exibição dinâmica de dados e tornará o componente mais versátil e útil em uma variedade maior de cenários.

**Simulação**
Para simular o novo comportamento, imagine um formulário de edição de usuário no qual há um campo 'Departamento'. Com a nova funcionalidade, ao selecionar 'Departamento', o po-dynamic-view consultaria automaticamente um serviço definido na propriedade optionsService para carregar a lista de departamentos disponíveis. Da mesma forma, se o campo fosse um campo de seleção múltipla para 'Habilidades', as opções seriam carregadas automaticamente com base no serviço especificado em optionsMulti. Essa simulação demonstra a utilidade da nova funcionalidade em proporcionar uma experiência de usuário mais rica e interativa, sem a necessidade de implementação de lógica adicional para carregar essas opções.

Código para teste no app de exemplo:

**app.component.ts**

```import { Component } from '@angular/core';
import { PoDynamicViewField } from '../../../ui/src/lib';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  fields: Array<PoDynamicViewField> = [
    { property: 'name', divider: 'Personal data', gridColumns: 4, order: 1 },
    { property: 'age', label: 'Age', gridColumns: 4 },
    { property: 'genre', gridColumns: 4 },
    { property: 'cpf', label: 'CPF', gridColumns: 4, order: 2 },
    { property: 'rg', label: 'RG', gridColumns: 4, order: 3 },
    { property: 'graduation', label: 'Graduation', gridColumns: 4 },
    { property: 'job', tag: true, icon: 'po-icon-copy' },
    { property: 'admissionDate', label: 'Admission date', type: 'date' },
    { property: 'hoursPerDay', label: 'Hours per day', type: 'time' },
    { property: 'availability', tag: true, color: '#C596E7', icon: 'po-icon-ok' },
    { property: 'city', label: 'City', divider: 'Address' },
    { property: 'addressStreet', label: 'Street' },
    { property: 'addressNumber', label: 'Number' },
    { property: 'zipCode', label: 'Zip Code' },
    {
      property: 'marriedStatus',
      options: [{ label: 'MARRIED', value: '1' }],
      label: 'Marital status',
      divider: 'ADDITIONAL DATA',
      tag: true,
      color: '#C596E7'
    },
    {
      property: 'children',
      options: [
        { label: 'yes ', value: '1' },
        { label: 'no', value: '2' }
      ]
    },
    {
      divider:"TESTES DE SERVIÇOS - optionsService, searchService, optionsService-optionsMulti",
      optionsService: 'https://smart-ui-lab-back-end.fly.dev/company',
      fieldLabel: 'name',
      fieldValue: 'id',      
      property: 'company',
      params: {clientId: '10'},
      label: 'Company - optionsService'
    },{
      searchService: 'https://smart-ui-lab-back-end.fly.dev/company',
      fieldLabel: 'name',
      fieldValue: 'id',
      property: 'company2',
      params: {clientId: '10'},
      label: 'Company - searchService'
    },
    {
      optionsService: 'https://smart-ui-lab-back-end.fly.dev/company',
      fieldLabel: 'name',
      fieldValue: 'id',
      property: 'companymulti',
      label: 'Company - optionsService - optionsMulti',
      optionsMulti: true
    },
  ];

  employee = {
    name: 'Carlos Almeida',
    age: '20',
    rg: '9999999',
    email: 'carlos.almeida@smart-ui.com',
    cpf: '999.999.999-99',
    birthday: '1998-03-14T00:00:01-00:00',
    graduation: 'Bachelor Degree',
    genre: 'male',
    job: 'Software Engineer',
    addressStreet: 'Avenida Barão de Studart',
    addressNumber: '1000',
    zipCode: '60120-000',
    city: 'Fortaleza',
    availability: 'Available',
    admissionDate: '2014-10-14T13:45:00-00:00',
    hoursPerDay: '08:30:00',
    marriedStatus: '1',
    children: '1',
    company: 1,
    company2: 2,
    companymulti: [3,4]
  };
}

```

**app.component.html**

```
<po-page-default p-title="Employee">
    <po-dynamic-view [p-fields]="fields" [p-value]="employee"></po-dynamic-view>
</po-page-default>
```
**Observação**: No campo companymulti, que utiliza o multi-select, a API de exemplo retorna todos os registros, pois não está preparada para esse tipo de requisição. A inclusão dessa funcionalidade foi apenas para fins demonstrativos. Nos demais casos, as expectativas quanto à melhoria implantada estão sendo atendidas.