### PR TITLE
fix(stepper): corrige status disabled do stepper

### DIFF
--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.spec.ts
@@ -54,6 +54,18 @@ describe('PoStepperBaseComponent:', () => {
       expect(component.step).toBe(1);
     });
 
+    it('p-steps: should respect status disabled', () => {
+      component.steps = [
+        { label: 'Step 1', status: PoStepperStatus.Active },
+        { label: 'Step 2', status: PoStepperStatus.Disabled },
+        { label: 'Step 3', status: PoStepperStatus.Disabled }
+      ];
+
+      expect(component.steps[0].status).toBe(PoStepperStatus.Active);
+      expect(component.steps[1].status).toBe(PoStepperStatus.Disabled);
+      expect(component.steps[2].status).toBe(PoStepperStatus.Disabled);
+    });
+
     it('p-orientation: should update property with `horizontal` when invalid values', () => {
       const invalidValues = [undefined, null, '', true, false, 0, 1, 'string', [], {}];
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
@@ -145,7 +145,7 @@ export class PoStepperBaseComponent {
    */
   @Input('p-steps') set steps(steps: Array<PoStepperItem>) {
     this._steps = Array.isArray(steps) ? steps : [];
-    this._steps.forEach(step => (step.status = PoStepperStatus.Default));
+    this._steps.forEach(step => (step.status = step.status ?? PoStepperStatus.Default));
     this.step = 1;
   }
 


### PR DESCRIPTION
po-stepper

DTHFUI-8956
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente po-stepper não está obedecendo o status `disabled`.

**Qual o novo comportamento?**
Corrigido o comportamento do po-stepper para desabilitar quando status for `disabled`.

**Simulação**
[simulacao.zip](https://github.com/user-attachments/files/16074830/simulacao.zip) 
