### PR TITLE
fix(tabs): corrige emissão de evento p-click

### DIFF
--- a/projects/ui/src/lib/components/po-tabs/po-tabs.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.component.spec.ts
@@ -61,7 +61,7 @@ describe('PoTabsComponent:', () => {
 
       component['tabsService'].triggerActiveOnChanges(tabMock);
 
-      expect(component.onTabActiveByDropdown).toHaveBeenCalledWith(tabMock);
+      expect(component.onTabActiveByDropdown).toHaveBeenCalledWith(tabMock, false);
     });
 
     it('ngOnInit: should unsubscribe', () => {
@@ -518,6 +518,7 @@ describe('PoTabsComponent:', () => {
 
     it('onTabActiveByDropdown: should correctly call methods and update styles when called', () => {
       const tabMock = jasmine.createSpyObj('PoTabComponent', ['id'], { id: 'tab-id' });
+      tabMock.click = { emit: () => {} };
       component.defaultLastTabWidth = 100;
 
       const nativeElementMock = { style: { width: '' }, getBoundingClientRect: () => ({ width: 100 }) };
@@ -531,10 +532,12 @@ describe('PoTabsComponent:', () => {
       component.tabsDefault = [tabMock];
       component.tabsDropdown = [tabMock];
 
+      spyOn(tabMock.click, 'emit');
       spyOn(component, 'handleKeyboardNavigationTab');
 
       component.onTabActiveByDropdown(tabMock);
 
+      expect(tabMock.click.emit).toHaveBeenCalledWith(tabMock);
       expect(component.tabButton.last.nativeElement.style.width).toBe('100px');
       expect(component.handleKeyboardNavigationTab).toHaveBeenCalled();
       expect(component.tabsDefault.includes(tabMock)).toBe(true);
@@ -543,6 +546,7 @@ describe('PoTabsComponent:', () => {
 
     it('reorderTabs: should reorder tabs if tabIndex is not -1', () => {
       const tabMock = jasmine.createSpyObj('PoTabComponent', ['id'], { id: 'tab4', widthButton: '130' });
+      tabMock.click = { emit: () => {} };
       const tabsArrayMock = [
         jasmine.createSpyObj('PoTabComponent', ['id'], { id: 'tab1', widthButton: '100' }),
         jasmine.createSpyObj('PoTabComponent', ['id'], { id: 'tab2', widthButton: '110' }),
@@ -556,6 +560,7 @@ describe('PoTabsComponent:', () => {
 
       component.quantityTabsButton = 3;
 
+      spyOn(tabMock.click, 'emit');
       spyOn(component, <any>'changeTabPositionByDropdown').and.callFake((tab: PoTabComponent) => {
         const tabIndex = component.tabsChildren.toArray().indexOf(tab);
         if (tabIndex !== -1) {
@@ -572,6 +577,7 @@ describe('PoTabsComponent:', () => {
 
       const reorderedTabs = component.tabsChildren.toArray();
 
+      expect(tabMock.click.emit).toHaveBeenCalledWith(tabMock);
       expect(reorderedTabs.map(tab => tab.id)).toEqual(['tab1', 'tab2', 'tab4', 'tab3']);
       expect(component.tabButton.last.nativeElement.style.width).toBe('130px');
     });

--- a/projects/ui/src/lib/components/po-tabs/po-tabs.component.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.component.ts
@@ -112,7 +112,7 @@ export class PoTabsComponent extends PoTabsBaseComponent implements OnInit, Afte
     this.subscriptionTabActive = this.tabsService.triggerActiveOnChanges$.subscribe(tab => {
       const isTabInDropdown = this.tabsDropdown.some(t => t.id === tab.id);
       if (isTabInDropdown) {
-        this.onTabActiveByDropdown(tab);
+        this.onTabActiveByDropdown(tab, false);
       }
     });
   }
@@ -166,7 +166,7 @@ export class PoTabsComponent extends PoTabsBaseComponent implements OnInit, Afte
     return !tab.hide;
   }
 
-  onTabActiveByDropdown(tab: PoTabComponent): void {
+  onTabActiveByDropdown(tab: PoTabComponent, eventEmitter = true): void {
     this.changeTabPositionByDropdown(tab);
     const lastTabWidth =
       this.defaultLastTabWidth > 0
@@ -177,6 +177,10 @@ export class PoTabsComponent extends PoTabsBaseComponent implements OnInit, Afte
     tab.widthButton = lastTabWidth;
     this.tabButton.last.nativeElement.style.width = `${lastTabWidth}px`;
     this.handleKeyboardNavigationTab();
+
+    if (eventEmitter) {
+      tab.click.emit(tab);
+    }
   }
 
   // Função disparada quando alguma tab ficar ativa


### PR DESCRIPTION
Corrige a emissão do Output p-click para disparar
corretamente.

fixes DTHFUI-9176

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
[app.zip](https://github.com/user-attachments/files/15890379/app.zip)

