### PR TITLE
feat(menu): customiza link do logo

### DIFF
--- a/projects/ui/src/lib/components/po-logo/po-logo.component.html
+++ b/projects/ui/src/lib/components/po-logo/po-logo.component.html
@@ -1,4 +1,4 @@
-<a *ngIf="link; else noLink" href="/">
+<a *ngIf="link !== false; else noLink" [href]="link === true ? './' : link">
   <img [alt]="logoAlt" [class]="className" [src]="logo" [title]="logoAlt" />
 </a>
 

--- a/projects/ui/src/lib/components/po-logo/po-logo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-logo/po-logo.component.spec.ts
@@ -3,11 +3,14 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { expectPropertiesValues } from './../../util-test/util-expect.spec';
 
 import { PoLogoComponent } from './po-logo.component';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
 
 describe('PoLogoComponent', () => {
   let component: PoLogoComponent;
   let fixture: ComponentFixture<PoLogoComponent>;
   let nativeElement: any;
+  let debugElement: DebugElement;
 
   const poLanguageService: any = {
     getShortLanguage: () => 'pt',
@@ -24,6 +27,7 @@ describe('PoLogoComponent', () => {
     fixture = TestBed.createComponent(PoLogoComponent);
     component = fixture.componentInstance;
     nativeElement = fixture.debugElement.nativeElement;
+    debugElement = fixture.debugElement;
 
     fixture.detectChanges();
   });
@@ -79,15 +83,37 @@ describe('PoLogoComponent', () => {
 
       expectPropertiesValues(component, 'logoAlt', validValues, validValues);
     });
+
+    it('link: should render an anchor tag with the correct href, when link is a string', () => {
+      const testLink = 'https://example.com';
+      component.link = testLink;
+      fixture.detectChanges();
+
+      const anchorElement = debugElement.query(By.css('a'));
+      expect(anchorElement).toBeTruthy();
+      expect(anchorElement.nativeElement.getAttribute('href')).toBe(testLink);
+    });
+
+    it('link: should render an anchor tag with "./" as the href, when link is true', () => {
+      component.link = true;
+      fixture.detectChanges();
+
+      const anchorElement = debugElement.query(By.css('a'));
+      expect(anchorElement).toBeTruthy();
+      expect(anchorElement.nativeElement.getAttribute('href')).toBe('./');
+    });
   });
 
   describe('Templates:', () => {
-    it(`should display template 'noLink' if 'link' is false.`, () => {
+    it(`link: should not render an anchor tag and should only render an img tag, when link is false`, () => {
       component.link = false;
-
       fixture.detectChanges();
 
-      expect(nativeElement.querySelector('a')).toBeNull();
+      const anchorElement = debugElement.query(By.css('a'));
+      const imgElement = debugElement.query(By.css('img'));
+
+      expect(anchorElement).toBeFalsy();
+      expect(imgElement).toBeTruthy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-logo/po-logo.component.ts
+++ b/projects/ui/src/lib/components/po-logo/po-logo.component.ts
@@ -29,6 +29,7 @@ export class PoLogoComponent {
 
   private _logo?: string;
   private _logoAlt: string;
+  private _link: boolean | string = './';
 
   /**
    * Define uma classe para o elemento `img` do componente.
@@ -40,13 +41,21 @@ export class PoLogoComponent {
   @Input('p-class') className: string = 'po-logo';
 
   /**
-   * Define se o componente terá o elemento âncora para a página inicial.
+   * Define se o componente terá o elemento âncora para uma rota específica.
    *
    * > Caso seja definido como false, o componente apenas renderizará o elemento `img`.
-   * O valor inicial é `true`.
+   * > Caso seja definido como true, a rota será `./`.
+   * > Caso seja definido como string, a rota será a string passada.
    *
+   * @default `true`
    */
-  @Input('p-link') link: boolean = true;
+  @Input('p-link') set link(value: boolean | string) {
+    this._link = value !== false ? value : false;
+  }
+
+  get link() {
+    return this._link;
+  }
 
   /**
    * Definie o caminho para a imagem, que será exibida como logomarca.

--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.spec.ts
@@ -491,6 +491,23 @@ describe('PoMenuBaseComponent:', () => {
 
       expectPropertiesValues(component, 'menus', invalidValues, []);
     });
+
+    describe('logoLink: ', () => {
+      it('should set logoLink as true if no value is provided', () => {
+        component.logoLink = undefined;
+        expect(component.logoLink).toBe(true);
+      });
+
+      it('should default to true if any other value is passed', () => {
+        component.logoLink = null;
+        expect(component.logoLink).toBe(true);
+      });
+
+      it('should set logoLink as false if the value is false', () => {
+        component.logoLink = false;
+        expect(component.logoLink).toBe(false);
+      });
+    });
   });
 
   describe('Integration:', () => {

--- a/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
+++ b/projects/ui/src/lib/components/po-menu/po-menu-base.component.ts
@@ -103,6 +103,7 @@ export abstract class PoMenuBaseComponent {
   private _menus = [];
   private _params: any;
   private _service: string | PoMenuFilter;
+  private _logoLink: boolean | string = true;
 
   /**
    * @optional
@@ -314,6 +315,26 @@ export abstract class PoMenuBaseComponent {
    * - Caso não informar um valor, esta propriedade passa a assumir o valor informado na propriedade `p-logo`.
    */
   @Input('p-short-logo') shortLogo: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Define o link para a rota ao clicar no logo do menu.
+   *
+   * - Se o valor for uma string, define a rota para o link informado.
+   * - Se for `false`, o logo não terá link associado.
+   * - Se for `true`, o logo terá a rota padrão `./`.
+   *
+   * @default `true`
+   */
+  @Input('p-logo-link') set logoLink(value: boolean | string) {
+    this._logoLink = value === false ? false : value || true;
+  }
+
+  get logoLink(): boolean | string {
+    return this._logoLink;
+  }
 
   constructor(
     public menuGlobalService: PoMenuGlobalService,

--- a/projects/ui/src/lib/components/po-menu/po-menu.component.html
+++ b/projects/ui/src/lib/components/po-menu/po-menu.component.html
@@ -13,6 +13,7 @@
             [p-class]="enableCollapse ? 'po-menu-short-logo' : 'po-menu-logo'"
             [p-logo]="enableCollapse ? shortLogo || logo : logo"
             [p-logo-alt]="logoAlt"
+            [p-link]="logoLink"
           ></po-logo>
         </div>
 

--- a/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.html
+++ b/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.html
@@ -2,6 +2,7 @@
   <po-menu
     [p-filter]="filter"
     [p-logo]="logo"
+    [p-logo-link]="logoLink"
     [p-menus]="menuItems"
     [p-params]="params"
     [p-service]="service"
@@ -158,6 +159,18 @@
           p-clean
           p-help="https://po-ui.io/assets/graphics/logo-dgeni.png"
           p-label="Short Logo"
+        >
+        </po-input>
+      </div>
+
+      <div class="po-row">
+        <po-input
+          class="po-md-12"
+          name="logo link"
+          [(ngModel)]="logoLink"
+          p-clean
+          p-help="ex.: '/documentation/po-menu','https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md'"
+          p-label="Logo link"
         >
         </po-input>
       </div>

--- a/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.ts
+++ b/projects/ui/src/lib/components/po-menu/samples/sample-po-menu-labs/sample-po-menu-labs.component.ts
@@ -35,6 +35,7 @@ export class SamplePoMenuLabsComponent implements OnInit {
   label: string;
   link: string;
   logo: string;
+  logoLink: string;
   maxBadgeValue = 999999999999999;
   menuItems: Array<PoMenuItem>;
   menuItemSelected: string;
@@ -128,6 +129,7 @@ export class SamplePoMenuLabsComponent implements OnInit {
     this.badgeColor = undefined;
     this.badgeValue = undefined;
     this.logo = undefined;
+    this.logoLink = undefined;
     this.params = undefined;
     this.parentList = [];
     this.menuItems = [];


### PR DESCRIPTION
**Menu**

**DTHFUI-9495**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Hoje o logo do menu possue apenas um link para a pagina inicial `./`

**Qual o novo comportamento?**
Adicionado customização ao link do logo, através da propriedade `[p-logo-link]`. 
Aceitando:
- caso true, rota padrão `./`; 
- caso false, não terá link associado; 
- caso string, define a rota para o link informado.

**Simulação**
[simulação_9495.zip](https://github.com/user-attachments/files/16935786/simulacao_9495.zip)

