### PR TITLE
fix(menu): corrige sobreposicao

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.html
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item/po-menu-item.component.html
@@ -9,6 +9,7 @@
   (keydown.space)="clickMenuItem($event)"
   p-tooltip-position="right"
   [p-tooltip]="collapsedMenu && shortLabel ? shortLabel : undefined"
+  [p-append-in-body]="true"
 >
   <ng-container *ngTemplateOutlet="menuItemTemplate"></ng-container>
 </a>
@@ -23,6 +24,7 @@
   (keydown.space)="clickMenuItem($event)"
   p-tooltip-position="right"
   [p-tooltip]="collapsedMenu && shortLabel ? shortLabel : undefined"
+  [p-append-in-body]="true"
 >
   <ng-container *ngTemplateOutlet="menuItemTemplate"></ng-container>
 </a>
@@ -37,6 +39,7 @@
   (keydown.space)="clickMenuItem($event)"
   p-tooltip-position="right"
   [p-tooltip]="collapsedMenu && shortLabel ? shortLabel : undefined"
+  [p-append-in-body]="true"
 >
   <ng-container *ngTemplateOutlet="menuItemTemplate"></ng-container>
 </a>
@@ -86,6 +89,7 @@
   <div
     p-tooltip-position="right"
     [p-tooltip]="type === 'subItems' && collapsedMenu && shortLabel ? shortLabel : undefined"
+    [p-append-in-body]="true"
     class="po-menu-item"
     [tabindex]="type === 'subItems' ? 0 : -1"
     [attr.aria-label]="label"


### PR DESCRIPTION
**MENU**

** DTHFUI-8947**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Tootip com shortLabel não sobrepõe elementos da página.

**Qual o novo comportamento?**
Tootip com shortLabel sobrepõe elementos da página.

**Simulação**
[app.zip](https://github.com/po-ui/po-angular/files/15393996/app.zip)

