### PR TITLE
fix(combo): Altera para `null` 'selectedValue' e 'selectedOption'

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -237,6 +237,15 @@ describe('PoComboComponent:', () => {
     expect(component.inputEl.nativeElement.value).toBe('1234567890');
   });
 
+  it('should have been called cleanListbox', () => {
+    spyOn(component, 'cleanListbox');
+
+    component.setInputValue(null);
+    fixture.detectChanges();
+
+    expect(component.cleanListbox).toHaveBeenCalled();
+  });
+
   it('should click in document', () => {
     component['initializeListeners']();
     const documentBody = document.body;
@@ -1043,6 +1052,22 @@ describe('PoComboComponent:', () => {
       const result = component.calculateScrollTop(selectedItem, index);
 
       expect(result).toBe(100);
+    });
+
+    it('cleanListbox: should have been called updateSelectedValue and update selected option', () => {
+      component.options = [
+        {
+          label: 'a',
+          value: 'a',
+          selected: true
+        }
+      ];
+      spyOn(component, 'updateSelectedValue');
+
+      component.cleanListbox();
+
+      expect(component.updateSelectedValue).toHaveBeenCalled();
+      expect(component.options).toEqual([{ label: 'a', value: 'a', selected: false }]);
     });
 
     it(`close: should call 'removeListeners' and 'detectChanges'

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -480,12 +480,21 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }
   }
 
+  cleanListbox() {
+    this.updateSelectedValue(null);
+    this.options.map(option => (option.selected = false));
+  }
+
   getInputValue() {
     return this.inputEl.nativeElement.value;
   }
 
   setInputValue(value: string): void {
     this.inputEl.nativeElement.value = value;
+
+    if (value === null) {
+      this.cleanListbox();
+    }
   }
 
   wasClickedOnToggle(event: MouseEvent): void {


### PR DESCRIPTION
Altera para `null` 'selectedValue' e 'selectedOption' usando `setInputValue`

**combo**

**DTHFUI-8405**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não tem ação no 'p-change' após usar o método do combo: 'setInputValue(null)';

**Qual o novo comportamento?**
Ao limpar o combo utilizando o método, 'setInputValue(null)', altera para `null` 'selectedValue' e 'selectedOption'

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/14499065/app.zip)
