### PR TITLE
fix(combo): corrige inicialização do focus

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -293,6 +293,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   loading: boolean = false;
   dynamicLabel: string = 'label';
   dynamicValue: string = 'value';
+  shouldApplyFocus: boolean = false;
 
   protected cacheStaticOptions: Array<any> = [];
   protected comboOptionsList: Array<any> = [];

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -341,6 +341,31 @@ describe('PoComboComponent:', () => {
       expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
     });
 
+    it('focus: should have shouldApplyFocus default to false', () => {
+      expect(component.shouldApplyFocus).toBe(false);
+    });
+
+    it('focus: should focus input element when shouldApplyFocus is true', () => {
+      const mockElement = document.createElement('div');
+      component.containerElement = { nativeElement: mockElement };
+
+      component.renderer = {
+        removeClass: jasmine.createSpy('removeClass'),
+        addClass: jasmine.createSpy('addClass')
+      } as any;
+
+      component.inputEl = {
+        nativeElement: {
+          focus: jasmine.createSpy('focus')
+        }
+      };
+
+      component.shouldApplyFocus = true;
+      component.onOptionClick({ value: 'test', label: 'Test' });
+
+      expect(component.inputEl.nativeElement.focus).toHaveBeenCalled();
+    });
+
     it('onBlur: should be called when blur event', () => {
       component['onModelTouched'] = () => {};
       spyOn(component, <any>'onModelTouched');

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -423,10 +423,16 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }, this.debounceTime);
   }
 
+  setShouldApplyFocus(value: boolean) {
+    this.shouldApplyFocus = value;
+  }
+
   toggleComboVisibility(isButton?: boolean): void {
     if (this.disabled) {
       return;
     }
+
+    this.setShouldApplyFocus(true);
 
     if (this.service && !this.disabledInitFilter) {
       this.applyFilterInFirstClick();
@@ -469,7 +475,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }
 
     this.previousSearchValue = this.selectedView[this.dynamicLabel];
-    this.inputEl.nativeElement.focus();
+
+    if (this.shouldApplyFocus) {
+      this.inputEl.nativeElement.focus();
+    }
   }
 
   calculateScrollTop(selectedItem, index) {


### PR DESCRIPTION
**COMBO**

**DTHFUI-8744**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao abrir um po-combo com valor inicial atribuído o scroll é acionado para dar foco no componente.

**Qual o novo comportamento?**
Ao abrir um po-combo com valor inicial atribuído o mesmo não interferi na jornada do usuário.

**Simulação**
[app-new-8774.zip](https://github.com/po-ui/po-angular/files/15421973/app-new-8774.zip)

style.css global
```
.spacing-lg {
  margin-top: 450px; 
}
  ```