### PR TITLE
fix(tabs): corrige renderização das tabs no estado inicial do componente

### DIFF
--- a/projects/ui/src/lib/components/po-tabs/po-tabs.component.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs.component.ts
@@ -283,10 +283,9 @@ export class PoTabsComponent extends PoTabsBaseComponent implements OnInit, Afte
     }
 
     if (this.tabsChildren) {
-      const _tabsChildren = this.tabsChildrenArray;
+      const _tabsChildren = [...this.tabsChildrenArray];
       if (initialState) {
         this.tabsDefault = _tabsChildren;
-        this.tabsDropdown = _tabsChildren;
       } else {
         this.tabsDefault = _tabsChildren.slice(0, this.quantityTabsButton);
         this.tabsDropdown = _tabsChildren.slice(this.quantityTabsButton);


### PR DESCRIPTION
As tabs eram adicionadas na lista dropdown antes da rotina que define a criação do dropdown com tabs ativas.

Fixes DTHFUI-9602

**< TABS >**

**< DTHFUI-9602 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao iniciar o componente po-tabs com uma tab ativa, mesmo esta sendo a primeira visível em tela, ela é apresentada por último na lista.

**Qual o novo comportamento?**
Ao iniciar uma tab como ativa, se ela não estiver sendo exibida no dropdown ela deve manter o posicionamento inicial dela;
Tabs que iniciaram no dropdown e estão ativas devem continuar sendo exibidas por último na listagem visível (fora do dropdown);

**Simulação**
Samples do portal e/ou app po-angular em anexo
[app_tabs_samples.zip](https://github.com/user-attachments/files/16698096/app_tabs_samples.zip)

