### PR TITLE
feat(stepper): implementa definições do AnimaliaDS

### DIFF
--- a/projects/ui/src/lib/components/po-stepper/po-step/po-step.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-step/po-step.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Component, ElementRef, Input } from '@angular/core';
+import { AfterContentInit, Component, ElementRef, Input, TemplateRef } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { uuid } from '../../../utils/util';
@@ -75,7 +75,7 @@ export class PoStepComponent implements AfterContentInit {
     | ((currentStep) => Observable<boolean>);
 
   /** Título que será exibido descrevendo o passo (*step*). */
-  @Input('p-label') label: string;
+  @Input('p-label') label: string = '';
 
   // ID do step
   id?: string = uuid();
@@ -92,6 +92,42 @@ export class PoStepComponent implements AfterContentInit {
   get status() {
     return this._status;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   * Define o ícone padrão do step em seu status *default*.
+   * Esta propriedade permite usar ícones da [Biblioteca de ícones](/guides/icons) ou da biblioteca [Phosphor](https://phosphoricons.com/).
+   *
+   * Exemplo usando a biblioteca de ícones padrão:
+   * ```
+   * <po-stepper>
+   *    ...
+   *    <po-step p-icon-default="po-icon po-icon-pin"></po-step>
+   * </po-stepper>
+   * ```
+   * Exemplo usando a biblioteca *Phosphor*:
+   * ```
+   * <po-stepper>
+   *    ...
+   *    <po-step p-icon-default="ph ph-map-pin"></po-step>
+   * </po-stepper>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-stepper>
+   *    ...
+   *    <po-step [p-icon-default]="template"></po-step>
+   * </po-stepper>
+   *
+   * <ng-template #template>
+   *    <i class="ph ph-shopping-cart"></i>
+   * </ng-template
+   * ```
+   * > Deve-se usar `font-size: inherit` para ajustar ícones que não se ajustam automaticamente.
+   */
+  @Input('p-icon-default') iconDefault?: string | TemplateRef<void>;
 
   constructor(private elementRef: ElementRef) {}
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Input, Output, Directive } from '@angular/core';
+import { EventEmitter, Input, Output, Directive, TemplateRef } from '@angular/core';
 
 import { convertToBoolean } from '../../utils/util';
 
@@ -49,6 +49,34 @@ const poStepperOrientationDefault = PoStepperOrientation.Horizontal;
  *
  * - Evite `labels` extensos que quebram o layout do `po-stepper`, use `labels` diretos, curtos e intuitivos.
  * - Utilize apenas um `po-stepper` por página.
+ *
+ * #### Tokens customizáveis
+ *
+ * É possível alterar o estilo do componente usando os seguintes tokens (CSS):
+ *
+ * > Para maiores informações, acesse o guia [Personalizando o Tema Padrão com Tokens CSS](https://po-ui.io/guides/theme-customization).
+ *
+ * | Propriedade                              | Descrição                                             | Valor Padrão                                      |
+ * |------------------------------------------|-------------------------------------------------------|---------------------------------------------------|
+ * | **Label**                                |                                                       |                                                   |
+ * | `--font-family`                          | Família tipográfica usada                             | `var(--font-family-theme)`                        |
+ * | `--font-size`                            | Tamanho da fonte                                      | `var(--font-size-default)`                        |
+ * | `--font-weight`                          | Peso da fonte                                         | `var(--font-weight-normal)`                       |
+ * | **Step - Done**                          |                                                       |                                                   |
+ * | `--text-color`                           | Cor do texto no step concluído                        | `var(--color-neutral-dark-70)`                    |
+ * | `--color-icon-done`                      | Cor do ícone no step concluído                        | `var(--color-neutral-dark-70)`                    |
+ * | `--background-done`                      | Cor de fundo no step concluído                        | `var(--color-neutral-light-00)`                   |
+ * | **Line - Done**                          |                                                       |                                                   |
+ * | `--color-line-done`                      | Cor da linha no step concluído                        | `var(--color-neutral-mid-40)`                     |
+ * | **Step - Current**                       |                                                       |                                                   |
+ * | `--color-icon-current`                   | Cor do ícone no step atual                            | `var(--color-neutral-light-00)`                   |
+ * | `--background-current`                   | Cor de fundo no step atual                            | `var(--color-action-default)`                     |
+ * | `--font-weight-current`                  | Peso da fonte no step atual                           | `var(--font-weight-bold)`                         |
+ * | **Step - Next**                          |                                                       |                                                   |
+ * | `--font-size-circle`                     | Tamanho da fonte no círculo do próximo step           | `var(--font-size-sm)`                             |
+ * | `--color-next`                           | Cor do ícone no próximo step                          | `var(--color-action-disabled)`                    |
+ * | `--text-color-next`                      | Cor do texto no próximo step                          | `var(--color-neutral-light-30)`                   |
+ *
  */
 @Directive()
 export class PoStepperBaseComponent {
@@ -171,4 +199,66 @@ export class PoStepperBaseComponent {
   get sequential(): boolean {
     return this._sequential;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   * Permite definir o ícone do step no status *done* (concluído).
+   * Esta propriedade permite usar ícones da [Biblioteca de ícones](/guides/icons) ou da biblioteca [Phosphor](https://phosphoricons.com/).
+   *
+   * Exemplo usando a biblioteca de ícones padrão:
+   * ```
+   * <po-stepper p-step-icon-done="po-icon po-icon-eye">
+   *    ...
+   * </po-stepper>
+   * ```
+   * Exemplo usando a biblioteca *Phosphor*:
+   * ```
+   * <po-stepper p-step-icon-done="ph ph-check-circle">
+   *    ...
+   * </po-stepper>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-stepper [p-step-icon-done]="doneIcon">
+   *    ...
+   * </po-stepper>
+   *
+   * <ng-template #doneIcon>
+   *    <i class="ph ph-check-fat"></i>
+   * </ng-template>
+   * ```
+   * > Deve-se usar `font-size: inherit` para ajustar ícones que não se ajustam automaticamente.
+   *
+   * @default `po-icon-ok`
+   */
+  @Input('p-step-icon-done') iconDone?: string | TemplateRef<void>;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Permite definir o ícone do step no status *active* (ativo).
+   * Esta propriedade permite usar ícones da [Biblioteca de ícones](/guides/icons) ou da biblioteca [Phosphor](https://phosphoricons.com/).
+   *
+   * Exemplo usando a biblioteca de ícones padrão:
+   * ```
+   * <po-stepper p-step-icon-active="po-icon po-icon-settings">
+   *    ...
+   * </po-stepper>
+   * ```
+   * Exemplo usando a biblioteca *Phosphor*:
+   * ```
+   * <po-stepper p-step-icon-active="ph ph-pencil-simple-line">
+   *    ...
+   * </po-stepper>
+   * ```
+   * Para customizar o ícone através do `TemplateRef`, veja a documentação da propriedade `p-step-icon-done`.
+   *
+   * > Deve-se usar `font-size: inherit` para ajustar ícones que não se ajustam automaticamente.
+   *
+   * @default `po-icon-edit`
+   */
+  @Input('p-step-icon-active') iconActive?: string | TemplateRef<void>;
 }

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.html
@@ -1,22 +1,30 @@
-<div class="po-stepper-circle" [style.height.px]="size" [style.width.px]="size" [tabindex]="isDisabled ? -1 : 0">
-  <po-icon
-    *ngIf="!isActive"
-    class="po-stepper-circle-content"
-    [class.po-icon]="icons || isDone"
-    [p-icon]="
-      icons && isError
-        ? 'ICON_EXCLAMATION'
-        : icons && (isActive || isDefault || isDisabled)
-          ? 'ICON_INFO'
-          : isDone
-            ? 'ICON_OK'
-            : ''
-    "
-    [class.po-stepper-circle-content-lg]="isLargeStep"
-    [class.po-stepper-circle-content-md]="isMediumStep"
-  >
-    {{ !icons && !isDone ? content : '' }}
-  </po-icon>
-
-  <div *ngIf="isActive || isError" class="po-stepper-circle-active"></div>
+<div
+  class="po-stepper-circle"
+  [ngClass]="{ 'po-stepper-circle-border': !isActive && !isError, 'po-stepper-circle-done': isDone }"
+  [style.height.px]="size"
+  [style.width.px]="size"
+>
+  <ng-container *ngIf="isActive || isError; else defaultContent">
+    <div class="po-stepper-circle-active">
+      <po-icon
+        class="po-stepper-circle-content"
+        [class.po-stepper-circle-content-lg]="isLargeStep"
+        [class.po-stepper-circle-content-md]="isMediumStep"
+        [class.po-icon]="true"
+        [p-icon]="iconActive ? iconActive : 'ICON_EDIT'"
+      ></po-icon>
+    </div>
+  </ng-container>
+  <ng-template #defaultContent>
+    <po-icon
+      *ngIf="!isActive"
+      class="po-stepper-circle-content"
+      [class.po-icon]="icons || isDone"
+      [p-icon]="isDone ? iconDone || 'ICON_OK' : iconDefault ? iconDefault : icons ? 'ICON_INFO' : ''"
+      [class.po-stepper-circle-content-lg]="isLargeStep"
+      [class.po-stepper-circle-content-md]="isMediumStep"
+    >
+      {{ !icons && !isDone && !iconDefault ? content : '' }}
+    </po-icon>
+  </ng-template>
 </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.spec.ts
@@ -168,24 +168,6 @@ describe('PoStepperCircleComponent:', () => {
   });
 
   describe('Templates:', () => {
-    it('should change `tabindex` to `-1` if component is disabled', () => {
-      component.status = PoStepperStatus.Disabled;
-      fixture.detectChanges();
-
-      const poStepperCircleElement = nativeElement.querySelector('.po-stepper-circle[tabindex="-1"]');
-
-      expect(poStepperCircleElement).toBeTruthy();
-    });
-
-    it('should change `tabindex` to `0` if component isn`t disabled', () => {
-      component.status = PoStepperStatus.Active;
-      fixture.detectChanges();
-
-      const poStepperCircleElement = nativeElement.querySelector('.po-stepper-circle[tabindex="0"]');
-
-      expect(poStepperCircleElement).toBeTruthy();
-    });
-
     it('should find `po-stepper-circle-content-md` in `span` if `isMediumStep` is `true`.', () => {
       spyOnProperty(component, 'isMediumStep').and.returnValue(true);
 
@@ -206,61 +188,21 @@ describe('PoStepperCircleComponent:', () => {
       expect(stepperCircleContentLg).toBeTruthy();
     });
 
-    it('shouldn`t find `po-stepper-circle-content` if `isActive` is true', () => {
-      spyOnProperty(component, 'isActive').and.returnValue(true);
-
-      fixture.detectChanges();
-
-      const stepperCircleContent = nativeElement.querySelector('.po-stepper-circle-content');
-
-      expect(stepperCircleContent).toBeNull();
-    });
-
-    it('shouldn`t find `po-stepper-circle-with-icon` and `po-icon` if `icons` is `false`.', () => {
-      component.icons = false;
-
-      fixture.detectChanges();
-      const StepperCircleWitchIcon = nativeElement.querySelector('.po-stepper-circle-with-icon');
-      const iconClass = nativeElement.querySelector('.po-icon');
-
-      expect(StepperCircleWitchIcon).toBeNull();
-      expect(iconClass).toBeNull();
-    });
-
-    it('should find `po-icon-info` if `status` is `Active`, `Default` or `Disabled` and `icons` is true.', () => {
-      component.icons = true;
-
+    it('should have `po-stepper-circle-border` when not active and not error', () => {
       component.status = PoStepperStatus.Default;
       fixture.detectChanges();
-      expect(PoIconInfo()).toBeTruthy();
 
-      component.status = PoStepperStatus.Disabled;
-      fixture.detectChanges();
-      expect(PoIconInfo()).toBeTruthy();
-
-      component.status = PoStepperStatus.Error;
-      fixture.detectChanges();
-      expect(PoIconInfo()).toBeNull();
+      const circleElement = fixture.nativeElement.querySelector('.po-stepper-circle');
+      expect(circleElement.classList).toContain('po-stepper-circle-border');
+      expect(circleElement.classList).not.toContain('po-stepper-circle-done');
     });
 
-    it('should find `po-icon` if `isDone` is true.', () => {
-      component.icons = false;
-      spyOnProperty(component, 'isDone').and.returnValue(true);
-
+    it('should have `po-stepper-circle-done` when isDone', () => {
+      component.status = PoStepperStatus.Done;
       fixture.detectChanges();
 
-      const poIcon = nativeElement.querySelector('.po-icon');
-      expect(poIcon).toBeTruthy();
-    });
-
-    it('shouldn`t find `po-icon` if `isDone` and `icons` is false.', () => {
-      component.icons = false;
-      spyOnProperty(component, 'isDone').and.returnValue(false);
-
-      fixture.detectChanges();
-
-      const poIcon = nativeElement.querySelector('.po-icon');
-      expect(poIcon).toBeNull();
+      const circleElement = fixture.nativeElement.querySelector('.po-stepper-circle');
+      expect(circleElement.classList).toContain('po-stepper-circle-done');
     });
 
     it('should find `po-stepper-circle-active` if `isActive` is true.', () => {
@@ -296,52 +238,165 @@ describe('PoStepperCircleComponent:', () => {
       expect(stepperCircleActive).toBeNull();
     });
 
-    it('should find `po-icon-ok` if `status` is `Done` and `icons` is true.', () => {
-      component.icons = true;
+    it('should find `po-icon` if `isDone` is true.', () => {
+      component.icons = false;
+      spyOnProperty(component, 'isDone').and.returnValue(true);
 
-      component.status = PoStepperStatus.Done;
       fixture.detectChanges();
-      expect(PoIconOk()).toBeTruthy();
 
-      component.status = PoStepperStatus.Default;
-      fixture.detectChanges();
-      expect(PoIconOk()).toBeNull();
-
-      component.status = PoStepperStatus.Disabled;
-      fixture.detectChanges();
-      expect(PoIconOk()).toBeNull();
-
-      component.status = PoStepperStatus.Error;
-      fixture.detectChanges();
-      expect(PoIconOk()).toBeNull();
+      const poIcon = nativeElement.querySelector('.po-icon');
+      expect(poIcon).toBeTruthy();
     });
 
-    it('should find `icon-exclamation` if `status` is `Error` and `icons` is true.', () => {
-      component.icons = true;
+    it('shouldn`t find `po-icon` if `isDone` and `icons` is false.', () => {
+      component.icons = false;
+      spyOnProperty(component, 'isDone').and.returnValue(false);
 
-      component.status = PoStepperStatus.Error;
       fixture.detectChanges();
-      expect(PoIconExclamation()).toBeTruthy();
 
+      const poIcon = nativeElement.querySelector('.po-icon');
+      expect(poIcon).toBeNull();
+    });
+
+    it('should apply `iconActive` from Phosphor library if `status` is `Active` and `iconActive` is set.', () => {
+      component.status = PoStepperStatus.Active;
+      component.iconActive = 'ph ph-anchor';
+      fixture.detectChanges();
+
+      const activeIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(activeIcon).toBeTruthy();
+      expect(activeIcon.classList.contains('ph-anchor')).toBeTrue();
+    });
+
+    it('should apply `iconActive` from Icons library if `status` is `Active` and `iconActive` is set.', () => {
+      component.status = PoStepperStatus.Active;
+      component.iconActive = 'po-icon po-icon-device-notebook';
+      fixture.detectChanges();
+
+      const activeIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(activeIcon).toBeTruthy();
+      expect(activeIcon.classList.contains('po-icon-device-notebook')).toBeTrue();
+    });
+
+    it('should apply `ICON_EDIT` if `status` is `Active` and `iconActive` is not set.', () => {
+      component.status = PoStepperStatus.Active;
+      component.iconActive = undefined;
+      fixture.detectChanges();
+
+      const activeIcon = PoIconEdit();
+
+      expect(activeIcon).toBeTruthy();
+      expect(activeIcon.classList.contains('ph-pencil-simple')).toBeTrue();
+    });
+
+    it('should apply `iconDone` from Phosphor library if `status` is `Done` and `iconDone` is set.', () => {
+      component.status = PoStepperStatus.Done;
+      component.iconDone = 'ph ph-check-circle';
+      fixture.detectChanges();
+
+      const doneIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+
+      expect(doneIcon).toBeTruthy();
+      expect(doneIcon.classList.contains('ph-check-circle')).toBeTrue();
+    });
+
+    it('should apply `iconDone` from Icons library if `status` is `Done` and `iconDone` is set.', () => {
+      component.status = PoStepperStatus.Done;
+      component.iconDone = 'po-icon-clock';
+      fixture.detectChanges();
+
+      const doneIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+
+      expect(doneIcon.classList.contains('po-icon-clock')).toBeTrue();
+    });
+
+    it('should apply `ICON_OK` if `status` is `Done` and `iconDone` is not set.', () => {
+      component.status = PoStepperStatus.Done;
+      component.iconDone = undefined;
+      fixture.detectChanges();
+
+      const doneIcon = PoIconOk;
+      expect(doneIcon).toBeTruthy();
+    });
+
+    it('should apply `iconDefault` from Phosphor library if `status` is `Default` or `Disabled` and `iconDefault` is set.', () => {
       component.status = PoStepperStatus.Default;
+      component.iconDefault = 'ph ph-first-aid';
       fixture.detectChanges();
-      expect(PoIconExclamation()).toBeNull();
+
+      let defaultIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('ph-first-aid')).toBeTrue();
 
       component.status = PoStepperStatus.Disabled;
       fixture.detectChanges();
-      expect(PoIconExclamation()).toBeNull();
+
+      defaultIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('ph-first-aid')).toBeTrue();
+    });
+
+    it('should apply `iconDefault` from Icons library if `status` is `Default` or `Disabled` and `iconDefault` is set.', () => {
+      component.status = PoStepperStatus.Default;
+      component.iconDefault = 'po-icon po-icon-user';
+      fixture.detectChanges();
+
+      let defaultIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('po-icon-user')).toBeTrue();
+
+      component.status = PoStepperStatus.Disabled;
+      fixture.detectChanges();
+
+      defaultIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('po-icon-user')).toBeTrue();
+    });
+
+    it('should apply `ICON_INFO` if `status` is `Default` or `Disabled`, `iconDefault` is not set, and `icons` is true.', () => {
+      component.status = PoStepperStatus.Default;
+      component.iconDefault = undefined;
+      component.icons = true;
+      fixture.detectChanges();
+
+      const defaultIcon = PoIconInfo();
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('ph-info')).toBeTrue();
+
+      component.status = PoStepperStatus.Disabled;
+      fixture.detectChanges();
+
+      const disabledIcon = PoIconInfo();
+      expect(disabledIcon).toBeTruthy();
+      expect(disabledIcon.classList.contains('ph-info')).toBeTrue();
+    });
+
+    it('should display an empty string if `status` is `Default` or `Disabled`, `iconDefault` is not set, and `icons` is false.', () => {
+      component.status = PoStepperStatus.Default;
+      component.iconDefault = undefined;
+      component.icons = false;
+      fixture.detectChanges();
+
+      const defaultIcon = nativeElement.querySelector('.po-stepper-circle-content');
+      expect(defaultIcon.textContent.trim()).toBe('');
+
+      component.status = PoStepperStatus.Disabled;
+      fixture.detectChanges();
+
+      const disabledIcon = nativeElement.querySelector('.po-stepper-circle-content');
+      expect(disabledIcon.textContent.trim()).toBe('');
     });
   });
 
   function PoIconInfo() {
-    return nativeElement.querySelector('.po-icon-info');
+    return nativeElement.querySelector('po-icon')?.querySelector('i.ph.ph-info');
   }
 
   function PoIconOk() {
     return nativeElement.querySelector('.po-icon-ok');
   }
 
-  function PoIconExclamation() {
-    return nativeElement.querySelector('.po-icon-exclamation');
+  function PoIconEdit() {
+    return nativeElement.querySelector('po-icon')?.querySelector('i.ph-pencil-simple');
   }
 });

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, TemplateRef } from '@angular/core';
 
 import { PoStepperStatus } from '../enums/po-stepper-status.enum';
 
@@ -28,6 +28,15 @@ export class PoStepperCircleComponent {
 
   // Status do *step*.
   @Input('p-status') status: string;
+
+  // Ícone para o status default do *step*.
+  @Input('p-icon-default') iconDefault?: string | TemplateRef<void>;
+
+  // Ícone para o status Done do *step*.
+  @Input('p-step-icon-done') iconDone?: string | TemplateRef<void>;
+
+  // Ícone para o status Active do *step*.
+  @Input('p-step-icon-active') iconActive?: string | TemplateRef<void>;
 
   get isActive(): boolean {
     return this.status === PoStepperStatus.Active;

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-item.interface.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-item.interface.ts
@@ -1,3 +1,4 @@
+import { TemplateRef } from '@angular/core';
 import { PoStepperStatus } from './enums/po-stepper-status.enum';
 
 /**
@@ -9,8 +10,17 @@ import { PoStepperStatus } from './enums/po-stepper-status.enum';
  */
 export interface PoStepperItem {
   /** Texto do item do stepper. */
-  label: string;
+  label?: string;
 
   /** Define o estado de exibição do *step*. */
   status?: PoStepperStatus;
+
+  /** Define o ícone Default do *step*. */
+  iconDefault?: string | TemplateRef<void>;
+
+  /** Define o ícone Active do *step*. */
+  iconActive?: string | TemplateRef<void>;
+
+  /** Define o ícone Done do *step*. */
+  iconDone?: string | TemplateRef<void>;
 }

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.html
@@ -1,3 +1,16 @@
-<div class="po-stepper-label">
+<div
+  [ngClass]="{
+    'po-stepper-label-vertical': isVerticalOrientation,
+    'po-stepper-label-active': status === 'active' || status === 'error',
+    'po-stepper-label': content && content.length > 0,
+    'po-stepper-label-none': !content || content.length === 0,
+    'po-stepper-label-done': status === 'done',
+    'po-link': status !== 'disabled'
+  }"
+  #labelElement
+  [p-tooltip]="tooltipContent"
+  (mouseover)="onMouseOver()"
+  (mouseout)="onMouseOut()"
+>
   {{ content }}
 </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { configureTestSuite } from './../../../util-test/util-expect.spec';
-
 import { PoStepperLabelComponent } from './po-stepper-label.component';
+import { configureTestSuite } from '../../../util-test/util-expect.spec';
 import { PoStepperModule } from '../po-stepper.module';
+import { By } from '@angular/platform-browser';
+import { SimpleChange } from '@angular/core';
 
 describe('PoStepperLabelComponent: ', () => {
   let component: PoStepperLabelComponent;
@@ -24,5 +25,272 @@ describe('PoStepperLabelComponent: ', () => {
 
   it('should be created', () => {
     expect(component instanceof PoStepperLabelComponent).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+    it('should set content property correctly', () => {
+      component.content = 'Step 1';
+      fixture.detectChanges();
+      expect(component.content).toBe('Step 1');
+    });
+
+    it('should handle vertical orientation property', () => {
+      component.isVerticalOrientation = true;
+      fixture.detectChanges();
+      expect(component.isVerticalOrientation).toBeTrue();
+    });
+
+    it('should handle status property', () => {
+      component.status = 'active';
+      fixture.detectChanges();
+      expect(component.status).toBe('active');
+    });
+  });
+
+  describe('Methods:', () => {
+    it('should call `updateLabel` and detectChanges when content changes', () => {
+      const updateLabelSpy = spyOn(component as any, 'updateLabel').and.callThrough();
+
+      const changes = {
+        content: new SimpleChange(null, 'Step 1', true),
+        isVerticalOrientation: null
+      };
+
+      component.ngOnChanges(changes);
+
+      fixture.detectChanges();
+
+      expect(updateLabelSpy).toHaveBeenCalled();
+    });
+
+    it('should call `updateLabel` and detectChanges when isVerticalOrientation changes', () => {
+      const updateLabelSpy = spyOn(component as any, 'updateLabel').and.callThrough();
+
+      const changes = {
+        content: null,
+        isVerticalOrientation: new SimpleChange(null, true, true)
+      };
+
+      component.ngOnChanges(changes);
+
+      fixture.detectChanges();
+
+      expect(updateLabelSpy).toHaveBeenCalled();
+    });
+
+    it('should call updateLabel and detectChanges when both content and isVerticalOrientation change', () => {
+      const updateLabelSpy = spyOn(component as any, 'updateLabel').and.callThrough();
+
+      const changes = {
+        content: new SimpleChange(null, 'New Content', true),
+        isVerticalOrientation: new SimpleChange(null, true, true)
+      };
+
+      component.ngOnChanges(changes);
+
+      fixture.detectChanges();
+
+      expect(updateLabelSpy).toHaveBeenCalled();
+    });
+
+    it('should not update label if labelElement is null', () => {
+      const updateLabelSpy = spyOn<any>(component, 'updateLabel').and.callThrough();
+      component.labelElement = null;
+
+      (component as any).updateLabel();
+
+      expect(updateLabelSpy).toHaveBeenCalled();
+      expect(component.tooltipContent).toBeNull();
+    });
+
+    it('should truncate content and show tooltip when isVerticalOrientation is true and content length exceeds maxLabelLength', () => {
+      const labelElement = document.createElement('div');
+      component.labelElement = { nativeElement: labelElement } as any;
+
+      component.content = 'This is a long content that needs truncation';
+      component.isVerticalOrientation = true;
+      (component as any).maxLabelLength = 20;
+
+      labelElement.style.width = '150px';
+      labelElement.style.whiteSpace = 'nowrap';
+
+      (component as any).updateLabel();
+      fixture.detectChanges();
+
+      expect(labelElement.innerText.trim()).toBe('This is a long conte...');
+      expect(component.tooltipContent).toBe(component.content);
+    });
+
+    it('should set tooltipContent to content if text overflows horizontally', () => {
+      const labelElement = document.createElement('div');
+      component.labelElement = { nativeElement: labelElement } as any;
+
+      component.content = 'Content that will overflow horizontally';
+      component.isVerticalOrientation = false;
+      (component as any).maxLabelLength = 50;
+
+      Object.defineProperty(labelElement, 'scrollWidth', { value: 200 });
+      Object.defineProperty(labelElement, 'clientWidth', { value: 50 });
+
+      (component as any).updateTooltip();
+
+      expect(component.tooltipContent).toBe(component.content);
+    });
+
+    it('should set tooltipContent to null if content length does not exceed maxLabelLength and no text overflow', () => {
+      const labelElement = document.createElement('div');
+      component.labelElement = { nativeElement: labelElement } as any;
+
+      component.content = 'Short content';
+      component.isVerticalOrientation = true;
+      (component as any).maxLabelLength = 20;
+
+      Object.defineProperty(labelElement, 'scrollWidth', { value: 50 });
+      Object.defineProperty(labelElement, 'clientWidth', { value: 50 });
+      Object.defineProperty(labelElement, 'scrollHeight', { value: 20 });
+      Object.defineProperty(labelElement, 'clientHeight', { value: 20 });
+
+      (component as any).updateTooltip();
+
+      expect(component.tooltipContent).toBeNull();
+    });
+
+    it('should set tooltipContent to content if content length exceeds maxLabelLength', () => {
+      const labelElement = document.createElement('div');
+      component.labelElement = { nativeElement: labelElement } as any;
+
+      component.content = 'This is a long content that needs truncation';
+      component.isVerticalOrientation = true;
+      (component as any).maxLabelLength = 20;
+
+      Object.defineProperty(labelElement, 'scrollWidth', { value: 50 });
+      Object.defineProperty(labelElement, 'clientWidth', { value: 50 });
+      Object.defineProperty(labelElement, 'scrollHeight', { value: 20 });
+      Object.defineProperty(labelElement, 'clientHeight', { value: 20 });
+
+      (component as any).updateTooltip();
+
+      expect(component.tooltipContent).toBe(component.content);
+    });
+
+    it('should call updateTooltip and add class on mouseover', () => {
+      const updateTooltipSpy = spyOn<any>(component, 'updateTooltip').and.callThrough();
+      const addClassSpy = spyOn((component as any).renderer, 'addClass').and.callThrough();
+
+      component.onMouseOver();
+
+      expect(updateTooltipSpy).toHaveBeenCalled();
+      expect(addClassSpy).toHaveBeenCalledWith(component.labelElement.nativeElement, 'hovered');
+    });
+
+    it('should remove class on mouseout', () => {
+      const removeClassSpy = spyOn((component as any).renderer, 'removeClass').and.callThrough();
+
+      component.onMouseOut();
+
+      expect(removeClassSpy).toHaveBeenCalledWith(component.labelElement.nativeElement, 'hovered');
+    });
+
+    it('should set tooltipContent to content if text overflows vertically', () => {
+      const labelElement = document.createElement('div');
+      component.labelElement = { nativeElement: labelElement } as any;
+
+      component.content = 'Content that will overflow vertically';
+      component.isVerticalOrientation = false;
+      (component as any).maxLabelLength = 50;
+
+      Object.defineProperty(labelElement, 'scrollHeight', { value: 100 });
+      Object.defineProperty(labelElement, 'clientHeight', { value: 20 });
+
+      (component as any).updateTooltip();
+
+      expect(component.tooltipContent).toBe(component.content);
+    });
+  });
+
+  describe('Templates:', () => {
+    it('should apply `po-stepper-label-vertical` when isVerticalOrientation is true', () => {
+      component.isVerticalOrientation = true;
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-vertical')).toBeTrue();
+    });
+
+    it('should apply `po-stepper-label-active` when status is active', () => {
+      component.status = 'active';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-active')).toBeTrue();
+    });
+
+    it('should apply `po-stepper-label-active` when status is error', () => {
+      component.status = 'error';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-active')).toBeTrue();
+    });
+
+    it('should apply `po-stepper-label` when content is set', () => {
+      component.content = 'Step 1';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label')).toBeTrue();
+      expect(element.nativeElement.classList.contains('po-stepper-label-none')).toBeFalse();
+    });
+
+    it('should apply `po-stepper-label-none` when content is not set', () => {
+      component.content = '';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-none')).toBeTrue();
+      expect(element.nativeElement.classList.contains('po-stepper-label')).toBeFalse();
+    });
+
+    it('should apply `po-stepper-label-none` when content is null', () => {
+      component.content = null;
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-none')).toBeTrue();
+      expect(element.nativeElement.classList.contains('po-stepper-label')).toBeFalse();
+    });
+
+    it('should apply `po-stepper-label-done` when status is done', () => {
+      component.status = 'done';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-done')).toBeTrue();
+    });
+
+    it('should add `po-link` class when status is not `disabled`.', () => {
+      component.status = 'active';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-link')).toBeTrue();
+    });
+
+    it('should not add `po-link` class when status is `disabled`.', () => {
+      component.status = 'disabled';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-link')).toBeFalse();
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.ts
@@ -1,4 +1,15 @@
-import { Component, Input } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  HostListener,
+  Input,
+  OnChanges,
+  Renderer2,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 
 /**
  * @docsPrivate
@@ -11,7 +22,75 @@ import { Component, Input } from '@angular/core';
   selector: 'po-stepper-label',
   templateUrl: './po-stepper-label.component.html'
 })
-export class PoStepperLabelComponent {
+export class PoStepperLabelComponent implements AfterViewInit, OnChanges {
   // Conteúdo da label.
   @Input('p-content') content: string;
+  @Input() isVerticalOrientation: boolean;
+  @Input() status: string;
+
+  @ViewChild('labelElement') labelElement: ElementRef;
+
+  tooltipContent: string;
+
+  private maxLabelLength: number = 100;
+
+  constructor(
+    private renderer: Renderer2,
+    private changeDetectorRef: ChangeDetectorRef
+  ) {}
+
+  ngAfterViewInit() {
+    this.updateLabel();
+    this.changeDetectorRef.detectChanges();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['content'] || changes['isVerticalOrientation']) {
+      this.updateLabel();
+      this.changeDetectorRef.detectChanges();
+    }
+  }
+
+  private updateLabel(): void {
+    if (!this.labelElement) return;
+
+    const element = this.labelElement.nativeElement;
+    const originalContent = this.content;
+    let displayedContent = originalContent;
+
+    if (this.isVerticalOrientation && originalContent.length > this.maxLabelLength) {
+      displayedContent = originalContent.substring(0, this.maxLabelLength) + '...';
+    }
+
+    this.renderer.setProperty(element, 'innerText', displayedContent);
+
+    const isTextOverflowing = element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight;
+
+    this.tooltipContent =
+      isTextOverflowing || (this.isVerticalOrientation && originalContent.length > this.maxLabelLength)
+        ? originalContent
+        : null;
+  }
+
+  @HostListener('mouseover')
+  onMouseOver() {
+    this.updateTooltip();
+    this.renderer.addClass(this.labelElement.nativeElement, 'hovered');
+  }
+
+  @HostListener('mouseout')
+  onMouseOut() {
+    this.renderer.removeClass(this.labelElement.nativeElement, 'hovered');
+  }
+
+  private updateTooltip(): void {
+    if (this.labelElement) {
+      const element = this.labelElement.nativeElement;
+      const isTextOverflowing =
+        element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight;
+      const isTextTooLong = this.isVerticalOrientation && this.content.length > this.maxLabelLength;
+
+      this.tooltipContent = isTextOverflowing || isTextTooLong ? this.content : null;
+    }
+  }
 }

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
@@ -1,12 +1,30 @@
-<div class="po-stepper-step" [ngClass]="getStatusClass(status)" (click)="onClick()" (keydown.enter)="onEnter()">
-  <div class="po-stepper-step-container" [style.width.px]="isVerticalOrientation ? stepSize : undefined">
+<div
+  class="po-stepper-step"
+  [ngClass]="getStatusClass(status)"
+  (click)="onClick()"
+  (keydown.enter)="onEnter()"
+  [tabindex]="status === 'disabled' ? -1 : 0"
+  role="tab"
+  [attr.aria-selected]="status === 'active'"
+  [attr.aria-disabled]="status === 'disabled'"
+  [attr.aria-invalid]="status === 'error'"
+>
+  <div class="po-stepper-step-container" [style.width.px]="isVerticalOrientation ? stepSize : null">
     <div
       [class.po-stepper-step-bar-top]="isVerticalOrientation"
       [class.po-stepper-step-bar-left]="!isVerticalOrientation"
       [style.margin-right.px]="marginHorizontalBar"
     ></div>
 
-    <po-stepper-circle [p-content]="circleContent" [p-icons]="stepIcons" [p-size]="stepSize" [p-status]="status">
+    <po-stepper-circle
+      [p-content]="circleContent"
+      [p-icons]="stepIcons"
+      [p-size]="stepSize"
+      [p-status]="status"
+      [p-icon-default]="iconDefault"
+      [p-step-icon-done]="iconDone"
+      [p-step-icon-active]="iconActive"
+    >
     </po-stepper-circle>
 
     <div
@@ -18,5 +36,11 @@
     ></div>
   </div>
 
-  <po-stepper-label class="po-stepper-step-label-position" [p-content]="label"> </po-stepper-label>
+  <po-stepper-label
+    class="po-stepper-step-label-position"
+    [p-content]="label"
+    [isVerticalOrientation]="isVerticalOrientation"
+    [status]="status"
+  >
+  </po-stepper-label>
 </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.spec.ts
@@ -212,6 +212,32 @@ describe('PoStepperStepComponent:', () => {
 
       expect(component.enter.emit).not.toHaveBeenCalled();
     });
+
+    it('setDefaultStepSize: should increase step size by 8px if status is `Active` and step size is default.', () => {
+      (component as any)._stepSize = 24;
+      component.status = PoStepperStatus.Active;
+
+      component.setDefaultStepSize();
+
+      expect((component as any)._stepSize).toBe(32);
+    });
+
+    it('setDefaultStepSize: should increase step size by 8px if status is `Error` and stepSizeOriginal is default.', () => {
+      component.stepSizeOriginal = 24;
+      component.status = PoStepperStatus.Error;
+
+      component.setDefaultStepSize();
+
+      expect((component as any)._stepSize).toBe(32);
+    });
+
+    it('setDefaultStepSize: should keep the original step size if step size is not default.', () => {
+      component.stepSizeOriginal = 64;
+
+      component.setDefaultStepSize();
+
+      expect((component as any)._stepSize).toBe(64);
+    });
   });
 
   describe('Templates:', () => {
@@ -220,7 +246,7 @@ describe('PoStepperStepComponent:', () => {
     it(`should find 'po-stepper-step-container' and style.width is stepSize value if 'isVerticalOrientation' is 'true'.`, () => {
       component.orientation = PoStepperOrientation.Vertical;
       component.stepSize = 60;
-
+      component.label = '';
       fixture.detectChanges();
 
       const stepperContainer = elementByClass('po-stepper-step-container');
@@ -365,13 +391,32 @@ describe('PoStepperStepComponent:', () => {
 
     it(`should create class 'po-stepper-step-dashed-border-vertical' if 'nextStatus' is disabled and position is vertical`, () => {
       component.orientation = PoStepperOrientation.Vertical;
-      component.nextStatus = 'disabled';
+      component.nextStatus = PoStepperStatus.Disabled;
+      component.label = '';
 
       fixture.detectChanges();
 
       const stepperDashedBorderVertical = elementByClass('po-stepper-step-dashed-border-vertical');
 
       expect(stepperDashedBorderVertical).toBeTruthy();
+    });
+
+    it('should change `tabindex` to `-1` if component is disabled', () => {
+      component.status = PoStepperStatus.Disabled;
+      fixture.detectChanges();
+
+      const poStepperStepElement = nativeElement.querySelector('.po-stepper-step[tabindex="-1"]');
+
+      expect(poStepperStepElement).toBeTruthy();
+    });
+
+    it('should change `tabindex` to `0` if component isn’t disabled', () => {
+      component.status = PoStepperStatus.Active;
+      fixture.detectChanges();
+
+      const poStepperStepElement = nativeElement.querySelector('.po-stepper-step[tabindex="0"]');
+
+      expect(poStepperStepElement).toBeTruthy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, TemplateRef } from '@angular/core';
 
 import { getShortBrowserLanguage, convertToBoolean, isTypeof } from './../../../utils/util';
 import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
@@ -24,7 +24,7 @@ const poStepLiteralsDefault = {
   selector: 'po-stepper-step',
   templateUrl: 'po-stepper-step.component.html'
 })
-export class PoStepperStepComponent {
+export class PoStepperStepComponent implements OnChanges {
   // Conteúdo que será repassado para o componente `p-circle-content` através da propriedade `p-content`.
   @Input('p-circle-content') circleContent: any;
 
@@ -48,10 +48,14 @@ export class PoStepperStepComponent {
     ...poStepLiteralsDefault[getShortBrowserLanguage()]
   };
 
+  stepSizeOriginal: number;
   private _label: string;
   private _status: PoStepperStatus;
   private _stepIcons?: boolean = false;
   private _stepSize: number = poStepperStepSizeDefault;
+  private _iconDefault?: string | TemplateRef<void>;
+  private _iconDone?: string | TemplateRef<void>;
+  private _iconActive?: string | TemplateRef<void>;
 
   // Label do *step*.
   @Input('p-label') set label(value: string) {
@@ -106,6 +110,40 @@ export class PoStepperStepComponent {
     return this.isVerticalOrientation ? undefined : this.halfStepSize;
   }
 
+  @Input('p-icon-default') set iconDefault(value: string | TemplateRef<void>) {
+    this._iconDefault = value;
+  }
+
+  get iconDefault(): string | TemplateRef<void> {
+    return this._iconDefault;
+  }
+
+  @Input('p-step-icon-done') set iconDone(value: string | TemplateRef<void>) {
+    this._iconDone = value;
+  }
+
+  get iconDone(): string | TemplateRef<void> {
+    return this._iconDone;
+  }
+
+  @Input('p-step-icon-active') set iconActive(value: string | TemplateRef<void>) {
+    this._iconActive = value;
+  }
+
+  get iconActive(): string | TemplateRef<void> {
+    return this._iconActive;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.stepSizeOriginal === undefined || changes['stepSize']) {
+      this.stepSizeOriginal = this._stepSize;
+    }
+
+    if (changes['status'] || changes['stepSize']) {
+      this.setDefaultStepSize();
+    }
+  }
+
   getStatusClass(status: string): string {
     switch (status) {
       case PoStepperStatus.Active:
@@ -130,6 +168,16 @@ export class PoStepperStepComponent {
   onEnter(): void {
     if (this.status !== PoStepperStatus.Disabled) {
       this.enter.emit();
+    }
+  }
+
+  setDefaultStepSize(): void {
+    if (this._stepSize === poStepperStepSizeDefault && this._status === PoStepperStatus.Active) {
+      this._stepSize = poStepperStepSizeDefault + 8;
+    } else if (this.stepSizeOriginal === poStepperStepSizeDefault && this._status === PoStepperStatus.Error) {
+      this._stepSize = poStepperStepSizeDefault + 8;
+    } else {
+      this._stepSize = this.stepSizeOriginal;
     }
   }
 }

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
@@ -1,5 +1,5 @@
 <div class="po-stepper po-stepper-{{ orientation }}">
-  <div class="po-stepper-container">
+  <div class="po-stepper-container po-md-12" role="tablist">
     <po-stepper-step
       *ngFor="let step of stepList; let index = index; trackBy: trackByFn"
       class="po-stepper-step-position"
@@ -13,11 +13,14 @@
       (p-activated)="onStepActive(step)"
       (p-click)="changeStep(index, step)"
       (p-enter)="changeStep(index, step)"
+      [p-icon-default]="step.iconDefault"
+      [p-step-icon-active]="iconActive"
+      [p-step-icon-done]="iconDone"
     >
     </po-stepper-step>
   </div>
 
-  <div *ngIf="usePoSteps" class="po-stepper-content">
+  <div *ngIf="usePoSteps" class="po-stepper-content" [ngClass]="{ 'po-md-12': orientation === 'horizontal' }">
     <ng-content></ng-content>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.ts
@@ -200,6 +200,13 @@ export class PoStepperComponent extends PoStepperBaseComponent implements AfterC
     return canActiveNextStep$.pipe(
       tap(isCanActiveNextStep => {
         currentActiveStep.status = this.getStepperStatusByCanActive(isCanActiveNextStep);
+        const { steps, stepIndex } = this.getStepsAndIndex(currentActiveStep);
+        const nextIndex = stepIndex + 1;
+
+        if (nextIndex < steps.length) {
+          const nextStep = steps[nextIndex];
+          nextStep.status = isCanActiveNextStep ? PoStepperStatus.Default : PoStepperStatus.Disabled;
+        }
       }),
       catchError(err => {
         currentActiveStep.status = PoStepperStatus.Error;

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.module.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.module.ts
@@ -6,14 +6,15 @@ import { PoStepperCircleComponent } from './po-stepper-circle/po-stepper-circle.
 import { PoStepperComponent } from './po-stepper.component';
 import { PoStepperLabelComponent } from './po-stepper-label/po-stepper-label.component';
 import { PoStepperStepComponent } from './po-stepper-step/po-stepper-step.component';
-import { PoIconModule } from '../po-icon';
+import { PoIconModule } from '../po-icon/po-icon.module';
+import { PoTooltipModule } from '../../directives/po-tooltip/index';
 
 /**
  * @description
  * Módulo do componente po-stepper
  */
 @NgModule({
-  imports: [CommonModule, PoIconModule],
+  imports: [CommonModule, PoIconModule, PoTooltipModule],
   declarations: [
     PoStepComponent,
     PoStepperCircleComponent,

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.html
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.html
@@ -1,37 +1,45 @@
-<po-stepper
-  [p-orientation]="properties.orientation"
-  [p-step-icons]="properties.stepIcons"
-  [p-step-size]="properties.stepSize"
-  (p-change-step)="changeStep('change')"
->
-  <po-step *ngFor="let step of steps" [p-label]="step.label">
-    <h2>Step Content {{ step.label }}</h2>
-  </po-step>
-</po-stepper>
+<po-container>
+  <po-stepper
+    [p-orientation]="properties.orientation"
+    [p-step-icons]="properties.stepIcons"
+    [p-step-size]="properties.stepSize"
+    [p-step-icon-active]="properties.iconActive"
+    [p-step-icon-done]="properties.iconDone"
+    (p-change-step)="changeStep('change')"
+  >
+    <po-step *ngFor="let step of steps" [p-label]="step.label" [p-icon-default]="step.iconDefault">
+      <h2>Step Content {{ step.label }}</h2>
+    </po-step>
+  </po-stepper>
 
-<hr />
+  <hr />
 
-<po-info p-label="Event" [p-value]="event"> </po-info>
+  <po-info p-label="Event" [p-value]="event"> </po-info>
 
-<form #stepForm="ngForm">
-  <po-dynamic-form p-group-form [p-fields]="stepItemFields" [p-value]="stepItem"> </po-dynamic-form>
+  <form #stepForm="ngForm">
+    <po-dynamic-form [p-group-form] [p-fields]="stepItemFields" [p-value]="stepItem"> </po-dynamic-form>
 
-  <div class="po-row">
-    <po-button
-      class="po-md-3"
-      p-label="Add Step"
-      [p-disabled]="stepForm.invalid"
-      (p-click)="addItem(stepItem); stepForm.reset()"
-    >
-    </po-button>
-  </div>
-</form>
+    <div class="po-row">
+      <po-button
+        class="po-md-3"
+        p-label="Add Step"
+        [p-disabled]="stepForm.invalid"
+        (p-click)="addItem(stepItem); stepForm.reset()"
+      >
+      </po-button>
+    </div>
+  </form>
 
-<form #propertiesForm="ngForm">
-  <po-dynamic-form p-group-form [p-fields]="propertiesFields" [p-value]="properties"> </po-dynamic-form>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore(); propertiesForm.reset(); stepForm.reset()">
-    </po-button>
-  </div>
-</form>
+  <form #propertiesForm="ngForm">
+    <po-dynamic-form [p-group-form] [p-fields]="propertiesFields" [p-value]="properties"> </po-dynamic-form>
+    <hr />
+    <div class="po-row">
+      <po-button
+        class="po-md-3"
+        p-label="Sample Restore"
+        (p-click)="restore(); propertiesForm.reset(); stepForm.reset()"
+      >
+      </po-button>
+    </div>
+  </form>
+</po-container>

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.ts
@@ -25,7 +25,7 @@ export class SamplePoStepperLabsComponent implements OnInit {
     {
       property: 'orientation',
       options: [
-        { value: 'vertical', label: 'Vertical' },
+        { value: 'vertical', label: 'Vertical', checked: true },
         { value: 'horizontal', label: 'Horizontal' }
       ],
       gridLgColumns: 4
@@ -35,6 +35,18 @@ export class SamplePoStepperLabsComponent implements OnInit {
       gridLgColumns: 4,
       property: 'stepIcons',
       type: 'boolean'
+    },
+    {
+      label: 'Step Icon Active Custom',
+      help: 'Ex.: po-icon po-icon-light',
+      gridLgColumns: 4,
+      property: 'iconActive'
+    },
+    {
+      label: 'Step Icon Done Custom',
+      help: 'Ex.: po-icon po-icon-arrow-right',
+      gridLgColumns: 4,
+      property: 'iconDone'
     }
   ];
 
@@ -43,7 +55,13 @@ export class SamplePoStepperLabsComponent implements OnInit {
       divider: 'Step form',
       property: 'label',
       label: 'Step Label',
-      required: true,
+      gridMdColumns: 6,
+      gridXlColumns: 6
+    },
+    {
+      property: 'iconDefault',
+      label: 'Step Icon Default Custom',
+      help: 'Ex.: po-icon po-icon-help',
       gridMdColumns: 6,
       gridXlColumns: 6
     }
@@ -57,6 +75,8 @@ export class SamplePoStepperLabsComponent implements OnInit {
 
   addItem(stepItem: PoStepperItem) {
     this.steps = [...this.steps, { ...stepItem }];
+    this.stepItem = {};
+    this.changeDetector.detectChanges();
   }
 
   changeStep(event) {
@@ -69,5 +89,6 @@ export class SamplePoStepperLabsComponent implements OnInit {
     this.properties = {};
     this.steps = [];
     this.event = undefined;
+    this.properties.orientation = 'horizontal';
   }
 }


### PR DESCRIPTION
**PO-STEPPER**

**DTHFUI-7810**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)


**Simulação**
[DTHFUI-7810_simulacao.zip](https://github.com/user-attachments/files/16475797/DTHFUI-7810_simulacao.zip) 


**Custom:**
```
@import url('https://fonts.googleapis.com/css2?family=Lumanosimo&family=Playfair+Display+SC&display=swap');

/* po-stepper {
      --font-family: 'Comic Sans MS', 'Comic Sans', cursive;
      --font-size: 50px;
      --font-weight: 700;
  
      --text-color: tomato;
      --color-icon-done: pink;
      --background-done: green;
      --color-line-done: yellow;
  
      --color-icon-current: purple;
      --background-current: #007bff;
      --font-weight-current: 200px;
  
      --font-size-circle: 10px;
      --color-next: cyan;
      --text-color-next: crimson;
  } */
  
  /* :root {
      --font-family: var(--font-family);
      --font-size: var(--font-size-circle);
      --font-weight: var(--font-weight);
      --color: var(--color-icon-done);
      --background-color: var(--background-done);
  }*/
```