### PR TITLE
feat(theme): adiciona serviço para a troca de tema

### DIFF
--- a/projects/ui/src/lib/services/index.ts
+++ b/projects/ui/src/lib/services/index.ts
@@ -9,3 +9,4 @@ export * from './po-dialog/index';
 export * from './po-language/index';
 export * from './po-i18n/index';
 export * from './po-notification/index';
+export * from './po-theme/index';

--- a/projects/ui/src/lib/services/po-theme/helpers/po-theme-default-values.constant.ts
+++ b/projects/ui/src/lib/services/po-theme/helpers/po-theme-default-values.constant.ts
@@ -1,0 +1,117 @@
+import { PoThemeTokens } from '../interfaces/po-theme-tokens.interface';
+
+/**
+ * @docsPrivate
+ *
+ * Tokens do tema Sunset
+ */
+export const poSunsetTheme: PoThemeTokens = {
+  '--color-brand-01-lightest': '#ffebee',
+  '--color-brand-01-lighter': '#ee7273',
+  '--color-brand-01-light': '#f03333',
+  '--color-brand-01-base': '#c20c18',
+  '--color-brand-02-base': '#c20c18',
+  '--color-brand-03-base': '#c20c18',
+  '--color-brand-01-dark': '#a5131a',
+  '--color-brand-01-darker': '#92131a',
+  '--color-brand-01-darkest': '#6a1915',
+  '--color-neutral-light-00': '#ffffff',
+  '--color-neutral-light-05': '#f2f2f2',
+  '--color-neutral-light-10': '#e5e5e5',
+  '--color-neutral-light-20': '#cccccc',
+  '--color-neutral-light-30': '#b2b2b2',
+  '--color-neutral-mid-40': '#999999',
+  '--color-neutral-mid-60': '#666666',
+  '--color-neutral-dark-70': '#4d4d4d',
+  '--color-neutral-dark-80': '#363636',
+  '--color-neutral-dark-90': '#1a1a1a',
+  '--color-neutral-dark-95': '#0d0d0d',
+  '--color-primary-light-80': '#ffebee'
+};
+
+/**
+ * @docsPrivate
+ *
+ * Tokens do tema Sunset Escuro
+ */
+export const poSunsetDarkTheme: PoThemeTokens = {
+  '--color-brand-01-lightest': '#ffebee',
+  '--color-brand-01-lighter': '#ee7273',
+  '--color-brand-01-light': '#f03333',
+  '--color-brand-01-base': '#c20c18',
+  '--color-brand-02-base': '#c20c18',
+  '--color-brand-03-base': '#c20c18',
+  '--color-brand-01-dark': '#a5131a',
+  '--color-brand-01-darker': '#92131a',
+  '--color-brand-01-darkest': '#6a1915',
+  '--color-neutral-light-00': '#0d0d0d',
+  '--color-neutral-light-05': '#363636',
+  '--color-neutral-light-10': '#606060',
+  '--color-neutral-light-20': '#818181',
+  '--color-neutral-light-30': '#979797',
+  '--color-neutral-mid-40': '#c2c2c2',
+  '--color-neutral-mid-60': '#dedede',
+  '--color-neutral-dark-70': '#818181',
+  '--color-neutral-dark-80': '#c2c2c2',
+  '--color-neutral-dark-90': '#f0f0f0',
+  '--color-neutral-dark-95': '#fafafa',
+  '--color-primary-light-80': '#ffebee'
+};
+
+/**
+ * @docsPrivate
+ *
+ * Tokens do tema TOTVS
+ */
+export const poTotvsTheme: PoThemeTokens = {
+  '--color-brand-01-lightest': '#d7f0fe',
+  '--color-brand-01-lighter': '#9cd8fc',
+  '--color-brand-01-light': '#6bc5fa',
+  '--color-brand-01-base': '#045b8f',
+  '--color-brand-02-base': '#045b8f',
+  '--color-brand-03-base': '#045b8f',
+  '--color-brand-01-dark': '#013f65',
+  '--color-brand-01-darker': '#002944',
+  '--color-brand-01-darkest': '#00182b',
+  '--color-neutral-light-00': '#ffffff',
+  '--color-neutral-light-05': '#f2f2f2',
+  '--color-neutral-light-10': '#e5e5e5',
+  '--color-neutral-light-20': '#cccccc',
+  '--color-neutral-light-30': '#b2b2b2',
+  '--color-neutral-mid-40': '#999999',
+  '--color-neutral-mid-60': '#666666',
+  '--color-neutral-dark-70': '#4d4d4d',
+  '--color-neutral-dark-80': '#363636',
+  '--color-neutral-dark-90': '#1a1a1a',
+  '--color-neutral-dark-95': '#0d0d0d',
+  '--color-primary-light-80': '#d7f0fe'
+};
+
+/**
+ * @docsPrivate
+ *
+ * Tokens do tema TOTVS escuro
+ */
+export const poTotvsDarkTheme: PoThemeTokens = {
+  '--color-brand-01-lightest': '#d7f0fe',
+  '--color-brand-01-lighter': '#9cd8fc',
+  '--color-brand-01-light': '#6bc5fa',
+  '--color-brand-01-base': '#045b8f',
+  '--color-brand-02-base': '#045b8f',
+  '--color-brand-03-base': '#045b8f',
+  '--color-brand-01-dark': '#013f65',
+  '--color-brand-01-darker': '#002944',
+  '--color-brand-01-darkest': '#00182b',
+  '--color-neutral-light-00': '#0d0d0d',
+  '--color-neutral-light-05': '#363636',
+  '--color-neutral-light-10': '#606060',
+  '--color-neutral-light-20': '#818181',
+  '--color-neutral-light-30': '#979797',
+  '--color-neutral-mid-40': '#c2c2c2',
+  '--color-neutral-mid-60': '#dedede',
+  '--color-neutral-dark-70': '#818181',
+  '--color-neutral-dark-80': '#c2c2c2',
+  '--color-neutral-dark-90': '#f0f0f0',
+  '--color-neutral-dark-95': '#fafafa',
+  '--color-primary-light-80': '#d7f0fe'
+};

--- a/projects/ui/src/lib/services/po-theme/index.ts
+++ b/projects/ui/src/lib/services/po-theme/index.ts
@@ -1,0 +1,4 @@
+export * from './helpers/po-theme-default-values.constant';
+export * from './interfaces/po-theme-tokens.interface';
+export * from './po-theme.service';
+export * from './po-theme.module';

--- a/projects/ui/src/lib/services/po-theme/interfaces/po-theme-tokens.interface.ts
+++ b/projects/ui/src/lib/services/po-theme/interfaces/po-theme-tokens.interface.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+/**
+ * @usedBy PoThemeService
+ *
+ * @description
+ *
+ * Interface para o método `setTheme()` do serviço PoThemeService.
+ */
+export interface PoThemeTokens {
+  /** Token para cor base 01 - Variação muito mais clara */
+  '--color-brand-01-lightest'?: string;
+
+  /** Token para cor base 01 - Variação mais clara */
+  '--color-brand-01-lighter'?: string;
+
+  /** Token para cor base 01 - Variação clara */
+  '--color-brand-01-light'?: string;
+
+  /** Token para cor base 01 - Variação escura */
+  '--color-brand-01-dark'?: string;
+
+  /** Token para cor base 01 - Variação mais escura */
+  '--color-brand-01-darker'?: string;
+
+  /** Token para cor base 01 - Variação muito mais escura */
+  '--color-brand-01-darkest'?: string;
+
+  /** Token para cor base 01 */
+  '--color-brand-01-base'?: string;
+
+  /** Token para cor base 02 */
+  '--color-brand-02-base'?: string;
+
+  /** Token para cor base 03 */
+  '--color-brand-03-base'?: string;
+
+  /** Token para cor de fundo de componentes de calendario */
+  '--color-primary-light-80'?: string;
+
+  /**Token para paleta de cores neutras - variação mais clara - 00*/
+  '--color-neutral-light-00'?: string;
+
+  /**Token para paleta de cores neutras - variação mais clara - 05*/
+  '--color-neutral-light-05'?: string;
+
+  /**Token para paleta de cores neutras - variação mais clara - 10*/
+  '--color-neutral-light-10'?: string;
+
+  /**Token para paleta de cores neutras - variação mais clara - 20*/
+  '--color-neutral-light-20'?: string;
+
+  /**Token para paleta de cores neutras - variação mais clara - 30*/
+  '--color-neutral-light-30'?: string;
+
+  /**Token para paleta de cores neutras - variação medio - 40*/
+  '--color-neutral-mid-40'?: string;
+
+  /**Token para paleta de cores neutras - variação medio - 60*/
+  '--color-neutral-mid-60'?: string;
+
+  /**Token para paleta de cores neutras - variação escura - 70*/
+  '--color-neutral-dark-70'?: string;
+
+  /**Token para paleta de cores neutras - variação escura - 80*/
+  '--color-neutral-dark-80'?: string;
+
+  /**Token para paleta de cores neutras - variação escura - 90*/
+  '--color-neutral-dark-90'?: string;
+
+  /**Token para paleta de cores neutras - variação escura - 95*/
+  '--color-neutral-dark-95'?: string;
+}

--- a/projects/ui/src/lib/services/po-theme/po-theme.module.ts
+++ b/projects/ui/src/lib/services/po-theme/po-theme.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { PoThemeService } from './po-theme.service';
+
+/**
+ * @description
+ * Modulo para o serviço po-theme
+ */
+@NgModule({
+  providers: [PoThemeService, { provide: 'Window', useValue: window }],
+  bootstrap: []
+})
+export class PoThemeModule {}

--- a/projects/ui/src/lib/services/po-theme/po-theme.service.spec.ts
+++ b/projects/ui/src/lib/services/po-theme/po-theme.service.spec.ts
@@ -1,0 +1,143 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Renderer2, RendererFactory2 } from '@angular/core';
+import { PoThemeService } from './po-theme.service';
+import { PoThemeTokens } from './interfaces/po-theme-tokens.interface';
+
+describe('PoThemeService:', () => {
+  let service: PoThemeService;
+  let mockRenderer: jasmine.SpyObj<Renderer2>;
+
+  beforeEach(() => {
+    mockRenderer = jasmine.createSpyObj<Renderer2>('Renderer2', [
+      'setProperty',
+      'createElement',
+      'appendChild',
+      'createText',
+      'removeChild'
+    ]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: 'Window', useValue: { document: { head: {} } } },
+        { provide: RendererFactory2, useValue: { createRenderer: () => mockRenderer } },
+        PoThemeService
+      ]
+    });
+
+    service = TestBed.inject(PoThemeService);
+  });
+
+  it('should be load `service` correctly', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('Methods: ', () => {
+    it('should set a theme empty', () => {
+      service.setTheme({});
+      expect(mockRenderer.setProperty).not.toHaveBeenCalled();
+    });
+
+    it('should set theme with background image in PoSelect', fakeAsync(() => {
+      const themeWithColorBrand: PoThemeTokens = {
+        '--color-brand-01-dark': '#123456'
+      };
+
+      service.setTheme(themeWithColorBrand);
+      tick();
+
+      expect(mockRenderer.setProperty).toHaveBeenCalledWith(
+        document.documentElement,
+        'style',
+        '--color-brand-01-dark: #123456;'
+      );
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('style');
+      expect(mockRenderer.appendChild).toHaveBeenCalled();
+      expect(mockRenderer.createText).toHaveBeenCalled();
+    }));
+
+    it('should not set theme with empty color brand property in PoSelect', fakeAsync(() => {
+      const themeWithColorBrand: PoThemeTokens = {
+        '--color-brand-01-dark': ''
+      };
+
+      service.setTheme(themeWithColorBrand);
+      tick();
+
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('style');
+      expect(mockRenderer.setProperty).not.toHaveBeenCalled();
+      expect(mockRenderer.appendChild).toHaveBeenCalled();
+      expect(mockRenderer.createText).toHaveBeenCalled();
+    }));
+
+    it('should clean background image style in PoSelect', fakeAsync(() => {
+      const getBGImageStyleSpy = spyOn<any>(service, 'getBGImageStyleInPoSelect').and.returnValue(
+        {} as HTMLStyleElement
+      );
+      tick();
+
+      service['cleanBGImageStyleInPoSelect']();
+
+      expect(getBGImageStyleSpy).toHaveBeenCalled();
+      expect(mockRenderer.removeChild).toHaveBeenCalled();
+    }));
+
+    it('should get background image style in PoSelect', fakeAsync(() => {
+      const css = 'select {--background-image: url(xpto)}';
+      const style = document.createElement('style');
+
+      document.head.appendChild(style);
+      style.appendChild(document.createTextNode(css));
+
+      const result = service['getBGImageStyleInPoSelect']();
+      tick();
+
+      expect(result?.textContent).toEqual(`select {--background-image: url(xpto)}`);
+
+      document.head.removeChild(style);
+    }));
+
+    it('should be set theme sunset', fakeAsync(() => {
+      const spyChangeBGImg = spyOn<any>(service, 'changeBGImagemInPoSelect').and.callThrough();
+      service.setSunsetTheme();
+      tick();
+      expect(spyChangeBGImg).toHaveBeenCalledWith('#a5131a');
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('style');
+      expect(mockRenderer.setProperty).toHaveBeenCalled();
+      expect(mockRenderer.appendChild).toHaveBeenCalled();
+      expect(mockRenderer.createText).toHaveBeenCalled();
+    }));
+
+    it('should be set theme sunset dark', fakeAsync(() => {
+      const spyChangeBGImg = spyOn<any>(service, 'changeBGImagemInPoSelect').and.callThrough();
+      service.setSunsetDarkTheme();
+      tick();
+      expect(spyChangeBGImg).toHaveBeenCalledWith('#a5131a');
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('style');
+      expect(mockRenderer.setProperty).toHaveBeenCalled();
+      expect(mockRenderer.appendChild).toHaveBeenCalled();
+      expect(mockRenderer.createText).toHaveBeenCalled();
+    }));
+
+    it('should be set theme TOTVS', fakeAsync(() => {
+      const spyChangeBGImg = spyOn<any>(service, 'changeBGImagemInPoSelect').and.callThrough();
+      service.setTotvsTheme();
+      tick();
+      expect(spyChangeBGImg).toHaveBeenCalledWith('#013f65');
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('style');
+      expect(mockRenderer.setProperty).toHaveBeenCalled();
+      expect(mockRenderer.appendChild).toHaveBeenCalled();
+      expect(mockRenderer.createText).toHaveBeenCalled();
+    }));
+
+    it('should be set theme TOTVS dark', fakeAsync(() => {
+      const spyChangeBGImg = spyOn<any>(service, 'changeBGImagemInPoSelect').and.callThrough();
+      service.setTotvsDarkTheme();
+      tick();
+      expect(spyChangeBGImg).toHaveBeenCalledWith('#013f65');
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('style');
+      expect(mockRenderer.setProperty).toHaveBeenCalled();
+      expect(mockRenderer.appendChild).toHaveBeenCalled();
+      expect(mockRenderer.createText).toHaveBeenCalled();
+    }));
+  });
+});

--- a/projects/ui/src/lib/services/po-theme/po-theme.service.ts
+++ b/projects/ui/src/lib/services/po-theme/po-theme.service.ts
@@ -1,0 +1,176 @@
+import { Inject, Injectable, Renderer2, RendererFactory2 } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { PoThemeTokens } from './interfaces/po-theme-tokens.interface';
+import {
+  poSunsetDarkTheme,
+  poSunsetTheme,
+  poTotvsDarkTheme,
+  poTotvsTheme
+} from './helpers/po-theme-default-values.constant';
+
+/**
+ * @description
+ *
+ * O `PoThemeService` possibilita a personalização das cores do tema padrão do `PO-UI`, permitindo a alteração dos valores das variáveis de estilo usadas no CSS padrão.
+ *
+ * > Para saber mais sobre como customizar as cores do tema padrão verifique o item [Customizando cores do tema padrão](https://po-ui.io/guides/colors-customization) na aba `Guias`.
+ *
+ * > Atenção: Para saber quais browsers dão suporte a variáveis você pode consultar a ferramenta [Can I use](https://caniuse.com/?search=CSS%20Variables).
+ *
+ * @example
+ *
+ * <example name="po-theme-basic" title="PO Theme Basic">
+ *  <file name="sample-po-theme-basic/sample-po-theme-basic.component.html"> </file>
+ *  <file name="sample-po-theme-basic/sample-po-theme-basic.component.ts"> </file>
+ * </example>
+ *
+ * <example name="po-theme-form" title="PO Theme Form">
+ *  <file name="sample-po-theme-form/sample-po-theme-form.component.html"> </file>
+ *  <file name="sample-po-theme-form/sample-po-theme-form.component.ts"> </file>
+ * </example>
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class PoThemeService {
+  private renderer: Renderer2;
+
+  constructor(
+    @Inject('Window') private window: Window,
+    @Inject(DOCUMENT) private document: Document,
+    rendererFactory: RendererFactory2
+  ) {
+    this.renderer = rendererFactory.createRenderer(null, null);
+  }
+
+  /**
+   * <a id="set-theme"></a>
+   *
+   * Método para alterar o tema utilizado.
+   *
+   * Ao utilizar este método, será adicionado um novo estilo (CSS) somente com as variáveis que foram informadas.
+   *
+   * > O método `setTheme()` recebe um parâmetro do tipo da interface `PoThemeTokens`, porém, nenhuma das propriedades são obrigatórias.
+   * Caso o valor de uma propriedade seja vazio, a mesma será ignorada.
+   *
+   * @param {PoThemeTokens} theme Objeto com os tokens do Tema.
+   */
+  setTheme(theme: PoThemeTokens): void {
+    let styleCss: string = '';
+
+    Object.keys(theme).forEach((token: string) => {
+      styleCss = theme[token as keyof any] ? styleCss.concat(`${token}: ${theme[token as keyof any]};`) : styleCss;
+      if (token === '--color-brand-01-dark') {
+        this.changeBGImagemInPoSelect(theme[token] || '5b1c7d');
+      }
+    });
+
+    if (styleCss) {
+      this.renderer.setProperty(this.document.documentElement, 'style', styleCss);
+    }
+  }
+
+  /**
+   * @docsPrivate
+   *
+   * Método para alterar o tema para o tema Sunset.
+   */
+  setSunsetTheme(): void {
+    this.setTheme(poSunsetTheme);
+  }
+
+  /**
+   * @docsPrivate
+   *
+   * Método para alterar o tema para o tema Sunset escuro.
+   */
+  setSunsetDarkTheme(): void {
+    this.setTheme(poSunsetDarkTheme);
+  }
+
+  /**
+   * @docsPrivate
+   *
+   * Método para alterar o tema para o tema TOTVS.
+   */
+  setTotvsTheme(): void {
+    this.setTheme(poTotvsTheme);
+  }
+
+  /**
+   * @docsPrivate
+   *
+   * Método para alterar o tema para o tema TOTVS escuro.
+   */
+  setTotvsDarkTheme(): void {
+    this.setTheme(poTotvsDarkTheme);
+  }
+
+  /**
+   * @docsPrivate
+   *
+   * Altera a cor de fundo da imagem utilizada no po-select.
+   * @param {string} color Cor da Imagem - Utilizada no atributo Fill.
+   */
+  private changeBGImagemInPoSelect(color: string): void {
+    const styleElement: HTMLStyleElement = this.renderer.createElement('style');
+
+    color = color[0] === '#' ? color.substring(1) : color;
+    const css: string = `select {--background-image: url(${this.getBGImageforPoSelect(color)})}`;
+
+    this.cleanBGImageStyleInPoSelect();
+
+    this.renderer.appendChild(styleElement, this.renderer.createText(css));
+    this.renderer.appendChild(this.window.document.head, styleElement);
+  }
+
+  /**
+   * @docsPrivate
+   *
+   * Limpa o estilo de uma imagem de fundo do po-select par aum tema personalizado.
+   */
+  private cleanBGImageStyleInPoSelect(): void {
+    const styleElement: HTMLStyleElement | undefined = this.getBGImageStyleInPoSelect();
+
+    if (styleElement) {
+      this.renderer.removeChild(this.window.document.head, styleElement);
+    }
+  }
+
+  /**
+   * @docsPrivate
+   *
+   * Obtem a Imagem no formato SVG utilizada como fundo do po-select
+   * @param {string} color Cor da Imagem - Utilizada no atributo Fill.
+   * @returns {string} Imagem SVG utilizada no componente po-select
+   */
+  private getBGImageforPoSelect(color: string): string {
+    let svg: string = `"data:image/svg+xml;charset=utf-8,%3Csvg width='24' height='24' fill='none' `;
+
+    svg = svg.concat(`xmlns='http://www.w3.org/2000/svg'%3E%3Cpath `);
+    svg = svg.concat(`fill-rule='evenodd' clip-rule='evenodd' `);
+    svg = svg.concat(`d='M18.707 8.293a.999.999 0 00-1.414 0L12 13.586 6.707 `);
+    svg = svg.concat(`8.293a.999.999 0 10-1.414 1.414l6 6a.997.997 `);
+
+    return svg.concat(`0 001.414 0l6-6a.999.999 0 000-1.414z' fill='%23${color}'/%3E%3C/svg%3E"`);
+  }
+
+  /**
+   * @docsPrivate
+   *
+   * Obtem o estilo (style) da imagem utilizada no po-select utilizado em um tema personalizado.
+   * @returns {HTMLStyleElement | undefined} Estilo (style) personalizado do po-select.
+   */
+  private getBGImageStyleInPoSelect(): HTMLStyleElement | undefined {
+    const styles = this.document.head.querySelectorAll('style');
+    let style: HTMLStyleElement | undefined;
+
+    styles.forEach((el: HTMLStyleElement) => {
+      if (el.textContent.includes('select {--background-image')) {
+        style = el;
+      }
+    });
+
+    return style;
+  }
+}

--- a/projects/ui/src/lib/services/po-theme/samples/sample-po-theme-basic/sample-po-theme-basic.component.html
+++ b/projects/ui/src/lib/services/po-theme/samples/sample-po-theme-basic/sample-po-theme-basic.component.html
@@ -1,0 +1,2 @@
+<po-button p-label="Set brand color blue" (p-click)="poTheme.setTheme({ '--color-brand-01-base': '#0470FF' })">
+</po-button>

--- a/projects/ui/src/lib/services/po-theme/samples/sample-po-theme-basic/sample-po-theme-basic.component.ts
+++ b/projects/ui/src/lib/services/po-theme/samples/sample-po-theme-basic/sample-po-theme-basic.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+import { PoThemeService } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-theme-basic',
+  templateUrl: './sample-po-theme-basic.component.html'
+})
+export class SamplePoThemeBasicComponent {
+  constructor(public poTheme: PoThemeService) {}
+}

--- a/projects/ui/src/lib/services/po-theme/samples/sample-po-theme-form/sample-po-theme-form.component.html
+++ b/projects/ui/src/lib/services/po-theme/samples/sample-po-theme-form/sample-po-theme-form.component.html
@@ -1,0 +1,120 @@
+<div class="po-row">
+  <po-combo
+    class="po-md-2"
+    p-label="Theme"
+    p-placeholder="Select a theme"
+    [p-options]="themeOptions"
+    (p-change)="onChangeTheme($event)"
+  ></po-combo>
+</div>
+
+<form #f="ngForm">
+  <div class="po-row">
+    <po-divider class="po-md-12" p-label="PERSONAL DATA"></po-divider>
+    <po-input
+      class="po-md-5"
+      name="name"
+      [(ngModel)]="name"
+      p-label="Name"
+      p-placeholder="Type your name"
+      [p-show-required]="true"
+      p-required
+      p-clean
+    ></po-input>
+
+    <po-datepicker
+      class="po-md-3"
+      name="dateOfBirth"
+      [(ngModel)]="dateOfBirth"
+      p-label="Date of Birth"
+      p-clean
+    ></po-datepicker>
+
+    <po-radio-group
+      class="po-md-3"
+      name="genre"
+      [(ngModel)]="genre"
+      p-label="Genre"
+      [p-columns]="3"
+      [p-options]="genreOptions"
+      [p-required]="true"
+      [p-show-required]="true"
+    ></po-radio-group>
+
+    <po-divider class="po-md-12" p-label="ADDRESS DATA"></po-divider>
+    <po-input
+      class="po-md-9"
+      name="address"
+      [(ngModel)]="address"
+      p-label="Address"
+      p-placeholder="Type your address"
+    ></po-input>
+
+    <po-number
+      class="po-md-3"
+      name="addressNumber"
+      [(ngModel)]="addressNumber"
+      p-label="Address number"
+      p-placeholder="0"
+    ></po-number>
+
+    <po-divider class="po-md-12" p-label="CONTACT DATA"></po-divider>
+    <po-input
+      class="po-md-2"
+      name="phone"
+      [(ngModel)]="phone"
+      p-label="Phone"
+      p-mask="(99) 9999-9999"
+      p-placeholder="(99) 9999-9999"
+      p-clean
+    ></po-input>
+
+    <po-email
+      class="po-md-5"
+      name="email"
+      [(ngModel)]="email"
+      p-label="E-Mail"
+      p-placeholder="Type your e-mail"
+      p-required
+      [p-show-required]="true"
+    ></po-email>
+
+    <po-url
+      class="po-lg-5"
+      name="website"
+      [(ngModel)]="website"
+      p-label="Website"
+      p-placeholder="Type your website"
+      [p-optional]="true"
+      p-clean
+    ></po-url>
+
+    <po-divider class="po-md-12" p-label="OTHERS"></po-divider>
+    <po-lookup
+      class="po-md-3"
+      name="hero"
+      [(ngModel)]="heros"
+      p-label="Favorite Hero"
+      [p-optional]="true"
+      p-field-label="label"
+      p-field-value="value"
+      p-filter-service="https://po-sample-api.onrender.com/v1/heroes"
+      p-multiple
+    ></po-lookup>
+  </div>
+
+  <div class="po-row">
+    <po-button
+      class="po-md-2"
+      p-label="Add"
+      (p-click)="onClickAdd()"
+      p-kind="primary"
+      [p-disabled]="f.form.invalid"
+    ></po-button>
+    <po-button class="po-md-2" p-label="Reset" (p-click)="onClickReset()" p-danger></po-button>
+  </div>
+</form>
+
+<hr />
+
+<po-table [p-columns]="columns" [p-items]="items" [p-hide-table-search]="false" p-striped></po-table>

--- a/projects/ui/src/lib/services/po-theme/samples/sample-po-theme-form/sample-po-theme-form.component.ts
+++ b/projects/ui/src/lib/services/po-theme/samples/sample-po-theme-form/sample-po-theme-form.component.ts
@@ -1,0 +1,111 @@
+import { Component } from '@angular/core';
+
+import { PoComboOption, PoRadioGroupOption, PoTableColumn, PoThemeTokens, PoThemeService } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-theme-form',
+  templateUrl: './sample-po-theme-form.component.html'
+})
+export class SamplePoThemeFormComponent {
+  address: string;
+  addressNumber: number;
+  dateOfBirth: Date;
+  email: string;
+  genre: string;
+  heros: Array<any>;
+  name: string;
+  phone: string;
+  website: string;
+
+  readonly columns: Array<PoTableColumn> = [
+    { property: 'name', label: 'Name' },
+    { property: 'email', label: 'E-mail' },
+    {
+      property: 'genre',
+      label: 'Genre',
+      type: 'label',
+      labels: [
+        { value: '1', color: 'color-02', label: 'Male' },
+        { value: '2', color: 'color-05', label: 'Female' },
+        { value: '3', color: 'color-10', label: 'Other' }
+      ]
+    }
+  ];
+
+  readonly genreOptions: Array<PoRadioGroupOption> = [
+    { label: 'Male', value: '1' },
+    { label: 'Female', value: '2' },
+    { label: 'Other', value: '3' }
+  ];
+
+  items: Array<any> = [
+    { name: 'James', email: 'james@xpto.com', genre: '1' },
+    { name: 'Thomas', email: 'thomas@xpto.com', genre: '1' },
+    { name: 'Sophia', email: 'sophia@poui.com', genre: '2' },
+    { name: 'John', email: 'john@xpto.com', genre: '1' },
+    { name: 'Emma', email: 'emma@xisto.com.br', genre: '2' }
+  ];
+
+  readonly themeOptions: Array<PoComboOption> = [
+    { label: 'Blue', value: 'blue' },
+    { label: 'Red', value: 'red' }
+  ];
+
+  readonly blueTheme: PoThemeTokens = {
+    '--color-brand-01-lightest': '#EBEBF5',
+    '--color-brand-01-lighter': '#C2C2E5',
+    '--color-brand-01-light': '#9898CD',
+    '--color-brand-01-dark': '#1F1F7A',
+    '--color-brand-01-darker': '#0D0D59',
+    '--color-brand-01-darkest': '#030330',
+    '--color-brand-01-base': '#4545A1',
+    '--color-brand-02-base': '#4545A1',
+    '--color-brand-03-base': '#4545A1',
+    '--color-primary-light-80': '#36364A',
+    '--color-neutral-light-05': '#F9F9FA',
+    '--color-neutral-light-10': '#ECECEE'
+  };
+
+  readonly redTheme: PoThemeTokens = {
+    '--color-brand-01-lightest': '#f9a8a3',
+    '--color-brand-01-lighter': '#ec7674',
+    '--color-brand-01-light': '#e55d5d',
+    '--color-brand-01-dark': '#8d1212',
+    '--color-brand-01-darker': '#780909',
+    '--color-brand-01-darkest': '#640000',
+    '--color-brand-01-base': '#b52424',
+    '--color-brand-02-base': '#b52424',
+    '--color-brand-03-base': '#b52424',
+    '--color-primary-light-80': '#b52424',
+    '--color-neutral-light-05': '#FDE6DC',
+    '--color-neutral-light-10': '#FDCCB2'
+  };
+
+  constructor(private poTheme: PoThemeService) {}
+
+  onChangeTheme(theme: string): void {
+    this.poTheme.setTheme(theme === 'blue' ? this.blueTheme : this.redTheme);
+  }
+
+  onClickAdd(): void {
+    this.items.push({
+      name: this.name,
+      email: this.email,
+      genre: this.genre
+    });
+
+    this.onClickReset();
+  }
+
+  onClickReset(): void {
+    this.name = '';
+    this.dateOfBirth = new Date();
+    this.genre = '';
+    this.address = '';
+    this.addressNumber = 0;
+    this.phone = '';
+    this.email = '';
+    this.website = '';
+    this.heros = [];
+  }
+}

--- a/projects/ui/src/lib/services/services.module.ts
+++ b/projects/ui/src/lib/services/services.module.ts
@@ -9,6 +9,7 @@ import { PoDialogModule } from './po-dialog/po-dialog.module';
 import { PoI18nPipe } from './po-i18n/po-i18n.pipe';
 import { PoLanguageModule } from './po-language/po-language.module';
 import { PoNotificationModule } from './po-notification/po-notification.module';
+import { PoThemeModule } from './po-theme/po-theme.module';
 
 @NgModule({
   declarations: [PoI18nPipe],
@@ -20,7 +21,8 @@ import { PoNotificationModule } from './po-notification/po-notification.module';
     PoDateTimeModule,
     PoDialogModule,
     PoLanguageModule,
-    PoNotificationModule
+    PoNotificationModule,
+    PoThemeModule
   ],
   exports: [
     PoActiveOverlayModule,
@@ -30,7 +32,8 @@ import { PoNotificationModule } from './po-notification/po-notification.module';
     PoDateTimeModule,
     PoDialogModule,
     PoI18nPipe,
-    PoNotificationModule
+    PoNotificationModule,
+    PoThemeModule
   ],
   providers: [],
   bootstrap: []


### PR DESCRIPTION
Theme

#1964
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ x [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente não é possível alterar o estilo de CSS em aplicações em PO-UI.

**Qual o novo comportamento?**
Adicionado o serviço PoTheme para alterar os tokens de tema padrão.

**Simulação**
Portal - Serviço PoTheme