### PR TITLE
feat(media-query): implementa serviço para media query customizável

### DIFF
--- a/projects/ui/src/lib/services/index.ts
+++ b/projects/ui/src/lib/services/index.ts
@@ -8,5 +8,6 @@ export * from './po-date/index';
 export * from './po-dialog/index';
 export * from './po-language/index';
 export * from './po-i18n/index';
+export * from './po-media-query/index';
 export * from './po-notification/index';
 export * from './po-theme/index';

--- a/projects/ui/src/lib/services/po-media-query/index.ts
+++ b/projects/ui/src/lib/services/po-media-query/index.ts
@@ -1,0 +1,4 @@
+export * from './po-media-query.service';
+export * from './po-media-query.interface';
+
+export * from './po-media-query.module';

--- a/projects/ui/src/lib/services/po-media-query/po-media-query.interface.ts
+++ b/projects/ui/src/lib/services/po-media-query/po-media-query.interface.ts
@@ -1,0 +1,144 @@
+/**
+ * @usedBy PoMediaQueryService
+ *
+ * @description
+ * Interface que define os tokens CSS utilizados em regras de media queries.
+ * Cada chave representa uma variável CSS que pode ser dinamicamente modificada.
+ *
+ * > Os tipos de valores aceitos para cada token são: `pixels` , `em` e `rem`.
+ *
+ */
+
+export interface PoMediaQueryTokens {
+  /**
+   * @description
+   *
+   * Define a regra para sm.
+   *
+   * `gridSystemSmMaxWidth` define a largura máxima para o grid no tamanho pequeno (`sm`).
+   *
+   * Exemplo de uso:
+   * ```typescript
+   * const tokens: PoMediaQueryTokens =  {
+   *  sm: {
+   *    gridSystemSmMaxWidth: '480px'
+   *  }
+   * };
+   * ```
+   */
+  sm?: {
+    'gridSystemSmMaxWidth': string;
+  };
+
+  /**
+   * @description
+   *
+   * Define a regra para md.
+   *
+   * `gridSystemMdMinWidth` define a largura mínima para o grid no tamanho pequeno (`md`).
+   *
+   * `gridSystemMdMaxWidth` define a largura máxima para o grid no tamanho pequeno (`md`).
+   *
+   * Exemplo de uso:
+   * ```typescript
+   * const tokens: PoMediaQueryTokens =  {
+   *  md: {
+   *    gridSystemMdMinWidth: '481px',
+   *    gridSystemMdMaxWidth: '960px'
+   *  }
+   * };
+   * ```
+   */
+  md?: {
+    'gridSystemMdMinWidth': string;
+    'gridSystemMdMaxWidth': string;
+  };
+
+  /**
+   * @description
+   *
+   * Define a regra para lg.
+   *
+   * `gridSystemLgMinWidth` define a largura mínima para o grid no tamanho pequeno (`lg`).
+   *
+   * `gridSystemLgMaxWidth` define a largura máxima para o grid no tamanho pequeno (`lg`).
+   *
+   * Exemplo de uso:
+   * ```typescript
+   * const tokens: PoMediaQueryTokens =  {
+   *  lg: {
+   *    gridSystemLgMinWidth: '961px',
+   *    gridSystemLgMaxnWidth: '1366px'
+   *  }
+   * };
+   * ```
+   */
+  lg?: {
+    'gridSystemLgMinWidth': string;
+    'gridSystemLgMaxWidth': string;
+  };
+
+  /**
+   * @description
+   *
+   * Define a regra offset.
+   *
+   * `gridSystemOffsetMinWidth` define a largura mínima para o grid no tamanho pequeno (`offset`).
+   *
+   * `gridSystemOffsetMaxWidth` define a largura máxima para o grid no tamanho pequeno (`offset`).
+   *
+   * Exemplo de uso:
+   * ```typescript
+   * const tokens: PoMediaQueryTokens =  {
+   *  offset: {
+   *    gridSystemOffsetMinWidth: '361px',
+   *    gridSystemOffsetMaxWidth: '480px'
+   *  }
+   * };
+   * ```
+   */
+  offset?: {
+    'gridSystemOffsetMinWidth': string;
+    'gridSystemOffsetMaxWidth': string;
+  };
+
+  /**
+   * @description
+   *
+   * Define a regra pull.
+   *
+   * `gridSystemPullMaxWidth` define a largura máxima para o grid no tamanho pequeno (`pull`).
+   *
+   * Exemplo de uso:
+   * ```typescript
+   * const tokens: PoMediaQueryTokens =  {
+   *  offset: {
+   *    gridSystemPullMaxWidth: '480px'
+   *  }
+   * };
+   * ```
+   */
+  pull?: {
+    'gridSystemPullMaxWidth': string;
+  };
+
+  /**
+   * @description
+   *
+   * Define a regra xl.
+   *
+   * `gridSystemXlMinWidth` define a largura mínima para o grid no tamanho pequeno (`pull`).
+   *
+   * Exemplo de uso:
+   * ```typescript
+   * const tokens: PoMediaQueryTokens =  {
+   *  offset: {
+   *    gridSystemXlMinWidth: '1367px'
+   *  }
+   * };
+   * ```
+   */
+  xl?: {
+    'gridSystemXlMinWidth': string;
+  };
+}

--- a/projects/ui/src/lib/services/po-media-query/po-media-query.module.ts
+++ b/projects/ui/src/lib/services/po-media-query/po-media-query.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { PoMediaQueryService } from './po-media-query.service';
+
+/**
+ * @description
+ *
+ * Módulo do serviço `po-media-query`.
+ */
+@NgModule({
+  providers: [PoMediaQueryService],
+  bootstrap: []
+})
+export class PoMediaQueryModule {}

--- a/projects/ui/src/lib/services/po-media-query/po-media-query.service.spec.ts
+++ b/projects/ui/src/lib/services/po-media-query/po-media-query.service.spec.ts
@@ -1,0 +1,225 @@
+import { Renderer2, RendererFactory2 } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { PoMediaQueryTokens } from './po-media-query.interface';
+import { PoMediaQueryService } from './po-media-query.service';
+
+describe('PoMediaQueryService:', () => {
+  let service: PoMediaQueryService;
+  let renderer: Renderer2;
+  let rendererFactory: RendererFactory2;
+
+  const mockTokens: PoMediaQueryTokens = {
+    md: {
+      gridSystemMdMinWidth: '1024px',
+      gridSystemMdMaxWidth: '1366px'
+    }
+  };
+
+  const mockCssRules = {
+    media: {
+      mediaText: '(min-width: var(--gridSystemMdMinWidth)) and (max-width: var(--gridSystemMdMaxWidth))'
+    },
+    cssText:
+      '@media (min-width: var(--gridSystemMdMinWidth)) and (max-width: var(--gridSystemMdMaxWidth)) { body { color: black; } }'
+  } as unknown as CSSMediaRule;
+
+  const mockMediaRule = {
+    media: {
+      mediaText: '(min-width: var(--gridSystemMdMinWidth)) and (max-width: var(--gridSystemMdMaxWidth))'
+    },
+    cssRules: [mockCssRules],
+    cssText:
+      '@media (min-width: var(--gridSystemMdMinWidth)) and (max-width: var(--gridSystemMdMaxWidth)) { body { color: black; } }'
+  } as unknown as CSSMediaRule;
+
+  let styleSheet: CSSStyleSheet;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PoMediaQueryService,
+        {
+          provide: RendererFactory2,
+          useValue: {
+            createRenderer: () => ({
+              createElement: (name: string) => document.createElement(name),
+              appendChild: (parent: HTMLElement, child: HTMLElement) => parent.appendChild(child)
+            })
+          }
+        }
+      ]
+    });
+    service = TestBed.inject(PoMediaQueryService);
+    rendererFactory = TestBed.inject(RendererFactory2);
+    renderer = rendererFactory.createRenderer(null, null);
+
+    const styleElement = renderer.createElement('style');
+    renderer.appendChild(document.head, styleElement);
+    styleSheet = styleElement.sheet as CSSStyleSheet;
+  });
+
+  describe('Methods:', () => {
+    it('buildMediaQuery: should return max-width media query for "sm" token', () => {
+      const token = 'system-grid-sm';
+      const variable = '--gridSystemSmMaxWidth';
+      const value = '600px';
+      const existingQuery = '';
+
+      const result = service['buildMediaQuery'](token, value, existingQuery);
+
+      expect(result).toBe('@media (max-width: 600px)');
+    });
+
+    it('buildMediaQuery: should return min-width media query for "xl" token', () => {
+      const token = 'system-grid-xl';
+      const variable = '--gridSystemXlMinWidth';
+      const value = '1200px';
+      const existingQuery = '';
+
+      const result = service['buildMediaQuery'](token, value, existingQuery);
+
+      expect(result).toBe('@media (min-width: 1200px)');
+    });
+
+    it('buildMediaQuery: should return combined min-width and max-width media query for "md" token', () => {
+      const token = 'system-grid-md';
+      const variable = '--gridSystemMdMaxWidth';
+      const value = '960px';
+      const existingQuery = '@media (min-width: 600px)';
+
+      const result = service['buildMediaQuery'](token, value, existingQuery);
+
+      expect(result).toBe('@media (min-width: 600px) and (max-width: 960px)');
+    });
+
+    it('buildMediaQuery: should return combined query if token contains "lg" with existingQuery', () => {
+      const token = 'system-grid-lg';
+      const variable = '--gridSystemLgMaxWidth';
+      const value = '1280px';
+      const existingQuery = '@media (min-width: 960px)';
+
+      const result = service['buildMediaQuery'](token, value, existingQuery);
+
+      expect(result).toBe('@media (min-width: 960px) and (max-width: 1280px)');
+    });
+
+    it('buildMediaQuery: should return the existing query if no matching token is found', () => {
+      const token = 'system-grid-unknown';
+      const variable = '--gridSystemUnknownWidth';
+      const value = '100px';
+      const existingQuery = '@media (min-width: 400px)';
+
+      const result = service['buildMediaQuery'](token, value, existingQuery);
+
+      expect(result).toBe(existingQuery);
+    });
+
+    it('buildMediaQuery: should return the existing query if token does not match "sm", "md", "lg", or "xl"', () => {
+      const token = 'other-grid';
+      const variable = '--otherGridWidth';
+      const value = '1000px';
+      const existingQuery = '@media (min-width: 800px)';
+
+      const result = service['buildMediaQuery'](token, value, existingQuery);
+
+      expect(result).toBe(existingQuery);
+    });
+
+    it('buildMediaQuery: should not call buildMediaQuery when no CSS variables are present in the mediaText', () => {
+      const mediaRule = {
+        media: {
+          mediaText: '(min-width: 1026px) and (max-width: 1365px)'
+        },
+        cssRules: [{ cssText: 'body { color: black; }' }]
+      } as unknown as CSSMediaRule;
+
+      const tokens: PoMediaQueryTokens = {
+        md: {
+          gridSystemMdMinWidth: '1024px',
+          gridSystemMdMaxWidth: '1366px'
+        }
+      };
+
+      const dynamicSheet = {
+        insertRule: jasmine.createSpy('insertRule')
+      } as unknown as CSSStyleSheet;
+
+      spyOn<any>(service, 'buildMediaQuery').and.returnValue('(min-width: 1026px)');
+
+      service['updateTokensMediaRule'](mediaRule, tokens, dynamicSheet);
+
+      expect(service['buildMediaQuery']).not.toHaveBeenCalled();
+    });
+
+    it('updateTokensMediaRule: should insert a media rule and check the cssText', () => {
+      const tokens: PoMediaQueryTokens = {
+        md: {
+          gridSystemMdMinWidth: '1024px',
+          gridSystemMdMaxWidth: '1366px'
+        }
+      };
+      const mediaQuery = '(min-width: var(--gridSystemMdMinWidth)) and (max-width: var(--gridSystemMdMaxWidth))';
+      const rule = 'body { background-color: blue; }';
+
+      styleSheet.insertRule(`@media ${mediaQuery} { ${rule} }`, styleSheet.cssRules.length);
+
+      const insertedRule = styleSheet.cssRules[0];
+
+      if (insertedRule instanceof CSSMediaRule) {
+        const expectedCssText = `@media ${mediaQuery} { ${rule} }`.replace(/\s+/g, ' ').trim();
+        const actualCssText = insertedRule.cssText.replace(/\s+/g, ' ').trim();
+
+        expect(insertedRule.media.mediaText).toBe(mediaQuery);
+        expect(actualCssText).toBe(expectedCssText);
+
+        spyOn<any>(service, 'updateTokensMediaRule').and.callThrough();
+        service.updateTokens(tokens);
+
+        expect(service['updateTokensMediaRule']).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            media: jasmine.objectContaining({
+              mediaText: '(min-width: var(--gridSystemMdMinWidth)) and (max-width: var(--gridSystemMdMaxWidth))'
+            }),
+            cssText: jasmine.any(String)
+          }),
+          tokens,
+          styleSheet
+        );
+      } else {
+        fail('The rule entered is not a MediaRule');
+      }
+    });
+
+    it('processStyleSheet: should warn and return when no rules are found', () => {
+      const styleSheetMock = {
+        rules: undefined,
+        cssRules: undefined
+      } as unknown as CSSStyleSheet;
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      const tokensMock: PoMediaQueryTokens = {};
+
+      service['processStyleSheet'](styleSheetMock, tokensMock, styleSheet);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith('No rules found in stylesheet');
+    });
+
+    it('updateTokensMediaRule: should handle the case when dynamicSheet is null', () => {
+      const mockStyleSheet = {
+        cssRules: [mockMediaRule]
+      } as unknown as CSSStyleSheet;
+
+      Object.defineProperty(document, 'styleSheets', {
+        value: [mockStyleSheet],
+        writable: true
+      });
+
+      const spyConsoleError = spyOn(console, 'error');
+
+      (service as any).updateTokensMediaRule(mockMediaRule, mockTokens, null);
+
+      expect(spyConsoleError).toHaveBeenCalledWith('dynamicSheet is null or undefined. Cannot insert rule.');
+    });
+  });
+});

--- a/projects/ui/src/lib/services/po-media-query/po-media-query.service.ts
+++ b/projects/ui/src/lib/services/po-media-query/po-media-query.service.ts
@@ -1,0 +1,159 @@
+import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
+import { PoMediaQueryTokens } from './po-media-query.interface';
+
+/**
+ * @description
+ *
+ * O PoMediaQueryService é um serviço que atualiza dinamicamente regras de media query dentro de folhas de estilo do DOM.
+ *
+ * Ele utiliza as regras de media queries que contêm tokens CSS (definidos como var(--nome-da-variavel)) e as replica, aplicando os novos valores fornecidos, facilitando a adaptação dos estilos com base nas condições das media queries.
+ *
+ * Exemplo de uso:
+ *
+ * Neste exemplo, estamos alterando os valores dos breakpoints para o grid system, que determina como o layout deve se comportar em diferentes larguras de tela. Utilizando o PoMediaQueryService, definimos os limites para três tamanhos de tela: pequeno (sm), médio (md), e grande (lg), e aplicamos esses valores dinamicamente para garantir que o layout responda adequadamente às mudanças no tamanho da janela.
+ * Isso permite que o grid system do PO UI seja personalizado para se ajustar às necessidades do seu projeto.
+ *
+ * ```
+ * import { PoMediaQueryService } from './po-media-query.service';
+ *
+ * @Component({
+ *  selector: 'app-root',
+ *  templateUrl: './app.component.html',
+ *  styleUrls: ['./app.component.css']
+ * })
+ *
+ * export class AppComponent {
+ *
+ *  // Definindo tokens personalizados para os breakpoints do grid system
+ *  constructor(private poMediaQueryService: PoMediaQueryService) {}
+ *
+ *  ngOnInit() {
+ *    const tokens: PoMediaQueryTokens =  {
+ *     sm: {
+ *      gridSystemSmMaxWidth: '1024px' // Limite máximo para telas pequenas (até 1024px)
+ *      },
+ *     md: {
+ *      gridSystemMdMinWidth: '1025px', // Limite mínimo para telas médias (a partir de 1025px)
+ *      gridSystemMdMaxWidth: '1366px' // Limite máximo para telas médias (até 1366px)
+ *     },
+ *     lg: {
+ *      gridSystemLgMinWidth: '1367px', // Limite mínimo para telas grandes (a partir de 1367px)
+ *      gridSystemLgMaxWidth: '1465px' // Limite máximo para telas grandes (até 1465px)
+ *     },
+ *     xl: {
+ *      gridSystemXlMinWidth: '1466px' // Limite mínimo para telas extra grandes (a partir de 1466px)
+ *     }
+ *    };
+ *
+ *    // Atualiza os tokens de media queries com os novos valores
+ *    this.styleService.updateTokens(tokensMediaQueries);
+ *  }
+ * }
+ * ```
+ *
+ */
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PoMediaQueryService {
+  private renderer: Renderer2;
+
+  constructor(rendererFactory: RendererFactory2) {
+    this.renderer = rendererFactory.createRenderer(null, null);
+  }
+
+  /**
+   * Método que replica as regras baseando-se pelos tokens de media query dentro das folhas de estilo do documento, permitindo a modificação dinâmica
+   * dos valores CSS correspondentes aos tokens fornecidos.
+   *
+   * @param {PoMediaQueryTokens} tokens Objeto contendo os tokens que devem ser atualizados. Cada propriedade corresponde a uma variável CSS que será
+   * dinamicamente modificada dentro das regras de media query.
+   *
+   */
+  updateTokens(tokens: PoMediaQueryTokens): void {
+    const styleSheets = document.styleSheets;
+    const styleElement = this.createStyleElement();
+    const dynamicSheet = styleElement.sheet;
+
+    Array.from(styleSheets).forEach(sheet => {
+      if (sheet) {
+        this.processStyleSheet(sheet, tokens, dynamicSheet);
+      }
+    });
+  }
+
+  private createStyleElement(): HTMLStyleElement {
+    const styleElement = this.renderer.createElement('style');
+    this.renderer.appendChild(document.head, styleElement);
+    return styleElement;
+  }
+
+  private processStyleSheet(sheet: CSSStyleSheet, tokens: PoMediaQueryTokens, dynamicSheet: CSSStyleSheet): void {
+    const rules: CSSRuleList = sheet.cssRules;
+
+    if (!rules) {
+      console.warn('No rules found in stylesheet');
+      return;
+    }
+
+    Array.from(rules).forEach(rule => {
+      if ('media' in rule) {
+        this.updateTokensMediaRule(rule as CSSMediaRule, tokens, dynamicSheet);
+      }
+    });
+  }
+
+  private updateTokensMediaRule(
+    mediaRule: CSSMediaRule,
+    tokens: PoMediaQueryTokens,
+    dynamicSheet: CSSStyleSheet
+  ): void {
+    if (!dynamicSheet) {
+      console.error('dynamicSheet is null or undefined. Cannot insert rule.');
+      return;
+    }
+
+    const variablesInMediaRule = mediaRule.media.mediaText.match(/var\(--[^)]+\)/g) || [];
+    if (variablesInMediaRule.length === 0) return;
+
+    let updatedMediaQuery = '';
+
+    variablesInMediaRule.forEach(variable => {
+      Object.entries(tokens).forEach(([token, breakpoints]) => {
+        if (breakpoints) {
+          Object.entries(breakpoints).forEach(([breakpointVariable, value]) => {
+            if (typeof value === 'string') {
+              const tokenToCompare = `var(--${breakpointVariable})`;
+
+              if (tokenToCompare === variable) {
+                updatedMediaQuery = this.buildMediaQuery(token, value, updatedMediaQuery);
+              }
+            }
+          });
+        }
+      });
+    });
+
+    if (updatedMediaQuery) {
+      const cssRules = Array.from(mediaRule.cssRules)
+        .map(rule => rule.cssText)
+        .join(' ');
+
+      dynamicSheet.insertRule(`${updatedMediaQuery} { ${cssRules} }`, dynamicSheet.cssRules.length);
+    }
+  }
+
+  private buildMediaQuery(token: string, value: string, existingQuery: string): string {
+    switch (true) {
+      case token.includes('sm') || token.includes('pull') || token.includes('offset'):
+        return `@media (max-width: ${value})`;
+      case token.includes('xl'):
+        return `@media (min-width: ${value})`;
+      case token.includes('md') || token.includes('lg'):
+        return existingQuery ? `${existingQuery} and (max-width: ${value})` : `@media (min-width: ${value})`;
+      default:
+        return existingQuery;
+    }
+  }
+}

--- a/projects/ui/src/lib/services/services.module.ts
+++ b/projects/ui/src/lib/services/services.module.ts
@@ -8,6 +8,7 @@ import { PoDateTimeModule } from './po-date/po-date.module';
 import { PoDialogModule } from './po-dialog/po-dialog.module';
 import { PoI18nPipe } from './po-i18n/po-i18n.pipe';
 import { PoLanguageModule } from './po-language/po-language.module';
+import { PoMediaQueryModule } from './po-media-query/po-media-query.module';
 import { PoNotificationModule } from './po-notification/po-notification.module';
 import { PoThemeModule } from './po-theme/po-theme.module';
 
@@ -21,6 +22,7 @@ import { PoThemeModule } from './po-theme/po-theme.module';
     PoDateTimeModule,
     PoDialogModule,
     PoLanguageModule,
+    PoMediaQueryModule,
     PoNotificationModule,
     PoThemeModule
   ],
@@ -32,6 +34,7 @@ import { PoThemeModule } from './po-theme/po-theme.module';
     PoDateTimeModule,
     PoDialogModule,
     PoI18nPipe,
+    PoMediaQueryModule,
     PoNotificationModule,
     PoThemeModule
   ],


### PR DESCRIPTION
**PoMediaQueryService**

**DTHFUI-9851**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente, os navegadores não interpretam a leitura de variáveis em regras de breakpoint como por exemplo:
@media (min-width: var(--variavel-customizavel))

**Qual o novo comportamento?**
Disponibilizamos os tokens de breakpoint no formato var(--nome-da-variavel) junto as regras de media query permitindo ao desenvolvedor realizar a customização dos breakpoints em tempo de execução através do serviço PoMediaQueryService.

Para mais informações:
http://localhost:4200/guides/grid-system (necessário build do po-style para o correto funcionamento pos é dependência) https://github.com/po-ui/po-style/pull/629/files

http://localhost:4200/documentation/po-media-query

**Simulação**
[app.zip](https://github.com/user-attachments/files/17213738/app.zip)

