### PR TITLE
fix(dynamic-view): Correção campos duplicados no dynamicview

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.spec.ts
@@ -410,6 +410,129 @@ describe('PoDynamicViewBaseComponent:', () => {
         })
       ));
 
+      it('should return ordering field if have duplicated order', () => {
+        const fields: Array<PoDynamicViewField> = [
+          { property: 'test 1', order: 1 },
+          { property: 'test 0', order: 1 },
+          { property: 'test 2', order: 2 },
+          { property: 'test 3' },
+          { property: 'test 4' },
+          { property: 'test 5' }
+        ];
+
+        const expectedFields = [
+          { property: 'test 1', order: 1 },
+          { property: 'test 0', order: 1 },
+          { property: 'test 2', order: 2 },
+          { property: 'test 3', order: 3 },
+          { property: 'test 4', order: 4 },
+          { property: 'test 5', order: 5 }
+        ];
+
+        component.fields = [...fields];
+
+        const newFields = component['getConfiguredFields']();
+
+        expectArraysSameOrdering(newFields, expectedFields);
+      });
+
+      it('should return ordering field with the order', () => {
+        const fields: Array<PoDynamicViewField> = [
+          { property: 'test 1' },
+          { property: 'test 0' },
+          { property: 'test 2' },
+          { property: 'test 3' },
+          { property: 'test 4' },
+          { property: 'test 5' }
+        ];
+
+        const expectedFields = [
+          { property: 'test 1', order: 1 },
+          { property: 'test 0', order: 2 },
+          { property: 'test 2', order: 3 },
+          { property: 'test 3', order: 4 },
+          { property: 'test 4', order: 5 },
+          { property: 'test 5', order: 6 }
+        ];
+
+        component.fields = [...fields];
+
+        const newFields = component['getConfiguredFields']();
+
+        expectArraysSameOrdering(newFields, expectedFields);
+      });
+
+      it('should return ordering fields with property searchService using service type with delay', fakeAsync(
+        inject([DynamicViewService], (dynamicService: DynamicViewService) => {
+          component.service = dynamicService;
+          const fields: Array<PoDynamicViewField> = [
+            { property: 'test 1' },
+            { property: 'test 0', searchService: new TestServiceWithDelay(), fieldLabel: 'name', fieldValue: 'id' },
+            { property: 'test 2', searchService: 'url.com' },
+            { property: 'test 3', searchService: 'url.com' },
+            { property: 'test 4' },
+            { property: 'test 5' }
+          ];
+          component.value[fields[1].property] = '123';
+          component.value[fields[2].property] = [{ test: 123 }];
+          component.value[fields[3].property] = { test: 123 };
+
+          const expectedFields = [
+            { property: 'test 1', order: 1 },
+            { property: 'test 0', order: 2 },
+            { property: 'test 2', order: 3 },
+            { property: 'test 3', order: 4 },
+            { property: 'test 4', order: 5 },
+            { property: 'test 5', order: 6 }
+          ];
+
+          component.fields = [...fields];
+
+          const newFields = component['getConfiguredFields']();
+          tick(2000);
+
+          expectArraysSameOrdering(newFields, expectedFields);
+        })
+      ));
+
+      it('should return ordering fields with property optionsService using service type with delay', fakeAsync(
+        inject([DynamicViewService], (dynamicService: DynamicViewService) => {
+          component.service = dynamicService;
+          const fields: Array<PoDynamicViewField> = [
+            { property: 'test 1' },
+            {
+              property: 'test 0',
+              optionsService: new TestComboServiceWithDelay(),
+              fieldLabel: 'name',
+              fieldValue: 'id'
+            },
+            { property: 'test 2', searchService: 'url.com' },
+            { property: 'test 3', searchService: 'url.com' },
+            { property: 'test 4' },
+            { property: 'test 5' }
+          ];
+          component.value[fields[1].property] = '123';
+          component.value[fields[2].property] = [{ test: 123 }];
+          component.value[fields[3].property] = { test: 123 };
+
+          const expectedFields = [
+            { property: 'test 1', order: 1 },
+            { property: 'test 0', order: 2 },
+            { property: 'test 2', order: 3 },
+            { property: 'test 3', order: 4 },
+            { property: 'test 4', order: 5 },
+            { property: 'test 5', order: 6 }
+          ];
+
+          component.fields = [...fields];
+
+          const newFields = component['getConfiguredFields']();
+          tick(2000);
+
+          expectArraysSameOrdering(newFields, expectedFields);
+        })
+      ));
+
       it('should process fields with optionsService', () => {
         component.fields = [{ property: 'category', optionsService: 'url.optionsService.com' }];
         component.value = { 'category': '123' };
@@ -455,98 +578,6 @@ describe('PoDynamicViewBaseComponent:', () => {
         expect(configuredFields.length).toBeGreaterThan(0);
       });
     });
-
-    it('should return ordering field with the order', () => {
-      const fields: Array<PoDynamicViewField> = [
-        { property: 'test 1' },
-        { property: 'test 0' },
-        { property: 'test 2' },
-        { property: 'test 3' },
-        { property: 'test 4' },
-        { property: 'test 5' }
-      ];
-
-      const expectedFields = [
-        { property: 'test 1', order: 1 },
-        { property: 'test 0', order: 2 },
-        { property: 'test 2', order: 3 },
-        { property: 'test 3', order: 4 },
-        { property: 'test 4', order: 5 },
-        { property: 'test 5', order: 6 }
-      ];
-
-      component.fields = [...fields];
-
-      const newFields = component['getConfiguredFields']();
-
-      expectArraysSameOrdering(newFields, expectedFields);
-    });
-
-    it('should return ordering fields with property searchService using service type with delay', fakeAsync(
-      inject([DynamicViewService], (dynamicService: DynamicViewService) => {
-        component.service = dynamicService;
-        const fields: Array<PoDynamicViewField> = [
-          { property: 'test 1' },
-          { property: 'test 0', searchService: new TestServiceWithDelay(), fieldLabel: 'name', fieldValue: 'id' },
-          { property: 'test 2', searchService: 'url.com' },
-          { property: 'test 3', searchService: 'url.com' },
-          { property: 'test 4' },
-          { property: 'test 5' }
-        ];
-        component.value[fields[1].property] = '123';
-        component.value[fields[2].property] = [{ test: 123 }];
-        component.value[fields[3].property] = { test: 123 };
-
-        const expectedFields = [
-          { property: 'test 1', order: 1 },
-          { property: 'test 0', order: 2 },
-          { property: 'test 2', order: 3 },
-          { property: 'test 3', order: 4 },
-          { property: 'test 4', order: 5 },
-          { property: 'test 5', order: 6 }
-        ];
-
-        component.fields = [...fields];
-
-        const newFields = component['getConfiguredFields']();
-        tick(2000);
-
-        expectArraysSameOrdering(newFields, expectedFields);
-      })
-    ));
-
-    it('should return ordering fields with property optionsService using service type with delay', fakeAsync(
-      inject([DynamicViewService], (dynamicService: DynamicViewService) => {
-        component.service = dynamicService;
-        const fields: Array<PoDynamicViewField> = [
-          { property: 'test 1' },
-          { property: 'test 0', optionsService: new TestComboServiceWithDelay(), fieldLabel: 'name', fieldValue: 'id' },
-          { property: 'test 2', searchService: 'url.com' },
-          { property: 'test 3', searchService: 'url.com' },
-          { property: 'test 4' },
-          { property: 'test 5' }
-        ];
-        component.value[fields[1].property] = '123';
-        component.value[fields[2].property] = [{ test: 123 }];
-        component.value[fields[3].property] = { test: 123 };
-
-        const expectedFields = [
-          { property: 'test 1', order: 1 },
-          { property: 'test 0', order: 2 },
-          { property: 'test 2', order: 3 },
-          { property: 'test 3', order: 4 },
-          { property: 'test 4', order: 5 },
-          { property: 'test 5', order: 6 }
-        ];
-
-        component.fields = [...fields];
-
-        const newFields = component['getConfiguredFields']();
-        tick(2000);
-
-        expectArraysSameOrdering(newFields, expectedFields);
-      })
-    ));
 
     it('searchById: should return null if value is empty', done => {
       const value = '';

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -138,20 +138,16 @@ export class PoDynamicViewBaseComponent {
     protected multiselectFilterService: PoMultiselectFilterService
   ) {}
 
-  /**
-   * Verifica se já existe algum outro campo com a order da posição dele no array,
-   * se houver ele adiciona +1 até achar uma proxima posição
-   */
-  protected getOrdertoField(field: PoDynamicViewField, index: number) {
+  protected getFieldOrder(field: PoDynamicViewField, index: number) {
     const position = index + 1;
-    return this.fields.findIndex(e => e.order === position) > -1 ? this.getOrdertoField(field, position) : position;
+    return this.fields.findIndex(e => e.order === position) > -1 ? this.getFieldOrder(field, position) : position;
   }
 
   protected getConfiguredFields(useSearchService = true) {
     const newFields = [];
 
     this.fields.forEach((field, index) => {
-      field.order = field.order || this.getOrdertoField(field, index);
+      field.order = field.order || this.getFieldOrder(field, index);
 
       if (!isVisibleField(field)) {
         return;
@@ -167,8 +163,8 @@ export class PoDynamicViewBaseComponent {
         (!Array.isArray(this.value[field.property]) && this.value[field.property] && useSearchService);
 
       if (hasValue) {
-        const tempField = this.returnValues({ ...field }, '');
-        newFields.push(this.createField(tempField));
+        const _field = this.returnValues({ ...field }, '');
+        newFields.push(_field);
 
         if (field.searchService) {
           if (typeof field.searchService === 'object') {
@@ -195,8 +191,7 @@ export class PoDynamicViewBaseComponent {
           }
         }
 
-        const indexUpdated = field.order;
-        this.createFieldWithService(field, newFields, indexUpdated);
+        this.createFieldWithService(field, newFields, _field);
       }
     });
 
@@ -240,13 +235,14 @@ export class PoDynamicViewBaseComponent {
     return this.returnValues(field, value);
   }
 
-  private createFieldWithService(field: PoDynamicViewField, newFields?, index?) {
+  private createFieldWithService(field: PoDynamicViewField, newFields?, oldField?) {
     const property = field.property;
 
     this.searchById(this.value[property], field).subscribe(response => {
       const value = response;
       const allValues = this.returnValues(field, value);
-      newFields.splice(index - 1, 1, allValues);
+      const oldFieldIndex = newFields.indexOf(newFields.find(field => field === oldField));
+      newFields.splice(oldFieldIndex, 1, allValues);
       sortFields(newFields);
     });
   }


### PR DESCRIPTION
**po-dynamic-view**

** 8512**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ocorre uma duplicação de alguns campos mostrados no dynamicview, quando esses campos não possue valor ou eles estão com visibilidade falsa

**Qual o novo comportamento?**
correção feita, não ocorre mais a duplicata dos campos

**Simulação**
- Abrir na documentação [PO-UI > dynamic view](https://po-ui.io/documentation/po-dynamic-view). O Ultimo exemplo tem campos com visible false, que estava duplicando o campo 'city'