### PR TITLE
feat(page-slide): implementa definições do animalia-DS

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-slide/index.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/index.ts
@@ -1,3 +1,4 @@
 export * from './po-page-slide.component';
+export * from './po-page-slide-footer/po-page-slide-footer.component';
 
 export * from './po-page-slide.module';

--- a/projects/ui/src/lib/components/po-page/po-page-slide/interfaces/po-page-slide-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/interfaces/po-page-slide-literals.interface.ts
@@ -1,0 +1,13 @@
+/**
+ * @docsPrivate
+ *
+ * @usedBy PoPageSlide
+ *
+ * @description
+ *
+ * Interface para as literais do `PoPageSlide`.
+ */
+export interface PoPageSlideLiterals {
+  /** Texto da aria-label do botão de fechar */
+  close?: string;
+}

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-base.component.ts
@@ -18,6 +18,38 @@ import { convertToBoolean } from '../../../utils/util';
  * > aplicação.
  *
  *  Caso utilize componentes de field dentro do page-slide, recomenda-se o uso do [Grid System](https://po-ui.io/guides/grid-system).
+ *
+ * No rodapé é possível utilizar o componente [`PoPageSlideFooter`](/documentation/po-page-slide-footer) para customização do template.
+ *
+ *  * #### Tokens customizáveis
+ *
+ * É possível alterar o estilo do componente usando os seguintes tokens (CSS):
+ *
+ * > Para maiores informações, acesse o guia [Personalizando o Tema Padrão com Tokens CSS](https://po-ui.io/guides/theme-customization).
+ *
+ * | Propriedade                              | Descrição                                                         | Valor Padrão                                                                  |
+ * |------------------------------------------|-------------------------------------------------------------------|-------------------------------------------------------------------------------|
+ * | `--font-family`                          | Família tipográfica usada                                         | `var(--font-family-theme)`                                                    |
+ * | `--font-weight`                          | Peso da fonte                                                     | `var(--font-weight-bold)`                                                     |
+ * | `--padding-header`                       | Espaçamento do header                                             | `var(--spacing-md)`                                                           |
+ * | `--padding-body`                         | Espaçamento do conteúdo                                           | `var(--line-height-none)`                                                     |
+ * | `--padding-footer`                       | Espaçamento do footer                                             | `var(--spacing-sm) var(--spacing-md) var(--spacing-xl) var(--spacing-md)`     |
+ * | **Default Values**                       |                                                                   |                                                                               |
+ * | `--color-overlay`                        | Cor do overlay                                                    | `var(--color-neutral-dark-80)`                                                |
+ * | `--opacity-overlay`                      | Cor da opacidade do overlay                                       | `0.7`                                                                         |
+ * | `--background-color`                     | Cor de background                                                 | `var(--color-neutral-light-00)`                                               |
+ * | `--border-color`                         | Cor da borda                                                      | `var(--color-neutral-light-20)`                                               |
+ * | `--color-title`                          | Cor do titulo do header                                           | `var(--color-neutral-dark-95)`                                                |
+ * | `--border-radius`                        | Radius da borda                                                   | `var(--border-radius-md) 0 0 var(--border-radius-md)`                         |
+ * | `--transition-duration`                  | Duração da transição                                              | `var(--duration-extra-fast)`                                                  |
+ * | `--transition-timing`                    | Duração da transição com o tipo de transição                      | `var(--duration-extra-slow) var(--timing-standart)`                           |
+ * | `--page-slide-width-sm`                  | Tamanho da largura do componente no tamanho `small`               | `40%`                                                                         |
+ * | `--page-slide-width-md`                  | Tamanho da largura do componente no tamanho `medium`              | `50%`                                                                         |
+ * | `--page-slide-width-lg`                  | Tamanho da largura do componente no tamanho `large`               | `60%`                                                                         |
+ * | `--page-slide-width-xl`                  | Tamanho da largura do componente no tamanho `extra large`         | `70%`                                                                         |
+ * | `--page-slide-min-width-auto`            | Tamanho da largura mínima do componente no tamanho `auto`         | `40%`                                                                         |
+ * | `--page-slide-max-width-auto`            | Tamanho da largura máxima do componente no tamanho `auto`         | `90%`                                                                         |
+ *
  */
 @Directive()
 export class PoPageSlideBaseComponent {

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-footer/po-page-slide-footer.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-footer/po-page-slide-footer.component.html
@@ -1,0 +1,3 @@
+<div class="po-page-slide-footer" [class.po-page-slide-footer-align-right]="!disabledAlign">
+  <ng-content></ng-content>
+</div>

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-footer/po-page-slide-footer.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-footer/po-page-slide-footer.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PoPageSlideFooterComponent } from './po-page-slide-footer.component';
+
+describe('PoPageSlideFooterComponent', () => {
+  let component: PoPageSlideFooterComponent;
+  let fixture: ComponentFixture<PoPageSlideFooterComponent>;
+  let nativeElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PoPageSlideFooterComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoPageSlideFooterComponent);
+    component = fixture.componentInstance;
+    nativeElement = fixture.debugElement.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it(`shouldn't align content on the right if 'disabledAlign' is true`, () => {
+    component.disabledAlign = true;
+
+    fixture.detectChanges();
+
+    const poModalFooter = nativeElement.querySelector('.po-page-slide-footer-align-right');
+
+    expect(poModalFooter).toBeFalsy();
+  });
+
+  it(`should align content on the right by default`, () => {
+    component.disabledAlign = false;
+
+    fixture.detectChanges();
+
+    const poModalFooter = nativeElement.querySelector('.po-page-slide-footer-align-right');
+
+    expect(poModalFooter).toBeTruthy();
+  });
+});

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-footer/po-page-slide-footer.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide-footer/po-page-slide-footer.component.ts
@@ -1,0 +1,36 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * @description
+ *
+ * O componente `po-page-slide-footer` pode ser utilizado para incluir os botões de ações no rodapé da [`PoPageSlide`](/documentation/po-page-slide), bem como para dar liberdade ao desenvolvedor de incluir outros itens necessários.
+ * > Como boa prática, deve-se observar a utilização de apenas um botão primário.
+ *
+ * ```
+ * <po-page-slide p-title="Title page-slide" #pageSlide>
+ *  <po-page-slide-footer>
+ *    <po-button p-label="Close" (p-click)="pageSlide.close()"> </po-button>
+ *    <po-button p-label="Clean" (p-click)="clean()"> </po-button>
+ *    <po-button p-label="Confirm" p-kind="primary" (p-click)="confirm()"> </po-button>
+ *  </po-page-slide-footer>
+ * </po-page-slide>
+ * ```
+ */
+@Component({
+  selector: 'po-page-slide-footer',
+  templateUrl: './po-page-slide-footer.component.html'
+})
+export class PoPageSlideFooterComponent {
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Desabilita o alinhamento padrão, à direita, dos botões de ações que ficam no rodapé da [`PoPageSlide`](/documentation/po-page-slide).
+   *
+   * > Caso a propriedade esteja habilitada, o alinhamento deverá ser a esquerda e pode ser personalizado.
+   *
+   * @default false
+   */
+  @Input('p-disabled-align') disabledAlign?: boolean = false;
+}

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.html
@@ -1,8 +1,8 @@
-<div class="po-page-slide" tabindex="0" *ngIf="!hidden" [@fade]>
+<div class="po-page-slide" tabindex="0" (keydown.esc)="close()" *ngIf="!hidden" [@fade]="fadeParams">
   <div class="po-page-slide-overlay" (mousedown)="onClickOut($event)"></div>
   <div
     class="po-page-slide-container po-page-slide-right po-page-slide-{{ size }}"
-    [@slide]
+    [@slide]="slideParams"
     [ngStyle]="{ 'width': flexibleWidth ? '' : size === 'auto' ? 'auto' : '' }"
   >
     <div class="po-page-slide-content" tabindex="-1" #pageContent>
@@ -11,10 +11,22 @@
           <span>{{ title }}</span>
           <div class="po-page-slide-subtitle" *ngIf="subtitle">{{ subtitle }}</div>
         </div>
-        <po-button *ngIf="!hideClose" p-icon="ICON_CLOSE" p-kind="tertiary" (p-click)="close()"> </po-button>
+        <po-button
+          *ngIf="!hideClose"
+          p-icon="ICON_CLOSE"
+          p-kind="tertiary"
+          (p-click)="close()"
+          [p-aria-label]="buttonAriaLabel"
+        >
+        </po-button>
       </div>
       <div class="po-page-slide-body">
         <ng-content></ng-content>
+      </div>
+
+      <div class="po-page-slide-footer-content" *ngIf="pageSlideFooter">
+        <po-divider></po-divider>
+        <ng-content select="po-page-slide-footer"></ng-content>
       </div>
     </div>
   </div>

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
@@ -23,6 +23,11 @@ class TestComponent {
 
   public username: string;
   public password: string;
+
+  constructor() {
+    this.poPage.duration = '70ms';
+    this.poPage.timing = '700ms cubic-bezier(0.35, 0, 0.1, 1)';
+  }
 }
 
 describe('PoPageSlideComponent', () => {
@@ -44,6 +49,10 @@ describe('PoPageSlideComponent', () => {
     component = fixture.componentInstance;
     debugElement = fixture.debugElement;
     element = debugElement.nativeElement;
+    component.duration = '70ms';
+    component.timing = '700ms cubic-bezier(0.35, 0, 0.1, 1)';
+
+    fixture.detectChanges();
   });
 
   afterEach(() => {
@@ -219,5 +228,15 @@ describe('PoPageSlideComponent', () => {
     component['initFocus']();
 
     expect(component.pageContent.nativeElement).toBeDefined();
+  });
+
+  it('getTextDefault: should return `Fechar` if `getShortLanguage` returns `pt`', () => {
+    const fakeThis = {
+      languageService: {
+        getShortLanguage: () => 'pt'
+      }
+    };
+
+    expect(component['getTextDefault'].call(fakeThis)).toBe('Fechar');
   });
 });

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.module.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.module.ts
@@ -3,10 +3,12 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PoPageSlideComponent } from './po-page-slide.component';
 import { PoButtonModule } from './../../po-button/po-button.module';
+import { PoDividerModule } from '../../po-divider/po-divider.module';
+import { PoPageSlideFooterComponent } from './po-page-slide-footer/po-page-slide-footer.component';
 
 @NgModule({
-  declarations: [PoPageSlideComponent],
-  exports: [PoPageSlideComponent],
-  imports: [CommonModule, FormsModule, PoButtonModule]
+  declarations: [PoPageSlideComponent, PoPageSlideFooterComponent],
+  exports: [PoPageSlideComponent, PoPageSlideFooterComponent],
+  imports: [CommonModule, FormsModule, PoButtonModule, PoDividerModule]
 })
 export class PoPageSlideModule {}

--- a/projects/ui/src/lib/components/po-page/po-page-slide/samples/sample-po-page-slide-configuration/sample-po-page-slide-configuration.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/samples/sample-po-page-slide-configuration/sample-po-page-slide-configuration.component.html
@@ -91,6 +91,9 @@
       >Designing Web Interfaces: Page Slide</a
     >
   </p>
+  <po-page-slide-footer>
+    <po-button p-label="Check footer" (p-click)="openPageSlideFooterDocumentation()"> </po-button>
+  </po-page-slide-footer>
 </po-page-slide>
 
 <div class="po-row">

--- a/projects/ui/src/lib/components/po-page/po-page-slide/samples/sample-po-page-slide-configuration/sample-po-page-slide-configuration.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/samples/sample-po-page-slide-configuration/sample-po-page-slide-configuration.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'sample-po-page-slide-configuration',
@@ -11,4 +12,10 @@ export class SamplePoPageSlideConfigurationComponent {
   public notification = true;
   public favorited = false;
   public localization = true;
+
+  constructor(private router: Router) {}
+
+  openPageSlideFooterDocumentation() {
+    this.router.navigate(['documentation', 'po-page-slide-footer']);
+  }
 }

--- a/projects/ui/src/lib/services/po-media-query/po-media-query.service.ts
+++ b/projects/ui/src/lib/services/po-media-query/po-media-query.service.ts
@@ -46,7 +46,7 @@ import { PoMediaQueryTokens } from './po-media-query.interface';
  *    };
  *
  *    // Atualiza os tokens de media queries com os novos valores
- *    this.styleService.updateTokens(tokensMediaQueries);
+ *    this.poMediaQueryService.updateTokens(tokens);
  *  }
  * }
  * ```

--- a/projects/ui/src/lib/services/po-theme/helpers/po-theme-dark-defaults.constant.ts
+++ b/projects/ui/src/lib/services/po-theme/helpers/po-theme-dark-defaults.constant.ts
@@ -160,7 +160,7 @@ const poThemeDefaultDarkValues = {
         'box-shadow': 'inset 0 0 20px 20px #23232329'
       },
     'po-overlay, po-page-slide': {
-      '--color-overlay': 'var(--color-neutral-light-20)'
+      '--color-overlay': 'var(--color-neutral-light-05)'
     },
     'po-select': {
       '--color-hover': 'var(--color-action-hover);'


### PR DESCRIPTION
Implementa definições do animaliaDS no page-slide

fixes DTHFUI-9873

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)




**Simulação**

[app.zip](https://github.com/user-attachments/files/17365455/app.zip)

https://github.com/po-ui/po-style/pull/641

https://github.com/totvs/po-theme-totvs/pull/389
```
@import url('https://fonts.googleapis.com/css2?family=Londrina+Sketch&family=Sixtyfour+Convergence&display=swap');


/* TOKENS ATUAIS DO FIGMA e NOVOS */
/* :root {
  --transition-duration: 1000ms;
  --transition-timing: 1000ms ease-in;
} */

/* po-page-slide {
  --background-color: red;
  --border-color: blue;
  --color-overlay: green;
  --font-family: 'Londrina Sketch', sans-serif;
  --padding-footer: 100px;
} */

/* po-page-slide po-divider {
  --border-color: orange;
} */

/* TOKENS JÁ EXISTENTES  mantém funcionamento*/

/* po-page-slide {
  --border-radius: 40px;

  --opacity-overlay: 1;

  --font-weight: normal;
  --color-title: green;

  --padding-header: 100px;
  --padding-body: 100px;
} */

```