### PR TITLE
feat(table): adiciona propriedade `textWrap`

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -483,6 +483,15 @@ describe('PoTableBaseComponent:', () => {
     expect(component.hasItems).toBeTruthy();
   });
 
+  it('textWrap: should accept input for text wrapping with default value', () => {
+    expect(component.textWrap).toBe(false);
+  });
+
+  it('textWrap: should accept input for text wrapping with value true', () => {
+    component.textWrap = true;
+    expect(component.textWrap).toBe(true);
+  });
+
   describe('Methods:', () => {
     const columnsColors = [
       { label: 'Destination', property: 'destination', type: 'string', color: 'color-07' },

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -177,6 +177,19 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    *
    * @description
    *
+   * Habilita ou desabilita a quebra automática de texto. Quando ativada, o texto que excede
+   * o espaço disponível é transferido para a próxima linha em pontos apropriados para uma
+   * leitura clara.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-text-wrap', transform: convertToBoolean }) textWrap?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Permite que as ações para fixar uma coluna da tabela sejam escondidas.
    *
    * @default `false`

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -104,7 +104,8 @@
       'po-table-interactive': selectable || sort,
       'po-table-selectable': selectable,
       'po-table-striped': striped,
-      'po-table-data-fixed-columns': applyFixedColumns()
+      'po-table-data-fixed-columns': applyFixedColumns(),
+      'po-table-text-wrap-enabled': textWrap
     }"
     [attr.p-spacing]="spacing"
   >
@@ -442,7 +443,8 @@
         'po-table-interactive': selectable || sort,
         'po-table-selectable': selectable,
         'po-table-striped': striped,
-        'po-table-data-fixed-columns': applyFixedColumns()
+        'po-table-data-fixed-columns': applyFixedColumns(),
+        'po-table-text-wrap-enabled': textWrap
       }"
       [attr.p-spacing]="spacing"
     >

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-heroes/sample-po-table-heroes.component.html
@@ -15,6 +15,7 @@
       [p-items]="items"
       (p-delete-items)="deleteItems($event)"
       [p-hide-action-fixed-columns]="true"
+      [p-text-wrap]="true"
     >
     </po-table>
   </div>
@@ -29,6 +30,7 @@
       p-height="300"
       [p-items]="itemsSelected"
       [p-hide-action-fixed-columns]="true"
+      [p-text-wrap]="true"
     >
     </po-table>
   </div>


### PR DESCRIPTION
**TABLE**

**DTHFUI-8743**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
 Quebra de linha nos textos das colunas não é possivel 

**Qual o novo comportamento?**
Quebra de linha nos textos das colunas é possivel 

**Simulação**
[app-wrap.zip](https://github.com/po-ui/po-angular/files/15168700/app-wrap.zip)

PR adicional
- https://github.com/po-ui/po-style/pull/535
