### PR TITLE
feat(search): inclusão da propriedade se filterSelect

### DIFF
--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.html
@@ -10,7 +10,7 @@
     class="po-dropdown-button"
     [ngClass]="{ 'po-dropdown-button-disabled': disabled, 'po-dropdown-button-open': open }"
   >
-    {{ label }}
+    <span>{{ label }}</span>
     <po-icon class="po-dropdown-icon" [p-icon]="icon"></po-icon>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.spec.ts
@@ -3,33 +3,36 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import * as UtilsFunction from '../../utils/util';
 
-import { configureTestSuite } from './../../util-test/util-expect.spec';
-
-import { PoDropdownComponent } from './po-dropdown.component';
+import { ChangeDetectionStrategy } from '@angular/core';
 import { PoPopupComponent } from '../po-popup';
+import { PoDropdownComponent } from './po-dropdown.component';
 
 describe('PoDropdownComponent: ', () => {
   let component: PoDropdownComponent;
   let fixture: ComponentFixture<PoDropdownComponent>;
   let nativeElement: any;
 
-  const eventClick = document.createEvent('Event');
-  eventClick.initEvent('click', false, true);
+  const keyboardEvents = (type: string, keyCode: number) => {
+    const event = new KeyboardEvent(type, { keyCode });
+    Object.defineProperty(event, 'keyCode', { value: keyCode });
+    return event;
+  };
 
-  configureTestSuite(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes([])],
       declarations: [PoDropdownComponent, PoPopupComponent]
-    });
+    })
+      .overrideComponent(PoDropdownComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoDropdownComponent);
-
     component = fixture.componentInstance;
-
     fixture.detectChanges();
-
     nativeElement = fixture.debugElement.nativeElement;
   });
 
@@ -124,15 +127,15 @@ describe('PoDropdownComponent: ', () => {
     and call 'popupRef.close'.`, () => {
       const fakeThis = {
         icon: undefined,
-        removeListeners: () => {},
+        removeListeners: jasmine.createSpy('removeListeners'),
         popupRef: {
-          close: () => {}
+          close: jasmine.createSpy('close')
         },
-        open: undefined
+        open: undefined,
+        changeDetector: {
+          detectChanges: jasmine.createSpy('detectChanges')
+        }
       };
-
-      spyOn(fakeThis, 'removeListeners');
-      spyOn(fakeThis.popupRef, 'close');
 
       component[`hideDropdown`].call(fakeThis);
 
@@ -140,6 +143,7 @@ describe('PoDropdownComponent: ', () => {
       expect(fakeThis.removeListeners).toHaveBeenCalled();
       expect(fakeThis.popupRef.close).toHaveBeenCalled();
       expect(fakeThis.open).toBe(false);
+      expect(fakeThis.changeDetector.detectChanges).toHaveBeenCalled();
     });
 
     it('initializeListeners: should initialize click, resize and scroll listeners.', () => {
@@ -244,7 +248,10 @@ describe('PoDropdownComponent: ', () => {
         popupRef: {
           open: () => {}
         },
-        open: undefined
+        open: undefined,
+        changeDetector: {
+          detectChanges: () => {}
+        }
       };
 
       spyOn(fakeThis, 'initializeListeners');
@@ -302,8 +309,12 @@ describe('PoDropdownComponent: ', () => {
       component.disabled = true;
 
       fixture.detectChanges();
+      fixture.whenStable();
 
-      expect(nativeElement.querySelector('.po-dropdown[tabindex="-1"]')).toBeTruthy();
+      const dropdownElement = nativeElement.querySelector('.po-dropdown');
+      expect(dropdownElement).toBeTruthy();
+
+      expect(dropdownElement.getAttribute('tabindex')).toBe('-1');
     });
 
     it(`should apply 0 to 'tabindex' if 'disabled' is 'false'`, () => {
@@ -319,7 +330,9 @@ describe('PoDropdownComponent: ', () => {
 
       spyOn(component, 'toggleDropdown');
 
-      poDropdown.dispatchEvent(eventClick);
+      const clickEvent = new MouseEvent('click');
+
+      poDropdown.dispatchEvent(clickEvent);
 
       expect(component.toggleDropdown).toHaveBeenCalled();
     });
@@ -334,12 +347,16 @@ describe('PoDropdownComponent: ', () => {
       expect(component.onKeyDown).toHaveBeenCalled();
     });
 
-    it(`should have a class 'po-dropdown-button-disabled' if 'disabled' is 'true'`, () => {
+    it(`should have a class 'po-dropdown-button-disabled' if 'disabled' is 'true'`, async () => {
       component.disabled = true;
 
       fixture.detectChanges();
+      await fixture.whenStable();
 
-      expect(nativeElement.querySelector('.po-dropdown-button-disabled')).toBeTruthy();
+      const disabledButton = nativeElement.querySelector('.po-dropdown-button-disabled');
+      console.log('Disabled button:', disabledButton);
+
+      expect(disabledButton).toBeTruthy();
     });
 
     it(`shouldn't have a class 'po-dropdown-button-disabled' if 'disabled' is 'false'`, () => {
@@ -351,31 +368,44 @@ describe('PoDropdownComponent: ', () => {
     });
 
     it(`should have a class 'po-icon-arrow-up' if 'click' in 'po-dropdown'`, () => {
-      const arrowDown = nativeElement.querySelector('.po-icon-arrow-down');
+      fixture.detectChanges();
       const poDropdown = nativeElement.querySelector('.po-dropdown');
 
-      expect(arrowDown).toBeTruthy();
+      expect(component.icon).toBe('ICON_ARROW_DOWN');
 
       component.actions = [{ label: 'action1', action: () => {} }];
 
       fixture.detectChanges();
 
-      poDropdown.dispatchEvent(eventClick);
+      const clickEvent = new MouseEvent('click');
+      poDropdown.dispatchEvent(clickEvent);
 
       fixture.detectChanges();
 
-      const arrowUp = nativeElement.querySelector('.po-icon-arrow-up');
-
-      expect(arrowUp).toBeTruthy();
+      expect(component.icon).toBe('ICON_ARROW_UP');
     });
 
     it(`should open a popup if have 'actions' and click in 'po-dropdown'`, () => {
       const poDropdown = nativeElement.querySelector('.po-dropdown');
       component.actions = [{ label: 'action1', action: () => {} }];
 
+      spyOn(component as any, 'showDropdown').and.callThrough();
+      if (component.popupRef) {
+        spyOn(component.popupRef, 'open').and.callThrough();
+      }
+
       fixture.detectChanges();
 
-      poDropdown.dispatchEvent(eventClick);
+      const clickEvent = new MouseEvent('click');
+      poDropdown.dispatchEvent(clickEvent);
+      fixture.detectChanges();
+      nativeElement = fixture.debugElement.nativeElement;
+
+      expect(component['showDropdown']).toHaveBeenCalled();
+
+      if (component.popupRef) {
+        expect(component.popupRef.open).toHaveBeenCalled();
+      }
 
       expect(nativeElement.querySelector('.po-popup')).toBeTruthy();
     });
@@ -386,18 +416,13 @@ describe('PoDropdownComponent: ', () => {
 
       fixture.detectChanges();
 
-      poDropdown.dispatchEvent(eventClick);
+      const clickEvent = new MouseEvent('click');
+      poDropdown.dispatchEvent(clickEvent);
 
       fixture.detectChanges();
+      nativeElement = fixture.debugElement.nativeElement;
 
       expect(nativeElement.querySelector('.po-popup')).toBeNull();
     });
   });
 });
-
-function keyboardEvents(event: string, keyCode: number) {
-  const eventKeyBoard = document.createEvent('KeyboardEvent');
-  eventKeyBoard.initEvent(event, true, true);
-  Object.defineProperty(eventKeyBoard, 'keyCode', { 'value': keyCode });
-  return eventKeyBoard;
-}

--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Renderer2, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Renderer2, ViewChild } from '@angular/core';
 
 import { isKeyCodeEnter } from './../../utils/util';
 
@@ -28,7 +28,8 @@ import { PoDropdownBaseComponent } from './po-dropdown-base.component';
  */
 @Component({
   selector: 'po-dropdown',
-  templateUrl: './po-dropdown.component.html'
+  templateUrl: './po-dropdown.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PoDropdownComponent extends PoDropdownBaseComponent {
   @ViewChild('dropdownRef', { read: ElementRef, static: true }) dropdownRef: ElementRef;
@@ -37,7 +38,10 @@ export class PoDropdownComponent extends PoDropdownBaseComponent {
   private clickoutListener: () => void;
   private resizeListener: () => void;
 
-  constructor(private renderer: Renderer2) {
+  constructor(
+    private renderer: Renderer2,
+    private changeDetector: ChangeDetectorRef
+  ) {
     super();
   }
 
@@ -60,6 +64,7 @@ export class PoDropdownComponent extends PoDropdownBaseComponent {
     this.removeListeners();
     this.popupRef.close();
     this.open = false;
+    this.changeDetector.detectChanges();
   }
 
   private initializeListeners() {
@@ -103,6 +108,7 @@ export class PoDropdownComponent extends PoDropdownBaseComponent {
     this.initializeListeners();
     this.popupRef.open();
     this.open = true;
+    this.changeDetector.detectChanges();
   }
 
   private wasClickedOnDropdown(event: MouseEvent) {

--- a/projects/ui/src/lib/components/po-search/index.ts
+++ b/projects/ui/src/lib/components/po-search/index.ts
@@ -1,4 +1,9 @@
 export * from './po-search.component';
 export * from './po-search.module';
+
 export * from './enum/po-search-filter-mode.enum';
+
+export * from './interfaces/po-search-filter-select.interface';
+export * from './interfaces/po-search-option.interface';
+
 export * from './literals/po-search-literals';

--- a/projects/ui/src/lib/components/po-search/interfaces/po-search-filter-select.interface.ts
+++ b/projects/ui/src/lib/components/po-search/interfaces/po-search-filter-select.interface.ts
@@ -1,0 +1,18 @@
+/**
+ * @usedBy PoSearchComponent
+ *
+ * @description
+ *
+ * Interface que define as opções que serão exibidas no dropdown do `po-search`, ao usar a propriedade `p-filter-select`.
+ */
+export interface PoSearchFilterSelect {
+  /**
+   * @description
+   *
+   * Descrição exibida nas opções da lista.
+   */
+  label: string;
+
+  /** Valores que serão atribuídos ao `p-filter-keys` */
+  value: Array<string> | string;
+}

--- a/projects/ui/src/lib/components/po-search/literals/po-search-literals-default.ts
+++ b/projects/ui/src/lib/components/po-search/literals/po-search-literals-default.ts
@@ -3,18 +3,22 @@ import { PoSearchLiterals } from './po-search-literals';
 export const poSearchLiteralsDefault = {
   en: <PoSearchLiterals>{
     search: 'Search',
-    clean: 'Clean'
+    clean: 'Clean',
+    all: 'All'
   },
   es: <PoSearchLiterals>{
     search: 'Buscar',
-    clean: 'limpiar'
+    clean: 'limpiar',
+    all: 'Todo'
   },
   pt: <PoSearchLiterals>{
     search: 'Pesquisar',
-    clean: 'Apagar'
+    clean: 'Apagar',
+    all: 'Todos'
   },
   ru: <PoSearchLiterals>{
     search: 'Поиск',
-    clean: 'чистый'
+    clean: 'чистый',
+    all: 'Все'
   }
 };

--- a/projects/ui/src/lib/components/po-search/literals/po-search-literals.ts
+++ b/projects/ui/src/lib/components/po-search/literals/po-search-literals.ts
@@ -20,4 +20,15 @@ export interface PoSearchLiterals {
    * search: Texto usado no leitor de tela para acessibilidade.
    */
   clean?: string;
+
+  /**
+   * @usedBy PoSearchComponent
+   *
+   * @optional
+   *
+   * @description
+   *
+   * search: Texto usado no dropdown, para demarcar todos os tipos de filtro.
+   */
+  all?: string;
 }

--- a/projects/ui/src/lib/components/po-search/po-search.component.html
+++ b/projects/ui/src/lib/components/po-search/po-search.component.html
@@ -1,4 +1,9 @@
 <div class="po-search" [class.po-search-disabled]="disabled">
+  <div class="po-search-select" *ngIf="filterSelect">
+    <po-dropdown [p-label]="searchFilterSelectLabel" [p-disabled]="disabled" [p-actions]="searchFilterSelectActions">
+    </po-dropdown>
+  </div>
+
   <div *ngIf="type === 'action'" class="po-search-icon">
     <po-icon [p-icon]="icon ? icon : 'ICON_SEARCH'"></po-icon>
   </div>

--- a/projects/ui/src/lib/components/po-search/po-search.module.ts
+++ b/projects/ui/src/lib/components/po-search/po-search.module.ts
@@ -7,6 +7,7 @@ import { PoSearchComponent } from './po-search.component';
 import { FormsModule } from '@angular/forms';
 import { PoAccordionModule } from '../po-accordion/po-accordion.module';
 import { PoListBoxModule } from '../po-listbox';
+import { PoDropdownModule } from '../po-dropdown';
 
 /**
  * @description
@@ -21,7 +22,8 @@ import { PoListBoxModule } from '../po-listbox';
     PoLoadingModule,
     PoAccordionModule,
     FormsModule,
-    PoListBoxModule
+    PoListBoxModule,
+    PoDropdownModule
   ],
   declarations: [PoSearchComponent],
   exports: [PoSearchComponent]

--- a/projects/ui/src/lib/components/po-search/samples/sample-po-search-filter-select/sample-po-search-filter-select.component.html
+++ b/projects/ui/src/lib/components/po-search/samples/sample-po-search-filter-select/sample-po-search-filter-select.component.html
@@ -1,0 +1,22 @@
+<div class="po-row">
+  <po-search
+    class="po-md-12"
+    p-aria-label="teste"
+    name="Po Search"
+    [p-items]="items"
+    (p-filtered-items-change)="filtered($event)"
+    p-search-type="trigger"
+    [p-filter-select]="filterSelect"
+    p-show-listbox="true"
+    p-disabled="false"
+  ></po-search>
+</div>
+
+<div class="po-row" *ngFor="let people of filteredItems">
+  <po-container class="po-row po-mt-2">
+    <po-info class="po-md-3" p-label="Name" [p-value]="people.name"> </po-info>
+    <po-info class="po-md-3" p-label="Gender" [p-value]="people.gender"> </po-info>
+    <po-info class="po-md-3" p-label="Planet" [p-value]="people.planet"> </po-info>
+    <po-info class="po-md-3" p-label="Father" [p-value]="people.father"> </po-info>
+  </po-container>
+</div>

--- a/projects/ui/src/lib/components/po-search/samples/sample-po-search-filter-select/sample-po-search-filter-select.component.ts
+++ b/projects/ui/src/lib/components/po-search/samples/sample-po-search-filter-select/sample-po-search-filter-select.component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'sample-po-search-filter-select',
+  templateUrl: './sample-po-search-filter-select.component.html'
+})
+export class SamplePoSearchFilterSelectComponent implements OnInit {
+  items: any;
+  filteredItems: Array<any> = [];
+  filterSelect = [
+    { label: 'Personal', value: ['name', 'gender'] },
+    { label: 'Planet', value: ['planet'] },
+    { label: 'Family', value: 'father' }
+  ];
+
+  ngOnInit() {
+    this.items = [
+      { name: 'Anakin Skywalker', gender: 'male', planet: 'Tatooine', father: 'Darth Sidious' },
+      { name: 'Luke Skywalker', gender: 'male', planet: 'Tatooine', father: 'Anakin Skywalker' },
+      { name: 'Leia Organa', gender: 'female', planet: 'Alderaan', father: 'Anakin Skywalker' },
+      { name: 'Han Solo', gender: 'male', planet: 'Corellia', father: 'Ovan' }
+    ];
+  }
+
+  filtered(event: Array<any>) {
+    this.filteredItems = event;
+  }
+}

--- a/projects/ui/src/lib/components/po-search/samples/sample-po-search-labs/sample-po-search-labs.component.html
+++ b/projects/ui/src/lib/components/po-search/samples/sample-po-search-labs/sample-po-search-labs.component.html
@@ -7,6 +7,7 @@
     [p-items]="items"
     [p-disabled]="properties.includes('disabled')"
     [p-filter-keys]="fieldKeys"
+    [p-filter-select]="fieldSelect"
     [p-literals]="customLiterals"
     [p-filter-type]="filterMode"
     [p-search-type]="searchMode"
@@ -69,6 +70,15 @@
       (p-change-model)="changeItems($event)"
     >
     </po-input>
+    <po-input
+      class="po-md-6"
+      name="literals"
+      [(ngModel)]="literals"
+      p-help='Ex.: {"search": "Search people"}'
+      p-label="Literals"
+      (p-change)="changeLiterals()"
+    >
+    </po-input>
   </div>
 
   <div class="po-row">
@@ -81,14 +91,13 @@
       (p-change-model)="updateFilterKeys($event)"
     >
     </po-input>
-
     <po-input
       class="po-md-6"
-      name="literals"
-      [(ngModel)]="literals"
-      p-help='Ex.: {"search": "Search people"}'
-      p-label="Literals"
-      (p-change)="changeLiterals()"
+      name="Filter Select"
+      [(ngModel)]="filterSelectModel"
+      p-label="Filter Select"
+      p-help='Ex.: [ { "label": "Name", "value": ["name", "nickname"] }, { "label": "Email", "value": "email" } ]'
+      (p-change)="updateFilterSelect($event)"
     >
     </po-input>
 

--- a/projects/ui/src/lib/components/po-search/samples/sample-po-search-labs/sample-po-search-labs.component.ts
+++ b/projects/ui/src/lib/components/po-search/samples/sample-po-search-labs/sample-po-search-labs.component.ts
@@ -39,6 +39,7 @@ export class SamplePoSearchLabsComponent implements OnInit, OnChanges {
   items: Array<any> = [];
   filteredItems: Array<any> = [];
   fieldKeys: Array<any> = [];
+  fieldSelect: Array<any> = [];
   tooltip: string;
   icon: string;
   filterMode: PoSearchFilterMode;
@@ -46,6 +47,7 @@ export class SamplePoSearchLabsComponent implements OnInit, OnChanges {
   fieldKey: any;
   itemsModel: any;
   filterModel: any;
+  filterSelectModel: any;
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [{ value: 'disabled', label: 'Disabled' }];
 
@@ -94,6 +96,10 @@ export class SamplePoSearchLabsComponent implements OnInit, OnChanges {
 
   updateFilterKeys(event: string) {
     this.fieldKeys = this.convertToArray(event);
+  }
+
+  updateFilterSelect(event: string) {
+    this.fieldSelect = this.convertToArray(event);
   }
 
   filter(event: Array<any>) {
@@ -153,7 +159,9 @@ export class SamplePoSearchLabsComponent implements OnInit, OnChanges {
     this.items = undefined;
     this.itemsModel = undefined;
     this.filterModel = '["name"]';
+    this.filterSelectModel = '';
     this.fieldKeys = undefined;
+    this.fieldSelect = undefined;
     this.filterMode = PoSearchFilterMode.startsWith;
     this.searchMode = 'action';
     this.literals = undefined;


### PR DESCRIPTION
**po-search**
**8644**

Adição da propriedade `p-filter-select`, a propriedade define os tipos de filtros (p-filter-keys) a serem aplicados na busca ou lista do componente (p-items).

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Hoje o Componente search não possui uma seletor para qual tipo de buscar fazer.

**Qual o novo comportamento?**
Com a nova propriedade é possui enviar mais de um tipo de filtro de busca, alterando o `p-filter-keys`

**Simulação**
[dthfui8644_simulação.zip](https://github.com/po-ui/po-angular/files/15236867/dthfui8644_simulacao.zip)
