### PR TITLE
fix(table): corrige erro no console

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -3170,6 +3170,9 @@ describe('PoTableComponent:', () => {
         nativeElement: {
           offsetHeight: 150
         }
+      },
+      changeDetector: {
+        detectChanges: () => {}
       }
     };
 
@@ -3185,6 +3188,9 @@ describe('PoTableComponent:', () => {
         nativeElement: {
           offsetHeight: 260
         }
+      },
+      changeDetector: {
+        detectChanges: () => {}
       }
     };
 
@@ -3200,6 +3206,9 @@ describe('PoTableComponent:', () => {
         nativeElement: {
           offsetHeight: 200
         }
+      },
+      changeDetector: {
+        detectChanges: () => {}
       }
     };
 
@@ -3217,6 +3226,9 @@ describe('PoTableComponent:', () => {
             anotherProperty: null
           }
         }
+      },
+      changeDetector: {
+        detectChanges: () => {}
       }
     };
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -762,6 +762,8 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     } else {
       this.sizeLoading = 'lg';
     }
+
+    this.changeDetector.detectChanges();
   }
 
   private checkChangesItems() {


### PR DESCRIPTION
po-table

DTHFUI-9159
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente po-table quando carregado dentro de uma po-modal, está apresentando erro no `console`.

**Qual o novo comportamento?**
Corrigido a inicialização do po-table que causava o erro no `console`.

**Simulação**
[simulacao.zip](https://github.com/user-attachments/files/16089206/simulacao.zip)
