### PR TITLE
feat(po-dynamic-edit): otimiza validacao

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -1184,27 +1184,6 @@ describe('PoPageDynamicEditComponent: ', () => {
       expect(component.model).toEqual(result);
     });
 
-    it('updateModel: should keep model if newResource is undefined', () => {
-      const newResource = undefined;
-      component.model = { prop1: 'test 1', prop2: 'test 2' };
-      const result = { prop1: 'test 1', prop2: 'test 2' };
-
-      component.dynamicForm = <any>{
-        form: {
-          form: {
-            patchValue: () => {}
-          }
-        }
-      };
-
-      const patchValueSpy = spyOn(component.dynamicForm.form.form, 'patchValue');
-
-      component['updateModel'](newResource);
-
-      expect(component.model).toEqual(result);
-      expect(patchValueSpy).toHaveBeenCalled();
-    });
-
     it('executeSave: should call `saveOperation`, `poNotification.success` and `navigateTo`', fakeAsync(() => {
       const saveRedirectPath = 'people';
 
@@ -1224,6 +1203,111 @@ describe('PoPageDynamicEditComponent: ', () => {
       });
       tick();
     }));
+
+    it('updateModel: should update model and call patchValue when newResource is defined and not empty', () => {
+      const newResource = { prop3: 'test 3' }; // Define newResource com uma nova propriedade
+      component.model = { prop1: 'test 1', prop2: 'test 2' }; // Estado inicial do modelo
+      const expectedModel = { ...component.model, ...newResource }; // Resultado esperado após a atualização
+
+      component.dynamicForm = <any>{
+        form: {
+          form: {
+            patchValue: () => {}
+          }
+        }
+      };
+
+      const patchValueSpy = spyOn(component.dynamicForm.form.form, 'patchValue');
+
+      component['updateModel'](newResource);
+
+      // Verifica se o modelo foi atualizado corretamente
+      expect(component.model).toEqual(expectedModel);
+      // Verifica se patchValue foi chamado com o modelo atualizado
+      expect(patchValueSpy).toHaveBeenCalledWith(expectedModel);
+    });
+
+    // Exemplo de teste ajustado sem modificar `keys`
+    it('updateModel: should update model properly without modifying read-only keys property', () => {
+      const newResource = { prop3: 'test 3' }; // Recurso para atualização
+      component.model = { prop1: 'test 1', prop2: 'test 2' };
+
+      component.dynamicForm = <any>{
+        form: {
+          form: {
+            patchValue: () => {}
+          }
+        }
+      };
+
+      const patchValueSpy = spyOn(component.dynamicForm.form.form, 'patchValue');
+
+      component['updateModel'](newResource);
+
+      // Verifique se o modelo foi atualizado corretamente
+      expect(component.model).toEqual(jasmine.objectContaining(newResource));
+      // Verifique se patchValue foi chamado
+      expect(patchValueSpy).toHaveBeenCalled();
+    });
+
+    it('updateModel: should not update model or call patchValue when newResource is undefined', () => {
+      component.model = { prop1: 'value1', prop2: 'value2' };
+      const originalModel = { ...component.model };
+
+      component.dynamicForm = <any>{
+        form: {
+          form: {
+            patchValue: () => {}
+          }
+        }
+      };
+      const patchValueSpy = spyOn(component.dynamicForm.form.form, 'patchValue');
+
+      component['updateModel'](undefined);
+
+      expect(component.model).toEqual(originalModel);
+      expect(patchValueSpy).not.toHaveBeenCalled();
+    });
+
+    it('updateModel: should not update model or call patchValue when newResource is an empty object', () => {
+      component.model = { prop1: 'value1', prop2: 'value2' };
+      const originalModel = { ...component.model };
+
+      component.dynamicForm = <any>{
+        form: {
+          form: {
+            patchValue: () => {}
+          }
+        }
+      };
+
+      const patchValueSpy = spyOn(component.dynamicForm.form.form, 'patchValue');
+
+      component['updateModel']({});
+
+      expect(component.model).toEqual(originalModel);
+      expect(patchValueSpy).not.toHaveBeenCalled();
+    });
+
+    it('updateModel: should update model and call patchValue when newResource is provided', () => {
+      component.model = { prop1: 'value1', prop2: 'value2' };
+      const newResource = { prop3: 'value3' };
+
+      component.dynamicForm = <any>{
+        form: {
+          form: {
+            patchValue: () => {}
+          }
+        }
+      };
+
+      const patchValueSpy = spyOn(component.dynamicForm.form.form, 'patchValue');
+
+      component['updateModel'](newResource);
+
+      expect(component.model).toEqual({ ...component.model, ...newResource });
+      expect(patchValueSpy).toHaveBeenCalledWith(component.model);
+    });
 
     it('executeSaveNew: should call `saveOperation`, `poNotification.success` and `navigateTo`', fakeAsync(() => {
       const saveNewRedirectPath = 'people';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -754,13 +754,15 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
   }
 
   private updateModel(newResource: any = {}) {
-    const dynamicNgForm = this.dynamicForm.form;
+    if (typeof newResource !== 'undefined' && Object.keys(newResource).length !== 0) {
+      const dynamicNgForm = this.dynamicForm.form;
 
-    removeKeysProperties(this.keys, newResource);
+      removeKeysProperties(this.keys, newResource);
 
-    this.model = { ...this.model, ...newResource };
+      this.model = { ...this.model, ...newResource };
 
-    dynamicNgForm.form.patchValue(this.model);
+      dynamicNgForm.form.patchValue(this.model);
+    }
   }
 
   private saveOperation() {


### PR DESCRIPTION
**< po-dynammic-edit>**

**< #1950 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao clicar no botão gravar no PoPageDynamicEdit, o componente valida seus campos obrigatórios. No entanto, se houver campos do tipo lookup já preenchidos (obrigatórios ou não), ao gravar, uma alteração no model é feita. Isso dispara o método writeValue do componente lookup, que executa um GET no serviço para recarregar as informações, mesmo que desnecessariamente. Esse comportamento resulta em um custo adicional para o servidor, especialmente em telas com vários componentes lookup, onde múltiplas requisições GET são enviadas desnecessariamente apenas para validar o formulário.

**Qual o novo comportamento?**
Com a melhoria proposta, alterações no model serão feitas apenas quando estritamente necessário, evitando requisições GET desnecessárias para campos do tipo lookup já preenchidos. Isso otimiza o uso dos recursos do servidor e melhora a performance da aplicação. A validação dos campos obrigatórios no PoPageDynamicEdit será mantida, mas o processo de atualização do model será otimizado para evitar disparar o writeValue de componentes lookup quando não houver necessidade real de recarregar os dados, reduzindo assim o número de requisições ao servidor.

**Simulação**
Para simular o comportamento atual, pode-se criar uma tela no PoPageDynamicEdit com vários campos do tipo lookup, marcá-los como obrigatórios ou não, preencha todos os campos exceto um dos obrigatórios e acione o botão de gravar. Observa-se que, mesmo sem alterações nos campos lookup, requisições GET são feitas para cada um deles.

Para simular o novo comportamento, após implementar a melhoria, o mesmo processo deverá resultar em nenhuma requisição GET adicional para os componentes lookup preenchidos, a menos que haja uma alteração real nos dados que exija a atualização do model. Isso pode ser verificado monitorando as chamadas de rede através das ferramentas de desenvolvedor do navegador ou de logs no servidor.