### PR TITLE
feat(lookup): inclui p-spacing e p-text-wrap

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -924,5 +924,9 @@ describe('PoLookupBaseComponent:', () => {
       const invalidValues = [false, 0, null, undefined, NaN];
       expectPropertiesValues(component, 'placeholder', invalidValues, '');
     });
+
+    it('p-spacing: should update property with valid values', () => {
+      expectPropertiesValues(component, 'spacing', 'small', 'small');
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -25,6 +25,7 @@ import { PoLookupFilter } from './interfaces/po-lookup-filter.interface';
 import { PoLookupLiterals } from './interfaces/po-lookup-literals.interface';
 import { PoLookupFilterService } from './services/po-lookup-filter.service';
 import { PoLookupModalService } from './services/po-lookup-modal.service';
+import { PoTableColumnSpacing } from '../../po-table/enums/po-table-spacing.enum';
 
 /**
  * @description
@@ -284,6 +285,34 @@ export abstract class PoLookupBaseComponent
    * @default `false`
    */
   @Input({ alias: 'p-auto-height', transform: convertToBoolean }) autoHeight: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Responsável por aplicar espaçamento nas colunas da tabela contida no lookup.
+   *
+   * Deve receber um dos valores do enum `PoTableColumnSpacing`.
+   *
+   * @default `medium`
+   */
+  @Input('p-spacing') spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Habilita ou desabilita a quebra automática de texto. Quando ativada, o texto que excede
+   * o espaço disponível é transferido para a próxima linha em pontos apropriados para uma
+   * leitura clara.
+   *
+   * Esta propriedade aplica-se ao texto contido nas células da tabela.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-text-wrap', transform: convertToBoolean }) textWrap?: boolean = false;
 
   /**
    * Evento será disparado quando ocorrer algum erro na requisição de busca do item.

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -8,7 +8,7 @@ import { PoModalComponent } from '../../../../components/po-modal/po-modal.compo
 import { poLocaleDefault } from '../../../../services/po-language/po-language.constant';
 import { PoLanguageService } from '../../../../services/po-language/po-language.service';
 import { capitalizeFirstLetter, convertToBoolean, isTypeof } from '../../../../utils/util';
-import { PoTableColumnSortType } from '../../../po-table';
+import { PoTableColumnSortType, PoTableColumnSpacing } from '../../../po-table';
 import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
 import { poTableLiteralsDefault } from '../../../po-table/po-table-base.component';
 
@@ -150,6 +150,19 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
    * > Atenção: Caso não seja passada ou tenha o conteúdo incorreto, não irá atualizar o model do formulário.
    */
   @Input('p-field-value') fieldValue: string;
+
+  /**
+   * Responsável por aplicar espaçamento nas colunas da tabela contida no lookup.
+   * Deve receber um dos valores do enum `PoTableColumnSpacing`.
+   */
+  @Input('p-spacing') spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
+
+  /**
+   * Habilita ou desabilita a quebra automática de texto. Quando ativada, o texto que excede
+   * o espaço disponível é transferido para a próxima linha em pontos apropriados para uma
+   * leitura clara.
+   */
+  @Input({ alias: 'p-text-wrap', transform: convertToBoolean }) textWrap?: boolean = false;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -62,6 +62,8 @@
         [p-loading]="isLoading"
         [p-show-more-disabled]="!hasNext"
         [p-infinite-scroll]="infiniteScroll"
+        [p-spacing]="spacing"
+        [p-text-wrap]="textWrap"
         (p-selected)="onSelect($event)"
         (p-unselected)="onUnselect($event)"
         (p-all-selected)="onAllSelected($event)"

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -14,6 +14,7 @@ import { PoLookupComponent } from './po-lookup.component';
 import { PoLookupFilter } from './interfaces/po-lookup-filter.interface';
 import { NgControl } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PoTableColumnSpacing } from '../../po-table';
 class LookupFilterService implements PoLookupFilter {
   getFilteredItems(params: any): Observable<any> {
     return of({ items: [{ value: 123, label: 'teste' }] });
@@ -958,6 +959,8 @@ describe('PoLookupComponent:', () => {
         component.multiple = false;
         component.fieldLabel = 'label';
         component.fieldValue = 'value';
+        component.spacing = PoTableColumnSpacing.Medium;
+        component.textWrap = false;
         component.changeVisibleColumns = new EventEmitter();
         component.columnRestoreManager = new EventEmitter();
 
@@ -972,6 +975,8 @@ describe('PoLookupComponent:', () => {
           multiple,
           fieldLabel,
           fieldValue,
+          spacing,
+          textWrap,
           changeVisibleColumns,
           columnRestoreManager
         } = component;
@@ -991,6 +996,8 @@ describe('PoLookupComponent:', () => {
           selectedItems,
           fieldLabel,
           fieldValue,
+          spacing,
+          textWrap,
           changeVisibleColumns,
           columnRestoreManager
         };

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -204,6 +204,8 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
         multiple,
         fieldLabel,
         fieldValue,
+        spacing,
+        textWrap,
         changeVisibleColumns,
         columnRestoreManager
       } = this;
@@ -223,6 +225,8 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
         selectedItems,
         fieldLabel,
         fieldValue,
+        spacing,
+        textWrap,
         changeVisibleColumns,
         columnRestoreManager
       });

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -1,29 +1,30 @@
 <po-lookup
   name="lookup"
   [(ngModel)]="lookup"
+  [p-advanced-filters]="customAdvancedFilters"
+  [p-auto-height]="properties.includes('autoHeight')"
   [p-clean]="properties.includes('clean')"
   [p-columns]="columns"
   [p-disabled]="properties.includes('disabled')"
-  [p-field-label]="fieldLabel"
-  [p-field-value]="fieldValue"
   [p-field-format]="fieldFormat"
+  [p-field-label]="fieldLabel"
   [p-filter-service]="filterService || sampleFilterService"
+  [p-field-value]="fieldValue"
   [p-help]="help"
+  [p-hide-columns-manager]="properties.includes('hideColumnsManager')"
   [p-label]="label"
   [p-literals]="customLiterals"
-  [p-advanced-filters]="customAdvancedFilters"
+  [p-multiple]="properties.includes('multiple')"
   [p-no-autocomplete]="properties.includes('noAutocomplete')"
   [p-optional]="properties.includes('optional')"
   [p-placeholder]="placeholder"
   [p-required]="properties.includes('required')"
   [p-show-required]="properties.includes('showRequired')"
-  [p-hide-columns-manager]="properties.includes('hideColumnsManager')"
-  [p-infinite-scroll]="properties.includes('infiniteScroll')"
-  [p-multiple]="properties.includes('multiple')"
-  [p-auto-height]="properties.includes('autoHeight')"
+  [p-spacing]="spacing"
+  [p-text-wrap]="properties.includes('textWrap')"
+  (p-change)="changeEvent('p-change')"
   (p-error)="changeEvent('p-error')"
   (p-selected)="changeEvent('p-selected')"
-  (p-change)="changeEvent('p-change')"
 >
 </po-lookup>
 
@@ -95,7 +96,7 @@
 
   <div class="po-row">
     <po-input
-      class="po-lg-12"
+      class="po-lg-6"
       name="literals"
       [(ngModel)]="literals"
       p-help='Ex.: { "modalTitle": "Select a register", "modalPrimaryActionLabel": "Select", "modalPlaceholder": "Search Value" }'
@@ -113,9 +114,11 @@
       (p-change)="onFieldFormatChange($event)"
     >
     </po-input>
+  </div>
 
+  <div class="po-row">
     <po-checkbox-group
-      class="po-lg-6 po-md-12"
+      class="po-lg-6"
       name="properties"
       [(ngModel)]="properties"
       p-columns="2"
@@ -123,6 +126,9 @@
       [p-options]="propertiesOptions"
     >
     </po-checkbox-group>
+
+    <po-radio-group class="po-lg-6" name="spacing" [(ngModel)]="spacing" p-label="Spacing" [p-options]="typeSpacing">
+    </po-radio-group>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
@@ -6,7 +6,9 @@ import {
   PoLookupFilter,
   PoLookupLiterals,
   PoDynamicFormField,
-  PoSelectOption
+  PoSelectOption,
+  PoTableColumnSpacing,
+  PoRadioGroupOption
 } from '@po-ui/ng-components';
 
 import { SamplePoLookupService } from '../sample-po-lookup.service';
@@ -34,6 +36,7 @@ export class SamplePoLookupLabsComponent implements OnInit {
   properties: Array<string>;
   advancedFilters: string;
   customAdvancedFilters: Array<PoDynamicFormField>;
+  spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
 
   public readonly columnsOptions: Array<PoCheckboxGroupOption> = [
     { value: 'id', label: 'Id' },
@@ -61,7 +64,8 @@ export class SamplePoLookupLabsComponent implements OnInit {
     { value: 'infiniteScroll', label: 'Infinite Scroll' },
     { value: 'multiple', label: 'Multiple' },
     { value: 'autoHeight', label: 'Auto Height' },
-    { value: 'hideColumnsManager', label: 'Hide Columns Manager' }
+    { value: 'hideColumnsManager', label: 'Hide Columns Manager' },
+    { value: 'textWrap', label: 'Text Wrap' }
   ];
 
   private readonly columnsDefinition = {
@@ -69,6 +73,12 @@ export class SamplePoLookupLabsComponent implements OnInit {
     name: <PoLookupColumn>{ property: 'name', label: 'Name' },
     email: <PoLookupColumn>{ property: 'email', label: 'Email' }
   };
+
+  public readonly typeSpacing: Array<PoRadioGroupOption> = [
+    { label: 'Small', value: 'small' },
+    { label: 'Medium', value: 'medium' },
+    { label: 'Large', value: 'large' }
+  ];
 
   constructor(public sampleFilterService: SamplePoLookupService) {}
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.spec.ts
@@ -46,6 +46,8 @@ describe('PoLookupModalService:', () => {
     selectedItems: null,
     fieldValue: 'value',
     fieldLabel: 'label',
+    spacing: 'medium',
+    textWrap: false,
     changeVisibleColumns: new EventEmitter(),
     columnRestoreManager: new EventEmitter()
   };

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-modal.service.ts
@@ -48,6 +48,8 @@ export class PoLookupModalService {
     selectedItems: Array<any>;
     fieldLabel: string;
     fieldValue: string;
+    spacing: string;
+    textWrap: boolean;
     changeVisibleColumns: Function;
     columnRestoreManager: Function;
   }): void {
@@ -64,6 +66,8 @@ export class PoLookupModalService {
       selectedItems,
       fieldLabel,
       fieldValue,
+      spacing,
+      textWrap,
       changeVisibleColumns,
       columnRestoreManager
     } = params;
@@ -86,6 +90,8 @@ export class PoLookupModalService {
     this.componentRef.instance.changeVisibleColumns = changeVisibleColumns;
     this.componentRef.instance.columnRestoreManager = columnRestoreManager;
     this.componentRef.instance.hideColumnsManager = hideColumnsManager;
+    this.componentRef.instance.spacing = spacing;
+    this.componentRef.instance.textWrap = textWrap;
     this.componentRef.changeDetectorRef.detectChanges();
     this.componentRef.instance.openModal();
   }


### PR DESCRIPTION
**PoLookup**

**DTHFUI-8745>**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o PoLookup exibe a tabela sem considerar o tamanho de espaçamento e quebra de texto, características já presentes na PoTable.

**Qual o novo comportamento?**
Realizado repasse das propriedades p-spacing e p-text-wrap já presentes na PoTable

**Simulação**
Nesta branch é possível subir o portal e testar o PoLookup Labs, as propriedades p-spacing e p-text-wrap estão disponíveis em tela para teste. 
