### PR TITLE
fix(dynamic-view): Correção campos duplicados no dynamicview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ name: CI
 # Define em quais situações esse workflow será executado
 on:
   push:
-    branches: [ master, '[0-9]+.x.x' ]
+    branches: [ master, development, '[0-9]+.x.x' ]
   pull_request:
-    branches: [ master, '[0-9]+.x.x' ]
+    branches: [ master, development, '[0-9]+.x.x' ]
 
 # Os jobs são conjuntos de actions que são executados na mesma máquina virtual.
 # É possível ter mais de um job e assim executar ações paralelamente.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,21 @@ on:
 # Os jobs são conjuntos de actions que são executados na mesma máquina virtual.
 # É possível ter mais de um job e assim executar ações paralelamente.
 jobs:
-
+  discord_notification_on_pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == false
+    steps:
+      - name: Notify Discord on PR
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          curl -X POST -H "Content-Type: application/json" \
+          -d "{\"content\": \"🚀 **PR Criada com Sucesso 🚀**\\n- Autor: $AUTHOR\\n- Título: $PR_TITLE\\n- Link: $PR_URL\"}" \
+          $DISCORD_WEBHOOK_URL
+          
   lint:
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish_po_angular_ci-beta.yml
+++ b/.github/workflows/publish_po_angular_ci-beta.yml
@@ -12,10 +12,19 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      version-beta:
+        description: Informe a versão do Beta do PO-UI
+        required: true
+      version-po-style:
+        description: Informe a versão do @po-ui/style
+        required: true
+        default: 'latest'
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/development'
     steps:
     - uses: actions/setup-node@v3
       with:
@@ -38,6 +47,10 @@ jobs:
       with:
         repository: po-ui/po-tslint
         path: po-tslint
+
+    - name: Update Version
+      run: node ./scripts/update-version.js ${{ github.event.inputs.version-beta }} ${{ github.event.inputs.version-po-style }}
+      working-directory: ${{env.WORKING_DIR}}
 
     - name: Install and Build
       run: npm install && npm run build

--- a/docs/guides/migration-poui.md
+++ b/docs/guides/migration-poui.md
@@ -13,6 +13,13 @@ Antes de atualizar a versão do PO UI, é importante que você tenha atualizado 
 o Angular que o PO UI está homologado, veja nossa
 [tabela de compatibilidade](https://github.com/po-ui/po-angular/wiki#vers%C3%B5es-angular-x-po-ui) em nosso Github Wiki.
 
+> Caso o seu projeto esteja na versão Angular@16:
+Realize a instalação do pacote Schematics do Angular para o nosso script de atualização funcionar corretamente: 
+
+```
+npm install @angular-devkit/schematics --save-dev
+```
+
 Para atualizar o Angular, execute o comando abaixo:
 
 ```
@@ -22,50 +29,15 @@ ng update @angular/cli@<version> @angular/core@<version> --force
 Por exemplo:
 
 ```
-ng update @angular/cli@17.0.9 @angular/core@17.0.9 --force
+ng update @angular/cli@17 @angular/core@17 --force
 ```
 
 > Para realizar a migração completa e avaliar se não precisa fazer alguma alteração veja o [**Guia de Upgrade do Angular**](https://update.angular.io/).
-
-> Caso o seu projeto esteja na versão Angular@16:
-Após a atualização dos pacotes @angular/cli && @angular/core, realize a instalação do pacote Schematics do Angular para o nosso script de atualização funcionar corretamente: 
-
-`` 
-npm install @angular-devkit/schematics
-``
 
 O nosso pacote possuía dependências que eram compatíveis com a versão anterior do Angular, portanto
 devemos utilizar a *flag* `--force` para que o Angular realize a migração do seu projeto, ignorando a versão das dependências.
 Para avaliar as *flags* disponíveis veja a [**documentação do ng update**](https://angular.io/cli/update).
 
-> Após a atualização, verifique se no arquivo `package.json` se as versões dos pacotes `@angular` estão definidas com `~`
-
-```
-  "dependencies": {
-    "@angular/animations": "~17.2.4",
-    "@angular/common": "~17.2.4",
-    "@angular/compiler": "~17.2.4",
-    "@angular/core": "~17.2.4",
-    "@angular/forms": "~17.2.4",
-    "@angular/platform-browser": "~17.2.4",
-    "@angular/platform-browser-dynamic": "~17.2.4",
-    "@angular/router": "~17.2.4",
-    ...
-    "zone.js": "~0.14.4"
-  },
-  "devDependencies": {
-    "@angular-devkit/build-angular": "~17.2.3,
-    "@angular/cli": "~17.2.3",
-    "@angular/compiler-cli": "~17.2.4",
-    ...
-    "typescript": "~5.2.2"
-  }  
-```
-
-Caso as versões estejam definidas com `^` realize as seguintes ações:
-* Altere para `~`, conforme exemplo acima.
-* Remova os diretórios `node_modules`, `.angular` (caso exista) e o arquivo `package-lock.json`
-* Execute o comando `npm install --force`
 
 ## Atualizando o PO UI
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
@@ -227,4 +227,78 @@ describe('PoPageDynamicListBaseComponent:', () => {
       });
     });
   });
+  describe('setColumns:', () => {
+    it('should correctly sort columns by order, placing undefined or invalid orders at the end', () => {
+      const unorderedColumns = [
+        { property: 'name', order: 3 },
+        { property: 'birthdate', order: 1 },
+        { property: 'address' }, // Sem 'order', deve ser colocado no final
+        { property: 'city', order: 2 },
+        { property: 'country', order: -1 } // 'order' inválido, deve ser tratado como se estivesse sem 'order'
+      ];
+
+      const orderedColumns = [
+        { property: 'birthdate', order: 1 },
+        { property: 'city', order: 2 },
+        { property: 'name', order: 3 },
+        { property: 'address' }, // Mantém a posição original entre os sem 'order'
+        { property: 'country', order: -1 } // Mantém a posição original entre os sem 'order'
+      ];
+
+      // Aqui estamos testando o comportamento indiretamente através do setter `columns`
+      component.columns = unorderedColumns;
+
+      expect(component.columns).toEqual(orderedColumns);
+    });
+    it('should correctly handle columns with duplicate order values by maintaining their original relative order', () => {
+      const duplicateOrderColumns = [
+        { property: 'name', order: 2 },
+        { property: 'birthdate', order: 1 },
+        { property: 'city', order: 2 }, // Duplicado 'order' com 'name'
+        { property: 'country', order: 1 } // Duplicado 'order' com 'birthdate'
+      ];
+
+      const expectedOrderWithDuplicates = [
+        { property: 'birthdate', order: 1 },
+        { property: 'country', order: 1 }, // Mantém ordem relativa original para valores de 'order' duplicados
+        { property: 'name', order: 2 },
+        { property: 'city', order: 2 } // Mantém ordem relativa original para valores de 'order' duplicados
+      ];
+
+      component.columns = duplicateOrderColumns;
+
+      expect(component.columns).toEqual(expectedOrderWithDuplicates);
+    });
+    it('should ignore non-integer order properties and treat them as having no order', () => {
+      const mixedOrderColumns = [
+        { property: 'name', order: '3' }, // 'order' como string
+        { property: 'birthdate', order: 1 },
+        { property: 'city', order: 'two' }, // 'order' inválido como string
+        { property: 'address', order: null } // 'order' como null
+      ];
+
+      const expectedOrder = [
+        { property: 'birthdate', order: 1 },
+        { property: 'name', order: '3' }, // Mantido como sem 'order'
+        { property: 'city', order: 'two' }, // Mantido como sem 'order'
+        { property: 'address', order: null } // Mantido como sem 'order'
+      ];
+
+      component.columns = mixedOrderColumns;
+
+      expect(component.columns).toEqual(expectedOrder);
+    });
+    it('should maintain the original order of columns without an order property at the end', () => {
+      const columnsWithoutOrder = [
+        { property: 'name' },
+        { property: 'birthdate' },
+        { property: 'city' },
+        { property: 'country' }
+      ];
+
+      component.columns = columnsWithoutOrder;
+
+      expect(component.columns).toEqual(columnsWithoutOrder);
+    });
+  });
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
@@ -177,7 +177,7 @@ export class PoPageDynamicListBaseComponent {
   }
 
   set columns(value) {
-    this._columns = [...value];
+    this._columns = [...(this._columns = this.sortColumnsByOrder(value))];
   }
 
   get columns() {
@@ -221,5 +221,54 @@ export class PoPageDynamicListBaseComponent {
     );
     this.keys = fields.filter(field => field.key === true).map(field => field.property);
     this.duplicates = fields.filter(field => field.duplicate === true).map(field => field.property);
+  }
+
+  /**
+   * Ordena um array de colunas com base na propriedade `order` de cada coluna.
+   *
+   * Este método é utilizado para organizar as colunas de uma tabela ou qualquer coleção similar
+   * que necessite de ordenação baseada em um critério numérico definido pela propriedade `order`.
+   * A ordenação segue as seguintes regras:
+   *
+   * 1. Colunas que possuem a propriedade `order` com um valor numérico válido e maior que zero
+   *    são ordenadas em ordem crescente de acordo com este valor.
+   *
+   * 2. Colunas que não possuem a propriedade `order` ou que possuem um valor inválido ou não numérico
+   *    para esta propriedade são consideradas iguais em termos de ordenação e mantêm a ordem original
+   *    em que apareceram no array fornecido.
+   *
+   * 3. No caso de duas colunas com valores de `order` válidos e idênticos, a ordem entre essas duas colunas
+   *    é determinada pela sua ordem original no array fornecido.
+   *
+   * @param columns Array de colunas a ser ordenado. Cada coluna é um objeto que pode conter uma propriedade `order`.
+   *                O tipo `Array<any>` é utilizado aqui para permitir flexibilidade nos objetos de coluna que podem ser passados,
+   *                mas espera-se que cada objeto tenha pelo menos uma propriedade `order` para a ordenação adequada.
+   *
+   * @returns Um novo array de colunas ordenado com base na propriedade `order`.
+   */
+  private sortColumnsByOrder(columns: Array<any>): Array<any> {
+    return columns.sort((a, b) => {
+      // Checa se 'order' existe e é um número válido em ambos os objetos
+      const hasValidOrderA = 'order' in a && typeof a.order === 'number' && a.order > 0;
+      const hasValidOrderB = 'order' in b && typeof b.order === 'number' && b.order > 0;
+
+      // Se ambos têm 'order' válido, compara diretamente
+      if (hasValidOrderA && hasValidOrderB) {
+        return a.order - b.order;
+      }
+
+      // Se apenas A tem 'order' válido, A vem antes de B
+      if (hasValidOrderA) {
+        return -1;
+      }
+
+      // Se apenas B tem 'order' válido, B vem antes de A
+      if (hasValidOrderB) {
+        return 1;
+      }
+
+      // Se nenhum dos dois tem 'order' válido, mantém a ordem original (considerando como iguais neste contexto)
+      return 0;
+    });
   }
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
@@ -410,6 +410,124 @@ describe('PoDynamicViewBaseComponent:', () => {
         })
       ));
 
+      it('should return ordering field if have duplicated order', () => {
+        const fields: Array<PoDynamicViewField> = [
+          { property: 'test 1', order: 1 },
+          { property: 'test 0', order: 1 },
+          { property: 'test 2', order: 2 },
+          { property: 'test 3' },
+          { property: 'test 4' },
+          { property: 'test 5' }
+        ];
+  
+        const expectedFields = [
+          { property: 'test 1', order: 1 },
+          { property: 'test 0', order: 1 },
+          { property: 'test 2', order: 2 },
+          { property: 'test 3', order: 3 },
+          { property: 'test 4', order: 4 },
+          { property: 'test 5', order: 5 }
+        ];
+  
+        component.fields = [...fields];
+  
+        const newFields = component['getConfiguredFields']();
+  
+        expectArraysSameOrdering(newFields, expectedFields);
+      });
+  
+      it('should return ordering field with the order property populated', () => {
+        const fields: Array<PoDynamicViewField> = [
+          { property: 'test 1' },
+          { property: 'test 0' },
+          { property: 'test 2' },
+          { property: 'test 3' },
+          { property: 'test 4' },
+          { property: 'test 5' }
+        ];
+  
+        const expectedFields = [
+          { property: 'test 1', order: 1 },
+          { property: 'test 0', order: 2 },
+          { property: 'test 2', order: 3 },
+          { property: 'test 3', order: 4 },
+          { property: 'test 4', order: 5 },
+          { property: 'test 5', order: 6 }
+        ];
+  
+        component.fields = [...fields];
+  
+        const newFields = component['getConfiguredFields']();
+  
+        expectArraysSameOrdering(newFields, expectedFields);
+      });
+  
+      it('should return ordering fields with property searchService using service type with delay', fakeAsync(
+        inject([DynamicViewService], (dynamicService: DynamicViewService) => {
+          component.service = dynamicService;
+          const fields: Array<PoDynamicViewField> = [
+            { property: 'test 1' },
+            { property: 'test 0', searchService: new TestServiceWithDelay(), fieldLabel: 'name', fieldValue: 'id' },
+            { property: 'test 2', searchService: 'url.com' },
+            { property: 'test 3', searchService: 'url.com' },
+            { property: 'test 4' },
+            { property: 'test 5' }
+          ];
+          component.value[fields[1].property] = '123';
+          component.value[fields[2].property] = [{ test: 123 }];
+          component.value[fields[3].property] = { test: 123 };
+  
+          const expectedFields = [
+            { property: 'test 1', order: 1 },
+            { property: 'test 0', order: 2 },
+            { property: 'test 2', order: 3 },
+            { property: 'test 3', order: 4 },
+            { property: 'test 4', order: 5 },
+            { property: 'test 5', order: 6 }
+          ];
+  
+          component.fields = [...fields];
+  
+          const newFields = component['getConfiguredFields']();
+          tick(2000);
+  
+          expectArraysSameOrdering(newFields, expectedFields);
+        })
+      ));
+  
+      it('should return ordering fields with property optionsService using service type with delay', fakeAsync(
+        inject([DynamicViewService], (dynamicService: DynamicViewService) => {
+          component.service = dynamicService;
+          const fields: Array<PoDynamicViewField> = [
+            { property: 'test 1' },
+            { property: 'test 0', optionsService: new TestComboServiceWithDelay(), fieldLabel: 'name', fieldValue: 'id' },
+            { property: 'test 2', searchService: 'url.com' },
+            { property: 'test 3', searchService: 'url.com' },
+            { property: 'test 4' },
+            { property: 'test 5' }
+          ];
+          component.value[fields[1].property] = '123';
+          component.value[fields[2].property] = [{ test: 123 }];
+          component.value[fields[3].property] = { test: 123 };
+  
+          const expectedFields = [
+            { property: 'test 1', order: 1 },
+            { property: 'test 0', order: 2 },
+            { property: 'test 2', order: 3 },
+            { property: 'test 3', order: 4 },
+            { property: 'test 4', order: 5 },
+            { property: 'test 5', order: 6 }
+          ];
+  
+          component.fields = [...fields];
+  
+          const newFields = component['getConfiguredFields']();
+          tick(2000);
+  
+          expectArraysSameOrdering(newFields, expectedFields);
+        })
+      ));
+
       it('should process fields with optionsService', () => {
         component.fields = [{ property: 'category', optionsService: 'url.optionsService.com' }];
         component.value = { 'category': '123' };
@@ -455,98 +573,6 @@ describe('PoDynamicViewBaseComponent:', () => {
         expect(configuredFields.length).toBeGreaterThan(0);
       });
     });
-
-    it('should return ordering field with the order', () => {
-      const fields: Array<PoDynamicViewField> = [
-        { property: 'test 1' },
-        { property: 'test 0' },
-        { property: 'test 2' },
-        { property: 'test 3' },
-        { property: 'test 4' },
-        { property: 'test 5' }
-      ];
-
-      const expectedFields = [
-        { property: 'test 1', order: 1 },
-        { property: 'test 0', order: 2 },
-        { property: 'test 2', order: 3 },
-        { property: 'test 3', order: 4 },
-        { property: 'test 4', order: 5 },
-        { property: 'test 5', order: 6 }
-      ];
-
-      component.fields = [...fields];
-
-      const newFields = component['getConfiguredFields']();
-
-      expectArraysSameOrdering(newFields, expectedFields);
-    });
-
-    it('should return ordering fields with property searchService using service type with delay', fakeAsync(
-      inject([DynamicViewService], (dynamicService: DynamicViewService) => {
-        component.service = dynamicService;
-        const fields: Array<PoDynamicViewField> = [
-          { property: 'test 1' },
-          { property: 'test 0', searchService: new TestServiceWithDelay(), fieldLabel: 'name', fieldValue: 'id' },
-          { property: 'test 2', searchService: 'url.com' },
-          { property: 'test 3', searchService: 'url.com' },
-          { property: 'test 4' },
-          { property: 'test 5' }
-        ];
-        component.value[fields[1].property] = '123';
-        component.value[fields[2].property] = [{ test: 123 }];
-        component.value[fields[3].property] = { test: 123 };
-
-        const expectedFields = [
-          { property: 'test 1', order: 1 },
-          { property: 'test 0', order: 2 },
-          { property: 'test 2', order: 3 },
-          { property: 'test 3', order: 4 },
-          { property: 'test 4', order: 5 },
-          { property: 'test 5', order: 6 }
-        ];
-
-        component.fields = [...fields];
-
-        const newFields = component['getConfiguredFields']();
-        tick(2000);
-
-        expectArraysSameOrdering(newFields, expectedFields);
-      })
-    ));
-
-    it('should return ordering fields with property optionsService using service type with delay', fakeAsync(
-      inject([DynamicViewService], (dynamicService: DynamicViewService) => {
-        component.service = dynamicService;
-        const fields: Array<PoDynamicViewField> = [
-          { property: 'test 1' },
-          { property: 'test 0', optionsService: new TestComboServiceWithDelay(), fieldLabel: 'name', fieldValue: 'id' },
-          { property: 'test 2', searchService: 'url.com' },
-          { property: 'test 3', searchService: 'url.com' },
-          { property: 'test 4' },
-          { property: 'test 5' }
-        ];
-        component.value[fields[1].property] = '123';
-        component.value[fields[2].property] = [{ test: 123 }];
-        component.value[fields[3].property] = { test: 123 };
-
-        const expectedFields = [
-          { property: 'test 1', order: 1 },
-          { property: 'test 0', order: 2 },
-          { property: 'test 2', order: 3 },
-          { property: 'test 3', order: 4 },
-          { property: 'test 4', order: 5 },
-          { property: 'test 5', order: 6 }
-        ];
-
-        component.fields = [...fields];
-
-        const newFields = component['getConfiguredFields']();
-        tick(2000);
-
-        expectArraysSameOrdering(newFields, expectedFields);
-      })
-    ));
 
     it('searchById: should return null if value is empty', done => {
       const value = '';

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -138,37 +138,33 @@ export class PoDynamicViewBaseComponent {
     protected multiselectFilterService: PoMultiselectFilterService
   ) {}
 
-  /**
-   * Verifica se já existe algum outro campo com a order da posição dele no array,
-   * se houver ele adiciona +1 até achar uma proxima posição
-   */
-  protected getOrdertoField(field: PoDynamicViewField, index: number) {
+  protected getFieldOrder(field: PoDynamicViewField, index: number) {
     const position = index + 1;
-    return this.fields.findIndex(e => e.order === position) > -1 ? this.getOrdertoField(field, position) : position;
+    return this.fields.findIndex(e => e.order === position) > -1 ? this.getFieldOrder(field, position) : position;
   }
 
   protected getConfiguredFields(useSearchService = true) {
     const newFields = [];
 
     this.fields.forEach((field, index) => {
-      field.order = field.order || this.getOrdertoField(field, index);
+      field.order = field.order || this.getFieldOrder(field, index);
 
       if (!isVisibleField(field)) {
         return;
       }
-
+      
       if (!field.searchService && !field.optionsService) {
         newFields.push(this.createField(field));
         return;
       }
-
+      
       const hasValue =
         this.value[field.property]?.length ||
         (!Array.isArray(this.value[field.property]) && this.value[field.property] && useSearchService);
-
+ 
       if (hasValue) {
-        const tempField = this.returnValues({ ...field }, '');
-        newFields.push(this.createField(tempField));
+        const _field = this.returnValues({ ...field }, '');
+        newFields.push(_field);
 
         if (field.searchService) {
           if (typeof field.searchService === 'object') {
@@ -195,8 +191,7 @@ export class PoDynamicViewBaseComponent {
           }
         }
 
-        const indexUpdated = field.order;
-        this.createFieldWithService(field, newFields, indexUpdated);
+        this.createFieldWithService(field, newFields, _field);
       }
     });
 
@@ -240,13 +235,14 @@ export class PoDynamicViewBaseComponent {
     return this.returnValues(field, value);
   }
 
-  private createFieldWithService(field: PoDynamicViewField, newFields?, index?) {
+  private createFieldWithService(field: PoDynamicViewField, newFields?, oldField?) {
     const property = field.property;
 
     this.searchById(this.value[property], field).subscribe(response => {
       const value = response;
       const allValues = this.returnValues(field, value);
-      newFields.splice(index - 1, 1, allValues);
+      const oldFieldIndex = newFields.indexOf(newFields.find(field => field === oldField));
+      newFields.splice(oldFieldIndex, 1, allValues);
       sortFields(newFields);
     });
   }
@@ -344,7 +340,7 @@ export class PoDynamicViewBaseComponent {
       const transformedValue = this.transformValue(field.type, this.value[field.fieldLabel], field.format);
       return `${transformedValue} - ${this.value[field.fieldValue]}`;
     }
-
+    
     if (field.fieldLabel && !field.concatLabelValue && !field.isArrayOrObject) {
       this.value[property] = this.value[field.fieldLabel];
     }

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+const packageDistPath = `${__dirname}/../package.json`;
+const packageContent = fs.readFileSync(packageDistPath);
+const packageJson = JSON.parse(packageContent);
+
+if (process.argv.length != 4) {
+  console.error('Expected at least one argument!');
+  process.exit(1);
+}
+
+const versionBeta = process.argv[2];
+const versionPoStyle = process.argv[3];
+
+packageJson.version = versionBeta;
+packageJson.dependencies['@po-ui/style'] = versionPoStyle;
+
+fs.writeFileSync(packageDistPath, JSON.stringify(packageJson, null, 2));
+
+console.log(JSON.stringify(packageJson, null, 2));


### PR DESCRIPTION
**po-dynamic-view **

**8512**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ocorre uma duplicação de alguns campos mostrados no dynamicview, quando esses campos não possue valor ou eles estão com visibilidade falsa

**Qual o novo comportamento?**
correção feita, não ocorre mais a duplicata dos campos

**Simulação**
- Abrir na documentação [PO-UI > dynamic view](https://po-ui.io/documentation/po-dynamic-view). O Ultimo exemplo tem campos com visible false, que estava duplicando o campo 'city'
- anexo 
[simulação.zip](https://github.com/po-ui/po-angular/files/14606977/simulacao.zip)
Existe campo sem valores que estava duplicado o campo 'partner'