### PR TITLE
docs(table): ajusta da definição p-show-more-disabled

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -252,7 +252,7 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   /**
    * @description
    *
-   * Se verdadeiro, torna habilitado o botão "Carregar mais resultados".
+   * Se verdadeiro, torna o botão "Carregar mais resultados" desabilitado.
    *
    * @default `false`
    */


### PR DESCRIPTION
**PoTable**

**DTHFUI-8795**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Descrição sobre a função de p-show-more-disabled informava que: " Se verdadeiro, torna o botão "Carregar mais resultados" desabilitado."

**Qual o novo comportamento?**
Corrigido descrição para: "Se verdadeiro, torna o botão "Carregar mais resultados" desabilitado."


**Simulação**
PoTable Labs
