### PR TITLE
feat(table): Permite maior visibilidade de itens e colunas

### DIFF
--- a/projects/ui/src/lib/components/po-table/enums/po-table-spacing.enum.ts
+++ b/projects/ui/src/lib/components/po-table/enums/po-table-spacing.enum.ts
@@ -5,7 +5,7 @@
  * Tipos de espaçamento das colunas da tabela.
  */
 export enum PoTableColumnSpacing {
-  /** Espaçamento pequeno, só funciona em colunas não interativas */
+  /** Espaçamento pequeno */
   Small = 'small',
 
   /** Espaçamento médio */

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -660,47 +660,6 @@ describe('PoTableBaseComponent:', () => {
       });
     });
 
-    describe('verifyInteractiveColumns: ', () => {
-      it('should call spacing `large`', () => {
-        component.columns = [
-          { label: 'Table', property: 'table', visible: true },
-          { label: 'Angular', property: 'angular', visible: true }
-        ];
-        component.spacing = PoTableColumnSpacing.Large;
-
-        component['verifyInteractiveColumns']();
-
-        expect(component.spacing).toBe('large');
-      });
-
-      it('should call spacing `small` when row is not interactive', () => {
-        component.columns = [
-          { label: 'Table', property: 'table', visible: true },
-          { label: 'Angular', property: 'angular', visible: true }
-        ];
-        component.selectable = false;
-        component.actions = [];
-        component.spacing = PoTableColumnSpacing.Small;
-
-        component['verifyInteractiveColumns']();
-
-        expect(component.spacing).toBe('small');
-      });
-
-      it('should call spacing `medium` when row is interactive and set spacing `small`', () => {
-        component.columns = [
-          { label: 'Table', property: 'table', visible: true },
-          { label: 'Angular', property: 'angular', visible: true, type: 'link' }
-        ];
-        component.selectable = true;
-        component.spacing = PoTableColumnSpacing.Small;
-
-        component['verifyInteractiveColumns']();
-
-        expect(component.spacing).toBe('medium');
-      });
-    });
-
     describe('setSelectedList: ', () => {
       const rows = [
         {
@@ -1598,19 +1557,6 @@ describe('PoTableBaseComponent:', () => {
       component.columns = [];
 
       expect(component['getDefaultColumns']).not.toHaveBeenCalled();
-    });
-
-    it('p-columns: should call `verifyInteractiveColumns` if have a column if visible propertie', () => {
-      spyOn(component, <any>'verifyInteractiveColumns');
-
-      component['initialVisibleColumns'] = false;
-      component.columns = [
-        { label: 'Table', property: 'table', visible: true },
-        { label: 'Angular', property: 'angular', visible: true }
-      ];
-
-      expect(component['initialVisibleColumns']).toBe(true);
-      expect(component['verifyInteractiveColumns']).toHaveBeenCalled();
     });
 
     it('p-container: should update property with valid values', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -559,7 +559,6 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
 
     if (hasColumnsWithVisible && !this.initialVisibleColumns) {
       this.initialVisibleColumns = true;
-      this.verifyInteractiveColumns();
     }
 
     if (this._columns.length) {
@@ -880,8 +879,6 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * Responsável por aplicar espaçamento nas colunas.
    *
    * Deve receber um dos valores do enum `PoTableColumnSpacing`.
-   *
-   * Valor `small` só funciona em tabelas não interativas. Caso seja setado com `small` e a tabela seja interativa, o valor será retornado para `medium`.
    *
    * @default `medium`
    */
@@ -1250,13 +1247,6 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
         item.$selected = false;
       }
     });
-  }
-
-  private verifyInteractiveColumns() {
-    const hasLinkOrDetail = this.columns.find(column => column.type === 'link' || column.type === 'detail');
-    if (this.spacing === 'small' && (this.selectable || hasLinkOrDetail || this.visibleActions.length > 0)) {
-      this.spacing = PoTableColumnSpacing.Medium;
-    }
   }
 
   private verifyWidthColumnsPixels() {

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -185,8 +185,8 @@
               <ng-container *ngIf="this.isDraggable && !column.fixed">
                 <svg
                   cdkDragHandle
-                  width="24"
-                  height="24"
+                  width="16"
+                  height="16"
                   viewBox="0 0 24 24"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -528,8 +528,8 @@
                 <ng-container *ngIf="this.isDraggable && !column.fixed">
                   <svg
                     cdkDragHandle
-                    width="24"
-                    height="24"
+                    width="16"
+                    height="16"
                     viewBox="0 0 24 24"
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
@@ -830,7 +830,7 @@
     "
   >
     <ng-container *ngIf="JSON.stringify(sortedColumn?.property) !== JSON.stringify(column)">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
           fill-rule="evenodd"
           clip-rule="evenodd"
@@ -841,7 +841,7 @@
     </ng-container>
 
     <ng-container *ngIf="JSON.stringify(sortedColumn?.property) === JSON.stringify(column) && sortedColumn.ascending">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
           fill-rule="evenodd"
           clip-rule="evenodd"
@@ -852,7 +852,7 @@
     </ng-container>
 
     <ng-container *ngIf="JSON.stringify(sortedColumn?.property) === JSON.stringify(column) && !sortedColumn.ascending">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
           fill-rule="evenodd"
           clip-rule="evenodd"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -2342,19 +2342,6 @@ describe('PoTableComponent:', () => {
       expect(nativeElement.querySelector('[p-spacing="small"]')).toBeTruthy();
     });
 
-    it('should call attr-p-spacing `medium` if p-spacing is `small` and row is interactive', () => {
-      component.spacing = PoTableColumnSpacing.Small;
-      component['initialVisibleColumns'] = false;
-      component.columns = [
-        { property: 'name', type: 'link', visible: true },
-        { property: 'age', visible: true }
-      ];
-      fixture.detectChanges();
-
-      expect(nativeElement.querySelector('[p-spacing="small"]')).toBeNull();
-      expect(nativeElement.querySelector('[p-spacing="medium"]')).toBeTruthy();
-    });
-
     it('should display .po-table-header-master-detail if columns contains detail and rowTemplate is undefined', () => {
       component.items = [...items];
       component.columns = [...columnsWithDetail];

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -106,7 +106,7 @@ export class SamplePoTableLabsComponent implements OnInit {
   ];
 
   public readonly typeSpacing: Array<PoRadioGroupOption> = [
-    { label: 'Small', value: 'small', disabled: false },
+    { label: 'Small', value: 'small' },
     { label: 'Medium', value: 'medium' },
     { label: 'Large', value: 'large' }
   ];
@@ -212,30 +212,14 @@ export class SamplePoTableLabsComponent implements OnInit {
 
   updateColumns() {
     this.columns = [];
-    this.typeSpacing[0].disabled = false;
     this.columnsName.forEach(column => {
       this.columns.push(this.columnsDefinition[column]);
-      this.verifySpacing(column);
     });
   }
 
   private spacingSelectOrAction() {
     if (this.columnsName.length > 0) {
       this.updateColumns();
-    } else {
-      this.verifySpacing();
-      if (this.actions.length === 0 && this.selection[0] !== 'selectable') {
-        this.typeSpacing[0].disabled = false;
-      }
-    }
-  }
-
-  private verifySpacing(column?: string) {
-    if (column === 'link' || column === 'detail' || this.selection[0] === 'selectable' || this.actions.length > 0) {
-      this.typeSpacing[0].disabled = true;
-      if (this.spacing === 'small') {
-        this.spacing = PoTableColumnSpacing.Medium;
-      }
     }
   }
 }


### PR DESCRIPTION
**PoTable**

**DTHFUI-8742**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Mesmo atribuindo p-sizing="small" a tabela ainda apresentava um espaçamento não tão pequeno entre os itens e colunas, dificultando a visualização dos dados em casos em que uma tabela venha conter um grande número de colunas e itens a serem exibidos.

**Qual o novo comportamento?**
A tabela passa assumir dimenssões menores nos ícones de "sort" e "draggable", o espaçamento dentro da célula foi reduzido e o p-sizing="small" passa a ser aplicável mesmo que a tabela passe a ser interativa. Entende-se interativa, tabela com p-selectable='true' ou que contenha colunas do tipo detail ou link, ou que possua ações por linha.

**Simulação**
É possível simular pelo Labs da PoTable do portal.
