### PR TITLE
feat(search): inclusão do listbox ao fazer o search

### DIFF
--- a/projects/ui/src/lib/components/po-search/interfaces/po-search-option.interface.ts
+++ b/projects/ui/src/lib/components/po-search/interfaces/po-search-option.interface.ts
@@ -1,0 +1,22 @@
+/**
+ * @usedBy PoSearchComponent
+ *
+ * @description
+ *
+ * Interface que define as opções que serão exibidas na lista ao procurar do `po-search`.
+ */
+export interface PoSearchOption {
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Descrição exibida nas opções da lista.
+   *
+   * > Caso não seja definida será assumido o valor definido na propriedade `value`.
+   */
+  label?: string;
+
+  /** Valor do objeto que será atribuído ao *model*. */
+  value: string | number;
+}

--- a/projects/ui/src/lib/components/po-search/po-search-base.component.ts
+++ b/projects/ui/src/lib/components/po-search/po-search-base.component.ts
@@ -204,6 +204,18 @@ export class PoSearchBaseComponent {
    *
    * @description
    *
+   * Exibe uma lista (auto-complete) com as opções definidas no `p-filter-keys` enquanto realiza uma busca,
+   * respeitando o `p-filter-type` como modo de pesquisa.
+   *
+   * @default `false`
+   */
+  @Input('p-show-listbox') showListbox: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Evento disparado ao alterar valor do model.
    */
   @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
@@ -225,6 +237,15 @@ export class PoSearchBaseComponent {
    * Pode ser informada uma função que será disparada quando houver alterações nos filtros.
    */
   @Output('p-filter') filter: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Pode ser informada uma função que será disparada quando houver click no listbox.
+   */
+  @Output('p-listbox-onclick') listboxOnClick = new EventEmitter<any>();
 
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();

--- a/projects/ui/src/lib/components/po-search/po-search.component.html
+++ b/projects/ui/src/lib/components/po-search/po-search.component.html
@@ -12,8 +12,15 @@
     [class.po-search-input-trigger]="type === 'trigger'"
     [disabled]="disabled"
     [placeholder]="literals.search"
-    (input)="onSearchChange($event.target.value, type === 'action' ? true : false)"
-    (keyup.enter)="onSearchChange($event.target.value, type === 'trigger' ? true : false)"
+    (input)="
+      onSearchChange($event.target.value, false); onSearchChange($event.target.value, type === 'action' ? true : false)
+    "
+    (keyup.enter)="
+      listboxOpen ? closeListbox() : onSearchChange($event.target.value, type === 'trigger' ? true : false, true);
+      closeListbox()
+    "
+    (keydown)="onKeyDown($event)"
+    (blur)="onBlur()"
   />
 
   <div class="po-search-buttons">
@@ -33,11 +40,27 @@
       class="po-search-button po-search-button-trigger"
       type="button"
       [ariaLabel]="literals.search"
-      (click)="onSearchChange(poSearchInput.value, true)"
-      (keydown.enter)="onSearchChange(poSearchInput.value, true)"
+      (click)="onSearchChange(poSearchInput.value, true, true)"
+      (keydown.enter)="onSearchChange(poSearchInput.value, true, true)"
       [disabled]="disabled"
     >
       <po-icon [p-icon]="icon ? icon : 'po-icon-search'"> </po-icon>
     </button>
   </div>
+</div>
+
+<div #poListboxContainerElement class="po-search-listbox-container" [hidden]="!listboxOpen">
+  <po-listbox
+    #poListbox
+    #poListboxElement
+    p-type="option"
+    [p-items]="listboxFilteredItems"
+    (p-selectcombo-item)="onListboxClick($event, $event.event)"
+    [p-visible]="listboxOpen"
+    [p-filter-mode]="filterType"
+    [p-should-mark-letter]="shouldMarkLetters"
+    [p-filtering]="isFiltering"
+    [p-search-value]="getInputValue()"
+    (p-close)="onCloseListbox()"
+  ></po-listbox>
 </div>

--- a/projects/ui/src/lib/components/po-search/po-search.component.spec.ts
+++ b/projects/ui/src/lib/components/po-search/po-search.component.spec.ts
@@ -1,28 +1,42 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ElementRef } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 
-import { PoSearchComponent } from './po-search.component';
+import { PoControlPositionService } from '../../services/po-control-position/po-control-position.service';
+import { PoIconModule } from '../po-icon';
+import { PoListBoxModule } from '../po-listbox';
 import { PoSearchFilterMode } from './enum/po-search-filter-mode.enum';
+import { PoSearchOption } from './interfaces/po-search-option.interface';
+import { PoSearchComponent } from './po-search.component';
 
 describe('PoSearchComponent', () => {
   let component: PoSearchComponent;
   let fixture: ComponentFixture<PoSearchComponent>;
+  let controlPositionMock: jasmine.SpyObj<PoControlPositionService>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PoSearchComponent]
+      imports: [PoIconModule, PoListBoxModule],
+      declarations: [PoSearchComponent],
+      providers: [PoControlPositionService]
     }).compileComponents();
   });
 
   beforeEach(() => {
+    controlPositionMock = jasmine.createSpyObj('PoControlPositionService', ['adjustPosition', 'setElements']);
+
     fixture = TestBed.createComponent(PoSearchComponent);
+
     component = fixture.componentInstance;
+
+    component['controlPosition'] = controlPositionMock;
+    fixture.detectChanges();
 
     component.poSearchInput = new ElementRef({ value: 'some search value' });
     component.items = [{ text: 'Text 1' }, { text: 'Text 2' }, { text: 'Other Text' }];
     component.filterKeys = ['text'];
 
     spyOn(component.filteredItemsChange, 'emit');
+    spyOn(component.listboxOnClick, 'emit');
 
     fixture.detectChanges();
   });
@@ -74,6 +88,14 @@ describe('PoSearchComponent', () => {
 
     expect(component.filteredItems).toEqual([{ text: 'Text 1' }, { text: 'Text 2' }, { text: 'Other Text' }]);
     expect(component.filteredItemsChange.emit).toHaveBeenCalledWith(component.items);
+  });
+
+  it('onSearchChange: should not add value if it is null or undefined', () => {
+    component.items = [{ text: '' }, { text: null }, { text: undefined }, { text: 'Text' }];
+
+    component.onSearchChange('Text', true);
+    expect(component.filteredItems).toEqual([{ text: 'Text' }]);
+    expect(component.filteredItemsChange.emit).toHaveBeenCalledWith([{ text: 'Text' }]);
   });
 
   it('onSearchChange: should return false if filter mode is not recognized', () => {
@@ -129,5 +151,317 @@ describe('PoSearchComponent', () => {
 
     expect(component.filteredItems).toEqual([]);
     expect(component.filteredItemsChange.emit).toHaveBeenCalledWith([]);
+  });
+
+  describe('showListbox: when searching with listbox', () => {
+    const eventClick = document.createEvent('MouseEvents');
+    eventClick.initEvent('click', false, true);
+
+    beforeEach(() => {
+      component.showListbox = true;
+
+      component.poSearchInput = {
+        nativeElement: {
+          focus: () => {},
+          contains: () => {},
+          dispatchEvent: () => {}
+        }
+      };
+    });
+
+    afterEach(() => {
+      component['removeListeners']();
+    });
+
+    it('should return the filtered list', () => {
+      component.filterType = PoSearchFilterMode.startsWith;
+      component.poSearchInput.nativeElement.value = 'text';
+      component.onSearchChange('text', true);
+
+      expect(component.listboxFilteredItems).toEqual([
+        { label: 'Text 1', value: 'Text 1' },
+        { label: 'Text 2', value: 'Text 2' }
+      ]);
+    });
+
+    it('should return the filtered list if filterType is contains', () => {
+      component.filterType = PoSearchFilterMode.contains;
+      component.poSearchInput.nativeElement.value = 'ther';
+      component.onSearchChange('ther', true);
+
+      expect(component.listboxFilteredItems).toEqual([{ label: 'Other Text', value: 'Other Text' }]);
+    });
+
+    it('should return the filtered list if filterType is endsWith', () => {
+      component.filterType = PoSearchFilterMode.endsWith;
+      component.poSearchInput.nativeElement.value = '1';
+      component.onSearchChange('1', true);
+
+      expect(component.listboxFilteredItems).toEqual([{ label: 'Text 1', value: 'Text 1' }]);
+    });
+
+    it("should return false list if filterType doesn't exist ", () => {
+      component.filterType = null;
+      component.onSearchChange('1', true);
+
+      expect(component.listboxFilteredItems).toEqual([]);
+    });
+
+    it('should set the value on click the list item', () => {
+      const option: PoSearchOption = { value: 'Text 1', label: 'Text 1' };
+      component.onListboxClick(option, new Event('click'));
+
+      expect(component.poSearchInput.nativeElement.value).toBe('Text 1');
+    });
+
+    it('should set the value on keypress enter into list item and if the `p-search-type` is trigger, should not search', () => {
+      const option: PoSearchOption = { value: 'Text 1', label: 'Text 1' };
+      component.type = 'trigger';
+      component['listboxItemclicked'] = true;
+      component.onListboxClick(
+        option,
+        new KeyboardEvent('keydown', {
+          code: 'Enter',
+          key: 'Enter',
+          charCode: 13,
+          keyCode: 13,
+          view: window
+        })
+      );
+
+      expect(component.poSearchInput.nativeElement.value).toBe('Text 1');
+      expect(component.listboxOnClick.emit).toHaveBeenCalledWith('Text 1');
+
+      component.onSearchChange('Text 1', true);
+      expect(component.filteredItems).toEqual([]);
+      expect(component.filteredItemsChange.emit).not.toHaveBeenCalled();
+    });
+
+    it('should set the value on keypress enter into list item and if the `p-search-type` is action, should search', () => {
+      const option: PoSearchOption = { value: 'Text 1', label: 'Text 1' };
+      component.type = 'action';
+      component.onListboxClick(
+        option,
+        new KeyboardEvent('keydown', {
+          code: 'Enter',
+          key: 'Enter',
+          charCode: 13,
+          keyCode: 13,
+          view: window
+        })
+      );
+
+      expect(component.poSearchInput.nativeElement.value).toBe('Text 1');
+      expect(component.filteredItems).toEqual([{ text: 'Text 1' }]);
+      expect(component.filteredItemsChange.emit).toHaveBeenCalledWith([{ text: 'Text 1' }]);
+    });
+
+    it('should set listboxFilteredItems to all items if the input value is empty', () => {
+      component.listboxFilteredItems = [
+        { label: 'Text 1', value: 'Text 1' },
+        { label: 'Text 2', value: 'Text 2' }
+      ];
+      component.poSearchInput.nativeElement.value = '';
+      component.poSearchInput.nativeElement.dispatchEvent(new Event('input'));
+
+      expect(component.listboxFilteredItems).toEqual([
+        { label: 'Text 1', value: 'Text 1' },
+        { label: 'Text 2', value: 'Text 2' }
+      ]);
+    });
+
+    it('should return the listboxFilteredItems with converting the boolean and number to string ', () => {
+      component.items = [{ text: true }, { text: 5 }, { text: 'Text' }];
+
+      component['ngOnInit']();
+
+      expect(component.listboxFilteredItems).toEqual([
+        { label: 'true', value: 'true' },
+        { label: '5', value: '5' },
+        { label: 'Text', value: 'Text' }
+      ]);
+    });
+
+    it('initializeListeners: should call removeListeners and initialize click, resize and scroll listeners', () => {
+      component['clickoutListener'] = undefined;
+      component['eventResizeListener'] = undefined;
+      const spyRemoveListeners = spyOn(component, <any>'removeListeners');
+
+      component['initializeListeners']();
+
+      document.dispatchEvent(eventClick);
+      window.dispatchEvent(new Event('resize'));
+
+      expect(spyRemoveListeners).toHaveBeenCalled();
+      expect(component['clickoutListener']).toBeDefined();
+      expect(component['eventResizeListener']).toBeDefined();
+    });
+
+    it('should hide the listbox when was click out of the input', () => {
+      component.listboxOpen = true;
+
+      spyOn(component, 'controlListboxVisibility');
+      component.clickedOutsideInput(eventClick);
+      expect(component.controlListboxVisibility).toHaveBeenCalled();
+    });
+
+    it('should not hide listbox when was click in input', () => {
+      component.poSearchInput.nativeElement.dispatchEvent(eventClick);
+
+      spyOn(component, 'controlListboxVisibility');
+      component.clickedOutsideInput(eventClick);
+      expect(component.controlListboxVisibility).not.toHaveBeenCalled();
+    });
+
+    it('should initialize all Listeners correctly', fakeAsync(() => {
+      spyOn(component, <any>'removeListeners').and.callThrough();
+      spyOn(component, <any>'adjustContainerPosition');
+
+      component['initializeListeners']();
+
+      expect(component['removeListeners']).toHaveBeenCalled();
+      expect(component['clickoutListener']).toBeDefined();
+      expect(component['eventResizeListener']).toBeDefined();
+
+      window.dispatchEvent(new Event('resize'));
+
+      tick(251);
+
+      expect(component['adjustContainerPosition']).toHaveBeenCalled();
+    }));
+
+    it('should adjustContainerPosition if the screen is resizing', () => {
+      spyOn(component, <any>'adjustContainerPosition');
+
+      component['initializeListeners']();
+
+      window.dispatchEvent(new Event('scroll'));
+
+      expect(component['adjustContainerPosition']).toHaveBeenCalled();
+    });
+
+    it('should focus the listbox if the input have a arrowdown keypress', () => {
+      component.poListbox.listboxItemList = {
+        nativeElement: { offsetHeight: 100, scrollTop: 100, scrollHeight: 200 }
+      };
+      component.type = 'trigger';
+      component.listboxOpen = true;
+
+      const event = new KeyboardEvent('keydown', { keyCode: 40, code: 'ArrowDown' });
+
+      spyOn(component, <any>'focusItem');
+
+      component.onKeyDown(event);
+
+      expect(component.listboxOpen).toBeTrue();
+      expect(component['focusItem']).toHaveBeenCalled();
+    });
+
+    it('should not focus the listbox if the input have a arrowdown keypress and listboxOpen is false', () => {
+      component.listboxOpen = false;
+      component.type = 'trigger';
+
+      const event = new KeyboardEvent('keydown', { keyCode: 40, code: 'ArrowDown' });
+      component.onKeyDown(event);
+
+      expect(component.listboxOpen).toBeFalse();
+    });
+
+    it('should hide the listbox if the input has a shift+tab keypress', () => {
+      spyOn(component, 'controlListboxVisibility');
+      component.type = 'trigger';
+
+      const event = new KeyboardEvent('keydown', { keyCode: 9, code: 'Tab', shiftKey: true });
+
+      component.onKeyDown(event);
+
+      expect(component.controlListboxVisibility).toHaveBeenCalledWith(false);
+    });
+
+    it('should hide the listbox if the input has a tab keypress', () => {
+      spyOn(component, 'controlListboxVisibility');
+      component.type = 'trigger';
+
+      const event = new KeyboardEvent('keydown', { keyCode: 9, code: 'Tab' });
+
+      component.onKeyDown(event);
+
+      expect(component.controlListboxVisibility).toHaveBeenCalledWith(false);
+    });
+
+    it('should close the listbox if the input has a esc keypress', () => {
+      spyOn(component, 'controlListboxVisibility');
+      component.type = 'trigger';
+      component.listboxOpen = true;
+
+      const event = new KeyboardEvent('keydown', { keyCode: 9, code: 'Tab', shiftKey: true });
+
+      component.onKeyDown(event);
+
+      expect(component.controlListboxVisibility).toHaveBeenCalledWith(false);
+    });
+
+    it('should close the listbox and focus the search input if the input has a keydown event with the Escape key', () => {
+      spyOn(component, 'controlListboxVisibility');
+      const focusSpy = spyOn(component.poSearchInput.nativeElement, 'focus');
+
+      component.listboxOpen = true;
+
+      const event = new KeyboardEvent('keydown', { keyCode: 27, code: 'Escape' });
+      component.onKeyDown(event);
+
+      expect(component.controlListboxVisibility).toHaveBeenCalledWith(false);
+      expect(focusSpy).toHaveBeenCalled();
+    });
+
+    it('should close the listbox if the input has a keydown event with the Enter key and the listbox is open', () => {
+      spyOn(component, 'controlListboxVisibility');
+      component.listboxOpen = true;
+
+      const event = new KeyboardEvent('keydown', { keyCode: 13, code: 'Enter' });
+      component.onKeyDown(event);
+
+      expect(component.controlListboxVisibility).toHaveBeenCalledWith(false);
+    });
+
+    it('should call controlListboxVisibility(false) when the input loses focus and the listbox is open and poListbox.items is empty', () => {
+      spyOn(component, 'controlListboxVisibility');
+      component.listboxOpen = true;
+      component.poListbox.items = [];
+
+      component.onBlur();
+      expect(component.controlListboxVisibility).toHaveBeenCalledWith(false);
+    });
+
+    it('should call focusItem() when the input loses focus and the listbox is open and poListbox.items is not empty', () => {
+      component.listboxOpen = true;
+      component.poListbox.items = [{ label: 'Item 1' }];
+      spyOn(component, <any>'focusItem');
+
+      component.onBlur();
+      expect(component['focusItem']).toHaveBeenCalled();
+    });
+
+    it('should focus the first option in the listbox and set its class to cdk-option-active', fakeAsync(() => {
+      const mockListboxItem = document.createElement('div');
+      mockListboxItem.classList.add('po-listbox-item');
+      document.body.appendChild(mockListboxItem);
+
+      const mockListboxItem2 = document.createElement('div');
+      mockListboxItem2.classList.add('po-listbox-item');
+      document.body.appendChild(mockListboxItem2);
+
+      spyOn(mockListboxItem, 'focus');
+
+      component['focusItem']();
+
+      tick(100);
+
+      expect(mockListboxItem.focus).toHaveBeenCalled();
+      expect(mockListboxItem2.classList.contains('cdk-option-active')).toBeFalse();
+
+      document.body.removeChild(mockListboxItem);
+      document.body.removeChild(mockListboxItem2);
+    }));
   });
 });

--- a/projects/ui/src/lib/components/po-search/po-search.component.ts
+++ b/projects/ui/src/lib/components/po-search/po-search.component.ts
@@ -1,8 +1,23 @@
-import { Component, ElementRef, OnInit, Renderer2, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  Renderer2,
+  ViewChild
+} from '@angular/core';
+import { PoControlPositionService } from '../../services/po-control-position/po-control-position.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
-import { PoSearchBaseComponent } from './po-search-base.component';
 import { PoSearchFilterMode } from './enum/po-search-filter-mode.enum';
-
+import { PoSearchOption } from './interfaces/po-search-option.interface';
+import { PoSearchBaseComponent } from './po-search-base.component';
+import { PoKeyCodeEnum } from './../../enums/po-key-code.enum';
+import { PoListBoxComponent } from '../po-listbox';
+import { CdkOption } from '@angular/cdk/listbox';
+const poSearchContainerOffset = 8;
+const poSearchContainerPositionDefault = 'bottom';
 /**
  * @docsExtends PoSearchBaseComponent
  *
@@ -25,66 +40,297 @@ import { PoSearchFilterMode } from './enum/po-search-filter-mode.enum';
  *  <file name="sample-po-search-find-people/sample-po-search-find-people.service.ts"> </file>
  * </example>
  *
+ * <example name="po-search-listbox" title="PO Search With Listbox">
+ *  <file name="sample-po-search-listbox/sample-po-search-listbox.component.html"> </file>
+ *  <file name="sample-po-search-listbox/sample-po-search-listbox.component.ts"> </file>
+ *  <file name="sample-po-search-listbox/sample-po-search-listbox.service.ts"> </file>
+ * </example>
+ *
  */
 @Component({
   selector: 'po-search',
-  templateUrl: './po-search.component.html'
+  templateUrl: './po-search.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [PoControlPositionService]
 })
-export class PoSearchComponent extends PoSearchBaseComponent implements OnInit {
-  @ViewChild('poSearchInput', { read: ElementRef, static: true }) poSearchInput: ElementRef;
+export class PoSearchComponent extends PoSearchBaseComponent implements OnInit, OnDestroy {
+  private clickoutListener: () => void;
+  private eventResizeListener: () => void;
 
+  @ViewChild('poSearchInput', { read: ElementRef, static: true }) poSearchInput: ElementRef;
+  @ViewChild('poListboxContainerElement', { read: ElementRef }) poListboxContainerElement: ElementRef;
+  @ViewChild('poListboxElement', { read: ElementRef }) poListboxElement: ElementRef;
+  @ViewChild('poListbox') poListbox: PoListBoxComponent;
+
+  listboxFilteredItems: Array<any> = [];
   filteredItems: Array<any> = [];
+  listboxOpen: boolean = false;
+  shouldMarkLetters: boolean = true;
+  isFiltering: boolean = false;
+  listboxItemclicked: boolean = false;
 
   constructor(
     public languageService: PoLanguageService,
-    private renderer: Renderer2
+    private renderer: Renderer2,
+    private changeDetector: ChangeDetectorRef,
+    private controlPosition: PoControlPositionService
   ) {
     super(languageService);
   }
 
   ngOnInit(): void {
     this.filteredItems = this.items;
+    if (this.showListbox) {
+      this.listboxFilteredItems = this.listboxItems;
+    }
+  }
+
+  ngOnDestroy() {
+    this.removeListeners();
   }
 
   clearSearch(): void {
     this.poSearchInput.nativeElement.value = '';
     this.onSearchChange('', true);
     this.filteredItemsChange.emit(this.items);
-    this.poSearchInput.nativeElement.focus();
+    this.onCloseListbox();
   }
 
-  onSearchChange(searchText: string, activated: boolean): void {
-    if (activated) {
-      searchText = searchText.toLowerCase();
+  onSearchChange(searchText: string, activated: boolean, buttonClick?: boolean): void {
+    searchText = searchText.toLowerCase();
+    this.isFiltering = true;
 
-      if (this.items && this.items.length > 0) {
-        this.filteredItems = this.items.filter(item =>
-          this.filterKeys.some(key => {
-            let value = item[key];
-
-            if (typeof value !== 'string') {
-              value = value != null ? value.toString() : null;
-            }
-
-            value = value != null ? value.toLowerCase() : null;
-
-            if (this.filterType === PoSearchFilterMode.startsWith) {
-              return value != null && value.startsWith(searchText);
-            } else if (this.filterType === PoSearchFilterMode.contains) {
-              return value != null && value.includes(searchText);
-            } else if (this.filterType === PoSearchFilterMode.endsWith) {
-              return value != null && value.endsWith(searchText);
-            }
-
-            return false;
-          })
-        );
-        this.filteredItemsChange.emit(this.filteredItems);
-      } else {
-        this.filteredItems = [];
-        this.filteredItemsChange.emit(this.filteredItems);
+    if (this.showListbox && !buttonClick && searchText.length > 0) {
+      this.controlListboxVisibility(true);
+      this.listboxFilteredItems = this.getListboxFilteredItems(searchText);
+    } else {
+      if (searchText.length === 0) {
+        this.listboxFilteredItems = this.listboxItems;
       }
+    }
+
+    if (activated && !this.listboxItemclicked) {
+      this.updateFilteredItems(searchText);
+      this.filteredItemsChange.emit(this.filteredItems);
       this.changeModel.emit(searchText);
     }
+
+    if (this.listboxItemclicked) {
+      this.listboxItemclicked = false;
+    }
+
+    this.changeDetector.detectChanges();
+  }
+
+  private updateFilteredItems(searchText: string): void {
+    if (this.items && this.items.length > 0) {
+      this.filteredItems = this.getFilteredItems(searchText);
+    } else {
+      this.filteredItems = [];
+    }
+  }
+
+  private getFilteredItems(searchText) {
+    return this.items.filter(item => this.itemMatchesFilter(item, searchText));
+  }
+
+  private itemMatchesFilter(item: any, searchText: string): boolean {
+    const valuesToSearch: Array<string> = this.filterKeys
+      .map(key => (typeof item[key] !== 'string' ? String(item[key]) : item[key]))
+      .map(value => (value ? value.toLowerCase() : ''));
+
+    return valuesToSearch.some(value => this.filterValue(value, searchText));
+  }
+
+  getListboxFilteredItems(searchText) {
+    return this.listboxItems.filter(item => this.filterValue(item.value, searchText));
+  }
+
+  private filterValue(value: string, searchText: string) {
+    value = value?.toLowerCase();
+    switch (this.filterType) {
+      case PoSearchFilterMode.startsWith:
+        return value?.startsWith(searchText);
+      case PoSearchFilterMode.contains:
+        return value?.includes(searchText);
+      case PoSearchFilterMode.endsWith:
+        return value?.endsWith(searchText);
+      default:
+        return false;
+    }
+  }
+
+  get listboxItems() {
+    return this.items
+      .map(item => this.filterKeys.map(key => item[key]).map(item => (typeof item !== 'string' ? String(item) : item)))
+      .flat()
+      .map(value => ({ label: value, value }));
+  }
+
+  onCloseListbox() {
+    this.poSearchInput.nativeElement.focus();
+    this.controlListboxVisibility(false);
+    this.isFiltering = false;
+  }
+
+  onListboxClick(option: PoSearchOption, event?: any) {
+    if (event) {
+      event.stopPropagation();
+    }
+
+    if (!event || event.code === 'Enter') {
+      this.listboxItemclicked = true;
+    }
+
+    this.poSearchInput.nativeElement.value = option.value;
+    this.listboxOnClick.emit(option.value);
+
+    this.onCloseListbox();
+    if (this.type === 'action') {
+      this.listboxItemclicked = false;
+      this.onSearchChange(option.value.toString(), true, true);
+    }
+  }
+
+  onBlur() {
+    if (this.listboxOpen) {
+      if (!this.poListbox.items.length) {
+        this.controlListboxVisibility(false);
+      } else {
+        this.focusItem();
+      }
+    }
+  }
+
+  onKeyDown(event?: any) {
+    const key = event.keyCode;
+
+    if (event.shiftKey && key === PoKeyCodeEnum.tab) {
+      this.controlListboxVisibility(false);
+      return;
+    }
+
+    if (key === PoKeyCodeEnum.tab) {
+      this.controlListboxVisibility(false);
+      return;
+    }
+
+    if (key === PoKeyCodeEnum.arrowDown) {
+      event.preventDefault();
+
+      if (!this.listboxOpen) {
+        return;
+      }
+
+      this.focusItem();
+      this.controlListboxVisibility(true);
+      return;
+    }
+
+    if (key === PoKeyCodeEnum.esc) {
+      this.controlListboxVisibility(false);
+      this.poSearchInput.nativeElement.focus();
+    }
+
+    if (key === PoKeyCodeEnum.enter && this.listboxOpen) {
+      this.controlListboxVisibility(false);
+      this.isFiltering = false;
+    }
+  }
+
+  private focusItem() {
+    const listboxItemList = document.querySelectorAll('.po-listbox-item');
+    setTimeout(() => {
+      Array.from(listboxItemList).forEach((el: HTMLElement) => {
+        el.tabIndex = -1;
+        el.classList.remove('cdk-option-active');
+      });
+
+      const firstOption = listboxItemList[0] as HTMLElement;
+      firstOption.focus();
+      firstOption.classList.add('cdk-option-active');
+    });
+  }
+
+  private setContainerPosition() {
+    if (this.poListboxContainerElement && this.poSearchInput) {
+      this.controlPosition.setElements(
+        this.poListboxContainerElement.nativeElement,
+        poSearchContainerOffset,
+        this.poSearchInput,
+        ['top', 'bottom'],
+        true
+      );
+
+      this.adjustContainerPosition();
+    }
+  }
+
+  private adjustContainerPosition() {
+    if (this.poListboxContainerElement && this.poSearchInput) {
+      this.controlPosition.adjustPosition(poSearchContainerPositionDefault);
+    }
+  }
+
+  controlListboxVisibility(toOpen: boolean) {
+    toOpen ? this.openListbox() : this.closeListbox();
+  }
+
+  private openListbox() {
+    this.listboxOpen = true;
+    this.changeDetector.detectChanges();
+    this.initializeListeners();
+    this.poSearchInput.nativeElement.focus();
+    this.setContainerPosition();
+  }
+
+  closeListbox() {
+    this.listboxOpen = false;
+    this.changeDetector.detectChanges();
+    this.removeListeners();
+  }
+
+  clickedOutsideInput(event: MouseEvent): void {
+    if (
+      this.listboxOpen &&
+      !this.poSearchInput.nativeElement.contains(event.target) &&
+      (!this.poListboxElement || !this.poListboxElement.nativeElement.contains(event.target))
+    ) {
+      this.controlListboxVisibility(false);
+    }
+  }
+
+  private initializeListeners() {
+    this.removeListeners();
+
+    this.clickoutListener = this.renderer.listen('document', 'click', (event: MouseEvent) => {
+      this.clickedOutsideInput(event);
+    });
+
+    this.eventResizeListener = this.renderer.listen('window', 'resize', () => {
+      setTimeout(() => this.adjustContainerPosition(), 250);
+    });
+
+    window.addEventListener('scroll', this.onScroll, true);
+  }
+
+  private removeListeners() {
+    if (this.clickoutListener) {
+      this.clickoutListener();
+    }
+
+    if (this.eventResizeListener) {
+      this.eventResizeListener();
+    }
+
+    window.removeEventListener('scroll', this.onScroll, true);
+  }
+
+  private onScroll = (): void => {
+    this.adjustContainerPosition();
+  };
+
+  getInputValue() {
+    return this.poSearchInput.nativeElement.value;
   }
 }

--- a/projects/ui/src/lib/components/po-search/po-search.module.ts
+++ b/projects/ui/src/lib/components/po-search/po-search.module.ts
@@ -6,6 +6,7 @@ import { PoLoadingModule } from '../po-loading';
 import { PoSearchComponent } from './po-search.component';
 import { FormsModule } from '@angular/forms';
 import { PoAccordionModule } from '../po-accordion/po-accordion.module';
+import { PoListBoxModule } from '../po-listbox';
 
 /**
  * @description
@@ -13,7 +14,15 @@ import { PoAccordionModule } from '../po-accordion/po-accordion.module';
  * Módulo do componente po-search.
  */
 @NgModule({
-  imports: [CommonModule, PoCleanModule, PoIconModule, PoLoadingModule, PoAccordionModule, FormsModule],
+  imports: [
+    CommonModule,
+    PoCleanModule,
+    PoIconModule,
+    PoLoadingModule,
+    PoAccordionModule,
+    FormsModule,
+    PoListBoxModule
+  ],
   declarations: [PoSearchComponent],
   exports: [PoSearchComponent]
 })

--- a/projects/ui/src/lib/components/po-search/samples/sample-po-search-labs/sample-po-search-labs.component.html
+++ b/projects/ui/src/lib/components/po-search/samples/sample-po-search-labs/sample-po-search-labs.component.html
@@ -10,6 +10,7 @@
     [p-literals]="customLiterals"
     [p-filter-type]="filterMode"
     [p-search-type]="searchMode"
+    [p-show-listbox]="showListbox"
     (p-filtered-items-change)="filter($event)"
     (p-change-model)="changeModel($event)"
   ></po-search>
@@ -47,7 +48,7 @@
 <form #f="ngForm">
   <div class="po-row">
     <po-checkbox-group
-      class="po-md-12"
+      class="po-md-6"
       name="properties"
       [(ngModel)]="properties"
       p-label="Properties"
@@ -55,6 +56,8 @@
       (p-change)="propertiesChange($event)"
     >
     </po-checkbox-group>
+
+    <po-switch class="po-md-6" name="switch" p-label="showListbox" [(ngModel)]="showListbox"> </po-switch>
   </div>
   <div class="po-row">
     <po-input

--- a/projects/ui/src/lib/components/po-search/samples/sample-po-search-labs/sample-po-search-labs.component.ts
+++ b/projects/ui/src/lib/components/po-search/samples/sample-po-search-labs/sample-po-search-labs.component.ts
@@ -32,6 +32,7 @@ export class SamplePoSearchLabsComponent implements OnInit, OnChanges {
   customLiterals: PoSearchLiterals;
   literals: any;
   properties: Array<string>;
+  showListbox: boolean;
   search: string;
   event: string;
   service: string = 'https://po-sample-api.onrender.com/v1/heroes';
@@ -147,6 +148,7 @@ export class SamplePoSearchLabsComponent implements OnInit, OnChanges {
     this.icon = undefined;
     this.customLiterals = undefined;
     this.properties = [];
+    this.showListbox = false;
     this.filteredItems = undefined;
     this.items = undefined;
     this.itemsModel = undefined;

--- a/projects/ui/src/lib/components/po-search/samples/sample-po-search-listbox/sample-po-search-listbox.component.html
+++ b/projects/ui/src/lib/components/po-search/samples/sample-po-search-listbox/sample-po-search-listbox.component.html
@@ -1,0 +1,18 @@
+<div class="po-row">
+  <po-search
+    class="po-md-12"
+    name="Po Search"
+    [p-items]="items"
+    [p-filter-keys]="filterKeys"
+    (p-filtered-items-change)="filtered($event)"
+    p-show-listbox="true"
+    p-search-type="trigger"
+  ></po-search>
+</div>
+
+<div class="po-row" *ngFor="let people of peopleFiltered">
+  <hr />
+  <po-info class="po-md-4" p-label="Name" [p-value]="people.name"> </po-info>
+  <po-info class="po-md-4" p-label="Nickname" [p-value]="people.nickname"> </po-info>
+  <po-info class="po-md-4" p-label="Email" [p-value]="people.email"> </po-info>
+</div>

--- a/projects/ui/src/lib/components/po-search/samples/sample-po-search-listbox/sample-po-search-listbox.component.ts
+++ b/projects/ui/src/lib/components/po-search/samples/sample-po-search-listbox/sample-po-search-listbox.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+import { SamplePoSearchListboxService } from './sample-po-search-listbox.service';
+
+@Component({
+  selector: 'sample-po-search-listbox',
+  templateUrl: './sample-po-search-listbox.component.html',
+  providers: [SamplePoSearchListboxService]
+})
+export class SamplePoSearchListboxComponent implements OnInit {
+  items: any;
+  filterKeys: Array<string> = ['name', 'nickname', 'email'];
+  peopleFiltered: Array<any> = [];
+
+  constructor(private service: SamplePoSearchListboxService) {}
+
+  ngOnInit() {
+    this.items = this.service.getItems();
+  }
+
+  filtered(event: Array<any>) {
+    this.peopleFiltered = event;
+    if (event.length === 4) {
+      this.peopleFiltered = [];
+    } else {
+      try {
+      } catch (error) {
+        return undefined;
+      }
+    }
+  }
+
+  compareObjects(value: any) {
+    return this.peopleFiltered.includes(value) ? true : false;
+  }
+}

--- a/projects/ui/src/lib/components/po-search/samples/sample-po-search-listbox/sample-po-search-listbox.service.ts
+++ b/projects/ui/src/lib/components/po-search/samples/sample-po-search-listbox/sample-po-search-listbox.service.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SamplePoSearchListboxService {
+  getItems(): Array<any> {
+    return [
+      {
+        'id': '0348093615904',
+        'name': 'Leonardo Silveiras',
+        'birthdate': '1995-07-15T00:00:00-00:00',
+        'genre': 'male',
+        'city': '4209102',
+        'status': 'active',
+        'nickname': 'leo.silveira',
+        'email': 'leonardo.silveira@gmail.com',
+        'nationality': 'Brazilian',
+        'birthPlace': 'São Paulo',
+        'graduation': 'College',
+        'father': 'Papai',
+        'mother': 'Mamãe',
+        'street': 'Santos Dumont',
+        'country': 'Brasil',
+        'genreDescription': 'Masculino',
+        'statusDescription': 'Ativo',
+        'cityName': 'Joinville',
+        'state': 'Santa Catarina',
+        'uf': 'SC',
+        'dependents': []
+      },
+      {
+        'id': '0648093812893',
+        'name': 'João Severino',
+        'birthdate': '1995-10-07T00:00:00-00:00',
+        'genre': 'male',
+        'city': '4216206',
+        'status': 'active',
+        'nickname': 'jseverino',
+        'email': 'jseverino@yahoo.com',
+        'nationality': 'Brazilian',
+        'birthPlace': 'São Paulo',
+        'graduation': 'College',
+        'father': 'Papai',
+        'mother': 'Mamãe',
+        'street': 'Santos Dumont',
+        'country': 'Brasil',
+        'genreDescription': 'Masculino',
+        'statusDescription': 'Ativo',
+        'cityName': 'São Francisco do Sul',
+        'state': 'Santa Catarina',
+        'uf': 'SC',
+        'dependents': [{ 'id': 109481, 'name': 'Maria', 'age': '10', 'related': 'Daughter', 'birthdate': '2008-12-10' }]
+      },
+      {
+        'id': '0748093840433',
+        'name': 'José Marcos Cardoso',
+        'birthdate': '1986-08-01T00:00:00-00:00',
+        'genre': 'male',
+        'city': '4201307',
+        'status': 'inactive',
+        'nickname': 'jose',
+        'email': 'jose@outlook.com',
+        'nationality': 'Brazilian',
+        'birthPlace': '3550308',
+        'graduation': 'College',
+        'father': 'Papai',
+        'mother': 'Mamãe',
+        'street': 'Santos Dumont',
+        'country': 'Brasil',
+        'genreDescription': 'Masculino',
+        'statusDescription': 'Inativo',
+        'cityName': 'Araquari',
+        'state': 'Santa Catarina',
+        'uf': 'SC',
+        'dependents': [
+          { 'id': 109483, 'name': 'Pedro', 'age': '13', 'related': 'Son', 'birthdate': '2008-12-10' },
+          { 'id': 109484, 'name': 'Paulo', 'age': '15', 'related': 'Son', 'birthdate': '2008-12-10' },
+          { 'id': 109485, 'name': 'José', 'age': '19', 'related': 'Son', 'birthdate': '2008-12-10' }
+        ]
+      },
+      {
+        'id': '0848094890811',
+        'name': 'Karlo Rodrigues',
+        'birthdate': '1989-12-28T00:00:00-00:00',
+        'genre': 'male',
+        'city': '3550308',
+        'status': 'active',
+        'nickname': 'krodrigues',
+        'email': 'krodrigues@uol.com.br',
+        'nationality': 'Brazilian',
+        'birthPlace': 'São Paulo',
+        'graduation': 'College',
+        'father': 'Papai',
+        'mother': 'Mamãe',
+        'street': 'Santos Dumont',
+        'country': 'Brasil',
+        'genreDescription': 'Masculino',
+        'statusDescription': 'Ativo',
+        'cityName': 'São Paulo',
+        'state': 'São Paulo',
+        'uf': 'SP',
+        'dependents': []
+      }
+    ];
+  }
+}


### PR DESCRIPTION
**po-search**

**DTHFUI-7812**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não tem a opção de ter um listbox ao fazer uma pesquisa 

**Qual o novo comportamento?**
Implementação da propriedade 't-show-listbox'.
Com essa propriedade ativa, sempre ira mostrar uma listbox das opções informadas, quando houver mudança no input. ela também obedece a regra do filterKeys

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/14727927/app.zip)
