### PR TITLE
feat(disclaimer): adiciona propriedades internas

### DIFF
--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.ts
@@ -31,6 +31,10 @@ export class PoDisclaimerBaseComponent {
   /** Nome da propriedade vinculada à este po-disclaimer. */
   @Input('p-property') property?: string;
 
+  @Input('p-last-disclaimer') lastDisclaimer: boolean = false;
+
+  @Input('p-tooltip-position') tooltipPosition: string = 'bottom';
+
   /**
    * @optional
    *
@@ -40,6 +44,8 @@ export class PoDisclaimerBaseComponent {
    * Para este evento será passado como parâmetro um objeto com value, label e property.
    */
   @Output('p-close-action') closeAction: EventEmitter<any> = new EventEmitter<any>();
+
+  @Output('p-click-number') clickNumber: EventEmitter<any> = new EventEmitter<any>();
 
   literals: any;
   showDisclaimer = true;

--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.html
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.html
@@ -5,8 +5,10 @@
     [class.po-disclaimer-remove-all]="hideClose"
     [class.po-disclaimer-danger]="type === 'danger'"
     [p-tooltip]="getWidthDisclaimer() ? getLabel() : ''"
-    p-tooltip-position="bottom"
+    [p-tooltip-position]="tooltipPosition"
     [tabindex]="hideClose ? '0' : '-1'"
+    (click)="emitLastDisclaimer(lastDisclaimer)"
+    (keydown.enter)="emitLastDisclaimer(lastDisclaimer)"
   >
     <div class="po-disclaimer-label" [class.show-close]="!hideClose">
       <span class="label">

--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.spec.ts
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.spec.ts
@@ -102,10 +102,19 @@ describe('PoDisclaimerComponent:', () => {
       const expectedValue = component.getWidthDisclaimer();
       expect(expectedValue).toBeTruthy();
     });
+
     it('getWidthDisclaimer: should return `false` when disclaimer-label offsetWidth < 201', () => {
       spyOnProperty(component.disclaimerContainer.nativeElement, 'offsetWidth').and.returnValue(50);
       const expectedValue = component.getWidthDisclaimer();
       expect(expectedValue).toBeFalsy();
+    });
+
+    it('emitLastDisclaimer: should emit last disclaimer', () => {
+      spyOn(component.clickNumber, 'emit');
+
+      component.emitLastDisclaimer(true);
+
+      expect(component.clickNumber.emit).toHaveBeenCalled();
     });
   });
 

--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.ts
@@ -29,6 +29,12 @@ export class PoDisclaimerComponent extends PoDisclaimerBaseComponent {
     }
   }
 
+  emitLastDisclaimer(isLast) {
+    if (isLast) {
+      this.clickNumber.emit();
+    }
+  }
+
   getWidthDisclaimer() {
     return this.disclaimerContainer.nativeElement.offsetWidth > 201;
   }


### PR DESCRIPTION
Adiciona propriedades internas afim de adequar ao lookup.

fixes DTHFUI-8646
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
N/A

**Qual o novo comportamento?**
Adiciona propriedades internas no disclaimer para o último disclaimer do lookup ser clicável.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/15042652/app.zip)
