### PR TITLE
feat(dynamic-table): repassa propriedade p-spacing e p-text-wrap

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -30,7 +30,9 @@
     (p-change-visible-columns)="onChangeVisibleColumns($event)"
     (p-restore-column-manager)="onColumnRestoreManager($event)"
     (p-sort-by)="onSortBy($event)"
+    [p-text-wrap]="textWrap"
     [p-draggable]="draggable"
+    [p-spacing]="spacing"
   >
   </po-table>
 </po-page-dynamic-search>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -6,7 +6,13 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { of, EMPTY } from 'rxjs';
 
-import { PoDialogModule, PoNotificationModule, PoTableColumnSort, PoTableColumnSortType } from '@po-ui/ng-components';
+import {
+  PoDialogModule,
+  PoNotificationModule,
+  PoTableColumnSort,
+  PoTableColumnSortType,
+  PoTableColumnSpacing
+} from '@po-ui/ng-components';
 
 import * as utilsFunctions from '../../utils/util';
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
@@ -150,6 +156,20 @@ describe('PoPageDynamicTableComponent:', () => {
       component.hideColumnsManager = utilsFunctions.convertToBoolean('true');
 
       expect(component.hideColumnsManager).toBe(true);
+    });
+
+    describe('spacing:', () => {
+      it('should set spacing to the given valid value', () => {
+        const validValues = [PoTableColumnSpacing.Small, PoTableColumnSpacing.Medium, PoTableColumnSpacing.Large];
+
+        expectPropertiesValues(component, 'spacing', validValues, validValues);
+      });
+
+      it('should set spacing to PoTableColumnSpacing.Medium if the given value is invalid', () => {
+        const invalidValue = 'double-extra-large' as unknown as PoTableColumnSpacing;
+
+        expectPropertiesValues(component, 'spacing', [invalidValue], PoTableColumnSpacing.Medium);
+      });
     });
   });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -13,6 +13,7 @@ import {
   PoTableAction,
   PoTableColumnSort,
   PoTableColumnSortType,
+  PoTableColumnSpacing,
   poLocaleDefault
 } from '@po-ui/ng-components';
 
@@ -295,6 +296,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   private _defaultTableActions: Array<PoTableAction> = [];
   private _hideCloseDisclaimers: Array<string> = [];
   private _draggable = false;
+  private _spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
 
   private set defaultPageActions(value: Array<PoPageAction>) {
     this._defaultPageActions = value;
@@ -517,6 +519,44 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
    * > O valor padrão será traduzido de acordo com o idioma configurado no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
    */
   @Input('p-literals') searchLiterals: PoPageDynamicSearchLiterals;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Responsável por aplicar espaçamento nas colunas.
+   *
+   * Deve receber um dos valores do enum `PoTableColumnSpacing`.
+   *
+   * Valor `small` só funciona em tabelas não interativas. Caso seja setado com `small` e a tabela seja interativa, o valor será retornado para `medium`.
+   *
+   * @default `medium`
+   */
+  @Input('p-spacing') set spacing(value: PoTableColumnSpacing) {
+    if (value === 'small' || value === 'medium' || value === 'large') {
+      this._spacing = value;
+    } else {
+      this._spacing = PoTableColumnSpacing.Medium;
+    }
+  }
+
+  get spacing() {
+    return this._spacing;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Habilita ou desabilita a quebra automática de texto. Quando ativada, o texto que excede
+   * o espaço disponível é transferido para a próxima linha em pontos apropriados para uma
+   * leitura clara.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-text-wrap', transform: convertToBoolean }) textWrap?: boolean = false;
 
   /**
    * @optional

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.html
@@ -13,6 +13,7 @@
   [p-quick-search-width]="quickSearchWidth"
   [p-hide-remove-all-disclaimer]="hideRemoveAllDisclaimer"
   [p-hide-close-disclaimers]="hideCloseDisclaimers"
+  [p-text-wrap]="true"
 >
 </po-page-dynamic-table>
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-hotels/sample-po-page-dynamic-table-hotels.component.ts
@@ -49,7 +49,7 @@ export class SamplePoPageDynamicTableHotelsComponent {
 
   readonly fields: Array<any> = [
     { property: 'id', key: true, visible: false },
-    { property: 'name', label: 'Name', filter: true, gridColumns: 6 },
+    { property: 'name', label: 'Name', width: '115px', filter: true, gridColumns: 6 },
     {
       property: 'floors',
       label: 'Floors',

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-people/sample-po-page-dynamic-table-people.component.html
@@ -3,6 +3,7 @@
   p-concat-filters
   p-keep-filters
   p-title="People"
+  p-spacing="large"
   [p-height]="300"
   [p-hide-columns-manager]="true"
   [p-infinite-scroll]="true"


### PR DESCRIPTION
**DYNAMIC-TABLE**

**DTHFUI-8744**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente `dynamic-table` não possui propriedades `textWrap` e `spacing` 

**Qual o novo comportamento?**
Componente `dynamic-table` compartilha propriedades `textWrap` e `spacing`  de `po-table`

**Simulação**
Portal e app 
-  [app-8747.zip](https://github.com/po-ui/po-angular/files/15308015/app-8747.zip)

