### PR TITLE
fix(select): campo reseta valor para nulo usando formulário reativo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -254,14 +254,14 @@ describe('PoSelectComponent:', () => {
       component.selectedValue = 'payment';
       component.options.length = 0;
       component.writeValue(undefined);
-      expect(component.selectedValue).toBeUndefined();
+      expect(component.selectedValue).toBeNull();
     });
 
     it('writeValue: should define selectedValue with undefined and doesn`t call setScrollPosition if optionsFound is false', () => {
       component.selectedValue = 'payment';
 
       component.writeValue('value invalid');
-      expect(component.selectedValue).toBeUndefined();
+      expect(component.selectedValue).toBeNull();
     });
 
     it('writeValue: should set property values and call `setScrollPosition` if is a valid option', () => {

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -323,10 +323,10 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
       this.selectedValue = optionFound[this.fieldValue];
       this.displayValue = optionFound[this.fieldLabel];
     } else if (validValue(this.selectedValue)) {
-      this.selectElement.nativeElement.value = undefined;
-      this.updateModel(undefined);
-      this.selectedValue = undefined;
-      this.displayValue = undefined;
+      this.selectElement.nativeElement.value = null;
+      this.updateModel(null);
+      this.selectedValue = null;
+      this.displayValue = null;
     }
 
     this.modelValue = value;


### PR DESCRIPTION
campo reseta valor para nulo usando formulário reativo.


**select**

**DTHFUI-8377**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
campo não limpa usando formulário reativo

**Qual o novo comportamento?**
campo limpa usando formulário reativo resetando para nulo

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/14560200/app.zip)
