### PR TITLE
feat(page-dynamic-edit): inclui p-notification-type para definir o tipo de notificação na validação

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-literals.interface.ts
@@ -51,6 +51,13 @@ export interface PoPageDynamicEditLiterals {
   /**
    * @description
    *
+   * Texto exibido para ocorrência de alguma inconsistência ao salvar.
+   */
+  saveNotificationError?: string;
+
+  /**
+   * @description
+   *
    * Texto exibido para recurso salvo com sucesso.
    */
   saveNotificationSuccessSave?: string;

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -109,6 +109,26 @@ describe('PoPageDynamicEditComponent: ', () => {
       expectPropertiesValues(component, 'autoRouter', invalidValues, false);
     });
 
+    it('p-notification-type: should set property to `error` if value equal `error`', () => {
+      const notificationType = 'error';
+
+      component.notificationType = notificationType;
+
+      expect(component['_notificationType']).toEqual(notificationType);
+    });
+
+    it('p-notification-type: should set property to `warning` if invalid values', () => {
+      const invalidValues = ['teste', undefined, null, NaN, 0, 'false', false];
+
+      expectPropertiesValues(component, 'notificationType', invalidValues, 'warning');
+    });
+
+    it('p-notification-type: should set property to `warning` if value is empty', () => {
+      component.notificationType = '';
+
+      expect(component.notificationType).toEqual('warning');
+    });
+
     describe('p-literals:', () => {
       it('should be in portuguese if browser is setted with an unsupported language', () => {
         component['language'] = 'zw';
@@ -1161,6 +1181,14 @@ describe('PoPageDynamicEditComponent: ', () => {
         component['save'](saveAction);
 
         expect(updateModelSpy).toHaveBeenCalledBefore(executeSaveSpy);
+      });
+    });
+
+    describe('showNotification:', () => {
+      it(`should call 'showNotification and notificationType be equal 'error'`, () => {
+        spyOn(component['poNotification'], 'error');
+        component['showNotification']('error');
+        expect(component['poNotification'].error).toHaveBeenCalled();
       });
     });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -32,6 +32,9 @@ import { PoPageDynamicEditLiterals } from './interfaces/po-page-dynamic-edit-lit
 type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicEditOptions);
 type SaveAction = PoPageDynamicEditActions['save'] | PoPageDynamicEditActions['saveNew'];
 
+export const poNotificationType = ['error', 'warning'];
+export const poNotificationTypeDefault = 'warning';
+
 export const poPageDynamicEditLiteralsDefault = {
   en: <PoPageDynamicEditLiterals>{
     cancelConfirmMessage: 'Are you sure you want to cancel this operation?',
@@ -40,6 +43,7 @@ export const poPageDynamicEditLiteralsDefault = {
     pageActionSave: 'Save',
     pageActionSaveNew: 'Save and new',
     registerNotFound: 'Register not found.',
+    saveNotificationError: 'Mandatory field(s) not filled.',
     saveNotificationSuccessSave: 'Resource successfully saved.',
     saveNotificationSuccessUpdate: 'Resource successfully updated.',
     saveNotificationWarning: 'Form must be filled out correctly.'
@@ -51,6 +55,7 @@ export const poPageDynamicEditLiteralsDefault = {
     pageActionSave: 'Guardar',
     pageActionSaveNew: 'Guardar y nuevo',
     registerNotFound: 'Registro no encontrado.',
+    saveNotificationError: 'Campo(s) obligatorio(s) no completado(s).',
     saveNotificationSuccessSave: 'Recurso salvo con éxito.',
     saveNotificationSuccessUpdate: 'Recurso actualizado con éxito.',
     saveNotificationWarning: 'El formulario debe llenarse correctamente.'
@@ -62,6 +67,7 @@ export const poPageDynamicEditLiteralsDefault = {
     pageActionSave: 'Salvar',
     pageActionSaveNew: 'Salvar e novo',
     registerNotFound: 'Registro não encontrado.',
+    saveNotificationError: 'Campo(s) obrigatório(s) sem preenchimento.',
     saveNotificationSuccessSave: 'Recurso salvo com sucesso.',
     saveNotificationSuccessUpdate: 'Recurso atualizado com sucesso.',
     saveNotificationWarning: 'Formulário precisa ser preenchido corretamente.'
@@ -73,6 +79,7 @@ export const poPageDynamicEditLiteralsDefault = {
     pageActionSave: 'Сохранить',
     pageActionSaveNew: 'Сохранить и создать',
     registerNotFound: 'Запись не найдена.',
+    saveNotificationError: 'Обязательное поле(я) не заполнено.',
     saveNotificationSuccessSave: 'Ресурс успешно сохранен.',
     saveNotificationSuccessUpdate: 'Ресурс успешно обновлен.',
     saveNotificationWarning: 'Форма должна быть заполнена правильно.'
@@ -340,7 +347,7 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
   private _fields: Array<any> = [];
   private _keys: Array<any> = [];
   private _pageActions: Array<PoPageAction> = [];
-
+  private _notificationType?: string = poNotificationTypeDefault;
   /**
    * @optional
    *
@@ -375,6 +382,7 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
    *    pageActionSave: 'Gravar',
    *    pageActionSaveNew: 'Gravar e incluir',
    *    registerNotFound: 'Nenhum registro encontrado.',
+   *    saveNotificationError: 'Campo(s) obrigatório(s) sem preenchimento.',
    *    saveNotificationSuccessSave: 'Item salvo com sucesso.',
    *    saveNotificationSuccessUpdate: 'Item atualizado com sucesso.',
    *    saveNotificationWarning: 'Necessário preencher o formulário corretamente.'
@@ -407,6 +415,32 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
 
   get literals() {
     return this._literals || poPageDynamicEditLiteralsDefault[this.language];
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Tipo da notificação.
+   *
+   * É possivel definir o tipo de notificação que será exibido quando houver algum campo inválido no formulário.
+   *
+   * ```
+   * <po-page-dynamic-edit
+   *   p-notification-type="warning">
+   * </po-page-dynamic-edit>
+   * ```
+   *
+   * > Os valores aceitos são 'warning' e 'error'.
+   * @default warning
+   */
+  @Input('p-notification-type') set notificationType(value: string) {
+    this._notificationType = poNotificationType.includes(value) ? value : poNotificationTypeDefault;
+  }
+
+  get notificationType() {
+    return this._notificationType;
   }
 
   /**
@@ -765,10 +799,21 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
     }
   }
 
+  private showNotification(type: string) {
+    switch (type) {
+      case 'warning':
+        this.poNotification.warning(this.literals.saveNotificationWarning);
+        break;
+      case 'error':
+        this.poNotification.error(this.literals.saveNotificationError);
+        break;
+    }
+  }
+
   private saveOperation() {
     if (this.dynamicForm.form.invalid) {
       this.markControlsAsDirtyAndFocusFirstInvalid();
-      this.poNotification.warning(this.literals.saveNotificationWarning);
+      this.showNotification(this._notificationType);
       return EMPTY;
     }
 


### PR DESCRIPTION
**PAGE-DYNAMIC-EDIT**

*DTHFUI-8576**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente não é possível definir o tipo de alerta na validação.

**Qual o novo comportamento?**
Adicionado propriedade p-notification-type onde é possível especificar se o tipo da notificação será 'warning' ou 'error'.

**Simulação**
No app em anexo, acessar no navegador o end-point /aluno e clicar no botão Gravar;
Por padrão aparecerá a notificação tipo 'warning'.

Ao selecionar a opção "Notification type Error" e clicar novamente no botão Gravar, deverá aparecer a notificação do tipo 'error'

[app.zip](https://github.com/po-ui/po-angular/files/14795674/app.zip)
