### PR TITLE
fix(listbox): ajusta dimensões do loading-overlay no po-listbox

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -56,6 +56,7 @@ const PO_COMBO_FIELD_VALUE_DEFAULT = 'value';
  * | `--color`                              | Cor principal do Combo                                | `var(--color-neutral-dark-70)`                    |
  * | `--background`                         | Cor de background                                     | `var(--color-neutral-light-05)`                   |
  * | `--border-radius`                      | Contém o valor do raio dos cantos do elemento&nbsp;   | `var(--border-width-lg)`                          |
+ * | `--min-width`                          | Largura mínima do combo                               | `150px`
  * | **Hover**                              |                                                       |                                                   |
  * | `--color-hover`                        | Cor principal no estado hover                         | `var(--color-action-hover)`                       |
  * | `--background-hover`                   | Cor de background no estado hover                     | `var(--color-brand-01-lightest)`                  |

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -1,105 +1,112 @@
-<po-field-container
-  [p-disabled]="disabled"
-  [p-id]="id"
-  [p-label]="label"
-  [p-optional]="optional"
-  [p-required]="required"
-  [p-show-required]="showRequired"
->
-  <div cdkOverlayOrigin #trigger="cdkOverlayOrigin" class="po-field-container-content po-combo-container-content">
-    <div *ngIf="icon" class="po-field-icon-container-left">
-      <po-icon class="po-field-icon po-icon-input" [class.po-field-icon-disabled]="disabled" [p-icon]="icon"></po-icon>
-    </div>
-
-    <input
-      #inp
-      class="po-combo-input"
-      [ngClass]="clean && inp.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
-      [class.po-input-icon-left]="icon"
-      autocomplete="off"
-      type="text"
-      [attr.name]="name"
-      [disabled]="disabled"
-      [id]="id"
-      [placeholder]="disabled ? '' : placeholder"
-      [required]="required"
-      (click)="toggleComboVisibility()"
-      (keyup)="onKeyUp($event)"
-      (blur)="onBlur()"
-      (keyup)="searchOnEnterOrArrow($event, $event.target.value)"
-      (keydown)="onKeyDown($event)"
-    />
-
-    <div class="po-field-icon-container-right">
-      <po-clean
-        tabindex="0"
-        role="button"
-        [attr.aria-label]="literals.clean"
-        class="po-combo-clean po-icon-input"
-        *ngIf="clean && !disabled && inp.value"
-        [p-element-ref]="inputEl"
-        (p-change-event)="clear($event)"
-        (click)="clear(null); $event.preventDefault()"
-        (keydown.enter)="clearAndFocus(); $event.preventDefault()"
-      >
-      </po-clean>
-
-      <div
-        #iconArrow
-        class="po-combo-arrow po-field-icon"
-        [class.po-field-icon-disabled]="disabled"
-        (click)="toggleComboVisibility(true)"
-      >
+<div #outerContainer>
+  <po-field-container
+    [p-disabled]="disabled"
+    [p-id]="id"
+    [p-label]="label"
+    [p-optional]="optional"
+    [p-required]="required"
+    [p-show-required]="showRequired"
+  >
+    <div cdkOverlayOrigin #trigger="cdkOverlayOrigin" class="po-field-container-content po-combo-container-content">
+      <div *ngIf="icon" class="po-field-icon-container-left">
         <po-icon
-          [p-icon]="comboOpen ? 'ICON_ARROW_UP po-icon-input' : 'ICON_ARROW_DOWN po-icon-input'"
-          [class.po-field-icon]="!disabled"
-          [class.po-combo-default-border]="!disabled && inp.value"
-          [class.po-combo-background-arrow-up]="!disabled && comboOpen"
+          class="po-field-icon po-icon-input"
+          [class.po-field-icon-disabled]="disabled"
+          [p-icon]="icon"
         ></po-icon>
       </div>
+
+      <input
+        #inp
+        class="po-combo-input"
+        [ngClass]="clean && inp.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
+        [class.po-input-icon-left]="icon"
+        autocomplete="off"
+        type="text"
+        [attr.name]="name"
+        [disabled]="disabled"
+        [id]="id"
+        [placeholder]="disabled ? '' : placeholder"
+        [required]="required"
+        (click)="toggleComboVisibility()"
+        (keyup)="onKeyUp($event)"
+        (blur)="onBlur()"
+        (keyup)="searchOnEnterOrArrow($event, $event.target.value)"
+        (keydown)="onKeyDown($event)"
+      />
+
+      <div class="po-field-icon-container-right">
+        <po-clean
+          tabindex="0"
+          role="button"
+          [attr.aria-label]="literals.clean"
+          class="po-combo-clean po-icon-input"
+          *ngIf="clean && !disabled && inp.value"
+          [p-element-ref]="inputEl"
+          (p-change-event)="clear($event)"
+          (click)="clear(null); $event.preventDefault()"
+          (keydown.enter)="clearAndFocus(); $event.preventDefault()"
+        >
+        </po-clean>
+
+        <div
+          #iconArrow
+          class="po-combo-arrow po-field-icon"
+          [class.po-field-icon-disabled]="disabled"
+          (click)="toggleComboVisibility(true)"
+        >
+          <po-icon
+            [p-icon]="comboOpen ? 'ICON_ARROW_UP po-icon-input' : 'ICON_ARROW_DOWN po-icon-input'"
+            [class.po-field-icon]="!disabled"
+            [class.po-combo-default-border]="!disabled && inp.value"
+            [class.po-combo-background-arrow-up]="!disabled && comboOpen"
+          ></po-icon>
+        </div>
+      </div>
     </div>
-  </div>
 
-  <ng-container *ngIf="appendBox; then dropdownCDK; else dropdownDefault"> </ng-container>
+    <ng-container *ngIf="appendBox; then dropdownCDK; else dropdownDefault"> </ng-container>
 
-  <ng-template #dropdownDefault>
-    <ng-container *ngTemplateOutlet="dropdownListbox"> </ng-container>
-  </ng-template>
-
-  <ng-template #dropdownCDK>
-    <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="true">
-      <ng-container *ngTemplateOutlet="dropdownListbox"></ng-container>
+    <ng-template #dropdownDefault>
+      <ng-container *ngTemplateOutlet="dropdownListbox"> </ng-container>
     </ng-template>
+
+    <ng-template #dropdownCDK>
+      <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="true">
+        <ng-container *ngTemplateOutlet="dropdownListbox"></ng-container>
+      </ng-template>
+    </ng-template>
+
+    <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
+  </po-field-container>
+
+  <ng-template #dropdownListbox>
+    <div #containerElement class="po-combo-container" [hidden]="!comboOpen && !isServerSearching">
+      <po-listbox
+        #poListbox
+        #contentElement
+        p-type="option"
+        [p-items]="visibleOptions"
+        [p-field-value]="dynamicValue"
+        [p-field-label]="dynamicLabel"
+        [p-template]="comboOptionTemplate"
+        [p-search-value]="getInputValue()"
+        [p-infinite-loading]="infiniteLoading"
+        [p-infinite-scroll]="infiniteScroll"
+        [p-filtering]="isFiltering"
+        [p-cache]="cache"
+        (p-selectcombo-item)="onOptionClick($event, $event.event)"
+        [p-filter-mode]="filterMode"
+        [p-visible]="comboOpen"
+        [p-is-searching]="isServerSearching"
+        [p-should-mark-letter]="shouldMarkLetters"
+        [p-compare-cache]="compareObjects(cacheOptions, visibleOptions)"
+        [p-combo-service]="service"
+        [p-infinite-scroll-distance]="infiniteScrollDistance"
+        (p-update-infinite-scroll)="showMoreInfiniteScroll()"
+        (p-close)="onCloseCombo()"
+        [p-container-width]="containerWidth"
+      ></po-listbox>
+    </div>
   </ng-template>
-
-  <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
-</po-field-container>
-
-<ng-template #dropdownListbox>
-  <div #containerElement class="po-combo-container" [hidden]="!comboOpen && !isServerSearching">
-    <po-listbox
-      #poListbox
-      #contentElement
-      p-type="option"
-      [p-items]="visibleOptions"
-      [p-field-value]="dynamicValue"
-      [p-field-label]="dynamicLabel"
-      [p-template]="comboOptionTemplate"
-      [p-search-value]="getInputValue()"
-      [p-infinite-loading]="infiniteLoading"
-      [p-infinite-scroll]="infiniteScroll"
-      [p-filtering]="isFiltering"
-      [p-cache]="cache"
-      (p-selectcombo-item)="onOptionClick($event, $event.event)"
-      [p-filter-mode]="filterMode"
-      [p-visible]="comboOpen"
-      [p-is-searching]="isServerSearching"
-      [p-should-mark-letter]="shouldMarkLetters"
-      [p-compare-cache]="compareObjects(cacheOptions, visibleOptions)"
-      [p-combo-service]="service"
-      [p-infinite-scroll-distance]="infiniteScrollDistance"
-      (p-update-infinite-scroll)="showMoreInfiniteScroll()"
-      (p-close)="onCloseCombo()"
-    ></po-listbox>
-  </div>
-</ng-template>
+</div>

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -101,7 +101,7 @@ const poComboContainerPositionDefault = 'bottom';
 })
 export class PoComboComponent extends PoComboBaseComponent implements AfterViewInit, OnChanges, OnDestroy {
   @ContentChild(PoComboOptionTemplateDirective, { static: true }) comboOptionTemplate: PoComboOptionTemplateDirective;
-
+  @ViewChild('outerContainer ', { read: ElementRef }) outerContainer: ElementRef;
   @ViewChild('containerElement', { read: ElementRef }) containerElement: ElementRef;
   @ViewChild('contentElement', { read: ElementRef }) contentElement: ElementRef;
   @ViewChild('iconArrow', { read: ElementRef, static: true }) iconElement: ElementRef;
@@ -116,6 +116,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   scrollTop = 0;
   shouldMarkLetters: boolean = true;
   infiniteLoading: boolean = false;
+  containerWidth: number;
 
   private _isServerSearching: boolean = false;
   private lastKey;
@@ -163,6 +164,8 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     if (this.autoFocus) {
       this.focus();
     }
+
+    this.setContainerWidth();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -648,6 +651,9 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
       : this.inputEl.nativeElement.focus();
 
     this.setContainerPosition();
+    if (this.comboOpen) {
+      this.setContainerWidth();
+    }
   }
 
   private removeListeners() {
@@ -672,6 +678,12 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     );
 
     this.adjustContainerPosition();
+  }
+
+  private setContainerWidth(): void {
+    if (this.outerContainer) {
+      this.containerWidth = this.outerContainer.nativeElement.offsetWidth;
+    }
   }
 
   private setOptions() {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
@@ -21,6 +21,7 @@
         (p-change-all)="onClickSelectAll()"
         (p-change-search)="callChangeSearch($event)"
         (p-close)="closeDropdown.emit()"
+        [p-container-width]="containerWidth"
       >
       </po-listbox>
     </ng-container>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
@@ -57,6 +57,8 @@ export class PoMultiselectDropdownComponent {
 
   @Input('p-multiselect-template') multiselectTemplate: TemplateRef<any> | any;
 
+  @Input('p-container-width') containerWidth: number;
+
   /** Evento disparado a cada tecla digitada na pesquisa. */
   @Output('p-change-search') changeSearch = new EventEmitter();
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -1,89 +1,92 @@
-<po-field-container
-  [p-disabled]="disabled"
-  [p-label]="label"
-  [p-optional]="optional"
-  [p-required]="required"
-  [p-show-required]="showRequired"
->
-  <div
-    cdkOverlayOrigin
-    #trigger="cdkOverlayOrigin"
-    class="po-field-container-content"
-    [class.po-multiselect-show]="dropdownOpen"
+<div #outerContainer>
+  <po-field-container
+    [p-disabled]="disabled"
+    [p-label]="label"
+    [p-optional]="optional"
+    [p-required]="required"
+    [p-show-required]="showRequired"
   >
     <div
-      #inputElement
-      [tabindex]="disabled ? -1 : 0"
-      [attr.disabled]="disabled"
-      [attr.aria-label]="label"
-      class="po-input-icon-right po-multiselect-input"
-      [class.po-multiselect-input-auto]="autoHeight"
-      [class.po-multiselect-input-static]="!autoHeight"
-      [class.po-multiselect-input-disabled]="disabled"
-      [class.po-multiselect-input-font]="!disabled && !visibleTags?.length"
-      (keydown)="onKeyDown($event)"
-      (click)="toggleDropdownVisibility()"
-      (blur)="onBlur()"
+      cdkOverlayOrigin
+      #trigger="cdkOverlayOrigin"
+      class="po-field-container-content"
+      [class.po-multiselect-show]="dropdownOpen"
     >
-      <span *ngIf="!disabled && !visibleTags?.length" class="po-multiselect-input-placeholder" aria-hidden="true">
-        {{ placeholder ? placeholder : literals.selectItem }}
-      </span>
+      <div
+        #inputElement
+        [tabindex]="disabled ? -1 : 0"
+        [attr.disabled]="disabled"
+        [attr.aria-label]="label"
+        class="po-input-icon-right po-multiselect-input"
+        [class.po-multiselect-input-auto]="autoHeight"
+        [class.po-multiselect-input-static]="!autoHeight"
+        [class.po-multiselect-input-disabled]="disabled"
+        [class.po-multiselect-input-font]="!disabled && !visibleTags?.length"
+        (keydown)="onKeyDown($event)"
+        (click)="toggleDropdownVisibility()"
+        (blur)="onBlur()"
+      >
+        <span *ngIf="!disabled && !visibleTags?.length" class="po-multiselect-input-placeholder" aria-hidden="true">
+          {{ placeholder ? placeholder : literals.selectItem }}
+        </span>
 
-      <po-tag
-        *ngFor="let tag of visibleTags; index as i"
-        [p-value]="tag[fieldLabel]"
-        [p-literals]="i + 1 === visibleTags.length && hasMoreTag ? literalsTag : undefined"
-        [p-removable]="true"
-        [class.po-clickable]="tag[fieldValue] === '' && !disabled"
-        [p-disabled]="disabled"
-        (p-close)="closeTag(tag[fieldValue], $event)"
-      ></po-tag>
+        <po-tag
+          *ngFor="let tag of visibleTags; index as i"
+          [p-value]="tag[fieldLabel]"
+          [p-literals]="i + 1 === visibleTags.length && hasMoreTag ? literalsTag : undefined"
+          [p-removable]="true"
+          [class.po-clickable]="tag[fieldValue] === '' && !disabled"
+          [p-disabled]="disabled"
+          (p-close)="closeTag(tag[fieldValue], $event)"
+        ></po-tag>
 
-      <div class="po-field-icon-container-right">
-        <po-icon
-          p-icon="{{ dropdownIcon }}"
-          #iconElement
-          class="po-field-icon {{ disabled ? 'po-icon-input-disabled' : 'po-icon-input' }}"
-          [ngClass]="disabled ? 'po-field-icon-disabled' : ''"
-        >
-        </po-icon>
+        <div class="po-field-icon-container-right">
+          <po-icon
+            p-icon="{{ dropdownIcon }}"
+            #iconElement
+            class="po-field-icon {{ disabled ? 'po-icon-input-disabled' : 'po-icon-input' }}"
+            [ngClass]="disabled ? 'po-field-icon-disabled' : ''"
+          >
+          </po-icon>
+        </div>
       </div>
     </div>
-  </div>
 
-  <ng-container *ngIf="appendBox; then dropdownCDK; else dropdownDefault"> </ng-container>
+    <ng-container *ngIf="appendBox; then dropdownCDK; else dropdownDefault"> </ng-container>
 
-  <ng-template #dropdownDefault>
-    <ng-container *ngTemplateOutlet="dropdownListbox"> </ng-container>
-  </ng-template>
-
-  <ng-template #dropdownCDK>
-    <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="true">
-      <ng-container *ngTemplateOutlet="dropdownListbox"></ng-container>
+    <ng-template #dropdownDefault>
+      <ng-container *ngTemplateOutlet="dropdownListbox"> </ng-container>
     </ng-template>
+
+    <ng-template #dropdownCDK>
+      <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="true">
+        <ng-container *ngTemplateOutlet="dropdownListbox"></ng-container>
+      </ng-template>
+    </ng-template>
+
+    <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
+  </po-field-container>
+
+  <ng-template #dropdownListbox>
+    <po-multiselect-dropdown
+      #dropdownElement
+      [p-searching]="isServerSearching"
+      [p-hide-search]="hideSearch"
+      [p-hide-select-all]="hideSelectAll"
+      [p-literals]="literals"
+      [p-options]="options"
+      [p-visible-options]="visibleOptionsDropdown"
+      [p-selected-options]="selectedOptions"
+      [p-placeholder-search]="placeholderSearch"
+      [p-field-value]="fieldValue"
+      [p-field-label]="fieldLabel"
+      [p-multiselect-template]="multiselectOptionTemplate"
+      (p-change)="changeItems($event)"
+      (p-change-search)="changeSearch($event)"
+      (p-close-dropdown)="controlDropdownVisibility(false)"
+      (keydown)="onKeyDownDropdown($event, 0)"
+      [p-container-width]="containerWidth"
+    >
+    </po-multiselect-dropdown>
   </ng-template>
-
-  <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
-</po-field-container>
-
-<ng-template #dropdownListbox>
-  <po-multiselect-dropdown
-    #dropdownElement
-    [p-searching]="isServerSearching"
-    [p-hide-search]="hideSearch"
-    [p-hide-select-all]="hideSelectAll"
-    [p-literals]="literals"
-    [p-options]="options"
-    [p-visible-options]="visibleOptionsDropdown"
-    [p-selected-options]="selectedOptions"
-    [p-placeholder-search]="placeholderSearch"
-    [p-field-value]="fieldValue"
-    [p-field-label]="fieldLabel"
-    [p-multiselect-template]="multiselectOptionTemplate"
-    (p-change)="changeItems($event)"
-    (p-change-search)="changeSearch($event)"
-    (p-close-dropdown)="controlDropdownVisibility(false)"
-    (keydown)="onKeyDownDropdown($event, 0)"
-  >
-  </po-multiselect-dropdown>
-</ng-template>
+</div>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -126,6 +126,7 @@ export class PoMultiselectComponent
   @ViewChild('dropdownElement') dropdown;
   @ViewChild('iconElement', { read: ElementRef, static: true }) iconElement: ElementRef;
   @ViewChild('inputElement', { read: ElementRef, static: true }) inputElement: ElementRef;
+  @ViewChild('outerContainer ', { read: ElementRef }) outerContainer: ElementRef;
 
   literalsTag;
   dropdownIcon: string = 'ICON_ARROW_DOWN';
@@ -134,6 +135,8 @@ export class PoMultiselectComponent
   hasMoreTag: boolean;
   timeoutResize;
   visibleElement = false;
+  containerWidth: number;
+
   private subscription: Subscription = new Subscription();
   private enterCloseTag = false;
   private initCalculateItems = true;
@@ -618,6 +621,10 @@ export class PoMultiselectComponent
 
     this.changeDetector.detectChanges();
     this.setPositionDropdown();
+
+    if (this.dropdownOpen) {
+      this.setContainerWidth();
+    }
   }
 
   private removeListeners(): void {
@@ -631,6 +638,12 @@ export class PoMultiselectComponent
 
     window.removeEventListener('scroll', this.onScroll, true);
     this.changeDetector.markForCheck();
+  }
+
+  private setContainerWidth(): void {
+    if (this.outerContainer) {
+      this.containerWidth = this.outerContainer.nativeElement.offsetWidth;
+    }
   }
 
   private setPositionDropdown(): void {

--- a/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.ts
@@ -153,6 +153,8 @@ export class PoListBoxBaseComponent {
 
   @Input('p-combo-service') comboService: any;
 
+  @Input('p-container-width') containerWidth: number;
+
   // Evento disparado quando uma tab é ativada
   @Output('p-activated-tabs') activatedTab = new EventEmitter();
 

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
@@ -86,7 +86,7 @@
   </ng-container>
 
   <div *ngIf="isServerSearching && type !== 'action'" [class.po-listbox-container-loading-default]="!infiniteLoading">
-    <po-loading-overlay p-size="md"></po-loading-overlay>
+    <po-loading-overlay [p-size]="getSizeLoading()" [p-text]="getTextLoading()"></po-loading-overlay>
   </div>
 
   <ng-template #noDataTemplate>

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, NO_ERRORS_SCHEMA, SimpleChange } from '@angular/core';
+import { ElementRef, NO_ERRORS_SCHEMA, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 
 import { PoListBoxComponent } from './po-listbox.component';
@@ -713,6 +713,112 @@ describe('PoListBoxComponent', () => {
 
         component.onSelectAllCheckboxKeyDown(mockEvent);
         expect(component.closeEvent.emit).toHaveBeenCalled();
+      });
+    });
+
+    describe('getSizeLoading', () => {
+      it('should return `md` when containerWidth > 180', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 0
+        });
+
+        component['listbox'] = listboxMock;
+        component.containerWidth = 190;
+
+        expect((component as any).getSizeLoading()).toBe('md');
+      });
+
+      it('should return `sm` when containerWidth is between 140 and 180', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 0
+        });
+
+        component['listbox'] = listboxMock;
+        component.containerWidth = 150;
+        expect((component as any).getSizeLoading()).toBe('sm');
+      });
+
+      it('should return `xs` when containerWidth < 140', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 0
+        });
+
+        component['listbox'] = listboxMock;
+        component.containerWidth = 130;
+        expect((component as any).getSizeLoading()).toBe('xs');
+      });
+
+      it('should return `md` when listbox width > 180', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 181
+        });
+
+        component['listbox'] = listboxMock;
+        component.containerWidth = 0;
+        expect((component as any).getSizeLoading()).toBe('md');
+      });
+
+      it('should return `sm` when listbox width is between 140 and 180', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 150
+        });
+
+        component['listbox'] = listboxMock;
+        component.containerWidth = 0;
+        expect((component as any).getSizeLoading()).toBe('sm');
+      });
+
+      it('should return `xs` when listbox width < 140', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 120
+        });
+
+        component['listbox'] = listboxMock;
+        component.containerWidth = 0;
+        expect((component as any).getSizeLoading()).toBe('xs');
+      });
+    });
+
+    describe('getTextLoading', () => {
+      it('should return space when containerWidth < 140', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 0
+        });
+
+        component['listbox'] = listboxMock;
+        component.containerWidth = 130;
+        expect((component as any).getTextLoading()).toBe(' ');
+      });
+
+      it('should return empty string when containerWidth >= 140', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 0
+        });
+
+        component['listbox'] = listboxMock;
+        component.containerWidth = 140;
+        expect((component as any).getTextLoading()).toBe('');
+      });
+
+      it('should return space when listbox width < 140', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 120
+        });
+
+        component['listbox'] = listboxMock;
+        component['containerWidth'] = 0;
+
+        expect((component as any).getTextLoading()).toBe(' ');
+      });
+
+      it('should return empty string when listbox width >= 140', () => {
+        const listboxMock = new ElementRef({
+          offsetWidth: 140
+        });
+
+        component['listbox'] = listboxMock;
+        component['containerWidth'] = 130;
+        expect((component as any).getTextLoading()).toBe('');
       });
     });
   });

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
@@ -1,6 +1,5 @@
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -8,8 +7,7 @@ import {
   OnDestroy,
   Renderer2,
   SimpleChanges,
-  ViewChild,
-  forwardRef
+  ViewChild
 } from '@angular/core';
 import { Router } from '@angular/router';
 
@@ -20,7 +18,7 @@ import { PoItemListOption } from './po-item-list/interfaces/po-item-list-option.
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { isExternalLink, isTypeof, openExternalLink } from '../../utils/util';
 import { PoSearchListComponent } from './po-search-list/po-search-list.component';
-import { Observable, Subscription, debounceTime, fromEvent, merge } from 'rxjs';
+import { Observable, Subscription, debounceTime, fromEvent } from 'rxjs';
 
 @Component({
   selector: 'po-listbox',
@@ -184,6 +182,24 @@ export class PoListBoxComponent extends PoListBoxBaseComponent implements AfterV
     if (this.hasInfiniteScroll()) {
       this.includeInfiniteScroll();
     }
+  }
+
+  protected getSizeLoading() {
+    const width = this.listbox.nativeElement.offsetWidth || this.containerWidth;
+
+    if (width > 180) {
+      return 'md';
+    } else if (width >= 140) {
+      return 'sm';
+    } else {
+      return 'xs';
+    }
+  }
+
+  protected getTextLoading() {
+    const width = this.listbox.nativeElement.offsetWidth || this.containerWidth;
+
+    return width < 140 ? ' ' : '';
   }
 
   private hasInfiniteScroll(): boolean {

--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.ts
@@ -61,7 +61,7 @@ export class PoLoadingOverlayBaseComponent {
    *
    * @description
    *
-   * Define se o *overlay* será aplicado a um *container* ou a página inteira.
+   * Define se o *overlay* será aplicado a um *container* ou à página inteira.
    *
    * Para utilizar o componente como um *container*, o elemento pai deverá receber uma posição relativa, por exemplo:
    *
@@ -93,7 +93,7 @@ export class PoLoadingOverlayBaseComponent {
    *
    * Texto a ser exibido no componente.
    *
-   * > O valor padrão será traduzido acordo com o idioma configurado no [**PoI18n**](/documentation/po-i18n) ou navegador.
+   * > O valor padrão será traduzido de acordo com o idioma configurado no [**PoI18n**](/documentation/po-i18n) ou navegador.
    *
    * @default `Carregando`
    */
@@ -110,7 +110,13 @@ export class PoLoadingOverlayBaseComponent {
    *
    * @description
    *
-   * Define o tamnho do componente.
+   * Define o tamanho do componente com base no tamanho do ícone de *loading*.
+   *
+   * Tamanhos disponíveis para o *loading*:
+   * - `xs`: 16px
+   * - `sm`: 24px
+   * - `md`: 48px
+   * - `lg`: 80px (valor padrão)
    *
    * @default `lg`
    */

--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/samples/sample-po-loading-overlay-labs/sample-po-loading-overlay-labs.component.html
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/samples/sample-po-loading-overlay-labs/sample-po-loading-overlay-labs.component.html
@@ -1,5 +1,6 @@
 <div class="sample-container">
-  <po-loading-overlay [p-screen-lock]="properties?.includes('screenLock')" [p-text]="text"> </po-loading-overlay>
+  <po-loading-overlay [p-screen-lock]="properties?.includes('screenLock')" [p-text]="text" [p-size]="size">
+  </po-loading-overlay>
 </div>
 
 <hr />
@@ -18,10 +19,14 @@
     >
     </po-checkbox-group>
   </div>
+  <div class="po-row">
+    <po-radio-group class="po-md-6" name="size" [(ngModel)]="size" p-label="Size" [p-options]="sizesOptions">
+    </po-radio-group>
+  </div>
 
   <div class="po-row">
     <div class="po-md-3">
-      <po-button p-label="Sample Restore" (p-click)="formProperties.reset()"> </po-button>
+      <po-button p-label="Sample Restore" (p-click)="restore()"> </po-button>
     </div>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/samples/sample-po-loading-overlay-labs/sample-po-loading-overlay-labs.component.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/samples/sample-po-loading-overlay-labs/sample-po-loading-overlay-labs.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import { PoCheckboxGroupOption } from '@po-ui/ng-components';
+import { PoCheckboxGroupOption, PoRadioGroupOption } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-loading-overlay-labs',
@@ -14,11 +14,22 @@ import { PoCheckboxGroupOption } from '@po-ui/ng-components';
     `
   ]
 })
-export class SamplePoLoadingOverlayLabsComponent {
+export class SamplePoLoadingOverlayLabsComponent implements OnInit {
   properties: Array<string> = [];
   text: string;
+  size: string;
+  sizesOptions: Array<PoRadioGroupOption> = [
+    { label: 'xs', value: 'xs' },
+    { label: 'sm', value: 'sm' },
+    { label: 'md', value: 'md' },
+    { label: 'lg', value: 'lg' }
+  ];
 
   readonly propertiesOptions: Array<PoCheckboxGroupOption> = [{ value: 'screenLock', label: 'Screen Lock' }];
+
+  ngOnInit() {
+    this.restore();
+  }
 
   onChangeCheckbox(checkbox: Array<string>) {
     if (checkbox.includes('screenLock')) {
@@ -26,5 +37,10 @@ export class SamplePoLoadingOverlayLabsComponent {
         this.properties = [];
       }, 2000);
     }
+  }
+
+  restore() {
+    this.size = 'lg';
+    this.text = null;
   }
 }


### PR DESCRIPTION
**po-listbox**

**DTHFUI-8490**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente loading-overlay não está respeitando as dimensões do po-listbox.

**Qual o novo comportamento?**
Ajusta dimensões do loading-overlay no componente po-listbox.

**Simulação**
[DTHFUI-8490_simulacao.zip](https://github.com/user-attachments/files/16630083/DTHFUI-8490_simulacao.zip)

