### PR TITLE
feat(clean): atualiza icone definido pelo animalia

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-clean/po-clean.component.html
+++ b/projects/ui/src/lib/components/po-field/po-clean/po-clean.component.html
@@ -1,1 +1,1 @@
-<po-icon p-icon="ICON_CLOSE po-field-icon" *ngIf="showIcon()" (click)="clear()"> </po-icon>
+<po-icon p-icon="ICON_CLEAR_CONTENT po-field-icon" *ngIf="showIcon()" (click)="clear()"> </po-icon>

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -31,21 +31,19 @@
     />
 
     <div class="po-field-icon-container-right">
-      <div
+      <po-clean
         tabindex="0"
         role="button"
         [attr.aria-label]="literals.clean"
+        class="po-combo-clean po-icon-input"
         *ngIf="clean && !disabled && inp.value"
-        class="po-combo-clean"
+        [p-element-ref]="inputEl"
+        (p-change-event)="clear($event)"
         (click)="clear(null); $event.preventDefault()"
         (keydown.enter)="clearAndFocus(); $event.preventDefault()"
       >
-        <po-icon
-          p-icon="ICON_CLEAR_CONTENT"
-          [class.po-border-focused]="!disabled && comboOpen"
-          class="po-field-icon"
-        ></po-icon>
-      </div>
+      </po-clean>
+
       <div
         #iconArrow
         class="po-combo-arrow po-field-icon"

--- a/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-filter/po-menu-filter.component.spec.ts
@@ -4,6 +4,7 @@ import { configureTestSuite } from './../../../util-test/util-expect.spec';
 import { PoCleanComponent } from './../../po-field/po-clean/po-clean.component';
 
 import { PoLoadingModule } from '../../po-loading';
+import { By } from '@angular/platform-browser';
 
 import { PoMenuFilterComponent } from './po-menu-filter.component';
 
@@ -30,10 +31,13 @@ describe('PoMenuFilterComponent:', () => {
   });
 
   it('should show po-clean icon', () => {
-    component.inputFilterElement.nativeElement.value = 'teste';
-    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      const inputFilterElement = fixture.debugElement.query(By.css('#inputFilter'));
+      inputFilterElement.nativeElement.value = 'teste';
+      fixture.detectChanges();
 
-    expect(fixture.debugElement.nativeElement.querySelector('.po-icon-close')).not.toBeNull();
+      expect(fixture.debugElement.nativeElement.querySelector('.po-icon-close')).not.toBeNull();
+    });
   });
 
   it('should hide po-clean icon', () => {

--- a/projects/ui/src/lib/components/po-search/po-search.component.html
+++ b/projects/ui/src/lib/components/po-search/po-search.component.html
@@ -37,7 +37,7 @@
       (click)="clearSearch()"
       (keydown.enter)="clearSearch()"
     >
-      <po-icon p-icon="ICON_CLEAR_CONTENT"></po-icon>
+      <po-clean class="po-icon-input"></po-clean>
     </button>
 
     <button


### PR DESCRIPTION
**CLEAN | COMBO**

**DTHDUI-8875**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
 Ícone do `po-clean` não é consistente em todos os componentes apresentando o ícone indicado pelo AnimaliaDS.

**Qual o novo comportamento?**
 Ícone do `po-clean` é consistente em todos os componentes apresentando o ícone indicado pelo AnimaliaDS.

**Simulação**
[app-8875.zip](https://github.com/po-ui/po-angular/files/15476190/app-8875.zip)

PR Adicional
- https://github.com/po-ui/po-style/pull/552
