### PR TITLE
fix(dynamic-table): corrige rota no PageCustomAction

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -990,6 +990,20 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(component['router'].navigate).toHaveBeenCalledWith([route.path], { queryParams: route.params });
     }));
 
+    it('navigateTo: should navigate to a external link', () => {
+      const route = {
+        path: 'http://google.com',
+        component: PoPageDynamicTableComponent,
+        params: {}
+      };
+
+      const openExternalLink = spyOn(utilsFunctions, 'openExternalLink');
+
+      component['navigateTo'](route);
+
+      expect(openExternalLink).toHaveBeenCalled();
+    });
+
     it('navigateTo: should call `router.config.unshift` and `navigateTo` only twice if `autoRouter` is true', fakeAsync(() => {
       const route: any = {
         path: '/people/api',

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -842,6 +842,10 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     route: { path: string; component?; url?: string; params?: any },
     forceStopAutoRouter: boolean = false
   ) {
+    if (isExternalLink(route.path)) {
+      return openExternalLink(route.path);
+    }
+
     this.router.navigate([route.url || route.path], { queryParams: route.params }).catch(() => {
       if (forceStopAutoRouter || !this.autoRouter) {
         return;


### PR DESCRIPTION
Corrige direcionamento de rota interna e externa quando utilizado `PageCustomAction`

fixes: DTHFUI-9660
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)



**Simulação**
https://github.com/po-ui/po-angular/pull/2238