### PR TITLE
feat(style): implementa media query com variáveis

### DIFF
--- a/projects/ui/src/lib/services/po-style/po-style.interface.ts
+++ b/projects/ui/src/lib/services/po-style/po-style.interface.ts
@@ -1,0 +1,4 @@
+export interface MediaQueryRule {
+  mediaRule: string;
+  valuesRule: Array<string>;
+}

--- a/projects/ui/src/lib/services/po-style/po-style.service.spec.ts
+++ b/projects/ui/src/lib/services/po-style/po-style.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PoStyleService } from './po-style.service';
+
+describe('PoStyleService', () => {
+  let service: PoStyleService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PoStyleService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/ui/src/lib/services/po-style/po-style.service.ts
+++ b/projects/ui/src/lib/services/po-style/po-style.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
+import { MediaQueryRule } from './po-style.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PoStyleService {
+  private renderer: Renderer2;
+
+  constructor(rendererFactory: RendererFactory2) {
+    this.renderer = rendererFactory.createRenderer(null, null);
+  }
+
+  updateMediaQueries(globalMediaQueriesRules: Array<MediaQueryRule>): void {
+    const styleSheets = document.styleSheets;
+
+    const styleElement = this.renderer.createElement('style');
+    this.renderer.appendChild(document.head, styleElement);
+
+    const sheetDom = styleElement.sheet as CSSStyleSheet;
+
+    Array.from(styleSheets).forEach(sheet => {
+      const rules = sheet.cssRules || sheet.rules;
+
+      Array.from(rules).forEach(rule => {
+        // Verifica se a regra é de mídia (CSSMediaRule)
+        if (rule instanceof CSSMediaRule) {
+          const mediaRule = rule;
+
+          // Itera sobre cada conjunto de regras de media queries fornecido
+          globalMediaQueriesRules.forEach(queryRule => {
+            if (mediaRule.media.mediaText.includes(queryRule.mediaRule)) {
+              let updatedMediaText = mediaRule.cssText;
+              const variablesInMediaRule = updatedMediaText.match(/var\(--[^)]+\)/g) || [];
+              console.log('variablesInMediaRule:', variablesInMediaRule);
+
+              // Substitui as variáveis de media queries pelos valores fornecidos
+              variablesInMediaRule.forEach((variable, index) => {
+                if (index < queryRule.valuesRule.length) {
+                  updatedMediaText = updatedMediaText.replace(variable, queryRule.valuesRule[index]);
+                  console.log('variable:', variable, ',', updatedMediaText);
+                }
+              });
+
+              // Adiciona a regra modificada à folha de estilo dinâmica
+              sheetDom.insertRule(updatedMediaText, sheetDom.cssRules.length);
+            }
+          });
+        }
+      });
+    });
+  }
+}


### PR DESCRIPTION
spike - grid-system: implementa customização dos breakpoints

**SPIKE po-style-service**

**DTHFUI-9712**

**Qual o comportamento atual?**
Atualmente não é possível implementar regras de media query com referência à variáveis, exemplo:
@media (min-width: var(--gridSystemMdMinWidth)) and (max-width: var(--gridSystemMdMaxWidth)){}

Foi realizado teste com o postcss-custom-properties e outros porém não reconheceram as variáveis quando referenciadas em regra de media query.

**Qual o novo comportamento?**
O estudo demonstrou como possibilitar a implementação de media query referenciando variáveis no lugar de valores;
A solução contempla dois lados:
1-O projeto Po-Style: Agora possibilita declararmos variáveis e com o auxílio do plugin postcss-simple-vars integrado ao gulp realiza a troca das respectivas variáveis para seus valores.
2-O serviço PoStyleService: Criado um serviço que possibilita ao desenvolver realizar a customização das variáveis informando a regra e qual valor ou valores deverá aplicar.


**Simulação**
