### PR TITLE
feat(lookup): implementa definições animalia-DS

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-literals.interface.ts
@@ -49,4 +49,10 @@ export interface PoLookupLiterals {
 
   /** Texto exibido no título do disclaimer. */
   modalDisclaimerGroupTitle?: string;
+
+  /** Texto usado no leitor de tela para acessibilidade. Aplica-se ao ícone de pesquisa. */
+  search?: string;
+
+  /** Texto usado no leitor de tela para acessibilidade. Aplica-se ao ícone de limpar. */
+  clean?: string;
 }

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -1,3 +1,5 @@
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 import {
   AfterViewInit,
   Directive,
@@ -27,6 +29,25 @@ import { PoLookupFilterService } from './services/po-lookup-filter.service';
 import { PoLookupModalService } from './services/po-lookup-modal.service';
 import { PoTableColumnSpacing } from '../../po-table/enums/po-table-spacing.enum';
 
+export const poLookupLiteralsDefault = {
+  en: <PoLookupLiterals>{
+    search: 'Search',
+    clean: 'Clean'
+  },
+  es: <PoLookupLiterals>{
+    search: 'Buscar',
+    clean: 'Limpiar'
+  },
+  pt: <PoLookupLiterals>{
+    search: 'Pesquisar',
+    clean: 'Apagar'
+  },
+  ru: <PoLookupLiterals>{
+    search: 'Поиск',
+    clean: 'чистый'
+  }
+};
+
 /**
  * @description
  *
@@ -47,6 +68,8 @@ import { PoTableColumnSpacing } from '../../po-table/enums/po-table-spacing.enum
 export abstract class PoLookupBaseComponent
   implements ControlValueAccessor, OnDestroy, OnInit, Validator, AfterViewInit, OnChanges
 {
+  private _literals?: PoLookupLiterals;
+  private language: string;
   /**
    * @optional
    *
@@ -112,7 +135,21 @@ export abstract class PoLookupBaseComponent
    * > O objeto padrão de literais será traduzido de acordo com o idioma do
    * [`PoI18nService`](/documentation/po-i18n) ou do browser.
    */
-  @Input('p-literals') literals?: PoLookupLiterals;
+  @Input('p-literals') set literals(value: PoLookupLiterals) {
+    if (value instanceof Object && !(value instanceof Array)) {
+      this._literals = {
+        ...poLookupLiteralsDefault[poLocaleDefault],
+        ...poLookupLiteralsDefault[this.language],
+        ...value
+      };
+    } else {
+      this._literals = poLookupLiteralsDefault[this.language];
+    }
+  }
+
+  get literals() {
+    return this._literals || poLookupLiteralsDefault[this.language];
+  }
 
   /** Texto de apoio do campo. */
   @Input('p-help') help?: string;
@@ -537,8 +574,11 @@ export abstract class PoLookupBaseComponent
   constructor(
     private defaultService: PoLookupFilterService,
     @Inject(Injector) private injector: Injector,
-    public poLookupModalService: PoLookupModalService
-  ) {}
+    public poLookupModalService: PoLookupModalService,
+    languageService: PoLanguageService
+  ) {
+    this.language = languageService.getShortLanguage();
+  }
 
   ngOnDestroy() {
     if (this.getSubscription) {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -19,13 +19,14 @@
           name="contentSearch"
           [(ngModel)]="searchValue"
           [placeholder]="literals.modalPlaceholder"
+          (keydown.enter)="search()"
           type="text"
         />
       </div>
 
       <div *ngIf="advancedFilters && advancedFilters.length > 0" class="po-lookup-advanced-search">
         <span
-          class="po-lookup-advanced-search-link po-icon-input"
+          class="po-lookup-advanced-search-link"
           tabindex="0"
           (click)="onAdvancedFilter()"
           (keydown.enter)="onAdvancedFilter()"

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
@@ -109,43 +109,6 @@ describe('PoLookupModalComponent', () => {
     expect(fixture.nativeElement.querySelector('.po-modal')).not.toBeNull();
   });
 
-  it('should filter the key pressed', () => {
-    component.ngOnInit();
-    component.openModal();
-    fixture.detectChanges();
-
-    spyOn(component, <any>'validateEnterPressed').and.returnValue(of(true));
-
-    const eventKeyBoard = document.createEvent('KeyboardEvent');
-    eventKeyBoard.initEvent('keyup', true, true);
-    Object.defineProperty(eventKeyBoard, 'keyCode', { 'value': 13 });
-    const element = fixture.debugElement.nativeElement.querySelector('input');
-    element.dispatchEvent(eventKeyBoard);
-
-    expect(component['validateEnterPressed']).toHaveBeenCalledWith(eventKeyBoard);
-  });
-
-  it('should call search method', (): void => {
-    component.openModal();
-    fixture.detectChanges();
-
-    spyOn(component, 'search');
-    spyOn(component, <any>'validateEnterPressed').and.returnValue(true);
-
-    const element = fixture.debugElement.nativeElement.querySelector('.ph-magnifying-glass');
-    element.click();
-
-    expect(component.search).toHaveBeenCalled();
-  });
-
-  it('the typed character must be validated', () => {
-    let isEnterKeyPressed = component['validateEnterPressed'].call(component, { keyCode: 13 });
-    expect(isEnterKeyPressed).toBeTruthy();
-
-    isEnterKeyPressed = component['validateEnterPressed'].call(component, { keyCode: 65 });
-    expect(isEnterKeyPressed).toBeFalsy();
-  });
-
   it('shouldn`t set tableHeight with Infinite Scroll enabled', () => {
     component.infiniteScroll = true;
     component['setTableHeight']();

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -29,7 +28,7 @@ import { sortArrayOfObjects } from '../../../../utils/util';
   templateUrl: './po-lookup-modal.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PoLookupModalComponent extends PoLookupModalBaseComponent implements OnInit, AfterViewInit {
+export class PoLookupModalComponent extends PoLookupModalBaseComponent implements OnInit {
   @ViewChild('inpsearch') inputSearchEl: ElementRef;
   @ViewChild('container', { read: ViewContainerRef }) container: ViewContainerRef;
 
@@ -51,10 +50,6 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
   ngOnInit() {
     super.ngOnInit();
     this.setTableHeight();
-  }
-
-  ngAfterViewInit() {
-    this.initializeEventInput();
   }
 
   // Seleciona um item na tabela
@@ -86,18 +81,6 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
     this.selecteds = [];
   }
 
-  initializeEventInput(): void {
-    this.keyUpObservable = fromEvent(this.inputSearchEl.nativeElement, 'keyup').pipe(
-      filter((e: any) => this.validateEnterPressed(e)),
-      debounceTime(400)
-    );
-
-    this.keyUpObservable.subscribe(() => {
-      this.search();
-      this.changeDetector.detectChanges();
-    });
-  }
-
   openModal() {
     this.poModal.open();
   }
@@ -122,10 +105,6 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
 
   private setTableHeight() {
     this.tableHeight = this.infiniteScroll ? 515 : 615;
-  }
-
-  private validateEnterPressed(e: any) {
-    return e.keyCode === 13;
   }
 
   private setupModalAdvancedFilter() {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
@@ -6,53 +6,54 @@
   [p-required]="required"
   [p-show-required]="showRequired"
 >
-  <div class="po-field-container-content" *ngIf="!disclaimers.length; else disclaimersTemplate">
+  <div class="po-lookup" [class.po-lookup-disabled]="disabled" *ngIf="!disclaimers.length; else disclaimersTemplate">
     <input
       #inp
-      class="po-input"
+      class="po-lookup-input po-lookup-input-trigger"
+      [ngClass]="clean && inp.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
       [id]="id"
       type="text"
-      [ngClass]="clean && inp.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
       [autocomplete]="autocomplete"
       [disabled]="disabled"
-      [placeholder]="disabled ? '' : placeholder"
+      [placeholder]="placeholder"
       [required]="required"
       (blur)="searchEvent()"
     />
-
-    <div class="po-field-icon-container-right">
-      <po-clean
-        class="po-icon-input po-field-icon"
-        *ngIf="clean && !disabled"
-        [p-element-ref]="inputEl"
-        (p-change-event)="cleanModel()"
+    <div class="po-lookup-buttons">
+      <button
+        *ngIf="clean && !disabled && !!inp.value"
+        type="button"
+        class="po-lookup-button po-lookup-button-clean"
+        [ariaLabel]="literals.clean"
+        (click)="cleanModel()"
       >
-      </po-clean>
-
-      <div
+        <po-clean class="po-icon-input"></po-clean>
+      </button>
+      <button
         #iconLookup
-        class="po-field-icon po-field-icon-right po-icon-input"
-        tabindex="-1"
-        [class.po-field-icon]="!disabled"
-        [class.po-field-icon-disabled]="disabled"
+        class="po-lookup-button po-lookup-button-trigger"
+        [class.po-lookup-button-disabled]="disabled"
+        [ariaLabel]="literals.search"
         (click)="openLookup()"
-        (focus)="inp.focus()"
+        [disabled]="disabled"
       >
-        <po-icon p-icon="ICON_SEARCH"></po-icon>
-      </div>
+        <po-icon p-icon="ICON_SEARCH" class="po-icon-input"></po-icon>
+      </button>
     </div>
   </div>
   <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
 </po-field-container>
 
 <ng-template #disclaimersTemplate>
-  <div class="po-field-container-content">
+  <div class="po-lookup" [class.po-lookup-disabled]="disabled">
     <div
       #inp
       [tabindex]="disabled ? -1 : 0"
-      class="po-input po-input-icon-right po-lookup-input po-icon-input"
+      class="po-lookup-input po-input-icon-right po-lookup-input po-icon-input"
+      [ngClass]="clean && inp.value ? 'po-input-double-icon-right' : 'po-input-icon-right'"
       [class.po-lookup-input-auto]="autoHeight"
       [class.po-lookup-input-static]="!autoHeight"
+      [class.po-lookup-input-padding-button-clean]="clean"
       [class.po-lookup-input-disabled]="disabled"
     >
       <span *ngIf="placeholder && !disclaimers?.length" class="po-lookup-input-placeholder">
@@ -70,19 +71,26 @@
       >
       </po-disclaimer>
     </div>
-
-    <div class="po-field-icon-container-right">
-      <div
-        #iconLookup
-        class="po-field-icon po-icon-input"
-        tabindex="-1"
-        [class.po-field-icon]="!disabled"
-        [class.po-field-icon-disabled]="disabled"
-        (click)="openLookup()"
-        (focus)="inp.focus()"
+    <div class="po-lookup-buttons">
+      <button
+        *ngIf="clean && !disabled"
+        type="button"
+        class="po-lookup-button po-lookup-button-clean"
+        [disabled]="disabled"
+        [ariaLabel]="literals.clean"
+        (click)="cleanModel()"
       >
-        <po-icon p-icon="ICON_SEARCH"></po-icon>
-      </div>
+        <po-clean class="po-icon-input"></po-clean>
+      </button>
+      <button
+        #iconLookup
+        class="po-lookup-button po-lookup-button-trigger"
+        [ariaLabel]="literals.search"
+        (click)="openLookup()"
+        [disabled]="disabled"
+      >
+        <po-icon p-icon="ICON_SEARCH" class="po-icon-input"></po-icon>
+      </button>
     </div>
   </div>
 </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -61,6 +61,11 @@ describe('PoLookupComponent:', () => {
       { property: 'label', label: 'Nome', type: 'string', fieldLabel: true }
     ];
     component['initializeColumn']();
+    component.inputEl = {
+      nativeElement: {
+        offsetHeight: 44
+      }
+    };
   });
 
   afterEach(() => {
@@ -646,7 +651,7 @@ describe('PoLookupComponent:', () => {
       const spyCalculateVisibleItems = spyOn(component, 'calculateVisibleItems');
 
       component.debounceResize();
-      tick(201);
+      tick(401);
 
       expect(spyCalculateVisibleItems).toHaveBeenCalled();
     }));

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -17,6 +17,7 @@ import { Subscription } from 'rxjs';
 
 import { uuid } from '../../../utils/util';
 
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 import { PoLookupBaseComponent } from './po-lookup-base.component';
 import { PoLookupFilterService } from './services/po-lookup-filter.service';
 import { PoLookupModalService } from './services/po-lookup-modal.service';
@@ -63,6 +64,38 @@ const providers = [
  *   [ngModelOptions]="{standalone: true}">
  * </po-lookup>
  * ```
+ *
+ * #### Tokens customizáveis
+ *
+ * É possível alterar o estilo do componente usando os seguintes tokens (CSS):
+ *
+ * > Para maiores informações, acesse o guia [Personalizando o Tema Padrão com Tokens CSS](https://po-ui.io/guides/theme-customization).
+ *
+ * | Propriedade                            |  Descrição                                            | Valor Padrão                                     |
+ * |----------------------------------------|-------------------------------------------------------|--------------------------------------------------|
+ * | **Default Values**                     |                                                       |                                                  |
+ * | `--font-family`                        | Família tipográfica usada                             | `var(--font-family-theme)`                       |
+ * | `--font-size`                          | Tamanho da fonte                                      | `var(--font-size-default)`                       |
+ * | `--text-color-placeholder`             | Cor do texto no placeholder                           | `var(--color-neutral-light-30)`                  |
+ * | `--color`                              | Cor principal do lookup                               | `var(--color-neutral-dark-70)`                   |
+ * | `--border-radius`                      | Contém o valor do raio dos cantos do elemento&nbsp;   | `var(--border-radius-md)`                        |
+ * | `--background`                         | Cor de background                                     | `var(--color-neutral-light-05)`                  |
+ * | `--text-color`                         | Cor do texto                                          | `var(--color-neutral-dark-90)`                   |
+ * | `--color-clear`                        | Cor principal do icone clear                          | `var(--color-action-default)`                    |
+ * | **Icon**                               |                                                       |                                                  |
+ * | `--color-icon`                         | Cor principal do icone pesquisar                      | `var(--color-action-default)`                    |
+ * | **Hover**                              |                                                       |                                                  |
+ * | `--color-hover`                        | Cor principal no estado hover                         | `var(--color-action-hover)`                      |
+ * | `--background-hover`                   | Cor de background no estado hover                     | `var(--color-brand-01-lightest)`                 |
+ * | **Focused**                            |                                                       |                                                  |
+ * | `--color-focused`                      | Cor principal no estado de focus                      | `var(--color-action-default)`                    |
+ * | `--outline-color-focused`              | Cor do outline do estado de focus                     | `var(--color-action-focus)`                      |
+ * | **Disabled**                           |                                                       |                                                  |
+ * | `--color-disabled`                     | Cor principal no estado disabled                      | `var(--color-action-disabled)`                   |
+ * | `--background-disabled`                | Cor de background no estado disabled                  | `var(--color-neutral-light-20)`                  |
+ * | `--text-color-disabled`                | Cor do texto quando campo está desabilitado           | `var(--color-action-disabled)`                   |
+ * | **Error**                              |                                                       |                                                  |
+ * | `--color-error`                        | Cor de background no estado de requerido              | `var(--color-feedback-negative-base)`            |
  *
  * @example
  *
@@ -113,6 +146,7 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
   initialized = false;
   timeoutResize;
   visibleElement = false;
+  heightGroupButtons = 44;
 
   disclaimers = [];
   visibleDisclaimers = [];
@@ -127,13 +161,14 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
   }
 
   constructor(
+    languageService: PoLanguageService,
     private renderer: Renderer2,
     poLookupFilterService: PoLookupFilterService,
     poLookupModalService: PoLookupModalService,
     private cd: ChangeDetectorRef,
     injector: Injector
   ) {
-    super(poLookupFilterService, injector, poLookupModalService);
+    super(poLookupFilterService, injector, poLookupModalService, languageService);
   }
 
   ngAfterViewInit() {
@@ -314,14 +349,16 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
   debounceResize() {
     if (!this.autoHeight) {
       clearTimeout(this.timeoutResize);
-      this.timeoutResize = setTimeout(() => {
-        this.calculateVisibleItems();
-      }, 200);
+      this.debounce(this.calculateVisibleItems.bind(this), 200);
     }
   }
 
+  debounce(func: () => void, delay: number) {
+    this.timeoutResize = setTimeout(func, delay);
+  }
+
   getInputWidth() {
-    return this.inputEl.nativeElement.offsetWidth - 40;
+    return this.inputEl.nativeElement.offsetWidth - (this.clean ? 80 : 40);
   }
 
   getDisclaimersWidth() {


### PR DESCRIPTION
**PO-LOOKUP**

**DTHFUI-9693**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente o po-lookup não contempla uma navegação pelo ícone de pesquisa do input nem tão pouco pelo ícone de limpar o valor contido nele, deixando a navegação pelo teclado uma experiência limitada.

**Qual o novo comportamento?**
Implementa definições Animalia no po-lookup:
Recebe comportamento semelhante do modo trigger do po-search onde possibilita navegar pelo input, realizar consulta, apagar o(s) valor(es) e abrir a modal, pelo teclado.
Mantém o estilo e a customização animalia;
Traz a compatibilidade para leitor de tela;

**Simulação**
1 - No app em anexo é possível simular o uso do componente pela navegação pelo teclado e pela navegação convencional através do mouse.
2 - No portal (localhost), é possível simular a navegação e o uso dos ícones de clear e search através do Labs do po-lookup apenas habilitando o checkbox Clean.

[app.zip](https://github.com/user-attachments/files/17385007/app.zip)

Para o correto funcionamente da estilização e customização, o projeto requer o style desta feat que está em https://github.com/po-ui/po-style/pull/644
