### PR TITLE
fix(po-page-dynamic-table): aplica ordem correta as colunas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ name: CI
 # Define em quais situações esse workflow será executado
 on:
   push:
-    branches: [ master, '[0-9]+.x.x' ]
+    branches: [ master, development, '[0-9]+.x.x' ]
   pull_request:
-    branches: [ master, '[0-9]+.x.x' ]
+    branches: [ master, development, '[0-9]+.x.x' ]
 
 # Os jobs são conjuntos de actions que são executados na mesma máquina virtual.
 # É possível ter mais de um job e assim executar ações paralelamente.

--- a/.github/workflows/publish_po_angular_ci-beta.yml
+++ b/.github/workflows/publish_po_angular_ci-beta.yml
@@ -12,10 +12,19 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      version-beta:
+        description: Informe a versão do Beta do PO-UI
+        required: true
+      version-po-style:
+        description: Informe a versão do @po-ui/style
+        required: true
+        default: 'latest'
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/development'
     steps:
     - uses: actions/setup-node@v3
       with:
@@ -38,6 +47,10 @@ jobs:
       with:
         repository: po-ui/po-tslint
         path: po-tslint
+
+    - name: Update Version
+      run: node ./scripts/update-version.js ${{ github.event.inputs.version-beta }} ${{ github.event.inputs.version-po-style }}
+      working-directory: ${{env.WORKING_DIR}}
 
     - name: Install and Build
       run: npm install && npm run build

--- a/docs/guides/migration-poui.md
+++ b/docs/guides/migration-poui.md
@@ -13,6 +13,13 @@ Antes de atualizar a versão do PO UI, é importante que você tenha atualizado 
 o Angular que o PO UI está homologado, veja nossa
 [tabela de compatibilidade](https://github.com/po-ui/po-angular/wiki#vers%C3%B5es-angular-x-po-ui) em nosso Github Wiki.
 
+> Caso o seu projeto esteja na versão Angular@16:
+Realize a instalação do pacote Schematics do Angular para o nosso script de atualização funcionar corretamente: 
+
+```
+npm install @angular-devkit/schematics --save-dev
+```
+
 Para atualizar o Angular, execute o comando abaixo:
 
 ```
@@ -22,50 +29,15 @@ ng update @angular/cli@<version> @angular/core@<version> --force
 Por exemplo:
 
 ```
-ng update @angular/cli@17.0.9 @angular/core@17.0.9 --force
+ng update @angular/cli@17 @angular/core@17 --force
 ```
 
 > Para realizar a migração completa e avaliar se não precisa fazer alguma alteração veja o [**Guia de Upgrade do Angular**](https://update.angular.io/).
-
-> Caso o seu projeto esteja na versão Angular@16:
-Após a atualização dos pacotes @angular/cli && @angular/core, realize a instalação do pacote Schematics do Angular para o nosso script de atualização funcionar corretamente: 
-
-`` 
-npm install @angular-devkit/schematics
-``
 
 O nosso pacote possuía dependências que eram compatíveis com a versão anterior do Angular, portanto
 devemos utilizar a *flag* `--force` para que o Angular realize a migração do seu projeto, ignorando a versão das dependências.
 Para avaliar as *flags* disponíveis veja a [**documentação do ng update**](https://angular.io/cli/update).
 
-> Após a atualização, verifique se no arquivo `package.json` se as versões dos pacotes `@angular` estão definidas com `~`
-
-```
-  "dependencies": {
-    "@angular/animations": "~17.2.4",
-    "@angular/common": "~17.2.4",
-    "@angular/compiler": "~17.2.4",
-    "@angular/core": "~17.2.4",
-    "@angular/forms": "~17.2.4",
-    "@angular/platform-browser": "~17.2.4",
-    "@angular/platform-browser-dynamic": "~17.2.4",
-    "@angular/router": "~17.2.4",
-    ...
-    "zone.js": "~0.14.4"
-  },
-  "devDependencies": {
-    "@angular-devkit/build-angular": "~17.2.3,
-    "@angular/cli": "~17.2.3",
-    "@angular/compiler-cli": "~17.2.4",
-    ...
-    "typescript": "~5.2.2"
-  }  
-```
-
-Caso as versões estejam definidas com `^` realize as seguintes ações:
-* Altere para `~`, conforme exemplo acima.
-* Remova os diretórios `node_modules`, `.angular` (caso exista) e o arquivo `package-lock.json`
-* Execute o comando `npm install --force`
 
 ## Atualizando o PO UI
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
@@ -227,4 +227,78 @@ describe('PoPageDynamicListBaseComponent:', () => {
       });
     });
   });
+  describe('setColumns:', () => {
+    it('should correctly sort columns by order, placing undefined or invalid orders at the end', () => {
+      const unorderedColumns = [
+        { property: 'name', order: 3 },
+        { property: 'birthdate', order: 1 },
+        { property: 'address' }, // Sem 'order', deve ser colocado no final
+        { property: 'city', order: 2 },
+        { property: 'country', order: -1 } // 'order' inválido, deve ser tratado como se estivesse sem 'order'
+      ];
+
+      const orderedColumns = [
+        { property: 'birthdate', order: 1 },
+        { property: 'city', order: 2 },
+        { property: 'name', order: 3 },
+        { property: 'address' }, // Mantém a posição original entre os sem 'order'
+        { property: 'country', order: -1 } // Mantém a posição original entre os sem 'order'
+      ];
+
+      // Aqui estamos testando o comportamento indiretamente através do setter `columns`
+      component.columns = unorderedColumns;
+
+      expect(component.columns).toEqual(orderedColumns);
+    });
+    it('should correctly handle columns with duplicate order values by maintaining their original relative order', () => {
+      const duplicateOrderColumns = [
+        { property: 'name', order: 2 },
+        { property: 'birthdate', order: 1 },
+        { property: 'city', order: 2 }, // Duplicado 'order' com 'name'
+        { property: 'country', order: 1 } // Duplicado 'order' com 'birthdate'
+      ];
+
+      const expectedOrderWithDuplicates = [
+        { property: 'birthdate', order: 1 },
+        { property: 'country', order: 1 }, // Mantém ordem relativa original para valores de 'order' duplicados
+        { property: 'name', order: 2 },
+        { property: 'city', order: 2 } // Mantém ordem relativa original para valores de 'order' duplicados
+      ];
+
+      component.columns = duplicateOrderColumns;
+
+      expect(component.columns).toEqual(expectedOrderWithDuplicates);
+    });
+    it('should ignore non-integer order properties and treat them as having no order', () => {
+      const mixedOrderColumns = [
+        { property: 'name', order: '3' }, // 'order' como string
+        { property: 'birthdate', order: 1 },
+        { property: 'city', order: 'two' }, // 'order' inválido como string
+        { property: 'address', order: null } // 'order' como null
+      ];
+
+      const expectedOrder = [
+        { property: 'birthdate', order: 1 },
+        { property: 'name', order: '3' }, // Mantido como sem 'order'
+        { property: 'city', order: 'two' }, // Mantido como sem 'order'
+        { property: 'address', order: null } // Mantido como sem 'order'
+      ];
+
+      component.columns = mixedOrderColumns;
+
+      expect(component.columns).toEqual(expectedOrder);
+    });
+    it('should maintain the original order of columns without an order property at the end', () => {
+      const columnsWithoutOrder = [
+        { property: 'name' },
+        { property: 'birthdate' },
+        { property: 'city' },
+        { property: 'country' }
+      ];
+
+      component.columns = columnsWithoutOrder;
+
+      expect(component.columns).toEqual(columnsWithoutOrder);
+    });
+  });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
@@ -177,7 +177,7 @@ export class PoPageDynamicListBaseComponent {
   }
 
   set columns(value) {
-    this._columns = [...value];
+    this._columns = [...(this._columns = this.sortColumnsByOrder(value))];
   }
 
   get columns() {
@@ -221,5 +221,54 @@ export class PoPageDynamicListBaseComponent {
     );
     this.keys = fields.filter(field => field.key === true).map(field => field.property);
     this.duplicates = fields.filter(field => field.duplicate === true).map(field => field.property);
+  }
+
+  /**
+   * Ordena um array de colunas com base na propriedade `order` de cada coluna.
+   *
+   * Este método é utilizado para organizar as colunas de uma tabela ou qualquer coleção similar
+   * que necessite de ordenação baseada em um critério numérico definido pela propriedade `order`.
+   * A ordenação segue as seguintes regras:
+   *
+   * 1. Colunas que possuem a propriedade `order` com um valor numérico válido e maior que zero
+   *    são ordenadas em ordem crescente de acordo com este valor.
+   *
+   * 2. Colunas que não possuem a propriedade `order` ou que possuem um valor inválido ou não numérico
+   *    para esta propriedade são consideradas iguais em termos de ordenação e mantêm a ordem original
+   *    em que apareceram no array fornecido.
+   *
+   * 3. No caso de duas colunas com valores de `order` válidos e idênticos, a ordem entre essas duas colunas
+   *    é determinada pela sua ordem original no array fornecido.
+   *
+   * @param columns Array de colunas a ser ordenado. Cada coluna é um objeto que pode conter uma propriedade `order`.
+   *                O tipo `Array<any>` é utilizado aqui para permitir flexibilidade nos objetos de coluna que podem ser passados,
+   *                mas espera-se que cada objeto tenha pelo menos uma propriedade `order` para a ordenação adequada.
+   *
+   * @returns Um novo array de colunas ordenado com base na propriedade `order`.
+   */
+  private sortColumnsByOrder(columns: Array<any>): Array<any> {
+    return columns.sort((a, b) => {
+      // Checa se 'order' existe e é um número válido em ambos os objetos
+      const hasValidOrderA = 'order' in a && typeof a.order === 'number' && a.order > 0;
+      const hasValidOrderB = 'order' in b && typeof b.order === 'number' && b.order > 0;
+
+      // Se ambos têm 'order' válido, compara diretamente
+      if (hasValidOrderA && hasValidOrderB) {
+        return a.order - b.order;
+      }
+
+      // Se apenas A tem 'order' válido, A vem antes de B
+      if (hasValidOrderA) {
+        return -1;
+      }
+
+      // Se apenas B tem 'order' válido, B vem antes de A
+      if (hasValidOrderB) {
+        return 1;
+      }
+
+      // Se nenhum dos dois tem 'order' válido, mantém a ordem original (considerando como iguais neste contexto)
+      return 0;
+    });
   }
 }

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+const packageDistPath = `${__dirname}/../package.json`;
+const packageContent = fs.readFileSync(packageDistPath);
+const packageJson = JSON.parse(packageContent);
+
+if (process.argv.length != 4) {
+  console.error('Expected at least one argument!');
+  process.exit(1);
+}
+
+const versionBeta = process.argv[2];
+const versionPoStyle = process.argv[3];
+
+packageJson.version = versionBeta;
+packageJson.dependencies['@po-ui/style'] = versionPoStyle;
+
+fs.writeFileSync(packageDistPath, JSON.stringify(packageJson, null, 2));
+
+console.log(JSON.stringify(packageJson, null, 2));


### PR DESCRIPTION
**< PoPageDynamicTable >**

**< 1998 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente PoPageDynamicTable não estava aplicando corretamente a ordem das colunas quando algumas possuíam a propriedade **order** definida ou não. Isso causava inconsistência na visualização dos dados, afetando a experiência do usuário.

**Qual o novo comportamento?**
Agora, o PoPageDynamicTable assegura a correta ordenação de todas as colunas, independente de possuírem ou não a propriedade **order** definida. Colunas sem order são agora consistentemente posicionadas após as colunas com order definido, preservando a ordem relativa entre elas conforme especificado.

**Simulação**
Para simular o comportamento, é possível utilizar o seguinte setup no StackBlitz, criando um PoPageDynamicTable com várias colunas, algumas com a propriedade order e outras sem. Verifique a ordenação das colunas no resultado final para confirmar a correção do comportamento.

[Exemplo no StackBlitz](https://stackblitz.com/edit/po-ui-ruuyem)