### PR TITLE
feat(tabs): adiciona reordenação visual das abas

### DIFF
--- a/projects/ui/src/lib/components/po-tabs/po-tab/po-tab-base.component.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tab/po-tab-base.component.ts
@@ -26,6 +26,7 @@ export abstract class PoTabBaseComponent {
   private _active?: boolean = false;
   private _disabled?: boolean = false;
   private _hide?: boolean = false;
+  widthButton;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-tabs/po-tab/po-tab.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tab/po-tab.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 
 import { PoTabsService } from '../po-tabs.service';
 import { PoTabComponent } from './po-tab.component';
+import { SimpleChange, SimpleChanges } from '@angular/core';
 
 describe('PoTabComponent:', () => {
   let component: PoTabComponent;
@@ -48,7 +49,11 @@ describe('PoTabComponent:', () => {
     it('should trigger onChanges after 100ms delay', fakeAsync(() => {
       spyOn(tabsService, 'triggerOnChanges');
 
-      component.ngOnChanges();
+      const changes: SimpleChanges = {
+        active: new SimpleChange(null, true, true)
+      };
+
+      component.ngOnChanges(changes);
       tick(101);
 
       expect(tabsService.triggerOnChanges).toHaveBeenCalled();

--- a/projects/ui/src/lib/components/po-tabs/po-tab/po-tab.component.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tab/po-tab.component.ts
@@ -22,9 +22,12 @@ export class PoTabComponent extends PoTabBaseComponent implements AfterContentIn
     this.setDisplayOnActive();
   }
 
-  ngOnChanges(): void {
+  ngOnChanges(changes: SimpleChanges): void {
     setTimeout(() => {
       this.tabsService.triggerOnChanges();
+      if (changes?.active?.currentValue) {
+        this.tabsService.triggerActiveOnChanges(this);
+      }
     }, 100);
   }
 

--- a/projects/ui/src/lib/components/po-tabs/po-tabs.component.html
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.component.html
@@ -30,9 +30,8 @@
         [p-label]="literals.moreTabs"
         [p-small]="small"
         [p-tabs]="overflowedTabs"
-        (p-activated)="onTabActive($event)"
         (p-change-state)="onTabChangeState($event)"
-        (p-click)="selectedTab($event)"
+        (p-click)="onTabActiveByDropdown($event)"
       >
       </po-tab-dropdown>
     </div>

--- a/projects/ui/src/lib/components/po-tabs/po-tabs.service.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.service.ts
@@ -1,13 +1,20 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
+import { PoTabComponent } from './po-tab/po-tab.component';
 
 @Injectable()
 export class PoTabsService {
   private onChangesTriggeredSource = new Subject<void>();
+  private onChangesTriggeredActiveSource = new Subject<any>();
 
   onChangesTriggered$ = this.onChangesTriggeredSource.asObservable();
+  triggerActiveOnChanges$ = this.onChangesTriggeredActiveSource.asObservable();
 
   triggerOnChanges() {
     this.onChangesTriggeredSource.next();
+  }
+
+  triggerActiveOnChanges(tab: PoTabComponent) {
+    this.onChangesTriggeredActiveSource.next(tab);
   }
 }


### PR DESCRIPTION
Permite a reordenação das abas visíveis quando uma aba do dropdown é selecionada. Ao selecionar uma aba do dropdown, ela se torna visível, e a última aba visível anteriormente é movida para o dropdown.

Isso proporciona uma melhor experiência de usuário ao gerenciar um grande número de abas.

Fixes DTHFUI-8578

**< po-tabs >**

**< DTHFUI-8578 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao selecionar uma aba do dropdown não há nenhum comportamento visual, fazendo com que o usuário fique com a dúvida se selecionou a aba ou não.

**Qual o novo comportamento?**
Ao selecionar uma aba do dropdown, ela se torna visível, e a última aba visível anteriormente é movida para o dropdown.

Isso proporciona uma melhor experiência de usuário ao gerenciar um grande número de abas.

**Simulação**
[app.zip](https://github.com/user-attachments/files/15526711/app.zip)
