### PR TITLE
Treeview/dthf UI 8465

### DIFF
--- a/projects/ui/src/lib/components/po-tree-view/po-tree-view-item/po-tree-view-item.component.html
+++ b/projects/ui/src/lib/components/po-tree-view/po-tree-view-item/po-tree-view-item.component.html
@@ -9,14 +9,16 @@
   >
   </po-tree-view-item-header>
 
-  <ul *ngIf="hasSubItems" class="po-tree-view-item-group" [@toggleBody]="item.expanded ? 'expanded' : 'collapsed'">
-    <po-tree-view-item
-      *ngFor="let subItem of item.subItems; trackBy: trackByFunction"
-      [p-item]="subItem"
-      [p-selectable]="selectable"
-      [p-single-select]="singleSelect"
-      [p-selected-value]="selectedValue"
-    >
-    </po-tree-view-item>
+  <ul *ngIf="hasSubItems" class="po-tree-view-item-group">
+    <div *ngIf="item.expanded" @toggleBody>
+      <po-tree-view-item
+        *ngFor="let subItem of item.subItems; trackBy: trackByFunction"
+        [p-item]="subItem"
+        [p-selectable]="selectable"
+        [p-single-select]="singleSelect"
+        [p-selected-value]="selectedValue"
+      >
+      </po-tree-view-item>
+    </div>
   </ul>
 </li>

--- a/projects/ui/src/lib/components/po-tree-view/po-tree-view-item/po-tree-view-item.component.ts
+++ b/projects/ui/src/lib/components/po-tree-view/po-tree-view-item/po-tree-view-item.component.ts
@@ -10,24 +10,25 @@ import { PoTreeViewService } from '../services/po-tree-view.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
     trigger('toggleBody', [
-      state(
-        'collapsed',
+      transition(':enter', [
         style({
           'overflow-y': 'hidden',
           visibility: 'hidden',
           opacity: 0,
           height: '0'
-        })
-      ),
-      transition('expanded => collapsed', [
-        style({ height: '*' }),
-        animate(100, style({ opacity: 0 })),
-        animate(200, style({ height: 0 }))
+        }),
+        animate(200, style({ height: '*' })),
+        animate(100, style({ opacity: 1 }))
       ]),
-      transition('collapsed => expanded', [
-        style({ height: '0' }),
-        animate(100, style({ opacity: 1 })),
-        animate(200, style({ height: '*' }))
+      transition(':leave', [
+        style({
+          'overflow-y': 'hidden',
+          visibility: 'visible',
+          opacity: 1,
+          height: '*'
+        }),
+        animate(200, style({ height: 0 })),
+        animate(100, style({ opacity: 0 }))
       ])
     ])
   ]


### PR DESCRIPTION
**Treeview**

**8465**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
o tree view expande dentro do page-slide após o fechamento

**Qual o novo comportamento?**
o tree view não expande dentro do page-slide após o fechamento


**Simulação**
app e portal
[app.zip](https://github.com/user-attachments/files/16442730/app.zip)
