### PR TITLE
fix(dynamic-view): corrige exibicao de campos com opcoes

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
@@ -702,15 +702,6 @@ describe('PoDynamicViewBaseComponent:', () => {
       expect(result).toBe('1 - Company1 - 261-81-7609');
     });
 
-    it(`createField: should call 'transformFieldLabel' and return a fieldLabel property`, () => {
-      const field = { property: 'name', label: 'Nome', fieldLabel: 'title', fieldValue: 'id' };
-      component.value = { name: 'Test Name', title: 'Title Test', id: 123 };
-
-      const newField = component['createField'](field);
-
-      expect(newField.value).toBe('Title Test');
-    });
-
     it('createField: should call `transformFieldLabel`, return a `fieldLabel` and `fieldValue` property if `concatLabelValue` is true', () => {
       const field = {
         property: 'name',

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -230,7 +230,7 @@ export class PoDynamicViewBaseComponent {
     if (field.isArrayOrObject && this.value[property]) {
       value = this.transformArrayValue(this.value[property], field);
     } else if (field.fieldLabel) {
-      value = this.transformFieldLabel(property, field);
+      value = this.transformFieldLabel(field);
     }
 
     if (!value) {
@@ -339,14 +339,10 @@ export class PoDynamicViewBaseComponent {
     }
   }
 
-  private transformFieldLabel(property: string, field: PoDynamicViewField) {
+  private transformFieldLabel(field: PoDynamicViewField) {
     if (field.concatLabelValue && field.fieldLabel && field.fieldValue && !field.isArrayOrObject) {
       const transformedValue = this.transformValue(field.type, this.value[field.fieldLabel], field.format);
       return `${transformedValue} - ${this.value[field.fieldValue]}`;
-    }
-
-    if (field.fieldLabel && !field.concatLabelValue && !field.isArrayOrObject) {
-      this.value[property] = this.value[field.fieldLabel];
     }
     return undefined;
   }


### PR DESCRIPTION
**< dynamic-view >** corrige exibição de campos com opções

Corrige um problema identificado na versão 16.4.0 do PO-UI, onde campos com opções no `PoDynamicView` estavam exibindo valores incorretamente, utilizando `fieldLabel` em vez de `property`. Esta correção aborda especificamente:

- A lógica de processamento que permitia a exibição equivocada de valores baseados em `fieldLabel` e `fieldValue`.
- A remoção da prática de definir o valor de uma propriedade baseada em `fieldLabel`, assegurando a independência entre a representação visual de um campo e seus dados subjacentes.

Este ajuste garante que a apresentação de campos dinâmicos no `dynamic-view` seja precisa e consistente.

**< #2006 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
No componente `PoDynamicView` do PO-UI, campos com opções estão sendo exibidos incorretamente devido a uma lógica que utiliza `fieldLabel` e `fieldValue` para determinar o valor a ser exibido. Isso ocorre porque o sistema não utiliza apropriadamente a propriedade `property` para definir o valor do campo, além de definir indevidamente o valor de uma propriedade baseando-se em `fieldLabel`, contrariando as diretrizes do PoDynamicView e boas práticas de desenvolvimento.


**Qual o novo comportamento?**
Com a correção aplicada, o `PoDynamicView` agora respeita corretamente a propriedade `property` na exibição de campos com opções, eliminando o uso de `fieldLabel` como critério para definir o valor de uma propriedade. A lógica de exibição foi ajustada para garantir que a visualização dos dados seja precisa e consistente, tratando de forma independente a representação visual dos campos e seus dados subjacentes. 

**Simulação**
Para reproduzir o bug relatado basta acessar o stackblitz:

Versão PO-UI 16.4.1: [Exemplo do erro](https://stackblitz.com/edit/po-ui-zozpvv-pun8qv)
Versão PO-UI 16.3.0: [Exemplo com a versão anterior do PO-UI sem o erro](https://stackblitz.com/edit/po-ui-zozpvv-dmk6m7)