### PR TITLE
fix(listbox): corrige erros ao usar TemplateRef

### DIFF
--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
@@ -54,7 +54,7 @@
           [p-disabled]="returnBooleanValue(item, 'disabled')"
           [p-visible]="returnBooleanValue(item, 'visible')"
           [p-checkbox-value]="isSelectedItem(item)"
-          [attr.data-item-list]="isTabs ? item.id : (item | json)"
+          [attr.data-item-list]="formatItemList(item)"
           [p-label]="item[fieldLabel]"
           [p-value]="item[fieldValue]"
           [p-selected]="isSelectedItem(item) || item.selected"

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
@@ -770,4 +770,26 @@ describe('PoListBoxComponent', () => {
       expect(component.checkTemplate()).toBeFalsy();
     });
   });
+
+  describe('formatItemList', () => {
+    it('should return item.id if isTabs is true', () => {
+      component.isTabs = true;
+      const item = { id: 'identifier' };
+      expect(component.formatItemList(item)).toEqual('identifier');
+    });
+
+    it('should return stringified item if isTabs is false and item is stringifiable', () => {
+      component.isTabs = false;
+      const item = { name: 'Test' };
+      expect(component.formatItemList(item)).toEqual(JSON.stringify(item));
+    });
+
+    it('should return item itself if isTabs is false and item cannot be stringified', () => {
+      component.isTabs = false;
+      const item: any = { self: null };
+      item.self = item;
+      const result = component.formatItemList(item);
+      expect(result).toBe(item);
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
@@ -238,4 +238,16 @@ export class PoListBoxComponent extends PoListBoxBaseComponent implements AfterV
       this.clickTab.emit(tab);
     }
   }
+
+  formatItemList(item: any): string {
+    if (this.isTabs) {
+      return item.id;
+    } else {
+      try {
+        return JSON.stringify(item);
+      } catch (error) {
+        return item;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Corrige listbox para permitir o uso de TemplateRef sem quebrar a aplicação

fixes DTHFUI-8417

**LISTBOX**

**DTHFUI-8417**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ocorrem diversos erros no console ao utilizar templateRef no item icon da interface PoPopupAction e o componente não é renderizado da maneira correta.

**Qual o novo comportamento?**
O componente e o ícone devem ser apresetados corretamente. 

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/14440694/app.zip)
