### PR TITLE
feat(dynamic-view): adiciona propriedade p-text-wrap

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -112,6 +112,29 @@ export class PoDynamicViewBaseComponent extends PoDynamicSharedBase {
   }
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Permite a quebra de linha no texto do `p-value`, aplicando-a onde há `\n`.
+   *
+   * ```
+   * <po-dynamic-view
+   *   [p-value]="{ description: 'Primeira linha\nSegunda linha' }"
+   *   [p-text-wrap]="true"
+   * ></po-dynamic-view>
+   * ```
+   *
+   * Saída:
+   * ```
+   * Primeira linha
+   * Segunda linha
+   * ```
+   * @default `false`
+   */
+  @Input('p-text-wrap') textWrap: boolean = false;
+
+  /**
    * @description
    *
    * Objeto que será utilizado para exibir as informações dinâmicas, o valor será recuperado através do atributo *property*

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.html
@@ -25,7 +25,18 @@
 </ng-template>
 
 <ng-template #poInfo let-field>
-  <po-info [ngClass]="field.cssClass" [p-label]="field.label" [p-value]="setFieldValue(field)"> </po-info>
+  <ng-container *ngIf="textWrap; else defaultInfo">
+    <po-info
+      [ngClass]="[field.cssClass, containsLineBreak(setFieldValue(field)) ? 'po-info-value-pre' : '']"
+      [p-label]="field.label"
+      [p-value]="setFieldValue(field)"
+    >
+    </po-info>
+  </ng-container>
+
+  <ng-template #defaultInfo>
+    <po-info [ngClass]="field.cssClass" [p-label]="field.label" [p-value]="setFieldValue(field)"> </po-info>
+  </ng-template>
 </ng-template>
 
 <ng-template #poTag let-field>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
@@ -319,6 +319,11 @@ describe('PoDynamicViewComponent:', () => {
         expect(component.setFieldValue(field)).toEqual(false);
       });
     });
+
+    it('containsLineBreak: should return true if the string contains a newline character', () => {
+      const value = 'Hello\nWorld';
+      expect(component['containsLineBreak'](value)).toBeTrue();
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
@@ -94,6 +94,10 @@ export class PoDynamicViewComponent extends PoDynamicViewBaseComponent implement
     }
   }
 
+  protected containsLineBreak(value: string): boolean {
+    return value && value.includes('\n');
+  }
+
   private async getValuesAndFieldsFromLoad(): Promise<{ value?: any; fields?: Array<PoDynamicViewField> }> {
     let valueAndFieldsFromLoad;
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.html
@@ -1,3 +1,3 @@
 <po-page-default p-title="Employee">
-  <po-dynamic-view [p-fields]="fields" [p-value]="employee"> </po-dynamic-view>
+  <po-dynamic-view [p-fields]="fields" [p-value]="employee" [p-text-wrap]="true"> </po-dynamic-view>
 </po-page-default>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/samples/sample-po-dynamic-view-employee/sample-po-dynamic-view-employee.component.ts
@@ -38,6 +38,12 @@ export class SamplePoDynamicViewEmployeeComponent {
         { label: 'yes ', value: '1' },
         { label: 'no', value: '2' }
       ]
+    },
+    {
+      property: 'hobbies',
+      label: 'Hobbies',
+      gridColumns: 12,
+      divider: 'Additional Information'
     }
   ];
 
@@ -61,6 +67,11 @@ export class SamplePoDynamicViewEmployeeComponent {
     admissionDate: '2014-10-14T13:45:00-00:00',
     hoursPerDay: '08:30:00',
     marriedStatus: '1',
-    children: '1'
+    children: '1',
+    hobbies:
+      'Leitura de livros técnicos e ficção científica.\n' +
+      'Prática de corrida ao ar livre.\n' +
+      'Jogos de tabuleiro e videogames.\n' +
+      'Culinária, especialmente cozinha italiana.'
   };
 }


### PR DESCRIPTION
**PO-DYNAMIC-VIEW**

**DTHFUI-9446**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O componente po-dynamic-view não preserva as quebras de linha dos dados recebidos da API.

**Qual o novo comportamento?**
Adiciona a propriedade `p-text-wrap` para garantir que as quebras de linha (`\n`) sejam respeitadas na visualização dos dados.

**Simulação**
