### PR TITLE
feat(disclaimer): adiciona propriedade para validar exibição do tooltip

### DIFF
--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer-base.component.ts
@@ -31,6 +31,8 @@ export class PoDisclaimerBaseComponent {
   /** Nome da propriedade vinculada à este po-disclaimer. */
   @Input('p-property') property?: string;
 
+  @Input('p-disclaimer-custom-width') disclaimerCustomWidth: number = 201;
+
   @Input('p-last-disclaimer') lastDisclaimer: boolean = false;
 
   @Input('p-tooltip-position') tooltipPosition: string = 'bottom';

--- a/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.ts
+++ b/projects/ui/src/lib/components/po-disclaimer/po-disclaimer.component.ts
@@ -36,6 +36,6 @@ export class PoDisclaimerComponent extends PoDisclaimerBaseComponent {
   }
 
   getWidthDisclaimer() {
-    return this.disclaimerContainer.nativeElement.offsetWidth > 201;
+    return this.disclaimerContainer.nativeElement.offsetWidth > this.disclaimerCustomWidth;
   }
 }


### PR DESCRIPTION
PO-DISCLAIMER

fixes DTHFUI-9088
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Disclaimer só exibe tooltip caso seja maior que 201px

**Qual o novo comportamento?**
Disclaimer exibe tooltip caso seja maior que o valor da nova propriedade criada. Seu valor default continua sendo 201.

**Simulação**
[app.zip](https://github.com/user-attachments/files/15686397/app.zip)
