### PR TITLE
feat(PoIcon): anuncia depreciação

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-action.interface.ts
@@ -48,10 +48,16 @@ export interface PoPageDynamicTableCustomAction {
    *
    * Define um ícone que será exibido ao lado esquerdo do rótulo.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-component
    *  [p-property]="[{ label: 'PO ICON', icon: 'po-icon-news' }]">
+   * </po-component>
+   * ```
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
    * </po-component>
    * ```
    *

--- a/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/interfaces/po-page-dynamic-table-custom-table-action.interface.ts
@@ -57,13 +57,19 @@ export interface PoPageDynamicTableCustomTableAction {
    *
    * Define um ícone que será exibido ao lado esquerdo do rótulo.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-component
    *  [p-property]="[{ label: 'PO ICON', icon: 'po-icon-news' }]">
    * </po-component>
    * ```
    *
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
+   * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
    * ```
    * <po-component

--- a/projects/ui/src/lib/components/po-badge/po-badge-base.component.ts
+++ b/projects/ui/src/lib/components/po-badge/po-badge-base.component.ts
@@ -88,9 +88,16 @@ export class PoBadgeBaseComponent {
    * ```
    * <po-badge [p-icon]="true"></po-badge>
    * ```
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-badge p-icon="po-icon-user"></po-badge>
+   * ```
+   *
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
    * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```

--- a/projects/ui/src/lib/components/po-button-group/po-button-group-item.interface.ts
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group-item.interface.ts
@@ -22,11 +22,17 @@ export interface PoButtonGroupItem {
   /**
    * Ícone exibido ao lado esquerdo do label do botão.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * buttons: Array<PoButtonGroupItem> = [
    *  { label: 'Button 1', action: this.action.bind(this), icon: 'po-icon-user' },
    * ];
+   * ```
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
    * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -86,9 +86,15 @@ export class PoButtonBaseComponent {
    * @description
    * Ícone exibido ao lado esquerdo do label do botão.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-button p-icon="po-icon-user" p-label="PO button"></po-button>
+   * ```
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
    * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -114,7 +114,14 @@ export interface PoDynamicFormField extends PoDynamicField {
    * - Combo;
    * - Password;
    *
-   * > Veja a disponibilidade de ícones em [biblioteca de ícones](guides/icons).
+   * > **Deprecated v20.x.x.** Veja a disponibilidade de ícones em [biblioteca de ícones](guides/icons).
+   *
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
+   * ```
    */
   icon?: string | TemplateRef<void>;
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-field.interface.ts
@@ -70,7 +70,14 @@ export interface PoDynamicViewField extends PoDynamicField {
   /**
    * Define um ícone que será exibido ao lado do valor para o campo do tipo *tag*.
    *
-   * > Veja os valores válidos na [biblioteca de ícones](guides/icons).
+   * > **Deprecated v20.x.x.** Veja os valores válidos na [biblioteca de ícones](guides/icons).
+   *
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
+   * ```
    */
   icon?: string;
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -163,9 +163,15 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * Define o ícone que será exibido no início do campo.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-combo p-icon="po-icon-user" p-label="PO combo"></po-combo>
+   * ```
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
    * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -72,9 +72,15 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    *
    * Define o ícone que será exibido no início do campo.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-input p-icon="po-icon-user" p-label="PO input"></po-input>
+   * ```
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
    * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```

--- a/projects/ui/src/lib/components/po-icon/po-icon.component.ts
+++ b/projects/ui/src/lib/components/po-icon/po-icon.component.ts
@@ -26,9 +26,15 @@ export class PoIconComponent {
   /**
    * Define o ícone a ser exibido.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-button p-icon="po-icon-user" p-label="PO button"></po-button>
+   * ```
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
    * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/interfaces/po-item-list-action.interface.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/interfaces/po-item-list-action.interface.ts
@@ -22,13 +22,18 @@ export interface PoItemListAction {
    *
    * Define um ícone que será exibido ao lado esquerdo do rótulo.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-component
    *  [p-property]="[{ label: 'PO ICON', icon: 'po-icon-news' }]">
    * </po-component>
    * ```
-   *
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
+   * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
    * ```
    * <po-component

--- a/projects/ui/src/lib/components/po-menu/po-menu-item.interface.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-item.interface.ts
@@ -33,13 +33,18 @@ export interface PoMenuItem {
   action?: Function;
 
   /**
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-menu
    *  [p-menus]="[{ link: '/', label: 'PO ICON', icon: 'po-icon-news' }]">
    * </po-menu>
    * ```
-   *
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
+   * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
    * ```
    * <po-menu

--- a/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
@@ -130,9 +130,15 @@ export class PoModalBaseComponent {
    * @description
    * Ícone exibido ao lado esquerdo do label do titúlo da modal.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-modal p-icon="po-icon-user" p-title="PO Modal"></po-modal>
+   * ```
+   *  Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
    * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```

--- a/projects/ui/src/lib/components/po-navbar/interfaces/po-navbar-icon-action.interface.ts
+++ b/projects/ui/src/lib/components/po-navbar/interfaces/po-navbar-icon-action.interface.ts
@@ -20,13 +20,18 @@ export interface PoNavbarIconAction {
   /**
    * Ícone exibido.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-navbar
    *   [p-icon-actions]="[{ link: '/', icon: 'po-icon-news' }]">
    * </po-navbar>
    * ```
-   *
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
+   * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
    * ```
    * <po-navbar

--- a/projects/ui/src/lib/components/po-popup/po-popup-action.interface.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup-action.interface.ts
@@ -25,13 +25,18 @@ export interface PoPopupAction {
    *
    * Define um ícone que será exibido ao lado esquerdo do rótulo.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-component
    *  [p-property]="[{ label: 'PO ICON', icon: 'po-icon-news' }]">
    * </po-component>
    * ```
-   *
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-component
+   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
+   * </po-component>
+   * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
    * ```
    * <po-component

--- a/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.interface.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.interface.ts
@@ -41,11 +41,14 @@ export interface PoTableColumnIcon {
   disabled?: Function;
 
   /**
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * [ { icon: 'po-icon-plus' } ]
    * ```
-   *
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * [{ icon: 'ph ph-user' }]
+   * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
    * ```
    * [ {  icon: 'fas fa-plus' } ]

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.interface.ts
@@ -75,9 +75,13 @@ export interface PoTableColumnLabel {
    * - <span class="po-icon po-icon-close"></span> - `danger`
    * - <span class="po-icon po-icon-info"></span> - `info`
    *
-   * Também É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** Também É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-tag p-icon="po-icon-user" p-value="PO Tag"></po-tag>
+   * ```
+   *  Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-tag p-icon="ph ph-user" p-value="PO Tag"></po-button>
    * ```
    * como também utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```

--- a/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
@@ -242,9 +242,13 @@ export class PoTagBaseComponent {
    * - <span class="po-icon po-icon-close"></span> - `danger`
    * - <span class="po-icon po-icon-info"></span> - `info`
    *
-   * Também É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** Também É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-tag p-icon="po-icon-user" p-value="PO Tag"></po-tag>
+   * ```
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-tag p-icon="ph ph-user" p-value="PO Tag"></po-button>
    * ```
    * como também utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-base.component.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-base.component.ts
@@ -28,9 +28,13 @@ export class PoToolbarBaseComponent {
    *
    * Define um [ícone](/guides/icons) para a propriedade `p-actions`.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
+   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:
    * ```
    * <po-toolbar p-actions-icon="po-icon-user" [p-actions]="actions"></po-toolbar>
+   * ```
+   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
+   * ```
+   * <po-tag p-icon="ph ph-user" p-value="PO Tag"></po-button>
    * ```
    * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca *Font Awesome*, da seguinte forma:
    * ```


### PR DESCRIPTION
Foi adiconado mesagens de depreciação do PoIcon a partir da v20.

Fixes DTHFUI-9008

BREAKING CHANGE: anuncia depreciação

Foi adicionado mensagens onde é chamado a Biblioteca de ícones (/guides/icons), nas documentações.

Antes:

   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:

Depois:

   * **Deprecated v20.x.x.** É possível usar qualquer um dos ícones da [Biblioteca de ícones](/guides/icons). conforme exemplo abaixo:

   * Utilize os ícones disponíveis na Lib [Phosphor](/guides/icons), conforme exemplo:
   * ```
   * <po-component
   *  [p-property]="[{ label: 'ICON', icon: 'ph ph-user' }]">
   * </po-component>
   * ```

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
