### PR TITLE
fix(toaster): corrige z-index e cor ícone warning no tema dark

### DIFF
--- a/projects/ui/src/lib/services/po-theme/helpers/po-theme-dark-defaults.constant.ts
+++ b/projects/ui/src/lib/services/po-theme/helpers/po-theme-dark-defaults.constant.ts
@@ -111,7 +111,8 @@ const poThemeDefaultDarkValues = {
     },
     /** TOASTER */
     'po-toaster': {
-      '--color-icon': 'var(--color-neutral-dark-80)'
+      '--color-icon': 'var(--color-neutral-dark-80)',
+      '--color-icon-warning': 'var(--color-neutral-light-00)'
     },
     /** BADGE */
     'po-badge': {


### PR DESCRIPTION
**po-toaster**

**DTHFUI-9230**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
po-toaster está sobrepondo outros componentes e no tema dark, a cor do ícone warning não está da cor esperada.

**Qual o novo comportamento?**
Foi corrigido o z-index do po-toaster para não ficar sobreposto a outros componentes e a cor do ícone do tipo `warning` para cor escura no tema dark

**Simulação**
[simulacao.zip](https://github.com/user-attachments/files/16054896/simulacao.zip)
