### PR TITLE
fix(menu): ajusta quando menu instanciado como componente

### DIFF
--- a/projects/ui/src/lib/components/po-menu/po-menu.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.ts
@@ -317,7 +317,8 @@ export class PoMenuComponent extends PoMenuBaseComponent implements AfterViewIni
   }
 
   protected validateCollapseClass(collapsedMobile: boolean = false) {
-    const wrapper = this.element.nativeElement.parentNode;
+    const wrapper = this.element.nativeElement.closest('.po-wrapper') || this.element.nativeElement.parentNode;
+
     this.renderer[this.isCollapsed && !collapsedMobile ? 'addClass' : 'removeClass'](wrapper, 'po-collapsed-menu');
   }
 


### PR DESCRIPTION
Ajusta o comportamento do menu quando o mesmo estiver instanciado como um componente da aplicação, permitindo que o componente de página, ocupe o espaço liberado pelo componente de menu, quando estiver retraído

Fixes #2183

**Menu**

**2183**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O menu não funciona corretamente quando instanciado como componente, o espaço liberado pelo componente de menu quando retraído, não é ocupado pelo componente de pagina.

**Qual o novo comportamento?**
O menu funciona corretamente quando instanciado como componente, o espaço liberado pelo componente de menu quando retraído, é ocupado pelo componente de pagina.

**Simulação**
Para simulação pode ser usado o [APP](https://github.com/user-attachments/files/16626566/app.zip)

