### PR TITLE
fix(page-slide): cobre teste para pageContent

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, ViewChild } from '@angular/core';
+import { Component, DebugElement, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -237,5 +237,19 @@ describe('PoPageSlideComponent', () => {
 
     component.close();
     expect(component['sourceElement'].focus).toHaveBeenCalled();
+  });
+
+  it('should have pageContent.nativeElement defined', () => {
+    const div = document.createElement('div');
+    div.setAttribute('tabindex', '-1');
+
+    const mockElementRef = {
+      nativeElement: div
+    } as ElementRef;
+
+    component.pageContent = mockElementRef;
+    component['initFocus']();
+
+    expect(component.pageContent.nativeElement).toBeDefined();
   });
 });

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
@@ -118,7 +118,6 @@ export class PoPageSlideComponent extends PoPageSlideBaseComponent {
       this.firstElement.focus();
     } else {
       const elements = getFocusableElements(this.pageContent.nativeElement);
-      /* istanbul ignore next */
       const element = elements[0] || this.pageContent.nativeElement;
       element.focus();
     }


### PR DESCRIPTION
**PAGE-SLIDE**

**DTHFUI-8546**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não havia cobertura para pageContent.nativeElement

**Qual o novo comportamento?**
Implementado cobertura.

**Simulação**
Rodar npm run test:ui para constatar a cobertura do teste.