### PR TITLE
fix(tab-dropdown): corrige posicionamento

### DIFF
--- a/projects/ui/src/lib/components/po-tabs/po-tab-dropdown/po-tab-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-tabs/po-tab-dropdown/po-tab-dropdown.component.html
@@ -2,7 +2,7 @@
   <po-button #button p-kind="tertiary" [p-aria-label]="label" p-icon="ICON_ARROW_DOWN"> </po-button>
 </div>
 
-<po-popover #popover p-hide-arrow p-position="bottom" [p-target]="buttonElement">
+<po-popover #popover p-hide-arrow p-position="bottom-left" [p-target]="buttonElement">
   <div class="po-tab-dropdown-container">
     <po-listbox
       #listbox


### PR DESCRIPTION
**TAB-DROPDOWN**

**DTHFUI-8917**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao abrir o `dropdown`, o alinhamento do `po-listbox` estava incorreto. 

**Qual o novo comportamento?**
Ao abrir o `dropdown`, o alinhamento do `po-listbox` é ajustado corretamente.

PR Adicional
- https://github.com/po-ui/po-style/pull/566

**Simulação**
[app-8917.zip](https://github.com/user-attachments/files/15891023/app-8917.zip)
