### PR TITLE
fix(page-job-scheduler): ajusta diferença na data selecionada

### DIFF
--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.spec.ts
@@ -192,7 +192,7 @@ describe('PoPageJobSchedulerService:', () => {
       const jobSchedulerInternal = {
         periodicity: 'single',
         recurrent: undefined,
-        firstExecution: new Date(),
+        firstExecution: new Date().toISOString(),
         firstExecutionHour: '10:00'
       };
 

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.ts
@@ -232,14 +232,16 @@ export class PoPageJobSchedulerService {
   }
 
   private replaceHourFirstExecution(date: string, time: string): string {
-    const firstExecutionDate = new Date(date);
+    const dateSplited = date.split('-');
+    const year = parseInt(dateSplited[0]);
+    const monthIndex = parseInt(dateSplited[1]) - 1;
+    const day = parseInt(dateSplited[2]);
 
     const timeSplited = time.split(':');
-
     const hours = parseInt(timeSplited[0], 10);
     const minutes = parseInt(timeSplited[1], 10);
 
-    firstExecutionDate.setHours(hours, minutes);
+    const firstExecutionDate = new Date(year, monthIndex, day, hours, minutes);
 
     return convertDateToISOExtended(firstExecutionDate);
   }


### PR DESCRIPTION
Ajustado a diferença entre a data selecionada e a data submitida para API

**<po-page-job-scheduler>**

**DTHFUI-10152**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao enviar a data selecionara para API existe uma diferenção de 1 dia a menos

**Qual o novo comportamento?**
Ao enviar a data selecionada para API a data se mantém a mesma informada pelo usuário

**Simulação**
Utilizar o portal para simular