### PR TITLE
fix(toolbar): corrige posicionamento do popup ao abrir notificação

### DIFF
--- a/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-basic/sample-po-popup-basic.component.html
+++ b/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-basic/sample-po-popup-basic.component.html
@@ -1,2 +1,2 @@
 <po-icon p-icon="ICON_HELP" #target class="po-clickable" (click)="popup.toggle()"> </po-icon>
-<po-popup #popup [p-actions]="[{ label: 'PO Popup' }]" [p-target]="target"> </po-popup>
+<po-popup #popup [p-actions]="[{ label: 'PO Popup' }]" [p-target]="targetRef"> </po-popup>

--- a/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-basic/sample-po-popup-basic.component.ts
+++ b/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-basic/sample-po-popup-basic.component.ts
@@ -1,7 +1,15 @@
-import { Component } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'sample-po-popup-basic',
   templateUrl: './sample-po-popup-basic.component.html'
 })
-export class SamplePoPopupBasicComponent {}
+export class SamplePoPopupBasicComponent implements AfterViewInit {
+  @ViewChild('target', { read: ElementRef }) targetRef: ElementRef;
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngAfterViewInit() {
+    this.cdr.detectChanges();
+  }
+}

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-notification/po-toolbar-notification.component.html
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-notification/po-toolbar-notification.component.html
@@ -5,4 +5,4 @@
   </div>
 </div>
 
-<po-popup #popup [p-actions]="notificationActions" [p-target]="notification"> </po-popup>
+<po-popup #popup [p-actions]="notificationActions" [p-target]="notificationRef"> </po-popup>

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-notification/po-toolbar-notification.component.spec.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-notification/po-toolbar-notification.component.spec.ts
@@ -42,10 +42,27 @@ describe('PoToolbarNotificationComponent: ', () => {
     nativeElement = fixture.debugElement.nativeElement;
 
     component['_notificationNumber'] = 0;
+
+    fixture.detectChanges();
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call detectChanges after view init', async () => {
+    const detectChangesSpy = spyOn(component['cdr'], 'detectChanges');
+
+    component.ngAfterViewInit();
+
+    expect(detectChangesSpy).toHaveBeenCalled();
+  });
+
+  it('should correctly reference the ViewChild notification element', () => {
+    fixture.detectChanges(); // Garante que o ViewChild foi inicializado após a renderização
+
+    const notificationElement = fixture.nativeElement.querySelector('po-icon');
+    expect(component.notificationRef.nativeElement).toBe(notificationElement);
   });
 
   describe('Properties: ', () => {

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-notification/po-toolbar-notification.component.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-notification/po-toolbar-notification.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, ViewChild } from '@angular/core';
 
 import { PoControlPositionService } from '../../../services/po-control-position/po-control-position.service';
 
@@ -22,18 +22,24 @@ import { PoToolbarAction } from '../po-toolbar-action.interface';
   templateUrl: './po-toolbar-notification.component.html',
   providers: [PoControlPositionService]
 })
-export class PoToolbarNotificationComponent {
-  /** Define uma lista de ações. */
+export class PoToolbarNotificationComponent implements AfterViewInit {
+  @ViewChild('notification', { read: ElementRef }) notificationRef: ElementRef;
+
   @Input('p-notification-actions') notificationActions?: Array<PoToolbarAction>;
 
   private _notificationNumber?: number = 0;
 
-  /** Define o número de notificações. */
   @Input('p-notification-number') set notificationNumber(value: number) {
     this._notificationNumber = Number.isInteger(value) ? value : 0;
   }
 
   get notificationNumber() {
     return this._notificationNumber;
+  }
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngAfterViewInit() {
+    this.cdr.detectChanges();
   }
 }


### PR DESCRIPTION
**PO-TOOLBAR**

**DTHFUI-9586**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
o popup da notificação da toolbar, esta aparecendo em local incorreto na tela.

**Qual o novo comportamento?**
corrigido o posicionamento ao abrir a popup da notificação no toolbar, tanto em tamanhos de tela pequena, quanto grande.

**Simulação**
[simulacao_dthfui-9586.zip](https://github.com/user-attachments/files/16853451/simulacao_dthfui-9586.zip)