### PR TITLE
feat(input): permite output através do `(p-change-model)`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
@@ -229,6 +229,7 @@ describe('PoInputBase:', () => {
     it('controlChangeModelEmitter: should not emit changeModel if previous model value is equal to current model value', () => {
       const newModelValue: number = 1;
       component.modelLastUpdate = 1;
+      component.emitAllChanges = false;
 
       spyOn(component.changeModel, 'emit');
       component.controlChangeModelEmitter.call(component, newModelValue);
@@ -237,9 +238,10 @@ describe('PoInputBase:', () => {
     });
 
     it(`controlChangeModelEmitter: should emit changeModel with new value if previous
-        model value is different from current model value`, () => {
+    model value is different from current model value`, () => {
       const newModelValue: number = 2;
       component.modelLastUpdate = 1;
+      component.emitAllChanges = true;
 
       spyOn(component.changeModel, 'emit');
       component.controlChangeModelEmitter.call(component, newModelValue);

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -63,6 +63,17 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    */
   @Input('p-icon') icon?: string | TemplateRef<void>;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Sempre emite as alterações do model mesmo quando o valor atual for igual ao valor anterior.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-emit-all-changes', transform: convertToBoolean }) emitAllChanges: boolean = false;
+
   /** Rótulo do campo. */
   @Input('p-label') label?: string;
 
@@ -358,7 +369,7 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
   }
 
   controlChangeModelEmitter(value: any) {
-    if (this.modelLastUpdate !== value) {
+    if (this.modelLastUpdate !== value || this.emitAllChanges) {
       this.changeModel.emit(value);
       this.modelLastUpdate = value;
     }


### PR DESCRIPTION
feat(input): permite output através do (p-change-model)

**input**

**DTHFUI-7232**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Chamadas à formGroup.reset(), parecem não resetar o valor do model

**Qual o novo comportamento?**
Chamadas à formGroup.reset(), reseta e emite o valor do model

**Simulação**
portal
[app.zip](https://github.com/po-ui/po-angular/files/14364568/app.zip)
