### PR TITLE
feat(menu): adiciona tooltip para exibição do shortLabel

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu-item.interface.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item.interface.ts
@@ -74,7 +74,7 @@ export interface PoMenuItem {
   icon?: string | TemplateRef<void>;
 
   /**
-   * Texto curto para o item que aparece quando o menu estiver colapsado.
+   * Texto curto exibido através de um tooltip para o item que aparece quando o menu estiver colapsado.
    * Se colapsado, aparecerá somente se todos os itens de primeiro nível de menu que possuírem ícones e textos curtos.
    */
   shortLabel?: string;

--- a/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.html
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.html
@@ -5,15 +5,39 @@
   role="menuitem"
   [attr.aria-label]="label"
   [routerLink]="link"
+  (keydown.enter)="clickMenuItem($event)"
+  (keydown.space)="clickMenuItem($event)"
+  p-tooltip-position="right"
+  [p-tooltip]="collapsedMenu && shortLabel ? shortLabel : undefined"
 >
   <ng-container *ngTemplateOutlet="menuItemTemplate"></ng-container>
 </a>
 <!-- menu com link externo -->
-<a *ngIf="type === 'externalLink'" class="po-menu-item-link" role="menuitem" [attr.aria-label]="label" [href]="link">
+<a
+  *ngIf="type === 'externalLink'"
+  class="po-menu-item-link"
+  role="menuitem"
+  [attr.aria-label]="label"
+  [href]="link"
+  (keydown.enter)="clickMenuItem($event)"
+  (keydown.space)="clickMenuItem($event)"
+  p-tooltip-position="right"
+  [p-tooltip]="collapsedMenu && shortLabel ? shortLabel : undefined"
+>
   <ng-container *ngTemplateOutlet="menuItemTemplate"></ng-container>
 </a>
 <!-- menu sem link -->
-<a *ngIf="type === 'noLink'" class="po-menu-item-link" href="javascript:;" role="menuitem" [attr.aria-label]="label">
+<a
+  *ngIf="type === 'noLink'"
+  class="po-menu-item-link"
+  href="javascript:;"
+  role="menuitem"
+  [attr.aria-label]="label"
+  (keydown.enter)="clickMenuItem($event)"
+  (keydown.space)="clickMenuItem($event)"
+  p-tooltip-position="right"
+  [p-tooltip]="collapsedMenu && shortLabel ? shortLabel : undefined"
+>
   <ng-container *ngTemplateOutlet="menuItemTemplate"></ng-container>
 </a>
 <!-- menu sem dados -->
@@ -60,6 +84,8 @@
 
 <ng-template #menuItemTemplate>
   <div
+    p-tooltip-position="right"
+    [p-tooltip]="type === 'subItems' && collapsedMenu && shortLabel ? shortLabel : undefined"
     class="po-menu-item"
     [tabindex]="type === 'subItems' ? 0 : -1"
     [attr.aria-label]="label"

--- a/projects/ui/src/lib/components/po-menu/po-menu.module.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.module.ts
@@ -12,6 +12,7 @@ import { PoMenuFilterComponent } from './po-menu-filter/po-menu-filter.component
 import { PoMenuHeaderTemplateDirective } from './po-menu-header-template/po-menu-header-template.directive';
 import { PoMenuItemComponent } from './po-menu-item/po-menu-item.component';
 import { PoMenuComponent } from './po-menu.component';
+import { PoTooltipModule } from '../../directives/po-tooltip/po-tooltip.module';
 
 /**
  * @description
@@ -19,7 +20,16 @@ import { PoMenuComponent } from './po-menu.component';
  * Módulo do componente po-menu.
  */
 @NgModule({
-  imports: [CommonModule, RouterModule, PoBadgeModule, PoFieldModule, PoLoadingModule, PoLogoModule, PoIconModule],
+  imports: [
+    CommonModule,
+    RouterModule,
+    PoBadgeModule,
+    PoFieldModule,
+    PoLoadingModule,
+    PoLogoModule,
+    PoIconModule,
+    PoTooltipModule
+  ],
   declarations: [PoMenuComponent, PoMenuFilterComponent, PoMenuHeaderTemplateDirective, PoMenuItemComponent],
   exports: [PoMenuComponent, PoMenuHeaderTemplateDirective]
 })


### PR DESCRIPTION
Adiciona tooltip para exibir shortLabel no menu colapsado

fixes DTHFUI-8903

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A propriedade shortLabel é obrigatória para colapsar o menu porém não é exibida em nenhum momento

**Qual o novo comportamento?**
A propriedade shortLabel segue sendo obrigatória para colapsar o menu, porém agora o valor da mesma será exibido através de um tooltip

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/15335904/app.zip)
Testar samples do portal