### PR TITLE
fix(rich-text-body): realiza sanitização do texto colado

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
@@ -1170,4 +1170,36 @@ describe('PoRichTextBodyComponent:', () => {
       expect(nativeElement.querySelector('.po-rich-text-body')).toBeTruthy();
     });
   });
+
+  it('sanitizeHtmlContent: should sanitize HTML content and extract text content', () => {
+    const htmlContent = '<div>Hello <a href="https://example.com">world</a>!</div>';
+    const sanitizedContent = component['sanitizeHtmlContent'](htmlContent);
+    expect(sanitizedContent).toBe('Hello world!');
+  });
+
+  it('extractTextContent: should extract text content from a node', () => {
+    const htmlContent = '<div>Hello <a href="https://example.com">world</a>!</div>';
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlContent, 'text/html');
+    const textContent = component['extractTextContent'](doc.body);
+    expect(textContent).toBe('Hello world!');
+  });
+
+  it('sanitizeHtmlContent: should handle nested HTML elements correctly', () => {
+    const htmlContent = '<div>Hello <div>beautiful <span>world</span></div>!</div>';
+    const sanitizedContent = component['sanitizeHtmlContent'](htmlContent);
+    expect(sanitizedContent).toBe('Hello beautiful world!');
+  });
+
+  it('sanitizeHtmlContent: should return empty string for empty HTML content', () => {
+    const htmlContent = '';
+    const sanitizedContent = component['sanitizeHtmlContent'](htmlContent);
+    expect(sanitizedContent).toBe('');
+  });
+
+  it('sanitizeHtmlContent: should return text content for text nodes only', () => {
+    const htmlContent = 'Just plain text';
+    const sanitizedContent = component['sanitizeHtmlContent'](htmlContent);
+    expect(sanitizedContent).toBe('Just plain text');
+  });
 });

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
@@ -341,7 +341,7 @@ export class PoRichTextBodyComponent implements OnInit, OnDestroy {
   }
 
   private updateModel() {
-    this.modelValue = this.bodyElement.nativeElement.innerHTML;
+    this.modelValue = this.sanitizeHtmlContent(this.bodyElement.nativeElement.innerHTML);
 
     this.value.emit(this.modelValue);
   }
@@ -370,5 +370,23 @@ export class PoRichTextBodyComponent implements OnInit, OnDestroy {
     }
 
     return isLink;
+  }
+
+  private sanitizeHtmlContent(htmlContent: string): string {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlContent, 'text/html');
+    return this.extractTextContent(doc.body);
+  }
+
+  private extractTextContent(node: Node): string {
+    let textContent = '';
+    node.childNodes.forEach(childNode => {
+      if (childNode.nodeType === Node.TEXT_NODE) {
+        textContent += childNode.textContent;
+      } else if (childNode.nodeType === Node.ELEMENT_NODE) {
+        textContent += this.extractTextContent(childNode);
+      }
+    });
+    return textContent;
   }
 }


### PR DESCRIPTION
**po-rich-text**

**#1872**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente po-rich-text ao receber um texto colado, não sanitiza o css do mesmo, gravando informações desnecessárias na model.

**Qual o novo comportamento?**

Realiza a sanitização da model, para que receba apenas o valor, deixando a estilização a cargo do usuário, através das ferramentas disponibilizadas no componente.

**Simulação**

Esta correção pode ser validada utilizando o sample labs no portal.