### PR TITLE
feat(stepper): adiciona propriedade p-align-center

### DIFF
--- a/projects/ui/src/lib/components/po-stepper/po-step/po-step.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-step/po-step.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Component, ElementRef, Input } from '@angular/core';
+import { AfterContentInit, Component, ElementRef, Input, TemplateRef } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { uuid } from '../../../utils/util';
@@ -75,7 +75,7 @@ export class PoStepComponent implements AfterContentInit {
     | ((currentStep) => Observable<boolean>);
 
   /** Título que será exibido descrevendo o passo (*step*). */
-  @Input('p-label') label: string;
+  @Input('p-label') label: string = '';
 
   // ID do step
   id?: string = uuid();
@@ -92,6 +92,42 @@ export class PoStepComponent implements AfterContentInit {
   get status() {
     return this._status;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   * Define o ícone padrão do step em seu status *default*.
+   * Esta propriedade permite usar ícones da [Biblioteca de ícones](/guides/icons) ou da biblioteca [Phosphor](https://phosphoricons.com/).
+   *
+   * Exemplo usando a biblioteca de ícones padrão:
+   * ```
+   * <po-stepper>
+   *    ...
+   *    <po-step p-icon-default="po-icon po-icon-pin"></po-step>
+   * </po-stepper>
+   * ```
+   * Exemplo usando a biblioteca *Phosphor*:
+   * ```
+   * <po-stepper>
+   *    ...
+   *    <po-step p-icon-default="ph ph-map-pin"></po-step>
+   * </po-stepper>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-stepper>
+   *    ...
+   *    <po-step [p-icon-default]="template"></po-step>
+   * </po-stepper>
+   *
+   * <ng-template #template>
+   *    <i class="ph ph-shopping-cart"></i>
+   * </ng-template
+   * ```
+   * > Deve-se usar `font-size: inherit` para ajustar ícones que não se ajustam automaticamente.
+   */
+  @Input('p-icon-default') iconDefault?: string | TemplateRef<void>;
 
   constructor(private elementRef: ElementRef) {}
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.spec.ts
@@ -11,6 +11,18 @@ describe('PoStepperBaseComponent:', () => {
   });
 
   describe('Properties:', () => {
+    it('p-align-center: should update property with `true` if valid values', () => {
+      const validValues = [true, 'true', 1, ''];
+
+      expectPropertiesValues(component, 'alignCenter', validValues, true);
+    });
+
+    it('p-align-center: should update property with `false` if invalid values', () => {
+      const invalidValues = [false, 'false', 0, undefined, null];
+
+      expectPropertiesValues(component, 'alignCenter', invalidValues, false);
+    });
+
     it('p-sequential: should update property with `true` if valid values', () => {
       const validValues = [true, 'true', 1, ''];
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.spec.ts
@@ -34,24 +34,21 @@ describe('PoStepperBaseComponent:', () => {
 
     it('p-step: shouldn`t set property with invalid values', () => {
       const invalidValues = [0, 3, undefined, null, {}, ''];
+      const validStep = 1;
 
       component.steps = [{ label: 'Step 1' }];
+      component.step = validStep;
 
-      expectPropertiesValues(component, 'step', invalidValues, 1);
+      invalidValues.forEach(value => {
+        component.step = value as any;
+        expect(component.step).toBe(validStep);
+      });
     });
 
     it('p-steps: should update property with empty `array` if invalid values', () => {
       const invalidValues = [false, 0, [], undefined, null, {}, ''];
 
       expectPropertiesValues(component, 'steps', invalidValues, []);
-    });
-
-    it('p-steps: should update property with `array` with status default and initial step 1', () => {
-      component.steps = [{ label: 'Step 1' }, { label: 'Step 2' }];
-
-      expect(component.steps[0].status).toBe(PoStepperStatus.Active);
-      expect(component.steps[1].status).toBe(PoStepperStatus.Default);
-      expect(component.step).toBe(1);
     });
 
     it('p-steps: should respect status disabled', () => {

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Input, Output, Directive } from '@angular/core';
+import { EventEmitter, Input, Output, Directive, TemplateRef } from '@angular/core';
 
 import { convertToBoolean } from '../../utils/util';
 
@@ -49,6 +49,35 @@ const poStepperOrientationDefault = PoStepperOrientation.Horizontal;
  *
  * - Evite `labels` extensos que quebram o layout do `po-stepper`, use `labels` diretos, curtos e intuitivos.
  * - Utilize apenas um `po-stepper` por página.
+ *
+ * #### Tokens customizáveis
+ *
+ * É possível alterar o estilo do componente usando os seguintes tokens (CSS):
+ *
+ * > Para maiores informações, acesse o guia [Personalizando o Tema Padrão com Tokens CSS](https://po-ui.io/guides/theme-customization).
+ *
+ * | Propriedade                              | Descrição                                             | Valor Padrão                                      |
+ * |------------------------------------------|-------------------------------------------------------|---------------------------------------------------|
+ * | **Label**                                |                                                       |                                                   |
+ * | `--font-family`                          | Família tipográfica usada                             | `var(--font-family-theme)`                        |
+ * | `--font-size`                            | Tamanho da fonte                                      | `var(--font-size-default)`                        |
+ * | `--font-weight`                          | Peso da fonte                                         | `var(--font-weight-normal)`                       |
+ * | **Step - Done**                          |                                                       |                                                   |
+ * | `--text-color`                           | Cor do texto no step concluído                        | `var(--color-neutral-dark-70)`                    |
+ * | `--color-icon-done`                      | Cor do ícone no step concluído                        | `var(--color-neutral-dark-70)`                    |
+ * | `--background-done`                      | Cor de fundo no step concluído                        | `var(--color-neutral-light-00)`                   |
+ * | **Line - Done**                          |                                                       |                                                   |
+ * | `--color-line-done`                      | Cor da linha no step concluído                        | `var(--color-neutral-mid-40)`                     |
+ * | **Step - Current**                       |                                                       |                                                   |
+ * | `--color-icon-current`                   | Cor do ícone no step atual                            | `var(--color-neutral-light-00)`                   |
+ * | `--background-current`                   | Cor de fundo no step atual                            | `var(--color-action-default)`                     |
+ * | `--font-weight-current`                  | Peso da fonte no step atual                           | `var(--font-weight-bold)`                         |
+ * | **Step - Next**                          |                                                       |                                                   |
+ * | `--font-size-circle`                     | Tamanho da fonte no círculo do próximo step           | `var(--font-size-sm)`                             |
+ * | `--color-next`                           | Cor do ícone no próximo step                          | `var(--color-action-disabled)`                    |
+ * | `--text-color-next`                      | Cor do texto no próximo step                          | `var(--color-neutral-light-30)`                   |
+ * | **Focused**                              |                                                       |                                                   |
+ * | `--outline-color-focused`                | Cor do outline do estado de focus                     | `var(--color-action-focus)`                       |
  */
 @Directive()
 export class PoStepperBaseComponent {
@@ -146,7 +175,7 @@ export class PoStepperBaseComponent {
   @Input('p-steps') set steps(steps: Array<PoStepperItem>) {
     this._steps = Array.isArray(steps) ? steps : [];
     this._steps.forEach(step => (step.status = step.status ?? PoStepperStatus.Default));
-    this.step = 1;
+    this.initializeSteps();
   }
 
   get steps(): Array<PoStepperItem> {
@@ -170,5 +199,75 @@ export class PoStepperBaseComponent {
 
   get sequential(): boolean {
     return this._sequential;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   * Permite definir o ícone do step no status concluído.
+   * Esta propriedade permite usar ícones da [Biblioteca de ícones](/guides/icons) ou da biblioteca [Phosphor](https://phosphoricons.com/).
+   *
+   * Exemplo usando a biblioteca de ícones padrão:
+   * ```
+   * <po-stepper p-step-icon-done="po-icon po-icon-eye">
+   *    ...
+   * </po-stepper>
+   * ```
+   * Exemplo usando a biblioteca *Phosphor*:
+   * ```
+   * <po-stepper p-step-icon-done="ph ph-check-circle">
+   *    ...
+   * </po-stepper>
+   * ```
+   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+   * ```
+   * <po-stepper [p-step-icon-done]="doneIcon">
+   *    ...
+   * </po-stepper>
+   *
+   * <ng-template #doneIcon>
+   *    <i class="ph ph-check-fat"></i>
+   * </ng-template>
+   * ```
+   * > Deve-se usar `font-size: inherit` para ajustar ícones que não se ajustam automaticamente.
+   *
+   * @default `po-icon-ok`
+   */
+  @Input('p-step-icon-done') iconDone?: string | TemplateRef<void>;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Permite definir o ícone do step no status ativo.
+   * Esta propriedade permite usar ícones da [Biblioteca de ícones](/guides/icons) ou da biblioteca [Phosphor](https://phosphoricons.com/).
+   *
+   * Exemplo usando a biblioteca de ícones padrão:
+   * ```
+   * <po-stepper p-step-icon-active="po-icon po-icon-settings">
+   *    ...
+   * </po-stepper>
+   * ```
+   * Exemplo usando a biblioteca *Phosphor*:
+   * ```
+   * <po-stepper p-step-icon-active="ph ph-pencil-simple-line">
+   *    ...
+   * </po-stepper>
+   * ```
+   * Para customizar o ícone através do `TemplateRef`, veja a documentação da propriedade `p-step-icon-done`.
+   *
+   * > Deve-se usar `font-size: inherit` para ajustar ícones que não se ajustam automaticamente.
+   *
+   * @default `po-icon-edit`
+   */
+  @Input('p-step-icon-active') iconActive?: string | TemplateRef<void>;
+
+  private initializeSteps(): void {
+    const hasStatus = this._steps.some(step => step.status !== PoStepperStatus.Default);
+
+    if (!hasStatus && this.step === 1) {
+      this.step = 1;
+    }
   }
 }

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
@@ -82,7 +82,6 @@ const poStepperOrientationDefault = PoStepperOrientation.Horizontal;
 @Directive()
 export class PoStepperBaseComponent {
   /**
-   *
    * @optional
    *
    * @description
@@ -113,10 +112,32 @@ export class PoStepperBaseComponent {
   /** Ação que será executada quando o usuário mudar o passo do `po-stepper`. */
   @Output('p-change-step') onChangeStep = new EventEmitter<number | PoStepComponent>();
 
+  private _alignCenter?: boolean = true;
   private _orientation?: PoStepperOrientation = poStepperOrientationDefault;
   private _sequential?: boolean = true;
   private _step: number = 1;
   private _steps: Array<PoStepperItem> = [];
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o alinhamento dos *steps* e *labels* no *stepper*, dependendo da orientação.
+   *
+   * - Quando `true`, ficam centralizados em ambas as orientações (horizontal e vertical).
+   * - Quando `false`, ficam alinhados à esquerda na orientação horizontal e ao topo na orientação vertical.
+   *
+   * @default `true`
+   */
+
+  @Input('p-align-center') set alignCenter(alignCenter: boolean) {
+    this._alignCenter = convertToBoolean(alignCenter);
+  }
+
+  get alignCenter(): boolean {
+    return this._alignCenter;
+  }
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.html
@@ -1,22 +1,30 @@
-<div class="po-stepper-circle" [style.height.px]="size" [style.width.px]="size" [tabindex]="isDisabled ? -1 : 0">
-  <po-icon
-    *ngIf="!isActive"
-    class="po-stepper-circle-content"
-    [class.po-icon]="icons || isDone"
-    [p-icon]="
-      icons && isError
-        ? 'ICON_EXCLAMATION'
-        : icons && (isActive || isDefault || isDisabled)
-          ? 'ICON_INFO'
-          : isDone
-            ? 'ICON_OK'
-            : ''
-    "
-    [class.po-stepper-circle-content-lg]="isLargeStep"
-    [class.po-stepper-circle-content-md]="isMediumStep"
-  >
-    {{ !icons && !isDone ? content : '' }}
-  </po-icon>
-
-  <div *ngIf="isActive || isError" class="po-stepper-circle-active"></div>
+<div
+  class="po-stepper-circle"
+  [ngClass]="{ 'po-stepper-circle-border': !isActive && !isError, 'po-stepper-circle-done': isDone }"
+  [style.height.px]="size"
+  [style.width.px]="size"
+>
+  <ng-container *ngIf="isActive || isError; else defaultContent">
+    <div class="po-stepper-circle-active">
+      <po-icon
+        class="po-stepper-circle-content"
+        [class.po-icon]="true"
+        [p-icon]="iconActive ? iconActive : 'ICON_EDIT'"
+        [class.po-stepper-circle-content-lg]="isLargeStep"
+        [class.po-stepper-circle-content-md]="isMediumStep"
+      ></po-icon>
+    </div>
+  </ng-container>
+  <ng-template #defaultContent>
+    <po-icon
+      *ngIf="!isActive"
+      class="po-stepper-circle-content"
+      [class.po-icon]="icons || isDone"
+      [p-icon]="isDone ? iconDone || 'ICON_OK' : iconDefault ? iconDefault : icons ? 'ICON_INFO' : ''"
+      [class.po-stepper-circle-content-lg]="isLargeStep"
+      [class.po-stepper-circle-content-md]="isMediumStep"
+    >
+      {{ !icons && !isDone && !iconDefault ? content : '' }}
+    </po-icon>
+  </ng-template>
 </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.html
@@ -1,5 +1,6 @@
 <div
   class="po-stepper-circle"
+  [class.po-stepper-circle-center]="alignCenter"
   [ngClass]="{ 'po-stepper-circle-border': !isActive && !isError, 'po-stepper-circle-done': isDone }"
   [style.height.px]="size"
   [style.width.px]="size"

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.spec.ts
@@ -168,24 +168,6 @@ describe('PoStepperCircleComponent:', () => {
   });
 
   describe('Templates:', () => {
-    it('should change `tabindex` to `-1` if component is disabled', () => {
-      component.status = PoStepperStatus.Disabled;
-      fixture.detectChanges();
-
-      const poStepperCircleElement = nativeElement.querySelector('.po-stepper-circle[tabindex="-1"]');
-
-      expect(poStepperCircleElement).toBeTruthy();
-    });
-
-    it('should change `tabindex` to `0` if component isn`t disabled', () => {
-      component.status = PoStepperStatus.Active;
-      fixture.detectChanges();
-
-      const poStepperCircleElement = nativeElement.querySelector('.po-stepper-circle[tabindex="0"]');
-
-      expect(poStepperCircleElement).toBeTruthy();
-    });
-
     it('should find `po-stepper-circle-content-md` in `span` if `isMediumStep` is `true`.', () => {
       spyOnProperty(component, 'isMediumStep').and.returnValue(true);
 
@@ -206,61 +188,21 @@ describe('PoStepperCircleComponent:', () => {
       expect(stepperCircleContentLg).toBeTruthy();
     });
 
-    it('shouldn`t find `po-stepper-circle-content` if `isActive` is true', () => {
-      spyOnProperty(component, 'isActive').and.returnValue(true);
-
-      fixture.detectChanges();
-
-      const stepperCircleContent = nativeElement.querySelector('.po-stepper-circle-content');
-
-      expect(stepperCircleContent).toBeNull();
-    });
-
-    it('shouldn`t find `po-stepper-circle-with-icon` and `po-icon` if `icons` is `false`.', () => {
-      component.icons = false;
-
-      fixture.detectChanges();
-      const StepperCircleWitchIcon = nativeElement.querySelector('.po-stepper-circle-with-icon');
-      const iconClass = nativeElement.querySelector('.po-icon');
-
-      expect(StepperCircleWitchIcon).toBeNull();
-      expect(iconClass).toBeNull();
-    });
-
-    it('should find `po-icon-info` if `status` is `Active`, `Default` or `Disabled` and `icons` is true.', () => {
-      component.icons = true;
-
+    it('should have `po-stepper-circle-border` when not active and not error', () => {
       component.status = PoStepperStatus.Default;
       fixture.detectChanges();
-      expect(PoIconInfo()).toBeTruthy();
 
-      component.status = PoStepperStatus.Disabled;
-      fixture.detectChanges();
-      expect(PoIconInfo()).toBeTruthy();
-
-      component.status = PoStepperStatus.Error;
-      fixture.detectChanges();
-      expect(PoIconInfo()).toBeNull();
+      const circleElement = fixture.nativeElement.querySelector('.po-stepper-circle');
+      expect(circleElement.classList).toContain('po-stepper-circle-border');
+      expect(circleElement.classList).not.toContain('po-stepper-circle-done');
     });
 
-    it('should find `po-icon` if `isDone` is true.', () => {
-      component.icons = false;
-      spyOnProperty(component, 'isDone').and.returnValue(true);
-
+    it('should have `po-stepper-circle-done` when isDone', () => {
+      component.status = PoStepperStatus.Done;
       fixture.detectChanges();
 
-      const poIcon = nativeElement.querySelector('.po-icon');
-      expect(poIcon).toBeTruthy();
-    });
-
-    it('shouldn`t find `po-icon` if `isDone` and `icons` is false.', () => {
-      component.icons = false;
-      spyOnProperty(component, 'isDone').and.returnValue(false);
-
-      fixture.detectChanges();
-
-      const poIcon = nativeElement.querySelector('.po-icon');
-      expect(poIcon).toBeNull();
+      const circleElement = fixture.nativeElement.querySelector('.po-stepper-circle');
+      expect(circleElement.classList).toContain('po-stepper-circle-done');
     });
 
     it('should find `po-stepper-circle-active` if `isActive` is true.', () => {
@@ -296,52 +238,165 @@ describe('PoStepperCircleComponent:', () => {
       expect(stepperCircleActive).toBeNull();
     });
 
-    it('should find `po-icon-ok` if `status` is `Done` and `icons` is true.', () => {
-      component.icons = true;
+    it('should find `po-icon` if `isDone` is true.', () => {
+      component.icons = false;
+      spyOnProperty(component, 'isDone').and.returnValue(true);
 
-      component.status = PoStepperStatus.Done;
       fixture.detectChanges();
-      expect(PoIconOk()).toBeTruthy();
 
-      component.status = PoStepperStatus.Default;
-      fixture.detectChanges();
-      expect(PoIconOk()).toBeNull();
-
-      component.status = PoStepperStatus.Disabled;
-      fixture.detectChanges();
-      expect(PoIconOk()).toBeNull();
-
-      component.status = PoStepperStatus.Error;
-      fixture.detectChanges();
-      expect(PoIconOk()).toBeNull();
+      const poIcon = nativeElement.querySelector('.po-icon');
+      expect(poIcon).toBeTruthy();
     });
 
-    it('should find `icon-exclamation` if `status` is `Error` and `icons` is true.', () => {
-      component.icons = true;
+    it('shouldn`t find `po-icon` if `isDone` and `icons` is false.', () => {
+      component.icons = false;
+      spyOnProperty(component, 'isDone').and.returnValue(false);
 
-      component.status = PoStepperStatus.Error;
       fixture.detectChanges();
-      expect(PoIconExclamation()).toBeTruthy();
 
+      const poIcon = nativeElement.querySelector('.po-icon');
+      expect(poIcon).toBeNull();
+    });
+
+    it('should apply `iconActive` from Phosphor library if `status` is `Active` and `iconActive` is set.', () => {
+      component.status = PoStepperStatus.Active;
+      component.iconActive = 'ph ph-anchor';
+      fixture.detectChanges();
+
+      const activeIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(activeIcon).toBeTruthy();
+      expect(activeIcon.classList.contains('ph-anchor')).toBeTrue();
+    });
+
+    it('should apply `iconActive` from Icons library if `status` is `Active` and `iconActive` is set.', () => {
+      component.status = PoStepperStatus.Active;
+      component.iconActive = 'po-icon po-icon-device-notebook';
+      fixture.detectChanges();
+
+      const activeIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(activeIcon).toBeTruthy();
+      expect(activeIcon.classList.contains('po-icon-device-notebook')).toBeTrue();
+    });
+
+    it('should apply `ICON_EDIT` if `status` is `Active` and `iconActive` is not set.', () => {
+      component.status = PoStepperStatus.Active;
+      component.iconActive = undefined;
+      fixture.detectChanges();
+
+      const activeIcon = PoIconEdit();
+
+      expect(activeIcon).toBeTruthy();
+      expect(activeIcon.classList.contains('ph-pencil-simple')).toBeTrue();
+    });
+
+    it('should apply `iconDone` from Phosphor library if `status` is `Done` and `iconDone` is set.', () => {
+      component.status = PoStepperStatus.Done;
+      component.iconDone = 'ph ph-check-circle';
+      fixture.detectChanges();
+
+      const doneIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+
+      expect(doneIcon).toBeTruthy();
+      expect(doneIcon.classList.contains('ph-check-circle')).toBeTrue();
+    });
+
+    it('should apply `iconDone` from Icons library if `status` is `Done` and `iconDone` is set.', () => {
+      component.status = PoStepperStatus.Done;
+      component.iconDone = 'po-icon-clock';
+      fixture.detectChanges();
+
+      const doneIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+
+      expect(doneIcon.classList.contains('po-icon-clock')).toBeTrue();
+    });
+
+    it('should apply `ICON_OK` if `status` is `Done` and `iconDone` is not set.', () => {
+      component.status = PoStepperStatus.Done;
+      component.iconDone = undefined;
+      fixture.detectChanges();
+
+      const doneIcon = PoIconOk;
+      expect(doneIcon).toBeTruthy();
+    });
+
+    it('should apply `iconDefault` from Phosphor library if `status` is `Default` or `Disabled` and `iconDefault` is set.', () => {
       component.status = PoStepperStatus.Default;
+      component.iconDefault = 'ph ph-first-aid';
       fixture.detectChanges();
-      expect(PoIconExclamation()).toBeNull();
+
+      let defaultIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('ph-first-aid')).toBeTrue();
 
       component.status = PoStepperStatus.Disabled;
       fixture.detectChanges();
-      expect(PoIconExclamation()).toBeNull();
+
+      defaultIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('ph-first-aid')).toBeTrue();
+    });
+
+    it('should apply `iconDefault` from Icons library if `status` is `Default` or `Disabled` and `iconDefault` is set.', () => {
+      component.status = PoStepperStatus.Default;
+      component.iconDefault = 'po-icon po-icon-user';
+      fixture.detectChanges();
+
+      let defaultIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('po-icon-user')).toBeTrue();
+
+      component.status = PoStepperStatus.Disabled;
+      fixture.detectChanges();
+
+      defaultIcon = nativeElement.querySelector('po-icon')?.querySelector('i');
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('po-icon-user')).toBeTrue();
+    });
+
+    it('should apply `ICON_INFO` if `status` is `Default` or `Disabled`, `iconDefault` is not set, and `icons` is true.', () => {
+      component.status = PoStepperStatus.Default;
+      component.iconDefault = undefined;
+      component.icons = true;
+      fixture.detectChanges();
+
+      const defaultIcon = PoIconInfo();
+      expect(defaultIcon).toBeTruthy();
+      expect(defaultIcon.classList.contains('ph-info')).toBeTrue();
+
+      component.status = PoStepperStatus.Disabled;
+      fixture.detectChanges();
+
+      const disabledIcon = PoIconInfo();
+      expect(disabledIcon).toBeTruthy();
+      expect(disabledIcon.classList.contains('ph-info')).toBeTrue();
+    });
+
+    it('should display an empty string if `status` is `Default` or `Disabled`, `iconDefault` is not set, and `icons` is false.', () => {
+      component.status = PoStepperStatus.Default;
+      component.iconDefault = undefined;
+      component.icons = false;
+      fixture.detectChanges();
+
+      const defaultIcon = nativeElement.querySelector('.po-stepper-circle-content');
+      expect(defaultIcon.textContent.trim()).toBe('');
+
+      component.status = PoStepperStatus.Disabled;
+      fixture.detectChanges();
+
+      const disabledIcon = nativeElement.querySelector('.po-stepper-circle-content');
+      expect(disabledIcon.textContent.trim()).toBe('');
     });
   });
 
   function PoIconInfo() {
-    return nativeElement.querySelector('.ph-info');
+    return nativeElement.querySelector('po-icon')?.querySelector('i.ph.ph-info');
   }
 
   function PoIconOk() {
     return nativeElement.querySelector('.ph-check');
   }
 
-  function PoIconExclamation() {
-    return nativeElement.querySelector('.ph-warning-circle');
+  function PoIconEdit() {
+    return nativeElement.querySelector('po-icon')?.querySelector('i.ph-pencil-simple');
   }
 });

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, TemplateRef } from '@angular/core';
 
 import { PoStepperStatus } from '../enums/po-stepper-status.enum';
 
@@ -19,6 +19,15 @@ const poLargeStepSize = 48;
 export class PoStepperCircleComponent {
   // Conteúdo que irá aparecer no círculo do *step*.
   @Input('p-content') content: any;
+
+  // Ícone para o status Active do *step*.
+  @Input('p-step-icon-active') iconActive?: string | TemplateRef<void>;
+
+  // Ícone para o status Done do *step*.
+  @Input('p-step-icon-done') iconDone?: string | TemplateRef<void>;
+
+  // Ícone para o status default do *step*.
+  @Input('p-icon-default') iconDefault?: string | TemplateRef<void>;
 
   // Define se serão exibidos ícones no lugar de números nos steps.
   @Input('p-icons') icons: boolean;

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-circle/po-stepper-circle.component.ts
@@ -17,6 +17,9 @@ const poLargeStepSize = 48;
   templateUrl: './po-stepper-circle.component.html'
 })
 export class PoStepperCircleComponent {
+  // Alinhamento do *step*.
+  @Input('p-align-center') alignCenter: boolean;
+
   // Conteúdo que irá aparecer no círculo do *step*.
   @Input('p-content') content: any;
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-item.interface.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-item.interface.ts
@@ -1,3 +1,4 @@
+import { TemplateRef } from '@angular/core';
 import { PoStepperStatus } from './enums/po-stepper-status.enum';
 
 /**
@@ -8,8 +9,17 @@ import { PoStepperStatus } from './enums/po-stepper-status.enum';
  * Interface para definição dos *steps* do componente `po-stepper` quando utilizada a propriedade `p-steps`.
  */
 export interface PoStepperItem {
+  /** Define o ícone do *step* ativo. */
+  iconActive?: string | TemplateRef<void>;
+
+  /** Define o ícone do *step* concluído. */
+  iconDone?: string | TemplateRef<void>;
+
+  /** Define o ícone do *step* default. */
+  iconDefault?: string | TemplateRef<void>;
+
   /** Texto do item do stepper. */
-  label: string;
+  label?: string;
 
   /** Define o estado de exibição do *step*. */
   status?: PoStepperStatus;

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.html
@@ -5,6 +5,7 @@
   [class.po-stepper-label-active]="status === 'active' || status === 'error'"
   [class.po-stepper-label-done]="status === 'done'"
   [class.po-stepper-label-vertical]="isVerticalOrientation"
+  [class.po-stepper-label-center]="alignCenter"
   [p-tooltip]="tooltipContent"
   aria-hidden="true"
   (mouseover)="onMouseOver()"

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.html
@@ -1,3 +1,14 @@
-<div class="po-stepper-label">
-  {{ content }}
+<div
+  #labelElement
+  class="po-stepper-label"
+  [class.po-link]="status !== 'disabled'"
+  [class.po-stepper-label-active]="status === 'active' || status === 'error'"
+  [class.po-stepper-label-done]="status === 'done'"
+  [class.po-stepper-label-vertical]="isVerticalOrientation"
+  [p-tooltip]="tooltipContent"
+  aria-hidden="true"
+  (mouseover)="onMouseOver()"
+  (mouseout)="onMouseOut()"
+>
+  {{ displayedContent }}
 </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { configureTestSuite } from './../../../util-test/util-expect.spec';
-
 import { PoStepperLabelComponent } from './po-stepper-label.component';
+import { configureTestSuite } from '../../../util-test/util-expect.spec';
 import { PoStepperModule } from '../po-stepper.module';
+import { By } from '@angular/platform-browser';
+import { SimpleChange } from '@angular/core';
 
 describe('PoStepperLabelComponent: ', () => {
   let component: PoStepperLabelComponent;
@@ -24,5 +25,246 @@ describe('PoStepperLabelComponent: ', () => {
 
   it('should be created', () => {
     expect(component instanceof PoStepperLabelComponent).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+    it('should set content property correctly', () => {
+      component.content = 'Step 1';
+      fixture.detectChanges();
+      expect(component.content).toBe('Step 1');
+    });
+
+    it('should handle vertical orientation property', () => {
+      component.isVerticalOrientation = true;
+      fixture.detectChanges();
+      expect(component.isVerticalOrientation).toBeTrue();
+    });
+
+    it('should handle status property', () => {
+      component.status = 'active';
+      fixture.detectChanges();
+      expect(component.status).toBe('active');
+    });
+  });
+
+  describe('Methods:', () => {
+    it('should call `updateLabel` and detectChanges when content changes', () => {
+      const updateLabelSpy = spyOn(component as any, 'updateLabel').and.callThrough();
+
+      const changes = {
+        content: new SimpleChange(null, 'Step 1', true),
+        isVerticalOrientation: null
+      };
+
+      component.ngOnChanges(changes);
+
+      fixture.detectChanges();
+
+      expect(updateLabelSpy).toHaveBeenCalled();
+    });
+
+    it('should call `updateLabel` and detectChanges when isVerticalOrientation changes', () => {
+      const updateLabelSpy = spyOn(component as any, 'updateLabel').and.callThrough();
+
+      const changes = {
+        content: null,
+        isVerticalOrientation: new SimpleChange(null, true, true)
+      };
+
+      component.ngOnChanges(changes);
+
+      fixture.detectChanges();
+
+      expect(updateLabelSpy).toHaveBeenCalled();
+    });
+
+    it('should call updateLabel and detectChanges when both content and isVerticalOrientation change', () => {
+      const updateLabelSpy = spyOn(component as any, 'updateLabel').and.callThrough();
+
+      const changes = {
+        content: new SimpleChange(null, 'New Content', true),
+        isVerticalOrientation: new SimpleChange(null, true, true)
+      };
+
+      component.ngOnChanges(changes);
+
+      fixture.detectChanges();
+
+      expect(updateLabelSpy).toHaveBeenCalled();
+    });
+
+    it('should not update label if labelElement is null', () => {
+      const updateLabelSpy = spyOn<any>(component, 'updateLabel').and.callThrough();
+      component.labelElement = null;
+
+      (component as any).updateLabel();
+
+      expect(updateLabelSpy).toHaveBeenCalled();
+      expect(component.tooltipContent).toBeNull();
+    });
+
+    it('should truncate content when isVerticalOrientation is true and content length exceeds maxLabelLength', () => {
+      const originalContent = 'This is a long content that needs truncation';
+      component.content = originalContent;
+      component.isVerticalOrientation = true;
+      (component as any).maxLabelLength = 10;
+
+      (component as any).updateLabel();
+
+      expect(component.displayedContent).toBe('This is a ...');
+    });
+
+    it('should set tooltipContent to content if text overflows horizontally', () => {
+      const labelElement = document.createElement('div');
+      component.labelElement = { nativeElement: labelElement } as any;
+
+      component.content = 'Content that will overflow horizontally';
+      component.isVerticalOrientation = false;
+      (component as any).maxLabelLength = 50;
+
+      Object.defineProperty(labelElement, 'scrollWidth', { value: 200 });
+      Object.defineProperty(labelElement, 'clientWidth', { value: 50 });
+
+      (component as any).updateTooltip();
+
+      expect(component.tooltipContent).toBe(component.content);
+    });
+
+    it('should set tooltipContent to null if content length does not exceed maxLabelLength and no text overflow', () => {
+      const labelElement = document.createElement('div');
+      component.labelElement = { nativeElement: labelElement } as any;
+
+      component.content = 'Short content';
+      component.isVerticalOrientation = true;
+      (component as any).maxLabelLength = 20;
+
+      Object.defineProperty(labelElement, 'scrollWidth', { value: 50 });
+      Object.defineProperty(labelElement, 'clientWidth', { value: 50 });
+      Object.defineProperty(labelElement, 'scrollHeight', { value: 20 });
+      Object.defineProperty(labelElement, 'clientHeight', { value: 20 });
+
+      (component as any).updateTooltip();
+
+      expect(component.tooltipContent).toBeNull();
+    });
+
+    it('should set tooltipContent to content if content length exceeds maxLabelLength', () => {
+      const labelElement = document.createElement('div');
+      component.labelElement = { nativeElement: labelElement } as any;
+
+      component.content = 'This is a long content that needs truncation';
+      component.isVerticalOrientation = true;
+      (component as any).maxLabelLength = 20;
+
+      Object.defineProperty(labelElement, 'scrollWidth', { value: 50 });
+      Object.defineProperty(labelElement, 'clientWidth', { value: 50 });
+      Object.defineProperty(labelElement, 'scrollHeight', { value: 20 });
+      Object.defineProperty(labelElement, 'clientHeight', { value: 20 });
+
+      (component as any).updateTooltip();
+
+      expect(component.tooltipContent).toBe(component.content);
+    });
+
+    it('should call updateTooltip and add class on mouseover', () => {
+      const updateTooltipSpy = spyOn<any>(component, 'updateTooltip').and.callThrough();
+      const addClassSpy = spyOn((component as any).renderer, 'addClass').and.callThrough();
+
+      component.onMouseOver();
+
+      expect(updateTooltipSpy).toHaveBeenCalled();
+      expect(addClassSpy).toHaveBeenCalledWith(component.labelElement.nativeElement, 'hovered');
+    });
+
+    it('should remove class on mouseout', () => {
+      const removeClassSpy = spyOn((component as any).renderer, 'removeClass').and.callThrough();
+
+      component.onMouseOut();
+
+      expect(removeClassSpy).toHaveBeenCalledWith(component.labelElement.nativeElement, 'hovered');
+    });
+
+    it('should set tooltipContent to content if text overflows vertically', () => {
+      const labelElement = document.createElement('div');
+
+      component.labelElement = { nativeElement: labelElement } as any;
+
+      component.content =
+        'Content that is very long and will overflow horizontally or exceed 100 characters vertically';
+      component.isVerticalOrientation = true;
+      (component as any).maxLabelLength = 100;
+
+      Object.defineProperty(labelElement, 'scrollWidth', { value: 150 });
+      Object.defineProperty(labelElement, 'clientWidth', { value: 100 });
+
+      (component as any).updateTooltip();
+
+      expect(component.tooltipContent).toBe(component.content);
+    });
+  });
+
+  describe('Templates:', () => {
+    it('should apply `po-stepper-label-vertical` when isVerticalOrientation is true', () => {
+      component.isVerticalOrientation = true;
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-vertical')).toBeTrue();
+    });
+
+    it('should apply `po-stepper-label-active` when status is active', () => {
+      component.status = 'active';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-active')).toBeTrue();
+    });
+
+    it('should apply `po-stepper-label-active` when status is error', () => {
+      component.status = 'error';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-active')).toBeTrue();
+    });
+
+    it('should apply `po-stepper-label` when content is set', () => {
+      component.content = 'Step 1';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label')).toBeTrue();
+    });
+
+    it('should apply `po-stepper-label-done` when status is done', () => {
+      component.status = 'done';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-stepper-label-done')).toBeTrue();
+    });
+
+    it('should add `po-link` class when status is not `disabled`.', () => {
+      component.status = 'active';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-link')).toBeTrue();
+    });
+
+    it('should not add `po-link` class when status is `disabled`.', () => {
+      component.status = 'disabled';
+      fixture.detectChanges();
+
+      const element = fixture.debugElement.query(By.css('div'));
+
+      expect(element.nativeElement.classList.contains('po-link')).toBeFalse();
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.ts
@@ -1,4 +1,15 @@
-import { Component, Input } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  HostListener,
+  Input,
+  OnChanges,
+  Renderer2,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 
 /**
  * @docsPrivate
@@ -11,7 +22,73 @@ import { Component, Input } from '@angular/core';
   selector: 'po-stepper-label',
   templateUrl: './po-stepper-label.component.html'
 })
-export class PoStepperLabelComponent {
+export class PoStepperLabelComponent implements AfterViewInit, OnChanges {
   // Conteúdo da label.
   @Input('p-content') content: string;
+
+  // Informa o status da etapa.
+  @Input('p-status') status: string;
+
+  // Informa se a orientação do stepper é vertical.
+  @Input('p-vertical-orientation') isVerticalOrientation: boolean;
+
+  @ViewChild('labelElement') labelElement: ElementRef;
+
+  displayedContent: string;
+  tooltipContent: string;
+
+  private maxLabelLength: number = 100;
+
+  constructor(
+    private renderer: Renderer2,
+    private changeDetectorRef: ChangeDetectorRef
+  ) {}
+
+  ngAfterViewInit() {
+    this.updateLabel();
+    this.changeDetectorRef.detectChanges();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['content'] || changes['isVerticalOrientation']) {
+      this.updateLabel();
+      this.changeDetectorRef.detectChanges();
+    }
+  }
+
+  @HostListener('mouseover')
+  onMouseOver() {
+    this.updateTooltip();
+    this.renderer.addClass(this.labelElement.nativeElement, 'hovered');
+  }
+
+  @HostListener('mouseout')
+  onMouseOut() {
+    this.renderer.removeClass(this.labelElement.nativeElement, 'hovered');
+  }
+
+  private updateLabel(): void {
+    if (!this.labelElement) return;
+
+    const originalContent = this.content;
+    let displayedContent = originalContent;
+
+    if (this.isVerticalOrientation && originalContent.length > this.maxLabelLength) {
+      displayedContent = originalContent.substring(0, this.maxLabelLength) + '...';
+    }
+
+    this.displayedContent = displayedContent;
+
+    this.updateTooltip();
+  }
+
+  private updateTooltip(): void {
+    if (this.labelElement) {
+      const element = this.labelElement.nativeElement;
+      const isTextOverflowing = element.scrollWidth > element.clientWidth;
+      const isTextTooLong = this.isVerticalOrientation && this.content.length > this.maxLabelLength;
+
+      this.tooltipContent = isTextOverflowing || isTextTooLong ? this.content : null;
+    }
+  }
 }

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.ts
@@ -23,6 +23,9 @@ import {
   templateUrl: './po-stepper-label.component.html'
 })
 export class PoStepperLabelComponent implements AfterViewInit, OnChanges {
+  // Alinhamento da label.
+  @Input('p-align-center') alignCenter: boolean;
+
   // Conteúdo da label.
   @Input('p-content') content: string;
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
@@ -1,22 +1,38 @@
-<div class="po-stepper-step" [ngClass]="getStatusClass(status)" (click)="onClick()" (keydown.enter)="onEnter()">
-  <div class="po-stepper-step-container" [style.width.px]="isVerticalOrientation ? stepSize : undefined">
-    <div
-      [class.po-stepper-step-bar-top]="isVerticalOrientation"
-      [class.po-stepper-step-bar-left]="!isVerticalOrientation"
-      [style.margin-right.px]="marginHorizontalBar"
-    ></div>
-
-    <po-stepper-circle [p-content]="circleContent" [p-icons]="stepIcons" [p-size]="stepSize" [p-status]="status">
+<div
+  class="po-stepper-step"
+  [ngClass]="getStatusClass(status)"
+  role="tab"
+  [tabindex]="status === 'disabled' ? -1 : 0"
+  [attr.aria-selected]="status === 'active'"
+  [attr.aria-disabled]="status === 'disabled'"
+  [attr.aria-required]="status === 'error'"
+  (click)="onClick()"
+  (keydown.enter)="onEnter()"
+>
+  <div class="po-stepper-step-container">
+    <po-stepper-circle
+      [p-content]="circleContent"
+      [p-icons]="stepIcons"
+      [p-size]="stepSize"
+      [p-status]="status"
+      [p-icon-default]="iconDefault"
+      [p-step-icon-done]="iconDone"
+      [p-step-icon-active]="iconActive"
+      [class.po-stepper-circle-vertical]="isVerticalOrientation"
+      [class.po-stepper-circle-horizontal]="!isVerticalOrientation"
+      [style.minWidth.px]="minWidthCircle"
+      [style.minHeight.px]="minHeightCircle"
+    >
     </po-stepper-circle>
 
-    <div
-      [class.po-stepper-step-bar-bottom]="isVerticalOrientation"
-      [class.po-stepper-step-bar-right]="!isVerticalOrientation"
-      [class.po-stepper-step-dashed-border]="nextStatus === 'disabled' && !isVerticalOrientation"
-      [class.po-stepper-step-dashed-border-vertical]="nextStatus === 'disabled' && isVerticalOrientation"
-      [style.margin-left.px]="marginHorizontalBar"
-    ></div>
+    <po-stepper-label
+      *ngIf="label"
+      class="po-stepper-step-label-position"
+      [p-content]="label"
+      [p-status]="status"
+      [p-vertical-orientation]="isVerticalOrientation"
+      [attr.aria-label]="label"
+    >
+    </po-stepper-label>
   </div>
-
-  <po-stepper-label class="po-stepper-step-label-position" [p-content]="label"> </po-stepper-label>
 </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
@@ -11,6 +11,7 @@
 >
   <div class="po-stepper-step-container">
     <po-stepper-circle
+      [p-align-center]="alignCenter"
       [p-content]="circleContent"
       [p-icons]="stepIcons"
       [p-size]="stepSize"
@@ -19,6 +20,7 @@
       [p-step-icon-done]="iconDone"
       [p-step-icon-active]="iconActive"
       [class.po-stepper-circle-vertical]="isVerticalOrientation"
+      [class.po-stepper-circle-vertical-center]="alignCenter"
       [class.po-stepper-circle-horizontal]="!isVerticalOrientation"
       [style.minWidth.px]="minWidthCircle"
       [style.minHeight.px]="minHeightCircle"
@@ -28,6 +30,7 @@
     <po-stepper-label
       *ngIf="label"
       class="po-stepper-step-label-position"
+      [p-align-center]="alignCenter"
       [p-content]="label"
       [p-status]="status"
       [p-vertical-orientation]="isVerticalOrientation"

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.spec.ts
@@ -86,41 +86,6 @@ describe('PoStepperStepComponent:', () => {
       expectPropertiesValues(component, 'stepSize', invalidValues, poStepperStepSizeDefault);
     });
 
-    it('halfStepSize: should return half of step size.', () => {
-      const expectedValue = 24;
-
-      component.stepSize = 48;
-
-      expect(component.halfStepSize).toBe(expectedValue);
-    });
-
-    it('isVerticalOrientation: should return `true` if `orientation` is `vertical`.', () => {
-      component.orientation = PoStepperOrientation.Vertical;
-
-      expect(component.isVerticalOrientation).toBeTruthy();
-    });
-
-    it('isVerticalOrientation: should return `false` if `orientation` is `horizontal`.', () => {
-      component.orientation = PoStepperOrientation.Horizontal;
-
-      expect(component.isVerticalOrientation).toBeFalsy();
-    });
-
-    it('marginHorizontalBar: should return half of step size if `orientation` is `horizontal`.', () => {
-      const defaultHalftStepSize = 12;
-
-      component.stepSize = 24;
-      component.orientation = PoStepperOrientation.Horizontal;
-
-      expect(component.marginHorizontalBar).toBe(defaultHalftStepSize);
-    });
-
-    it('marginHorizontalBar: should return undefined if `orientation` is `vertical`.', () => {
-      component.orientation = PoStepperOrientation.Vertical;
-
-      expect(component.marginHorizontalBar).toBeUndefined();
-    });
-
     it('p-step-icons: should update property with valid values to `true`.', () => {
       const booleanValidTrueValues = [true, 'true', 1, ''];
 
@@ -131,6 +96,40 @@ describe('PoStepperStepComponent:', () => {
       const booleanInvalidValues = [undefined, null, 2, 'string'];
 
       expectPropertiesValues(component, 'stepIcons', booleanInvalidValues, false);
+    });
+
+    it('minHeightCircle: should return 32 if `stepSize` is less than or equal to 24 and orientation is vertical.', () => {
+      component.stepSize = 24;
+      component.isVerticalOrientation = true;
+
+      expect(component.minHeightCircle).toBe(32);
+    });
+
+    it('minHeightCircle: should return `stepSize + 8` if `stepSize` is greater than 24 and orientation is vertical.', () => {
+      component.stepSize = 40;
+      component.isVerticalOrientation = true;
+
+      expect(component.minHeightCircle).toBe(48);
+    });
+
+    it('minHeightCircle: should return 32 if `stepSize` is 24 and the orientation is horizontal.', () => {
+      component.stepSize = 24;
+      component.isVerticalOrientation = false;
+
+      expect(component.minHeightCircle).toBe(32);
+    });
+
+    it('minWidthCircle: should return 32 if `stepSize` is 24 and the orientation is vertical.', () => {
+      component.stepSize = 24;
+      component.isVerticalOrientation = true;
+
+      expect(component.minWidthCircle).toBe(32);
+    });
+
+    it('minWidthCircle: should return null if orientation is horizontal.', () => {
+      component.isVerticalOrientation = false;
+
+      expect(component.minWidthCircle).toBeNull();
     });
   });
 
@@ -212,22 +211,91 @@ describe('PoStepperStepComponent:', () => {
 
       expect(component.enter.emit).not.toHaveBeenCalled();
     });
+
+    it('setDefaultStepSize: should increase step size by 8px if status is `Active` and step size is default.', () => {
+      (component as any)._stepSize = 24;
+      component.status = PoStepperStatus.Active;
+
+      component.setDefaultStepSize();
+
+      expect((component as any)._stepSize).toBe(32);
+    });
+
+    it('setDefaultStepSize: should increase step size by 8px if status is `Error` and stepSizeOriginal is default.', () => {
+      component.stepSizeOriginal = 24;
+      component.status = PoStepperStatus.Error;
+
+      component.setDefaultStepSize();
+
+      expect((component as any)._stepSize).toBe(32);
+    });
+
+    it('setDefaultStepSize: should keep the original step size if step size is not default.', () => {
+      component.stepSizeOriginal = 64;
+
+      component.setDefaultStepSize();
+
+      expect((component as any)._stepSize).toBe(64);
+    });
+
+    it('should update stepSizeOriginal and call setDefaultStepSize if stepSize changes and stepSizeOriginal is undefined', () => {
+      (component as any)._stepSize = 40;
+      component.stepSizeOriginal = undefined;
+
+      spyOn(component, 'setDefaultStepSize');
+
+      const changes = {
+        stepSize: { currentValue: 40, previousValue: 30, firstChange: false, isFirstChange: () => false }
+      };
+
+      component.ngOnChanges(changes);
+
+      expect(component.stepSizeOriginal).toBe((component as any)._stepSize);
+      expect(component.setDefaultStepSize).toHaveBeenCalled();
+    });
+
+    it('should call setDefaultStepSize if status changes', () => {
+      component.stepSizeOriginal = 30;
+
+      spyOn(component, 'setDefaultStepSize');
+
+      const changes = {
+        status: {
+          currentValue: PoStepperStatus.Active,
+          previousValue: PoStepperStatus.Default,
+          firstChange: false,
+          isFirstChange: () => false
+        }
+      };
+
+      component.ngOnChanges(changes);
+
+      expect(component.setDefaultStepSize).toHaveBeenCalled();
+    });
+
+    it('should call setDefaultStepSize if both stepSize and status change', () => {
+      component.stepSizeOriginal = 30;
+
+      spyOn(component, 'setDefaultStepSize');
+
+      const changes = {
+        stepSize: { currentValue: 40, previousValue: 30, firstChange: false, isFirstChange: () => false },
+        status: {
+          currentValue: PoStepperStatus.Active,
+          previousValue: PoStepperStatus.Default,
+          firstChange: false,
+          isFirstChange: () => false
+        }
+      };
+
+      component.ngOnChanges(changes);
+
+      expect(component.setDefaultStepSize).toHaveBeenCalled();
+    });
   });
 
   describe('Templates:', () => {
     const elementByClass = (className: string) => nativeElement.querySelector(`.${className}`);
-
-    it(`should find 'po-stepper-step-container' and style.width is stepSize value if 'isVerticalOrientation' is 'true'.`, () => {
-      component.orientation = PoStepperOrientation.Vertical;
-      component.stepSize = 60;
-
-      fixture.detectChanges();
-
-      const stepperContainer = elementByClass('po-stepper-step-container');
-
-      expect(stepperContainer).toBeTruthy();
-      expect(stepperContainer.style.width).toBe('60px');
-    });
 
     it('should find `po-stepper-step-container` and it not contains width if `orientation` is `horizontal`.', () => {
       component.orientation = PoStepperOrientation.Horizontal;
@@ -239,52 +307,6 @@ describe('PoStepperStepComponent:', () => {
 
       expect(stepperContainer).toBeTruthy();
       expect(stepperContainer.style.width).toBe('');
-    });
-
-    it(`should create class 'po-stepper-step-bar-left' and 'po-stepper-step-bar-right' if 'p-orientation' is 'horizontal'.`, () => {
-      component.orientation = PoStepperOrientation.Horizontal;
-      component.label = 'Step 1';
-
-      fixture.detectChanges();
-
-      const stepperBarLeft = elementByClass('po-stepper-step-bar-left');
-      const stepperBarRight = elementByClass('po-stepper-step-bar-right');
-
-      expect(stepperBarLeft).toBeTruthy();
-      expect(stepperBarRight).toBeTruthy();
-      expect(elementByClass('po-stepper-bar-top')).toBeFalsy();
-      expect(elementByClass('po-stepper-bar-bottom')).toBeFalsy();
-    });
-
-    it(`should create class 'po-stepper-step-bar-top' and 'po-stepper-step-bar-bottom' if 'p-orientation' is 'vertical'.`, () => {
-      component.orientation = PoStepperOrientation.Vertical;
-      component.label = 'Step 1';
-
-      fixture.detectChanges();
-
-      const stepperBarLeft = elementByClass('po-stepper-step-bar-left');
-      const stepperBarRight = elementByClass('po-stepper-step-bar-right');
-
-      expect(stepperBarLeft).toBeFalsy();
-      expect(stepperBarRight).toBeFalsy();
-      expect(elementByClass('po-stepper-step-bar-top')).toBeTruthy();
-      expect(elementByClass('po-stepper-step-bar-bottom')).toBeTruthy();
-    });
-
-    it(`should add margin-left and margin-right in 'step-bar-left' and 'step-bar-right' with 'marginHorizontalBar'.`, () => {
-      const marginHorizontalBar = 12;
-      component.orientation = PoStepperOrientation.Horizontal;
-      component.label = 'Step 1';
-
-      spyOnProperty(component, 'marginHorizontalBar').and.returnValue(marginHorizontalBar);
-
-      fixture.detectChanges();
-
-      const stepperBarLeft = elementByClass('po-stepper-step-bar-left');
-      const stepperBarRight = elementByClass('po-stepper-step-bar-right');
-
-      expect(stepperBarLeft.style.marginRight).toBe(`${marginHorizontalBar}px`);
-      expect(stepperBarRight.style.marginLeft).toBe(`${marginHorizontalBar}px`);
     });
 
     it('should find `po-stepper-circle` and it contains height and width with 24px if stepSize is greater than 64.', () => {
@@ -352,26 +374,22 @@ describe('PoStepperStepComponent:', () => {
       expect(elementByClass('po-stepper-step-default')).toBeTruthy();
     });
 
-    it(`should create class 'po-stepper-step-dashed-border' if 'nextStatus' is disabled and position is not vertical`, () => {
-      component.orientation = PoStepperOrientation.Horizontal;
-      component.nextStatus = 'disabled';
-
+    it('should change `tabindex` to `-1` if component is disabled', () => {
+      component.status = PoStepperStatus.Disabled;
       fixture.detectChanges();
 
-      const stepperDashedBorder = elementByClass('po-stepper-step-dashed-border');
+      const poStepperStepElement = nativeElement.querySelector('.po-stepper-step[tabindex="-1"]');
 
-      expect(stepperDashedBorder).toBeTruthy();
+      expect(poStepperStepElement).toBeTruthy();
     });
 
-    it(`should create class 'po-stepper-step-dashed-border-vertical' if 'nextStatus' is disabled and position is vertical`, () => {
-      component.orientation = PoStepperOrientation.Vertical;
-      component.nextStatus = 'disabled';
-
+    it('should change `tabindex` to `0` if component isn’t disabled', () => {
+      component.status = PoStepperStatus.Active;
       fixture.detectChanges();
 
-      const stepperDashedBorderVertical = elementByClass('po-stepper-step-dashed-border-vertical');
+      const poStepperStepElement = nativeElement.querySelector('.po-stepper-step[tabindex="0"]');
 
-      expect(stepperDashedBorderVertical).toBeTruthy();
+      expect(poStepperStepElement).toBeTruthy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
@@ -25,6 +25,9 @@ const poStepLiteralsDefault = {
   templateUrl: 'po-stepper-step.component.html'
 })
 export class PoStepperStepComponent implements OnChanges {
+  // Alinhamento do *step* e da label.
+  @Input('p-align-center') alignCenter: boolean;
+
   // Conteúdo que será repassado para o componente `p-circle-content` através da propriedade `p-content`.
   @Input('p-circle-content') circleContent: any;
 
@@ -180,7 +183,10 @@ export class PoStepperStepComponent implements OnChanges {
   setDefaultStepSize(): void {
     if (this._stepSize === poStepperStepSizeDefault && this._status === PoStepperStatus.Active) {
       this._stepSize = poStepperStepSizeDefault + 8;
-    } else if (this.stepSizeOriginal === poStepperStepSizeDefault && this._status === PoStepperStatus.Error) {
+    } else if (
+      this.stepSizeOriginal === poStepperStepSizeDefault &&
+      (this._status === PoStepperStatus.Error || this._status === PoStepperStatus.Active)
+    ) {
       this._stepSize = poStepperStepSizeDefault + 8;
     } else {
       this._stepSize = this.stepSizeOriginal;

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, TemplateRef } from '@angular/core';
 
 import { getShortBrowserLanguage, convertToBoolean, isTypeof } from './../../../utils/util';
 import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
@@ -24,34 +24,15 @@ const poStepLiteralsDefault = {
   selector: 'po-stepper-step',
   templateUrl: 'po-stepper-step.component.html'
 })
-export class PoStepperStepComponent {
+export class PoStepperStepComponent implements OnChanges {
   // Conteúdo que será repassado para o componente `p-circle-content` através da propriedade `p-content`.
   @Input('p-circle-content') circleContent: any;
 
-  // Define a orientação de exibição.
-  @Input('p-orientation') orientation: PoStepperOrientation;
-
-  // Informa o status da proxima etapa.
+  // Informa o status da próxima etapa.
   @Input('p-next-status') nextStatus;
 
-  // Evento que será emitido quando o status do *step* estiver ativo (`PoStepperStatus.Active`).
-  @Output('p-activated') activated = new EventEmitter<any>();
-
-  // Evento que será emitido ao clicar no *step*.
-  @Output('p-click') click = new EventEmitter<any>();
-
-  // Evento que será emitido ao focar no *step* e pressionar a tecla *enter*.
-  @Output('p-enter') enter = new EventEmitter<any>();
-
-  readonly literals = {
-    ...poStepLiteralsDefault[poLocaleDefault],
-    ...poStepLiteralsDefault[getShortBrowserLanguage()]
-  };
-
-  private _label: string;
-  private _status: PoStepperStatus;
-  private _stepIcons?: boolean = false;
-  private _stepSize: number = poStepperStepSizeDefault;
+  // Define a orientação de exibição.
+  @Input('p-orientation') orientation: PoStepperOrientation;
 
   // Label do *step*.
   @Input('p-label') set label(value: string) {
@@ -94,16 +75,79 @@ export class PoStepperStepComponent {
     return this._stepSize;
   }
 
-  get halfStepSize(): number {
-    return this.stepSize / 2;
+  @Input('p-icon-default') set iconDefault(value: string | TemplateRef<void>) {
+    this._iconDefault = value;
   }
 
-  get isVerticalOrientation(): boolean {
-    return this.orientation === PoStepperOrientation.Vertical;
+  get iconDefault(): string | TemplateRef<void> {
+    return this._iconDefault;
   }
 
-  get marginHorizontalBar(): number {
-    return this.isVerticalOrientation ? undefined : this.halfStepSize;
+  @Input('p-step-icon-done') set iconDone(value: string | TemplateRef<void>) {
+    this._iconDone = value;
+  }
+
+  get iconDone(): string | TemplateRef<void> {
+    return this._iconDone;
+  }
+
+  @Input('p-step-icon-active') set iconActive(value: string | TemplateRef<void>) {
+    this._iconActive = value;
+  }
+
+  get iconActive(): string | TemplateRef<void> {
+    return this._iconActive;
+  }
+
+  // Informa se a orientação do stepper é vertical.
+  @Input('p-vertical-orientation') isVerticalOrientation: boolean;
+
+  // Evento que será emitido quando o status do *step* estiver ativo (`PoStepperStatus.Active`).
+  @Output('p-activated') activated = new EventEmitter<any>();
+
+  // Evento que será emitido ao clicar no *step*.
+  @Output('p-click') click = new EventEmitter<any>();
+
+  // Evento que será emitido ao focar no *step* e pressionar a tecla *enter*.
+  @Output('p-enter') enter = new EventEmitter<any>();
+
+  readonly literals = {
+    ...poStepLiteralsDefault[poLocaleDefault],
+    ...poStepLiteralsDefault[getShortBrowserLanguage()]
+  };
+
+  stepSizeOriginal: number;
+  private _label: string;
+  private _status: PoStepperStatus;
+  private _stepIcons?: boolean = false;
+  private _stepSize: number = poStepperStepSizeDefault;
+  private _iconDefault?: string | TemplateRef<void>;
+  private _iconDone?: string | TemplateRef<void>;
+  private _iconActive?: string | TemplateRef<void>;
+
+  get minHeightCircle(): number | null {
+    if (this.stepSize === 24) {
+      return 32;
+    }
+
+    return this.isVerticalOrientation ? Math.max(this.stepSize, 24) + 8 : null;
+  }
+
+  get minWidthCircle(): number | null {
+    if (this.isVerticalOrientation && this.stepSize === 24) {
+      return 32;
+    }
+    return null;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.stepSizeOriginal === undefined || changes['stepSize']) {
+      this.stepSizeOriginal = this._stepSize;
+    }
+
+    if (changes['status'] || changes['stepSize']) {
+      this.setDefaultStepSize();
+    }
   }
 
   getStatusClass(status: string): string {
@@ -130,6 +174,16 @@ export class PoStepperStepComponent {
   onEnter(): void {
     if (this.status !== PoStepperStatus.Disabled) {
       this.enter.emit();
+    }
+  }
+
+  setDefaultStepSize(): void {
+    if (this._stepSize === poStepperStepSizeDefault && this._status === PoStepperStatus.Active) {
+      this._stepSize = poStepperStepSizeDefault + 8;
+    } else if (this.stepSizeOriginal === poStepperStepSizeDefault && this._status === PoStepperStatus.Error) {
+      this._stepSize = poStepperStepSizeDefault + 8;
+    } else {
+      this._stepSize = this.stepSizeOriginal;
     }
   }
 }

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
@@ -1,20 +1,39 @@
-<div class="po-stepper po-stepper-{{ orientation }}">
-  <div class="po-stepper-container">
-    <po-stepper-step
-      *ngFor="let step of stepList; let index = index; trackBy: trackByFn"
-      class="po-stepper-step-position"
-      [p-circle-content]="index + 1"
-      [p-label]="step.label"
-      [p-orientation]="orientation"
-      [p-status]="step.status"
-      [p-step-icons]="stepIcons"
-      [p-step-size]="stepSize"
-      [p-next-status]="poSteps.get(index + 1)?.status"
-      (p-activated)="onStepActive(step)"
-      (p-click)="changeStep(index, step)"
-      (p-enter)="changeStep(index, step)"
-    >
-    </po-stepper-step>
+<div class="po-stepper-{{ orientation }}">
+  <div role="tablist" class="po-stepper-container-{{ orientation }}">
+    <ng-container *ngFor="let step of stepList; let index = index; trackBy: trackByFn">
+      <div class="po-stepper-step-wrapper">
+        <po-stepper-step
+          class="po-stepper-step-position"
+          [p-circle-content]="index + 1"
+          [p-label]="step.label"
+          [p-orientation]="orientation"
+          [p-status]="step.status"
+          [p-step-icons]="stepIcons"
+          [p-step-size]="stepSize"
+          [p-next-status]="poSteps.get(index + 1)?.status"
+          [p-icon-default]="step.iconDefault"
+          [p-step-icon-active]="iconActive"
+          [p-step-icon-done]="iconDone"
+          [p-vertical-orientation]="isVerticalOrientation"
+          (p-activated)="onStepActive(step)"
+          (p-click)="changeStep(index, step)"
+          (p-enter)="changeStep(index, step)"
+        >
+        </po-stepper-step>
+
+        <div
+          *ngIf="index < stepList.length - 1"
+          [class.po-stepper-step-bar-bottom]="isVerticalOrientation"
+          [class.po-stepper-step-bar-right]="!isVerticalOrientation"
+          [class.po-stepper-step-dashed-border]="!isVerticalOrientation && isDashedBorder(step, index)"
+          [class.po-stepper-step-dashed-border-vertical]="isVerticalOrientation && isDashedBorder(step, index)"
+          [style.top.px]="!isVerticalOrientation ? (stepSizeCircle === 24 ? 16 : stepSizeCircle / 2) : null"
+          [style.left.px]="
+            isVerticalOrientation ? (!stepSizeCircle || stepSizeCircle === 24 ? 16 : stepSizeCircle / 2) : null
+          "
+        ></div>
+      </div>
+    </ng-container>
   </div>
 
   <div *ngIf="usePoSteps" class="po-stepper-content">

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
@@ -2,8 +2,20 @@
   <div role="tablist" class="po-stepper-container-{{ orientation }}">
     <ng-container *ngFor="let step of stepList; let index = index; trackBy: trackByFn">
       <div class="po-stepper-step-wrapper">
+        <div
+          *ngIf="index > 0"
+          [class.po-stepper-step-bar-top]="alignCenter && isVerticalOrientation"
+          [class.po-stepper-step-dashed-border-vertical]="
+            alignCenter && isVerticalOrientation && isDashedBorderTop(step, index)
+          "
+          [style.left.px]="
+            isVerticalOrientation ? (!stepSizeCircle || stepSizeCircle === 24 ? 16 : stepSizeCircle / 2) : null
+          "
+        ></div>
+
         <po-stepper-step
-          class="po-stepper-step-position"
+          [class.po-stepper-step-position-center]="alignCenter"
+          [p-align-center]="alignCenter"
           [p-circle-content]="index + 1"
           [p-label]="step.label"
           [p-orientation]="orientation"
@@ -24,7 +36,9 @@
         <div
           *ngIf="index < stepList.length - 1"
           [class.po-stepper-step-bar-bottom]="isVerticalOrientation"
+          [class.po-stepper-step-bar-bottom-center]="alignCenter && isVerticalOrientation"
           [class.po-stepper-step-bar-right]="!isVerticalOrientation"
+          [class.po-stepper-step-bar-center]="alignCenter && !isVerticalOrientation"
           [class.po-stepper-step-dashed-border]="!isVerticalOrientation && isDashedBorder(step, index)"
           [class.po-stepper-step-dashed-border-vertical]="isVerticalOrientation && isDashedBorder(step, index)"
           [style.top.px]="!isVerticalOrientation ? (stepSizeCircle === 24 ? 16 : stepSizeCircle / 2) : null"

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
@@ -9,6 +9,7 @@ import { PoStepComponent } from './po-step/po-step.component';
 import { PoStepperBaseComponent } from './po-stepper-base.component';
 import { PoStepperComponent } from './po-stepper.component';
 import { PoStepperModule } from './po-stepper.module';
+import { PoStepperItem } from './po-stepper-item.interface';
 
 describe('PoStepperComponent:', () => {
   let component: PoStepperComponent;
@@ -324,6 +325,89 @@ describe('PoStepperComponent:', () => {
       expect(spyAllowNextStep).toHaveBeenCalledWith(stepIndex);
       expect(spyOnChangeStep).toHaveBeenCalledWith(stepNumber);
     }));
+
+    it('isDashedBorderTop: should return true when the step status is done and the previous step is not done or active', () => {
+      const step = { status: 'done' } as PoStepComponent;
+      const previousStep = { status: 'error' } as PoStepComponent;
+
+      spyOn(component, 'getPreviousPoSteps').and.returnValue(previousStep);
+      spyOn(component, 'getPreviousSteps').and.returnValue(previousStep);
+
+      const result = component.isDashedBorderTop(step, 1);
+
+      expect(result).toBeTrue();
+    });
+
+    it('isDashedBorderTop: should return false when the step status is done and the previous step is done', () => {
+      const step = { status: 'done' } as PoStepComponent;
+      const previousStep = { status: 'done' } as PoStepComponent;
+
+      spyOn(component, 'getPreviousPoSteps').and.returnValue(previousStep);
+      spyOn(component, 'getPreviousSteps').and.returnValue(previousStep);
+
+      const result = component.isDashedBorderTop(step, 1);
+
+      expect(result).toBeFalse();
+    });
+
+    it('isDashedBorderTop: should return true when the step status is active and the previous step status is error', () => {
+      const step = { status: 'active' } as PoStepComponent;
+      const previousStep = { status: 'error' } as PoStepComponent;
+
+      spyOn(component, 'getPreviousPoSteps').and.returnValue(previousStep);
+      spyOn(component, 'getPreviousSteps').and.returnValue(previousStep);
+
+      const result = component.isDashedBorderTop(step, 1);
+
+      expect(result).toBeTrue();
+    });
+
+    it('isDashedBorderTop: should return false when the step status is active and the previous step status is done', () => {
+      const step = { status: 'active' } as PoStepComponent;
+      const previousStep = { status: 'done' } as PoStepComponent;
+
+      spyOn(component, 'getPreviousPoSteps').and.returnValue(previousStep);
+      spyOn(component, 'getPreviousSteps').and.returnValue(previousStep);
+
+      const result = component.isDashedBorderTop(step, 1);
+
+      expect(result).toBeFalse();
+    });
+
+    it('isDashedBorderTop: should return true when the step status is error and the next step is done', () => {
+      const step = { status: 'error' } as PoStepComponent;
+      const nextStep = { status: 'done' } as PoStepComponent;
+
+      spyOn(component, 'getNextPoSteps').and.returnValue(nextStep);
+
+      const result = component.isDashedBorderTop(step, 1);
+
+      expect(result).toBeTrue();
+    });
+
+    it('isDashedBorderTop: should return true when the step status is default and the previous step is not done', () => {
+      const step = { status: 'default' } as PoStepComponent;
+      const previousStep = { status: 'active' } as PoStepperItem;
+
+      spyOn(component, 'getPreviousPoSteps').and.returnValue(previousStep as unknown as PoStepComponent);
+      spyOn(component, 'getPreviousSteps').and.returnValue(previousStep);
+
+      const result = component.isDashedBorderTop(step, 1);
+
+      expect(result).toBeTrue();
+    });
+
+    it('isDashedBorderTop: should return true when the step status is disabled', () => {
+      const step = { status: 'disabled' } as PoStepComponent;
+      const previousStep = { status: 'default' } as PoStepperItem;
+
+      spyOn(component, 'getPreviousPoSteps').and.returnValue(previousStep as unknown as PoStepComponent);
+      spyOn(component, 'getPreviousSteps').and.returnValue(previousStep);
+
+      const result = component.isDashedBorderTop(step, 1);
+
+      expect(result).toBeTrue();
+    });
 
     it('onStepActive: should set `currentActiveStep` to `currentActiveStep`', () => {
       component['currentActiveStep'] = undefined;

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.module.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.module.ts
@@ -6,14 +6,15 @@ import { PoStepperCircleComponent } from './po-stepper-circle/po-stepper-circle.
 import { PoStepperComponent } from './po-stepper.component';
 import { PoStepperLabelComponent } from './po-stepper-label/po-stepper-label.component';
 import { PoStepperStepComponent } from './po-stepper-step/po-stepper-step.component';
-import { PoIconModule } from '../po-icon';
+import { PoIconModule } from '../po-icon/po-icon.module';
+import { PoTooltipModule } from '../../directives/po-tooltip/index';
 
 /**
  * @description
  * Módulo do componente po-stepper
  */
 @NgModule({
-  imports: [CommonModule, PoIconModule],
+  imports: [CommonModule, PoIconModule, PoTooltipModule],
   declarations: [
     PoStepComponent,
     PoStepperCircleComponent,

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-active/sample-po-stepper-active.component.html
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-active/sample-po-stepper-active.component.html
@@ -1,103 +1,112 @@
-<po-stepper>
-  <po-step p-label="Basic information">
-    <form #basicInformationForm="ngForm">
-      <div class="po-row">
-        <po-input class="po-md-6" name="name" [(ngModel)]="basicInformation.name" p-clean p-label="Name" p-required>
-        </po-input>
-        <po-email class="po-md-6" name="email" [(ngModel)]="basicInformation.email" p-clean p-label="Email" p-required>
-        </po-email>
-        <po-input class="po-md-4" name="phone" [(ngModel)]="basicInformation.phone" p-label="Phone" p-optional>
-        </po-input>
-        <po-select
-          class="po-md-4"
-          name="state"
-          [(ngModel)]="basicInformation.state"
-          p-label="State"
-          [p-options]="stateOptions"
-          (p-change)="onChangeState()"
-        >
-        </po-select>
-        <po-select
-          class="po-md-4"
-          name="city"
-          [(ngModel)]="basicInformation.city"
-          p-label="City"
-          [p-options]="cityOptions"
-        >
-        </po-select>
+<po-container>
+  <po-stepper>
+    <po-step p-label="Basic information">
+      <form #basicInformationForm="ngForm">
+        <div class="po-row">
+          <po-input class="po-md-6" name="name" [(ngModel)]="basicInformation.name" p-clean p-label="Name" p-required>
+          </po-input>
+          <po-email
+            class="po-md-6"
+            name="email"
+            [(ngModel)]="basicInformation.email"
+            p-clean
+            p-label="Email"
+            p-required
+          >
+          </po-email>
+          <po-input class="po-md-4" name="phone" [(ngModel)]="basicInformation.phone" p-label="Phone" p-optional>
+          </po-input>
+          <po-select
+            class="po-md-4"
+            name="state"
+            [(ngModel)]="basicInformation.state"
+            p-label="State"
+            [p-options]="stateOptions"
+            (p-change)="onChangeState()"
+          >
+          </po-select>
+          <po-select
+            class="po-md-4"
+            name="city"
+            [(ngModel)]="basicInformation.city"
+            p-label="City"
+            [p-options]="cityOptions"
+          >
+          </po-select>
+        </div>
+      </form>
+    </po-step>
+    <po-step p-label="Academic formation">
+      <form #academicFormationForm="ngForm">
+        <div class="po-row">
+          <po-divider class="po-md-12" p-label="High school"></po-divider>
+          <po-input class="po-md-6" name="highSchoolName" [(ngModel)]="highSchool.name" p-clean p-label="Name">
+          </po-input>
+          <po-input class="po-md-3" name="highSchoolCity" [(ngModel)]="highSchool.city" p-clean p-label="City">
+          </po-input>
+          <po-input class="po-md-3" name="highSchoolPeriod" [(ngModel)]="highSchool.conclusionYear" p-label="Period">
+          </po-input>
+        </div>
+        <div class="po-row">
+          <po-divider class="po-md-12" p-label="University education"> </po-divider>
+          <po-input
+            class="po-md-6"
+            name="universityEducationName"
+            [(ngModel)]="universityEducation.name"
+            p-clean
+            p-label="Name"
+          >
+          </po-input>
+          <po-input
+            class="po-md-3"
+            name="universityEducationCity"
+            [(ngModel)]="universityEducation.city"
+            p-clean
+            p-label="City"
+          >
+          </po-input>
+          <po-input
+            class="po-md-3"
+            name="universityEducationPeriod"
+            [(ngModel)]="universityEducation.conclusionYear"
+            p-label="Period"
+          >
+          </po-input>
+        </div>
+      </form>
+    </po-step>
+    <po-step p-label="Professional experiences">
+      <form #professionalExperiencesForm="ngForm">
+        <div class="po-row">
+          <po-input
+            class="po-md-12"
+            name="experienceTitle"
+            [(ngModel)]="experienceTitle"
+            p-label="Professional position"
+          ></po-input>
+          <po-textarea
+            class="po-md-12"
+            name="experienceDescripton"
+            [(ngModel)]="experienceDescripton"
+            p-label="Describe your responsibilities"
+            p-rows="4"
+          ></po-textarea>
+          <po-button
+            class="po-md-4"
+            type="submit"
+            p-label="Add professional experience"
+            (p-click)="addProfessionalExperiences(professionalExperiencesForm); professionalExperiencesForm.reset()"
+          ></po-button>
+        </div>
+      </form>
+      <div class="po-row" *ngIf="professionalExperiences">
+        <po-divider class="po-md-12"> </po-divider>
+        <div class="po-md-12" *ngFor="let experience of professionalExperiences">
+          <po-widget class="po-md-12" [p-title]="experience.title">
+            <p>{{ experience.description }}</p>
+          </po-widget>
+        </div>
       </div>
-    </form>
-  </po-step>
-  <po-step p-label="Academic formation">
-    <form #academicFormationForm="ngForm">
-      <div class="po-row">
-        <po-divider class="po-md-12" p-label="High school"></po-divider>
-        <po-input class="po-md-6" name="highSchoolName" [(ngModel)]="highSchool.name" p-clean p-label="Name">
-        </po-input>
-        <po-input class="po-md-3" name="highSchoolCity" [(ngModel)]="highSchool.city" p-clean p-label="City">
-        </po-input>
-        <po-input class="po-md-3" name="highSchoolPeriod" [(ngModel)]="highSchool.conclusionYear" p-label="Period">
-        </po-input>
-      </div>
-      <div class="po-row">
-        <po-divider class="po-md-12" p-label="University education"> </po-divider>
-        <po-input
-          class="po-md-6"
-          name="universityEducationName"
-          [(ngModel)]="universityEducation.name"
-          p-clean
-          p-label="Name"
-        >
-        </po-input>
-        <po-input
-          class="po-md-3"
-          name="universityEducationCity"
-          [(ngModel)]="universityEducation.city"
-          p-clean
-          p-label="City"
-        >
-        </po-input>
-        <po-input
-          class="po-md-3"
-          name="universityEducationPeriod"
-          [(ngModel)]="universityEducation.conclusionYear"
-          p-label="Period"
-        >
-        </po-input>
-      </div>
-    </form>
-  </po-step>
-  <po-step p-label="Professional experiences">
-    <form #professionalExperiencesForm="ngForm">
-      <div class="po-row">
-        <po-input
-          class="po-md-12"
-          name="experienceTitle"
-          [(ngModel)]="experienceTitle"
-          p-label="Professional position"
-        ></po-input>
-        <po-textarea
-          class="po-md-12"
-          name="experienceDescripton"
-          [(ngModel)]="experienceDescripton"
-          p-label="Describe your responsibilities"
-          p-rows="4"
-        ></po-textarea>
-        <po-button
-          class="po-md-4"
-          type="submit"
-          p-label="Add professional experience"
-          (p-click)="addProfessionalExperiences(professionalExperiencesForm); professionalExperiencesForm.reset()"
-        ></po-button>
-      </div>
-    </form>
-    <div class="po-row" *ngIf="professionalExperiences">
-      <po-divider class="po-md-12"> </po-divider>
-      <div class="po-md-12" *ngFor="let experience of professionalExperiences">
-        <po-widget class="po-md-12" [p-title]="experience.title">
-          <p>{{ experience.description }}</p>
-        </po-widget>
-      </div>
-    </div>
-  </po-step>
-</po-stepper>
+    </po-step>
+  </po-stepper>
+</po-container>

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-basic/sample-po-stepper-basic.component.html
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-basic/sample-po-stepper-basic.component.html
@@ -1,4 +1,4 @@
-<po-stepper>
+<po-stepper [p-align-center]="false">
   <po-step p-label="Step 1"></po-step>
   <po-step p-label="Step 2"></po-step>
   <po-step p-label="Step 3"></po-step>

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.html
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.html
@@ -1,5 +1,6 @@
 <po-container>
   <po-stepper
+    [p-align-center]="properties.alignCenter"
     [p-orientation]="properties.orientation"
     [p-step-icons]="properties.stepIcons"
     [p-step-size]="properties.stepSize"

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.html
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.html
@@ -1,37 +1,45 @@
-<po-stepper
-  [p-orientation]="properties.orientation"
-  [p-step-icons]="properties.stepIcons"
-  [p-step-size]="properties.stepSize"
-  (p-change-step)="changeStep('change')"
->
-  <po-step *ngFor="let step of steps" [p-label]="step.label">
-    <h2>Step Content {{ step.label }}</h2>
-  </po-step>
-</po-stepper>
+<po-container>
+  <po-stepper
+    [p-orientation]="properties.orientation"
+    [p-step-icons]="properties.stepIcons"
+    [p-step-size]="properties.stepSize"
+    [p-step-icon-active]="properties.iconActive"
+    [p-step-icon-done]="properties.iconDone"
+    (p-change-step)="changeStep('change')"
+  >
+    <po-step *ngFor="let step of steps" [p-label]="step.label" [p-icon-default]="step.iconDefault">
+      <h2>Step Content {{ step.label }}</h2>
+    </po-step>
+  </po-stepper>
 
-<hr />
+  <hr />
 
-<po-info p-label="Event" [p-value]="event"> </po-info>
+  <po-info p-label="Event" [p-value]="event"> </po-info>
 
-<form #stepForm="ngForm">
-  <po-dynamic-form p-group-form [p-fields]="stepItemFields" [p-value]="stepItem"> </po-dynamic-form>
+  <form #stepForm="ngForm">
+    <po-dynamic-form [p-group-form] [p-fields]="stepItemFields" [p-value]="stepItem"> </po-dynamic-form>
 
-  <div class="po-row">
-    <po-button
-      class="po-md-3"
-      p-label="Add Step"
-      [p-disabled]="stepForm.invalid"
-      (p-click)="addItem(stepItem); stepForm.reset()"
-    >
-    </po-button>
-  </div>
-</form>
+    <div class="po-row">
+      <po-button
+        class="po-md-3"
+        p-label="Add Step"
+        [p-disabled]="stepForm.invalid"
+        (p-click)="addItem(stepItem); stepForm.reset()"
+      >
+      </po-button>
+    </div>
+  </form>
 
-<form #propertiesForm="ngForm">
-  <po-dynamic-form p-group-form [p-fields]="propertiesFields" [p-value]="properties"> </po-dynamic-form>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore(); propertiesForm.reset(); stepForm.reset()">
-    </po-button>
-  </div>
-</form>
+  <form #propertiesForm="ngForm">
+    <po-dynamic-form [p-group-form] [p-fields]="propertiesFields" [p-value]="properties"> </po-dynamic-form>
+    <hr />
+    <div class="po-row">
+      <po-button
+        class="po-md-3"
+        p-label="Sample Restore"
+        (p-click)="restore(); propertiesForm.reset(); stepForm.reset()"
+      >
+      </po-button>
+    </div>
+  </form>
+</po-container>

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.ts
@@ -25,7 +25,7 @@ export class SamplePoStepperLabsComponent implements OnInit {
     {
       property: 'orientation',
       options: [
-        { value: 'vertical', label: 'Vertical' },
+        { value: 'vertical', label: 'Vertical', checked: true },
         { value: 'horizontal', label: 'Horizontal' }
       ],
       gridLgColumns: 4
@@ -35,6 +35,18 @@ export class SamplePoStepperLabsComponent implements OnInit {
       gridLgColumns: 4,
       property: 'stepIcons',
       type: 'boolean'
+    },
+    {
+      label: 'Step Icon Active Custom',
+      help: 'Ex.: ph ph-pencil-simple-line',
+      gridLgColumns: 4,
+      property: 'iconActive'
+    },
+    {
+      label: 'Step Icon Done Custom',
+      help: 'Ex.: ph ph-check-fat',
+      gridLgColumns: 4,
+      property: 'iconDone'
     }
   ];
 
@@ -43,7 +55,13 @@ export class SamplePoStepperLabsComponent implements OnInit {
       divider: 'Step form',
       property: 'label',
       label: 'Step Label',
-      required: true,
+      gridMdColumns: 6,
+      gridXlColumns: 6
+    },
+    {
+      property: 'iconDefault',
+      label: 'Step Icon Default Custom',
+      help: 'Ex.: ph ph-question',
       gridMdColumns: 6,
       gridXlColumns: 6
     }
@@ -57,6 +75,8 @@ export class SamplePoStepperLabsComponent implements OnInit {
 
   addItem(stepItem: PoStepperItem) {
     this.steps = [...this.steps, { ...stepItem }];
+    this.stepItem = {};
+    this.changeDetector.detectChanges();
   }
 
   changeStep(event) {
@@ -69,5 +89,6 @@ export class SamplePoStepperLabsComponent implements OnInit {
     this.properties = {};
     this.steps = [];
     this.event = undefined;
+    this.properties.orientation = 'horizontal';
   }
 }

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.ts
@@ -31,8 +31,14 @@ export class SamplePoStepperLabsComponent implements OnInit {
       gridLgColumns: 4
     },
     {
+      label: 'Align Steps Center',
+      gridLgColumns: 3,
+      property: 'alignCenter',
+      type: 'boolean'
+    },
+    {
       label: 'Step icons',
-      gridLgColumns: 4,
+      gridLgColumns: 3,
       property: 'stepIcons',
       type: 'boolean'
     },
@@ -90,5 +96,6 @@ export class SamplePoStepperLabsComponent implements OnInit {
     this.steps = [];
     this.event = undefined;
     this.properties.orientation = 'horizontal';
+    this.properties.alignCenter = false;
   }
 }

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-sales/sample-po-stepper-sales.component.html
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-sales/sample-po-stepper-sales.component.html
@@ -28,7 +28,7 @@
 <div style="position: relative">
   <po-loading-overlay *ngIf="isLoadingPayment" p-text="Loading"> </po-loading-overlay>
 
-  <po-stepper #stepper p-orientation="vertical" p-step-icons p-step-size="32">
+  <po-stepper #stepper p-align-center="false" p-orientation="vertical" p-step-icons p-step-size="32">
     <po-step p-label="Personal" [p-can-active-next-step]="canActiveNextStep.bind(this, personalForm)">
       <po-widget
         class="po-md-12"

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-steps/sample-po-stepper-steps.component.html
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-steps/sample-po-stepper-steps.component.html
@@ -1,0 +1,7 @@
+<po-stepper
+  [p-sequential]="false"
+  [p-step]="currentStep"
+  [p-steps]="stepsWithStatus"
+  (p-change-step)="onChangeStatus($event)"
+>
+</po-stepper>

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-steps/sample-po-stepper-steps.component.html
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-steps/sample-po-stepper-steps.component.html
@@ -1,4 +1,5 @@
 <po-stepper
+  [p-align-center]="false"
   [p-sequential]="false"
   [p-step]="currentStep"
   [p-steps]="stepsWithStatus"

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-steps/sample-po-stepper-steps.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-steps/sample-po-stepper-steps.component.ts
@@ -1,0 +1,45 @@
+import { AfterViewInit, ChangeDetectorRef, Component } from '@angular/core';
+import { PoStepperItem, PoStepperStatus } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-stepper-steps',
+  templateUrl: './sample-po-stepper-steps.component.html'
+})
+export class SamplePoStepperStepsComponent implements AfterViewInit {
+  currentStep: number;
+  stepsWithStatus: Array<PoStepperItem> = [
+    { label: 'Step 1', status: PoStepperStatus.Done },
+    { label: 'Step 2', status: PoStepperStatus.Active },
+    { label: 'Step 3', status: PoStepperStatus.Default },
+    { label: 'Step 4', status: PoStepperStatus.Disabled }
+  ];
+
+  constructor(private changeDetector: ChangeDetectorRef) {}
+
+  ngAfterViewInit(): void {
+    this.currentStep = 2;
+    this.changeDetector.detectChanges();
+  }
+
+  onChangeStatus(event: number): void {
+    this.currentStep = event;
+
+    this.stepsWithStatus.forEach(step => {
+      if (step.status === PoStepperStatus.Active) {
+        step.status = PoStepperStatus.Done;
+      }
+    });
+
+    this.stepsWithStatus.forEach((step, index) => {
+      if (index > this.currentStep && step.status === PoStepperStatus.Active) {
+        step.status = PoStepperStatus.Default;
+      }
+    });
+    if (
+      this.currentStep < this.stepsWithStatus.length &&
+      this.stepsWithStatus[this.currentStep].status === PoStepperStatus.Disabled
+    ) {
+      this.stepsWithStatus[this.currentStep].status = PoStepperStatus.Default;
+    }
+  }
+}


### PR DESCRIPTION
**PO-STEPPER**

**DTHFUI-9714**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Após as implementações do animalia, os steps passaram a ser alinhados à esquerda no modo horizontal e ao topo no modo vertical.

**Qual o novo comportamento?**
Adiciona propriedade p-align-center que permite o alinhamento centralizado dos steps em ambas as orientações.

**Simulação**
[DTHFUI-9714_simulacao.zip](https://github.com/user-attachments/files/16999961/DTHFUI-9714_simulacao.zip)
