### PR TITLE
fix(lookup): corrige itens selecionados que são omitidos após a pesquisa

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
@@ -733,6 +733,16 @@ describe('PoLookupModalBaseComponent:', () => {
       expect(component.selecteds).toEqual(expectSelecteds);
     });
 
+    it('setDisclaimersItems: should set selecteds with selectedItems if selecteds is empty and selectedItems is an array with elements', () => {
+      const expectSelecteds = [{ value: 123, label: '123' }];
+      component.selecteds = [];
+      component.selectedItems = [...expectSelecteds];
+
+      component.setDisclaimersItems();
+
+      expect(component.selecteds).toEqual(expectSelecteds);
+    });
+
     it('Should emit item selected when component is not multiple ', () => {
       component.selecteds = [{ value: 123456789 }];
       component.multiple = true;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -419,7 +419,7 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
       return;
     }
 
-    if (this.selectedItems && this.selectedItems.length) {
+    if (this.selecteds.length === 0 && this.selectedItems && this.selectedItems.length) {
       this.selecteds = [...this.selectedItems];
     }
   }

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -30,11 +30,13 @@
 
 <hr />
 
-<div class="po-row">
-  <po-info class="po-md-6" p-label="Model" [p-value]="lookup"> </po-info>
+<po-container p-no-border="true" p-no-padding="true">
+  <div class="po-row">
+    <po-info class="po-md-12" p-label="Model" [p-value]="lookup"> </po-info>
 
-  <po-info class="po-md-6" p-label="Event" [p-value]="event"> </po-info>
-</div>
+    <po-info class="po-md-6" p-label="Event" [p-value]="event"> </po-info>
+  </div>
+</po-container>
 
 <hr />
 


### PR DESCRIPTION
po-lookup

DTHFUI-9253
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao selecionar itens no componente po-lookup, pesquisando e selecionando novos itens, alguns itens previamente selecionados sumiam.

**Qual o novo comportamento?**
Corrige itens selecionados que são omitidos após a pesquisa.

**Simulação**
Testar no labs