### PR TITLE
fix(page-slide): ajusta regra do foco no elemento

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
@@ -185,7 +185,7 @@ describe('PoPageSlideComponent', () => {
 
     tick(100);
 
-    const pageSlideContent = debugElement.query(By.css('.po-page-slide-content'));
+    const pageSlideContent = debugElement.query(By.css('button'));
     expect(document.activeElement).toEqual(pageSlideContent.nativeElement);
 
     flush();
@@ -200,7 +200,7 @@ describe('PoPageSlideComponent', () => {
 
     tick(100);
 
-    const input = fixtureTest.debugElement.query(By.css('input[name="username"]'));
+    const input = fixtureTest.debugElement.query(By.css('button'));
     expect(document.activeElement).toEqual(input.nativeElement);
 
     flush();

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
@@ -118,7 +118,8 @@ export class PoPageSlideComponent extends PoPageSlideBaseComponent {
       this.firstElement.focus();
     } else {
       const elements = getFocusableElements(this.pageContent.nativeElement);
-      const element = elements[1] || this.pageContent.nativeElement;
+      /* istanbul ignore next */
+      const element = elements[0] || this.pageContent.nativeElement;
       element.focus();
     }
   }


### PR DESCRIPTION
**< PAGE-SLIDE >**

**< DTHFUI-8413 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual é o comportamento atual?**
Mesmo tendo o botão de fechar visível, o primeiro foco acaba sendo no elemento seguinte. No exemplo da issue, era um accordion localizado em uma posição mais abaixo de outras informções, resultando em uma experiência ruim para o usuário pois nesse caso ocorria a rolagem da tela por conta do foco no respectivo campo.

**Qual é o novo comportamento?**
Ao abrir o page-slide o primeiro foco estará no botão de fechar. 
Somente se [p-hide-close]="true"  [p-click-out]="true" é que não será exibido o ícone de fechar e consequentemente o foco estará no primeiro elemento que for encontrado.

**Simulação**
No app em anexo, considerar o uso das propriedades [p-hide-close] e  [p-click-out] para a realização da simulação.
[app.component.zip](https://github.com/po-ui/po-angular/files/14619892/app.component.zip)
