### PR TITLE
fix(table): aplica regra indeterminate no checkbox

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -1024,6 +1024,11 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
 
       this.items.forEach(item => {
         item.$selected = this.selectAll;
+
+        if (item[this.nameColumnDetail]) {
+          const childItems = item[this.nameColumnDetail];
+          childItems.forEach(childItem => (childItem.$selected = this.selectAll));
+        }
       });
 
       this.emitSelectAllEvents(this.selectAll, [...this.items]);
@@ -1035,8 +1040,13 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     row.$selected = !row.$selected;
 
     this.emitSelectEvents(row);
-
     this.configAfterSelectRow(this.items, row);
+
+    if (row[this.nameColumnDetail] && (row.$selected === true || row.$selected === false)) {
+      const childItems = row[this.nameColumnDetail];
+      childItems.forEach(item => (item.$selected = row.$selected));
+    }
+
     this.setSelectedList();
   }
 
@@ -1044,8 +1054,29 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
     return this.selectable && this.selectableEntireLine;
   }
 
-  selectDetailRow(row: any) {
-    this.emitSelectEvents(row);
+  selectDetailRow(event: any) {
+    const { item, parentRow } = event;
+    this.emitSelectEvents(item);
+    this.updateParentRowSelection(parentRow);
+  }
+
+  updateParentRowSelection(parentRow: any) {
+    const old = parentRow.$selected || null;
+    const childItems = parentRow[this.nameColumnDetail];
+
+    if (childItems.every(item => item.$selected)) {
+      parentRow.$selected = true;
+    } else if (childItems.every(item => !item.$selected)) {
+      parentRow.$selected = false;
+    } else {
+      parentRow.$selected = null;
+    }
+    if (old != parentRow.$selected && !(old == null && parentRow.$selected === false)) {
+      this.emitSelectEvents(parentRow);
+    }
+
+    this.configAfterSelectRow(this.items, parentRow);
+    this.setSelectedList();
   }
 
   setSelectedList() {

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
@@ -22,12 +22,7 @@
       <ng-container *ngIf="isSelectable; else masterDetailSpace">
         <td class="po-table-column-master-detail-space-checkbox"></td>
         <td class="po-table-column po-table-column-selectable">
-          <po-checkbox
-            name="checkbox"
-            (click)="onSelectRow(item)"
-            (p-change)="onSelectRow(item)"
-            [(ngModel)]="item.$selected"
-          ></po-checkbox>
+          <po-checkbox name="checkbox" (p-change)="onSelectRow(item)" [p-checkboxValue]="item.$selected"></po-checkbox>
         </td>
       </ng-container>
 

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.spec.ts
@@ -178,7 +178,7 @@ describe('PoTableDetailComponent', () => {
       component.onSelectRow(row);
 
       expect(row.$selected).toBeTruthy();
-      expect(component.selectRow.emit).toHaveBeenCalledWith(row);
+      expect(component.selectRow.emit).toHaveBeenCalledWith({ item: row, parentRow: undefined });
     });
 
     describe('returnPoTableDetailObject: ', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.ts
@@ -24,6 +24,12 @@ export class PoTableDetailComponent {
   @Input('p-items') items: Array<any>;
 
   /**
+   * Linha do registro pai correspondente ao item de detalhe selecionado. Utilizado para gerenciar o estado de seleção do elemento pai,
+   * permitindo que o mesmo seja atualizado para refletir a seleção de todos os filhos ou estado indeterminado.
+   */
+  @Input('p-parent-row') parentRow: PoTableDetail;
+
+  /**
    * Define se a tabela possui a opção de `selectable` habilitada.
    */
   @Input('p-selectable') isSelectable?: boolean = false;
@@ -92,7 +98,7 @@ export class PoTableDetailComponent {
 
   onSelectRow(item) {
     item.$selected = !item.$selected;
-    this.selectRow.emit(item);
+    this.selectRow.emit({ item: item, parentRow: this.parentRow });
   }
 
   private returnPoTableDetailObject(value: any) {

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -434,6 +434,7 @@
               [p-selectable]="selectable && !detailHideSelect"
               [p-detail]="columnMasterDetail.detail"
               [p-items]="row[nameColumnDetail]"
+              [p-parent-row]="row"
               (p-select-row)="selectDetailRow($event)"
             >
             </po-table-detail>
@@ -790,6 +791,7 @@
                 [p-selectable]="selectable && !detailHideSelect"
                 [p-detail]="columnMasterDetail.detail"
                 [p-items]="row[nameColumnDetail]"
+                [p-parent-row]="row"
                 (p-select-row)="selectDetailRow($event)"
               >
               </po-table-detail>
@@ -820,7 +822,7 @@
   <po-checkbox
     name="checkbox"
     (p-change)="selectable ? selectRow(row) : 'javascript:;'"
-    [p-checkboxValue]="row.$selected"
+    [p-checkboxValue]="row.$selected === null ? 'mixed' : row.$selected"
   ></po-checkbox>
 </ng-template>
 


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-7346**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao selecionar um registro filho (master detail) do componente po-table, o elemento pai não fica indeterminate

**Qual o novo comportamento?**
Ao selecionar um registro filho (master detail) do componente po-table, o elemento pai fica indeterminate

**Simulação**
[app-7346.zip](https://github.com/user-attachments/files/17347132/app-7346.zip)
