### PR TITLE
fix(accordion): corrige texto grande no componente (17)

### DIFF
--- a/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.html
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.html
@@ -7,8 +7,8 @@
     class="po-accordion-item-header-button po-clickable"
     (click)="onClick()"
   >
-    <div class="po-accordion-item-header-button-content">
-      <div class="po-text-ellipsis po-accordion-item-header-title">{{ label }}</div>
+    <div class="po-accordion-item-header-button-content" [p-tooltip]="getTooltip()">
+      <div #accordionHeaderElement class="po-text-ellipsis po-accordion-item-header-title">{{ label }}</div>
       <po-tag *ngIf="labelTag" class="po-accordion-item-header-tag" [p-value]="labelTag" [p-type]="typeTag"> </po-tag>
     </div>
     <po-icon p-icon="ICON_ARROW_DOWN" class="po-icon po-accordion-item-header-icon"></po-icon>

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.spec.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.spec.ts
@@ -38,6 +38,26 @@ describe('PoAccordionItemHeaderComponent:', () => {
       expect(component.expanded).toBe(expectedValue);
       expect(component.toggle.emit).toHaveBeenCalledWith(expectedValue);
     });
+
+    it('getTooltip: should return label', () => {
+      component.label = 'my Label';
+      spyOnProperty(component.accordionElement.nativeElement, 'offsetWidth').and.returnValue(156);
+
+      spyOnProperty(component.accordionHeaderElement.nativeElement, 'offsetWidth').and.returnValue(100);
+
+      const tooltip = component.getTooltip();
+      expect(tooltip).toBe(component.label);
+    });
+
+    it('getTooltip: should not return label', () => {
+      component.label = 'my Label';
+      spyOnProperty(component.accordionElement.nativeElement, 'offsetWidth').and.returnValue(200);
+
+      spyOnProperty(component.accordionHeaderElement.nativeElement, 'offsetWidth').and.returnValue(100);
+
+      const tooltip = component.getTooltip();
+      expect(tooltip).toBe(null);
+    });
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.ts
@@ -11,6 +11,7 @@ export class PoAccordionItemHeaderComponent {
   private language: string = poLocaleDefault;
 
   @ViewChild('accordionElement', { read: ElementRef, static: true }) accordionElement: ElementRef;
+  @ViewChild('accordionHeaderElement', { read: ElementRef, static: true }) accordionHeaderElement: ElementRef;
 
   @Input('p-expanded') expanded: boolean = false;
 
@@ -32,5 +33,15 @@ export class PoAccordionItemHeaderComponent {
     this.expanded = !this.expanded;
 
     this.toggle.emit(this.expanded);
+  }
+
+  getTooltip() {
+    const widthContainer = this.accordionElement.nativeElement.offsetWidth - 56;
+    const widthHeaderElement = this.accordionHeaderElement.nativeElement.offsetWidth;
+
+    if (widthHeaderElement >= widthContainer) {
+      return this.label;
+    }
+    return null;
   }
 }

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.html
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.html
@@ -1,6 +1,12 @@
 <div class="po-accordion-manager-header">
-  <button class="po-accordion-manager-button po-clickable" (click)="onClick()" [attr.aria-expanded]="expandedAllItems">
-    <div class="po-text-ellipsis po-accordion-manager-button-content">
+  <button
+    #accordionHeaderButtonManagerElement
+    class="po-accordion-manager-button po-clickable"
+    (click)="onClick()"
+    [attr.aria-expanded]="expandedAllItems"
+    [p-tooltip]="getTooltip()"
+  >
+    <div #accordionHeaderManagerElement class="po-text-ellipsis po-accordion-manager-button-content">
       {{ expandedAllItems ? literals.closeAllItems : literals.expandAllItems }}
     </div>
     <po-icon

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.spec.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.spec.ts
@@ -36,5 +36,61 @@ describe('PoAccordionManagerComponent:', () => {
       expect(component.expandedAllItems).toBe(expectedValue);
       expect(component.clickManager.emit).toHaveBeenCalled();
     });
+
+    it('onChange: should set labelValue to `literals.closeAllItems`', () => {
+      component.literals = {
+        expandAllItems: 'Teste label',
+        closeAllItems: 'Teste label 2'
+      };
+
+      const changes: any = {
+        expandedAllItems: {
+          currentValue: true
+        }
+      };
+
+      component.ngOnChanges(changes);
+
+      expect(component.labelValue).toBe(component.literals.closeAllItems);
+    });
+
+    it('onChange: should set labelValue to `literals.expandAllItems`', () => {
+      component.literals = {
+        expandAllItems: 'Teste label',
+        closeAllItems: 'Teste label 2'
+      };
+
+      const changes: any = {
+        expandedAllItems: {
+          currentValue: false
+        }
+      };
+
+      component.ngOnChanges(changes);
+
+      expect(component.labelValue).toBe(component.literals.expandAllItems);
+    });
+
+    it('getTooltip: should return label', () => {
+      component.labelValue = 'Test Label';
+      component.expandedAllItems = true;
+      spyOnProperty(component.accordionElement.nativeElement, 'offsetWidth').and.returnValue(160);
+
+      spyOnProperty(component.accordionHeaderElement.nativeElement, 'offsetWidth').and.returnValue(100);
+
+      const tooltip = component.getTooltip();
+      expect(tooltip).toBe(component.labelValue);
+    });
+
+    it('getTooltip: should not return label', () => {
+      component.labelValue = 'Test Label';
+      component.expandedAllItems = true;
+      spyOnProperty(component.accordionElement.nativeElement, 'offsetWidth').and.returnValue(200);
+
+      spyOnProperty(component.accordionHeaderElement.nativeElement, 'offsetWidth').and.returnValue(100);
+
+      const tooltip = component.getTooltip();
+      expect(tooltip).toBe(null);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.ts
@@ -1,18 +1,52 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  inject,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 import { PoAccordionLiterals } from '../interfaces/po-accordion-literals.interface';
 
 @Component({
   selector: 'po-accordion-manager',
   templateUrl: 'po-accordion-manager.component.html'
 })
-export class PoAccordionManagerComponent {
+export class PoAccordionManagerComponent implements OnChanges {
+  labelValue: string = '';
+  changeDetector = inject(ChangeDetectorRef);
+
+  @ViewChild('accordionHeaderButtonManagerElement', { read: ElementRef, static: true }) accordionElement: ElementRef;
+  @ViewChild('accordionHeaderManagerElement', { read: ElementRef, static: true }) accordionHeaderElement: ElementRef;
+
   @Input('p-expanded-all-items') expandedAllItems: boolean = false;
 
   @Input('p-literals') literals: PoAccordionLiterals;
 
   @Output('p-click') clickManager = new EventEmitter<boolean>();
 
+  ngOnChanges(changes: SimpleChanges): void {
+    this.labelValue = changes.expandedAllItems.currentValue
+      ? this.literals.closeAllItems
+      : this.literals.expandAllItems;
+    this.changeDetector.detectChanges();
+  }
+
   onClick() {
     this.clickManager.emit();
+  }
+
+  getTooltip() {
+    const widthContainer = this.accordionElement.nativeElement.offsetWidth - 69;
+    const widthHeaderElement = this.accordionHeaderElement.nativeElement.offsetWidth;
+
+    if (widthHeaderElement >= widthContainer) {
+      return this.labelValue;
+    }
+    return null;
   }
 }

--- a/projects/ui/src/lib/components/po-accordion/po-accordion.module.ts
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion.module.ts
@@ -4,6 +4,7 @@ import { NgModule } from '@angular/core';
 import { PoDividerModule } from '../po-divider';
 import { PoIconModule } from '../po-icon';
 import { PoTagModule } from '../po-tag';
+import { PoTooltipModule } from '../../directives/po-tooltip/po-tooltip.module';
 
 import { PoAccordionItemBodyComponent } from './po-accordion-item-body/po-accordion-item-body.component';
 import { PoAccordionItemHeaderComponent } from './po-accordion-item-header/po-accordion-item-header.component';
@@ -43,7 +44,7 @@ import { PoAccordionComponent } from './po-accordion.component';
  * ```
  */
 @NgModule({
-  imports: [CommonModule, PoTagModule, PoIconModule, PoDividerModule],
+  imports: [CommonModule, PoTagModule, PoIconModule, PoDividerModule, PoTooltipModule],
   declarations: [
     PoAccordionComponent,
     PoAccordionItemBodyComponent,


### PR DESCRIPTION
Corrige texto estourando a tela no accordion

fixes DTHFUI-9636

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
