### PR TITLE
ci: permite publicar no npm com tag especifica

### DIFF
--- a/.github/workflows/publish_po_angular_ci-beta.yml
+++ b/.github/workflows/publish_po_angular_ci-beta.yml
@@ -17,6 +17,10 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Check out po-angular
       uses: actions/checkout@v4
@@ -39,13 +43,9 @@ jobs:
       run: npm install && npm run build
       working-directory: ${{env.WORKING_DIR}}
 
-    # Pega a última versão dos pacotes publicados no npm e armazena em variáveis
-    - run: echo "SCHEMATICS_LAST_PUBLISHED_VERSION=$(npm view @${{ env.SCHEMATICS_NPM_PATH }} dist-tags.beta)" >> $GITHUB_ENV
-    - run: echo "STORAGE_LAST_PUBLISHED_VERSION=$(npm view @${{ env.STORAGE_NPM_PATH }} dist-tags.beta)" >> $GITHUB_ENV
-    - run: echo "SYNC_LAST_PUBLISHED_VERSION=$(npm view @${{ env.SYNC_NPM_PATH }} dist-tags.beta)" >> $GITHUB_ENV
-    - run: echo "COMPONENTS_LAST_PUBLISHED_VERSION=$(npm view @${{ env.COMPONENTS_NPM_PATH }} dist-tags.beta)" >> $GITHUB_ENV
-    - run: echo "TEMPLATES_LAST_PUBLISHED_VERSION=$(npm view @${{ env.TEMPLATES_NPM_PATH }} dist-tags.beta)" >> $GITHUB_ENV
-    - run: echo "CODE_EDITOR_LAST_PUBLISHED_VERSION=$(npm view @${{ env.CODE_EDITOR_NPM_PATH }} dist-tags.beta)" >> $GITHUB_ENV
+    # Pega as versões publicadas no NPM e salva no arquivo versions.json
+    - name: Obter todas as versões publicadas
+      run: npm show @${{ env.COMPONENTS_NPM_PATH }} versions --json > versions.json
 
     # Pega a versão no package.json
     - name: Get package.json version.
@@ -54,75 +54,109 @@ jobs:
       with:
         path: po-angular
 
+    # Verifica se a versão a ser publicada já existe no NPM
+    - name: Verificar se a versão existe
+      id: version
+      run: |
+        VERSION_TO_CHECK=${{ steps.package-version.outputs.current-version }}
+        if jq -e --arg version "$VERSION_TO_CHECK" '.[] | select(. == $version)' versions.json; then
+          echo "publish=no" >> "$GITHUB_OUTPUT"
+        else
+          echo "publish=yes" >> "$GITHUB_OUTPUT"
+        fi
+
     # PUBLISH NG-SCHEMATICS
     - name: ng-schematics - publish
-      # Se a versão remota for igual à versão que será publicada então ele pula o publish deste pacote e tenta publicar os demais pacotes
-      if: (!contains(env.PACKAGE_VERSION, env.SCHEMATICS_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-schematics --tag beta --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-schematics --tag beta --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-schematics - add "beta" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.SCHEMATICS_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "beta"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-STORAGE
     - name: ng-storage - publish
-      if: (!contains(env.PACKAGE_VERSION, env.STORAGE_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-storage --tag beta --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-storage --tag beta --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-storage - add "beta" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.STORAGE_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "beta"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-SYNC
     - name: ng-sync - publish
-      if: (!contains(env.PACKAGE_VERSION, env.SYNC_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-sync --tag beta --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-sync --tag beta --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-sync - add "beta" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.SYNC_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "beta"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-COMPONENTS
     - name: ng-components - publish
-      if: (!contains(env.PACKAGE_VERSION, env.COMPONENTS_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-components --tag beta --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-components --tag beta --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-components - add "beta" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.COMPONENTS_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "beta"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-TEMPLATES
     - name: ng-templates - publish
-      if: (!contains(env.PACKAGE_VERSION, env.TEMPLATES_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-templates --tag beta --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-templates --tag beta --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-templates - add "beta" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.TEMPLATES_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "beta"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-CODE-EDITOR
     - name: ng-code-editor - publish
-      if: (!contains(env.PACKAGE_VERSION, env.CODE_EDITOR_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-code-editor --tag beta --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-code-editor --tag beta --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-code-editor - add "beta" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.CODE_EDITOR_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "beta"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_po_angular_ci-latest.yml
+++ b/.github/workflows/publish_po_angular_ci-latest.yml
@@ -8,8 +8,6 @@ env:
   COMPONENTS_NPM_PATH: po-ui/ng-components
   TEMPLATES_NPM_PATH: po-ui/ng-templates
   CODE_EDITOR_NPM_PATH: po-ui/ng-code-editor
-  AZURE_WEBAPP_NAME: wa-po-ui
-  AZURE_WEBAPP_PACKAGE_PATH: /home/runner/work/po-angular/po-angular/po-angular/dist/portal
   WORKING_DIR: /home/runner/work/po-angular/po-angular/po-angular
 
 on:
@@ -19,6 +17,10 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Check out po-angular
       uses: actions/checkout@v4
@@ -41,13 +43,9 @@ jobs:
       run: npm install && npm run build
       working-directory: ${{env.WORKING_DIR}}
 
-    # Pega a última versão dos pacotes publicados no npm e armazena em variáveis
-    - run: echo "SCHEMATICS_LAST_PUBLISHED_VERSION=$(npm view @${{ env.SCHEMATICS_NPM_PATH }} dist-tags.latest)" >> $GITHUB_ENV
-    - run: echo "STORAGE_LAST_PUBLISHED_VERSION=$(npm view @${{ env.STORAGE_NPM_PATH }} dist-tags.latest)" >> $GITHUB_ENV
-    - run: echo "SYNC_LAST_PUBLISHED_VERSION=$(npm view @${{ env.SYNC_NPM_PATH }} dist-tags.latest)" >> $GITHUB_ENV
-    - run: echo "COMPONENTS_LAST_PUBLISHED_VERSION=$(npm view @${{ env.COMPONENTS_NPM_PATH }} dist-tags.latest)" >> $GITHUB_ENV
-    - run: echo "TEMPLATES_LAST_PUBLISHED_VERSION=$(npm view @${{ env.TEMPLATES_NPM_PATH }} dist-tags.latest)" >> $GITHUB_ENV
-    - run: echo "CODE_EDITOR_LAST_PUBLISHED_VERSION=$(npm view @${{ env.CODE_EDITOR_NPM_PATH }} dist-tags.latest)" >> $GITHUB_ENV
+    # Pega as versões publicadas no NPM e salva no arquivo versions.json
+    - name: Obter todas as versões publicadas
+      run: npm show @${{ env.COMPONENTS_NPM_PATH }} versions --json > versions.json
 
     # Pega a versão no package.json
     - name: Get package.json version.
@@ -56,87 +54,109 @@ jobs:
       with:
         path: po-angular
 
+    # Verifica se a versão a ser publicada já existe no NPM
+    - name: Verificar se a versão existe
+      id: version
+      run: |
+        VERSION_TO_CHECK=${{ steps.package-version.outputs.current-version }}
+        if jq -e --arg version "$VERSION_TO_CHECK" '.[] | select(. == $version)' versions.json; then
+          echo "publish=no" >> "$GITHUB_OUTPUT"
+        else
+          echo "publish=yes" >> "$GITHUB_OUTPUT"
+        fi
+
     # PUBLISH NG-SCHEMATICS
     - name: ng-schematics - publish
-      # Se a versão remota for igual à versão que será publicada então ele pula o publish deste pacote e tenta publicar os demais pacotes
-      if: (!contains(env.PACKAGE_VERSION, env.SCHEMATICS_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-schematics --tag latest --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-schematics --tag latest --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-schematics - add "latest" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.SCHEMATICS_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "latest"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-STORAGE
     - name: ng-storage - publish
-      if: (!contains(env.PACKAGE_VERSION, env.STORAGE_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-storage --tag latest --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-storage --tag latest --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-storage - add "latest" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.STORAGE_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "latest"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-SYNC
     - name: ng-sync - publish
-      if: (!contains(env.PACKAGE_VERSION, env.SYNC_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-sync --tag latest --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-sync --tag latest --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-sync - add "latest" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.SYNC_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "latest"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-COMPONENTS
     - name: ng-components - publish
-      if: (!contains(env.PACKAGE_VERSION, env.COMPONENTS_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-components --tag latest --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-components --tag latest --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-components - add "latest" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.COMPONENTS_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "latest"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-TEMPLATES
     - name: ng-templates - publish
-      if: (!contains(env.PACKAGE_VERSION, env.TEMPLATES_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-templates --tag latest --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-templates --tag latest --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-templates - add "latest" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.TEMPLATES_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "latest"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-CODE-EDITOR
     - name: ng-code-editor - publish
-      if: (!contains(env.PACKAGE_VERSION, env.CODE_EDITOR_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-code-editor --tag latest --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-code-editor --tag latest --ignore-scripts
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    # PUBLISH PORTAL
-    - name: portal build
-      run: npm run build:portal:docs && npm run build:portal:prod
+    - name: ng-code-editor - add "latest" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.CODE_EDITOR_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "latest"
       working-directory: ${{env.WORKING_DIR}}
-
-    - name: 'Deploy to Azure Web App'
-      uses: azure/webapps-deploy@v2
-      with:
-        app-name: ${{ env.AZURE_WEBAPP_NAME }}
-        package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-        publish-profile: ${{ secrets.AZURE_TOKEN }}
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_po_angular_ci-next.yml
+++ b/.github/workflows/publish_po_angular_ci-next.yml
@@ -17,6 +17,10 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Check out po-angular
       uses: actions/checkout@v4
@@ -39,13 +43,9 @@ jobs:
       run: npm install && npm run build
       working-directory: ${{env.WORKING_DIR}}
 
-    # Pega a última versão dos pacotes publicados no npm e armazena em variáveis
-    - run: echo "SCHEMATICS_LAST_PUBLISHED_VERSION=$(npm view @${{ env.SCHEMATICS_NPM_PATH }} dist-tags.next)" >> $GITHUB_ENV
-    - run: echo "STORAGE_LAST_PUBLISHED_VERSION=$(npm view @${{ env.STORAGE_NPM_PATH }} dist-tags.next)" >> $GITHUB_ENV
-    - run: echo "SYNC_LAST_PUBLISHED_VERSION=$(npm view @${{ env.SYNC_NPM_PATH }} dist-tags.next)" >> $GITHUB_ENV
-    - run: echo "COMPONENTS_LAST_PUBLISHED_VERSION=$(npm view @${{ env.COMPONENTS_NPM_PATH }} dist-tags.next)" >> $GITHUB_ENV
-    - run: echo "TEMPLATES_LAST_PUBLISHED_VERSION=$(npm view @${{ env.TEMPLATES_NPM_PATH }} dist-tags.next)" >> $GITHUB_ENV
-    - run: echo "CODE_EDITOR_LAST_PUBLISHED_VERSION=$(npm view @${{ env.CODE_EDITOR_NPM_PATH }} dist-tags.next)" >> $GITHUB_ENV
+    # Pega as versões publicadas no NPM e salva no arquivo versions.json
+    - name: Obter todas as versões publicadas
+      run: npm show @${{ env.COMPONENTS_NPM_PATH }} versions --json > versions.json
 
     # Pega a versão no package.json
     - name: Get package.json version.
@@ -54,75 +54,109 @@ jobs:
       with:
         path: po-angular
 
+    # Verifica se a versão a ser publicada já existe no NPM
+    - name: Verificar se a versão existe
+      id: version
+      run: |
+        VERSION_TO_CHECK=${{ steps.package-version.outputs.current-version }}
+        if jq -e --arg version "$VERSION_TO_CHECK" '.[] | select(. == $version)' versions.json; then
+          echo "publish=no" >> "$GITHUB_OUTPUT"
+        else
+          echo "publish=yes" >> "$GITHUB_OUTPUT"
+        fi
+
     # PUBLISH NG-SCHEMATICS
     - name: ng-schematics - publish
-      # Se a versão remota for igual à versão que será publicada então ele pula o publish deste pacote e tenta publicar os demais pacotes
-      if: (!contains(env.PACKAGE_VERSION, env.SCHEMATICS_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-schematics --tag next --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-schematics --tag next --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-schematics - add "next" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.SCHEMATICS_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "next"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-STORAGE
     - name: ng-storage - publish
-      if: (!contains(env.PACKAGE_VERSION, env.STORAGE_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-storage --tag next --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-storage --tag next --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-storage - add "next" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.STORAGE_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "next"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-SYNC
     - name: ng-sync - publish
-      if: (!contains(env.PACKAGE_VERSION, env.SYNC_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-sync --tag next --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-sync --tag next --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-sync - add "next" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.SYNC_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "next"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-COMPONENTS
     - name: ng-components - publish
-      if: (!contains(env.PACKAGE_VERSION, env.COMPONENTS_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-components --tag next --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-components --tag next --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-components - add "next" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.COMPONENTS_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "next"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-TEMPLATES
     - name: ng-templates - publish
-      if: (!contains(env.PACKAGE_VERSION, env.TEMPLATES_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-templates --tag next --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-templates --tag next --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-templates - add "next" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.TEMPLATES_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "next"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # PUBLISH NG-CODE-EDITOR
     - name: ng-code-editor - publish
-      if: (!contains(env.PACKAGE_VERSION, env.CODE_EDITOR_LAST_PUBLISHED_VERSION))
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm publish ${{env.WORKING_DIR}}/dist/ng-code-editor --tag next --ignore-scripts
+      if: contains(steps.version.outputs.publish, 'yes')
+      run: npm publish ${{env.WORKING_DIR}}/dist/ng-code-editor --tag next --ignore-scripts
+      env:
+        PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: ng-code-editor - add "next" tag
+      if: contains(steps.version.outputs.publish, 'no')
+      run: npm dist-tags add @${{ env.CODE_EDITOR_NPM_PATH }}@${{ env.PACKAGE_VERSION }} "next"
+      working-directory: ${{env.WORKING_DIR}}
       env:
         PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/projects/code-editor/package.json
+++ b/projects/code-editor/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@po-ui/ng-code-editor",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "next",
   "description": "PO UI - Code Editor",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@po-ui/ng-schematics",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "next",
   "description": "PO UI - Schematics",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/storage/package.json
+++ b/projects/storage/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@po-ui/ng-storage",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "next",
   "description": "PO UI - Storage",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/sync/package.json
+++ b/projects/sync/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@po-ui/ng-sync",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "next",
   "description": "PO UI - Sync",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/templates/package.json
+++ b/projects/templates/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@po-ui/ng-templates",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "next",
   "description": "PO UI - Templates",
   "author": "PO UI",
   "license": "MIT",

--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@po-ui/ng-components",
   "version": "0.0.0-PLACEHOLDER",
-  "tag": "next",
   "description": "PO UI - Components",
   "author": "PO UI",
   "license": "MIT",


### PR DESCRIPTION
Permite publicar no NPM com as tag's: next, latest e beta

Fixes DTHFUI-807

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Hoje existe apenas um action que envia a versão para o npm com as tag next e latest

**Qual o novo comportamento?**
Os actions serão separado pela tag que se deseja enviar para ao npm

**Simulação**
Dentro do GitHub na aba "Action" executar conforme a necessidade da publicação