### PR TITLE
feat(richtext): inclusão propriedade para ocultar botões do toolbar

### DIFF
--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -37,7 +37,11 @@ export * from './po-number/po-number.component';
 export * from './po-password/po-password.component';
 export * from './po-radio-group/po-radio-group-option.interface';
 export * from './po-radio-group/po-radio-group.component';
+
 export * from './po-rich-text/po-rich-text.component';
+export * from './po-rich-text/enum/po-rich-text-toolbar-actions.enum';
+export * from './po-rich-text/interfaces/po-rich-text-toolbar-button-group-item.interface';
+
 export * from './po-select/po-select-option.interface';
 export * from './po-select/po-select-option-group.interface';
 export * from './po-select/po-select.component';

--- a/projects/ui/src/lib/components/po-field/po-rich-text/enum/po-rich-text-toolbar-actions.enum.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/enum/po-rich-text-toolbar-actions.enum.ts
@@ -1,0 +1,39 @@
+/**
+ * @usedBy PoRichTextComponent
+ *
+ * @description
+ * Enumeração que define as ações disponíveis na barra de ferramentas do `PoRichTextComponent`.
+ * Cada ação corresponde a um conjunto de botões ou funcionalidades que podem ser habilitados ou desabilitados
+ * na barra de ferramentas do editor do rich-text.
+ */
+export enum PoRichTextToolbarActions {
+  /**
+   * Seletor de cores, Ação que permite que o usuário altere a cor do texto selecionado.
+   */
+  Color = 'color',
+
+  /**
+   * Alinhamento de texto, incluindo alinhamento à esquerda, centralizado, à direita e justificado.
+   */
+  Align = 'align',
+
+  /**
+   * Formatação de texto, como aplicar negrito, itálico ou sublinhado ao texto selecionado.
+   */
+  Format = 'format',
+
+  /**
+   * Listas com marcadores (bullet points) ou listas numeradas.
+   */
+  List = 'list',
+
+  /**
+   * Links no conteúdo, aplica partes do texto para serem clicáveis e direcionem para URLs especificadas.
+   */
+  Link = 'link',
+
+  /**
+   * Mídias, como imagens, no conteúdo do editor.
+   */
+  Media = 'media'
+}

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.spec.ts
@@ -6,6 +6,7 @@ import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 
 import { PoRichTextBaseComponent } from './po-rich-text-base.component';
 import { PoRichTextService } from './po-rich-text.service';
+import { PoRichTextToolbarActions } from './enum/po-rich-text-toolbar-actions.enum';
 
 @Directive()
 class PoRichTextComponent extends PoRichTextBaseComponent {}
@@ -59,6 +60,32 @@ describe('PoRichTextBaseComponent:', () => {
       expectPropertiesValues(component, 'required', booleanInvalidValues, false);
 
       expect(component['validateModel']).toHaveBeenCalledWith(component.value);
+    });
+
+    describe('p-hide-toolbar-actions:', () => {
+      it('should set hideToolbarActions as an array if provided with a single action', () => {
+        component.hideToolbarActions = PoRichTextToolbarActions.Align;
+        expect(component.hideToolbarActions).toEqual([PoRichTextToolbarActions.Align]);
+      });
+
+      it('should set hideToolbarActions as an array if provided with multiple actions', () => {
+        const actions = [PoRichTextToolbarActions.Align, PoRichTextToolbarActions.Color];
+        component.hideToolbarActions = actions;
+        expect(component.hideToolbarActions).toEqual(actions);
+      });
+
+      it('should set hideToolbarActions as an empty array if provided with an empty array', () => {
+        component.hideToolbarActions = [];
+        expect(component.hideToolbarActions).toEqual([]);
+      });
+
+      it('should update hideToolbarActions correctly when changed', () => {
+        component.hideToolbarActions = PoRichTextToolbarActions.Format;
+        expect(component.hideToolbarActions).toEqual([PoRichTextToolbarActions.Format]);
+
+        component.hideToolbarActions = [PoRichTextToolbarActions.List, PoRichTextToolbarActions.Link];
+        expect(component.hideToolbarActions).toEqual([PoRichTextToolbarActions.List, PoRichTextToolbarActions.Link]);
+      });
     });
   });
 

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
@@ -1,9 +1,9 @@
 import { Directive, EventEmitter, Input, Output } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 
-import { InputBoolean } from '../../../decorators';
 import { convertToBoolean } from '../../../utils/util';
 import { requiredFailed } from '../validators';
+import { PoRichTextToolbarActions } from './enum/po-rich-text-toolbar-actions.enum';
 import { PoRichTextService } from './po-rich-text.service';
 
 /**
@@ -39,7 +39,7 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
    *
    * @default `false`
    */
-  @Input({ alias: 'p-disabled-text-align', transform: convertToBoolean }) disabledTextAlign: boolean = false;
+  @Input({ alias: 'p-disabled-text-align', transform: convertToBoolean }) disabledTextAlign: boolean;
 
   /**
    * @description
@@ -83,6 +83,39 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
    * @default `false`
    */
   @Input('p-optional') optional: boolean;
+
+  private _hideToolbarActions: Array<PoRichTextToolbarActions> = [];
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define as ações da barra de ferramentas do `PoRichTextComponent` que serão ocultadas.
+   * Aceita um único valor do tipo `PoRichTextToolbarActions` ou uma lista de valores.
+   *
+   * > Esta propriedade sobrepõe a configuração da propriedade `p-disabled-text-align` quando for passada como `false`, caso sejam definidas simultaneamente.
+   *
+   * @default `[]`
+   *
+   * @example
+   * ```
+   * // Oculta apenas o seletor de cores
+   * component.hideToolbarActions = PoRichTextToolbarActions.Color;
+   *
+   * // Oculta as opções de alinhamento e link
+   * component.hideToolbarActions = [PoRichTextToolbarActions.Align, PoRichTextToolbarActions.Link];
+   * ```
+   */
+  @Input('p-hide-toolbar-actions') set hideToolbarActions(
+    actions: Array<PoRichTextToolbarActions> | PoRichTextToolbarActions
+  ) {
+    this._hideToolbarActions = Array.isArray(actions) ? [...actions] : [actions];
+  }
+
+  get hideToolbarActions(): Array<PoRichTextToolbarActions> {
+    return this._hideToolbarActions;
+  }
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
@@ -1,9 +1,13 @@
 <div class="po-rich-text-toolbar" #toolbarElement>
-  <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="format">
+  <div
+    class="po-rich-text-toolbar-button-align"
+    data-rich-text-toolbar="format"
+    *ngIf="!isActionHidden(formatToolbarAction)"
+  >
     <po-button-group p-toggle="multiple" [p-buttons]="formatButtons"> </po-button-group>
   </div>
 
-  <div *ngIf="!isInternetExplorer" class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="color">
+  <div *ngIf="showColor()" class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="color">
     <div class="po-rich-text-toolbar-color-picker-container">
       <button
         type="button"
@@ -24,19 +28,35 @@
     </div>
   </div>
 
-  <div *ngIf="!disabledTextAlign" class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="align">
+  <div
+    class="po-rich-text-toolbar-button-align"
+    data-rich-text-toolbar="align"
+    *ngIf="!isActionHidden(alignToolbarAction)"
+  >
     <po-button-group p-toggle="single" [p-buttons]="alignButtons"> </po-button-group>
   </div>
 
-  <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="list">
+  <div
+    class="po-rich-text-toolbar-button-align"
+    data-rich-text-toolbar="list"
+    *ngIf="!isActionHidden(listToolbarAction)"
+  >
     <po-button-group p-toggle="single" [p-buttons]="listButtons"> </po-button-group>
   </div>
 
-  <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="link">
+  <div
+    class="po-rich-text-toolbar-button-align"
+    data-rich-text-toolbar="link"
+    *ngIf="!isActionHidden(linkToolbarAction)"
+  >
     <po-button-group [p-buttons]="linkButtons"> </po-button-group>
   </div>
 
-  <div class="po-rich-text-toolbar-button-align" data-rich-text-toolbar="media">
+  <div
+    class="po-rich-text-toolbar-button-align"
+    data-rich-text-toolbar="media"
+    *ngIf="!isActionHidden(mediaToolbarAction)"
+  >
     <po-button-group [p-buttons]="mediaButtons"> </po-button-group>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.spec.ts
@@ -3,15 +3,14 @@ import { FormsModule } from '@angular/forms';
 
 import * as UtilsFunction from '../../../../utils/util';
 
-import { PoButtonGroupModule } from '../../../po-button-group';
-import { PoFieldModule } from '../../po-field.module';
-import { PoModalModule } from '../../../po-modal/po-modal.module';
-import { PoRichTextToolbarComponent } from './po-rich-text-toolbar.component';
-import { PoRichTextLinkModalComponent } from '../po-rich-text-link-modal/po-rich-text-link-modal.component';
-import { PoRichTextImageModalComponent } from '../po-rich-text-image-modal/po-rich-text-image-modal.component';
-import { PoTooltipModule } from './../../../../directives/po-tooltip/po-tooltip.module';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { PoButtonGroupModule } from '../../../po-button-group';
+import { PoModalModule } from '../../../po-modal/po-modal.module';
+import { PoFieldModule } from '../../po-field.module';
+import { PoRichTextToolbarActions } from '../enum/po-rich-text-toolbar-actions.enum';
+import { PoTooltipModule } from './../../../../directives/po-tooltip/po-tooltip.module';
+import { PoRichTextToolbarComponent } from './po-rich-text-toolbar.component';
 
 describe('PoRichTextToolbarComponent:', () => {
   let component: PoRichTextToolbarComponent;
@@ -36,26 +35,6 @@ describe('PoRichTextToolbarComponent:', () => {
   });
 
   describe('Properties:', () => {
-    it('disabledTextAlign: should remove a children element from po-rich-text', () => {
-      component.disabledTextAlign = true;
-
-      fixture.detectChanges();
-
-      const poRichTextToolbarButtonAlign = nativeElement.querySelector('[data-rich-text-toolbar="align"]');
-
-      expect(poRichTextToolbarButtonAlign).toBeNull();
-    });
-
-    it('disabledTextAlign: should keep all children elements inside component po-rich-text', () => {
-      component.disabledTextAlign = false;
-
-      fixture.detectChanges();
-
-      const poRichTextToolbarButtonAlign = nativeElement.querySelector('[data-rich-text-toolbar="align"]');
-
-      expect(poRichTextToolbarButtonAlign).toBeDefined();
-    });
-
     it('readonly: should call toggleDisableButtons', () => {
       spyOn(component, <any>'toggleDisableButtons');
 
@@ -87,6 +66,43 @@ describe('PoRichTextToolbarComponent:', () => {
       component.linkButtons[0].action();
 
       expect(component.richTextLinkModal.openModal).toHaveBeenCalledWith(component['selectedLinkElement']);
+    });
+
+    describe('hideToolbarActions:', () => {
+      it('should initialize with an empty array by default', () => {
+        expect(component.hideToolbarActions).toEqual([]);
+      });
+
+      it('should hide specified toolbar actions, when passed as array', () => {
+        component.hideToolbarActions = [PoRichTextToolbarActions.Align, PoRichTextToolbarActions.Color];
+        fixture.detectChanges();
+
+        expect(component.hideToolbarActions).toContain(PoRichTextToolbarActions.Align);
+        expect(component.hideToolbarActions).toContain(PoRichTextToolbarActions.Color);
+      });
+
+      it('should hide specified toolbar action when passed as string', () => {
+        component.hideToolbarActions = 'color' as PoRichTextToolbarActions;
+        fixture.detectChanges();
+
+        expect(component.hideToolbarActions).toContain(PoRichTextToolbarActions.Color);
+      });
+
+      it('should show media button when media action is not in hideToolbarActions', () => {
+        component.hideToolbarActions = [PoRichTextToolbarActions.Color];
+        fixture.detectChanges();
+
+        const mediaButton = nativeElement.querySelector('[data-rich-text-toolbar="media"]');
+        expect(mediaButton).toBeTruthy();
+      });
+
+      it('should hide media button when media action is in hideToolbarActions', () => {
+        component.hideToolbarActions = [PoRichTextToolbarActions.Media];
+        fixture.detectChanges();
+
+        const mediaButton = nativeElement.querySelector('[data-rich-text-toolbar="media"]');
+        expect(mediaButton).toBeNull();
+      });
     });
   });
 
@@ -278,6 +294,20 @@ describe('PoRichTextToolbarComponent:', () => {
 
       expect(component.richTextLinkModal.openModal).toHaveBeenCalledWith(component['selectedLinkElement']);
     });
+
+    describe('isActionHidden:', () => {
+      it('should return true if the action is hidden', () => {
+        component.hideToolbarActions = [PoRichTextToolbarActions.Color];
+
+        expect(component.isActionHidden(PoRichTextToolbarActions.Color)).toBeTrue();
+      });
+
+      it('should return false if the action is not hidden', () => {
+        component.hideToolbarActions = [PoRichTextToolbarActions.Align];
+
+        expect(component.isActionHidden(PoRichTextToolbarActions.Color)).toBeFalse();
+      });
+    });
   });
 
   describe('Templates:', () => {
@@ -305,6 +335,54 @@ describe('PoRichTextToolbarComponent:', () => {
 
       expect(inputColorPicker.getAttribute('aria-label')).toBe(component.literals.textColor);
       expect(buttonColorPicker.getAttribute('aria-label')).toBe(component.literals.textColor);
+    });
+
+    it('should show format button group when format action is not hidden', () => {
+      component.hideToolbarActions = [];
+      fixture.detectChanges();
+
+      const formatButton = nativeElement.querySelector('[data-rich-text-toolbar="format"]');
+      expect(formatButton).toBeTruthy();
+    });
+
+    it('should hide format button group when format action is hidden', () => {
+      component.hideToolbarActions = [PoRichTextToolbarActions.Format];
+      fixture.detectChanges();
+
+      const formatButton = nativeElement.querySelector('[data-rich-text-toolbar="format"]');
+      expect(formatButton).toBeNull();
+    });
+
+    it('should show align button group when align action is not hidden', () => {
+      component.hideToolbarActions = [];
+      fixture.detectChanges();
+
+      const alignButton = nativeElement.querySelector('[data-rich-text-toolbar="align"]');
+      expect(alignButton).toBeTruthy();
+    });
+
+    it('should hide align button group when align action is hidden', () => {
+      component.hideToolbarActions = [PoRichTextToolbarActions.Align];
+      fixture.detectChanges();
+
+      const alignButton = nativeElement.querySelector('[data-rich-text-toolbar="align"]');
+      expect(alignButton).toBeNull();
+    });
+
+    it('should show color picker when color action is not hidden', () => {
+      component.hideToolbarActions = [];
+      fixture.detectChanges();
+
+      const colorPicker = nativeElement.querySelector('[data-rich-text-toolbar="color"]');
+      expect(colorPicker).toBeTruthy();
+    });
+
+    it('should hide color picker when color action is hidden', () => {
+      component.hideToolbarActions = [PoRichTextToolbarActions.Color];
+      fixture.detectChanges();
+
+      const colorPicker = nativeElement.querySelector('[data-rich-text-toolbar="color"]');
+      expect(colorPicker).toBeNull();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.ts
@@ -1,13 +1,14 @@
 import { AfterViewInit, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 
-import { isIE } from '../../../../utils/util';
 import { PoLanguageService } from '../../../../services/po-language/po-language.service';
+import { isIE } from '../../../../utils/util';
 
 import { PoButtonGroupItem } from '../../../po-button-group';
-import { poRichTextLiteralsDefault } from '../po-rich-text-literals';
+import { PoRichTextToolbarActions } from '../enum/po-rich-text-toolbar-actions.enum';
 import { PoRichTextToolbarButtonGroupItem } from '../interfaces/po-rich-text-toolbar-button-group-item.interface';
 import { PoRichTextImageModalComponent } from '../po-rich-text-image-modal/po-rich-text-image-modal.component';
 import { PoRichTextLinkModalComponent } from '../po-rich-text-link-modal/po-rich-text-link-modal.component';
+import { poRichTextLiteralsDefault } from '../po-rich-text-literals';
 
 const poRichTextDefaultColor = '#000000';
 
@@ -42,16 +43,47 @@ export class PoRichTextToolbarComponent implements AfterViewInit {
 
   mediaButtons: Array<PoButtonGroupItem>;
 
-  private _disabledTextAlign: boolean;
   private _readonly: boolean;
   private selectedLinkElement;
 
-  @Input('p-disabled-text-align') set disabledTextAlign(value: boolean) {
-    this._disabledTextAlign = value;
+  private _hideToolbarActions: Array<PoRichTextToolbarActions> = [];
+
+  formatToolbarAction = PoRichTextToolbarActions.Format;
+  colorToolbarAction = PoRichTextToolbarActions.Color;
+  alignToolbarAction = PoRichTextToolbarActions.Align;
+  listToolbarAction = PoRichTextToolbarActions.List;
+  linkToolbarAction = PoRichTextToolbarActions.Link;
+  mediaToolbarAction = PoRichTextToolbarActions.Media;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define as ações da barra de ferramentas do `PoRichTextComponent` que serão ocultadas.
+   * Aceita um único valor do tipo `PoRichTextToolbarActions` ou uma lista de valores.
+   *
+   * > Esta propriedade sobrepõe a configuração da propriedade `p-disabled-text-align` quando for passada como `false`, caso sejam definidas simultaneamente.
+   *
+   * @default `[]`
+   *
+   * @example
+   * ```
+   * // Oculta apenas o seletor de cores
+   * component.hideToolbarActions = PoRichTextToolbarActions.Color;
+   *
+   * // Oculta as opções de alinhamento e link
+   * component.hideToolbarActions = [PoRichTextToolbarActions.Align, PoRichTextToolbarActions.Link];
+   * ```
+   */
+  @Input('p-hide-toolbar-actions') set hideToolbarActions(
+    actions: Array<PoRichTextToolbarActions> | PoRichTextToolbarActions
+  ) {
+    this._hideToolbarActions = Array.isArray(actions) ? [...actions] : [actions];
   }
 
-  get disabledTextAlign() {
-    return this._disabledTextAlign;
+  get hideToolbarActions(): Array<PoRichTextToolbarActions> {
+    return this._hideToolbarActions;
   }
 
   @Input('p-readonly') set readonly(value: boolean) {
@@ -149,7 +181,9 @@ export class PoRichTextToolbarComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     this.removeButtonFocus();
-    this.setColorInColorPicker(poRichTextDefaultColor);
+    if (this.showColor()) {
+      this.setColorInColorPicker(poRichTextDefaultColor);
+    }
   }
 
   changeTextColor(value) {
@@ -174,6 +208,15 @@ export class PoRichTextToolbarComponent implements AfterViewInit {
       this.linkButtons[0].selected = obj.commands.includes(this.linkButtons[0].command);
       this.setColorInColorPicker(obj.hexColor);
     }
+  }
+
+  // Verifica se uma ação específica do toolbar está oculta
+  isActionHidden(action: PoRichTextToolbarActions): boolean {
+    return this.hideToolbarActions.includes(action);
+  }
+
+  showColor(): boolean {
+    return !this.isInternetExplorer && !this.isActionHidden(PoRichTextToolbarActions.Color);
   }
 
   shortcutTrigger() {

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
@@ -8,9 +8,9 @@
       [p-placeholder]="placeholder"
       [p-readonly]="readonly"
       (p-change)="onChangeValue($event)"
-      (p-commands)="richTextToolbar.setButtonsStates($event)"
-      (p-selected-link)="richTextToolbar.selectedLink($event)"
-      (p-shortcut-command)="richTextToolbar.shortcutTrigger()"
+      (p-commands)="richTextToolbar?.setButtonsStates($event)"
+      (p-selected-link)="richTextToolbar?.selectedLink($event)"
+      (p-shortcut-command)="richTextToolbar?.shortcutTrigger()"
       (p-value)="updateValue($event)"
       (p-blur)="onBlur()"
     >
@@ -18,8 +18,9 @@
 
     <po-rich-text-toolbar
       #richTextToolbar
+      *ngIf="!isAllActionsHidden()"
       [p-readonly]="readonly"
-      [p-disabled-text-align]="disabledTextAlign"
+      [p-hide-toolbar-actions]="toolbarActions"
       (p-link-editing)="richTextBody.linkEditing($event)"
       (p-command)="richTextBody.executeCommand($event)"
     >

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
@@ -1,7 +1,6 @@
 <po-rich-text
   name="richText"
   [(ngModel)]="richText"
-  [p-disabled-text-align]="properties.includes('disabledTextAlign')"
   [p-error-message]="errorMessage"
   [p-height]="height"
   [p-help]="help"
@@ -10,6 +9,7 @@
   [p-placeholder]="placeholder"
   [p-readonly]="properties.includes('readonly')"
   [p-required]="properties.includes('required')"
+  [p-hide-toolbar-actions]="toolbarHideActions"
   [p-show-required]="properties.includes('showRequired')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
@@ -41,10 +41,10 @@
   </div>
 
   <div class="po-row">
-    <po-number class="po-md-6" name="height" [(ngModel)]="height" p-label="Height"> </po-number>
+    <po-number class="po-md-1" name="height" [(ngModel)]="height" p-label="Height"> </po-number>
 
     <po-checkbox-group
-      class="po-md-6"
+      class="po-md-5"
       name="properties"
       [(ngModel)]="properties"
       p-columns="4"
@@ -52,6 +52,16 @@
       [p-options]="propertiesOptions"
     >
     </po-checkbox-group>
+
+    <po-multiselect
+      class="po-md-6"
+      name="multiselect"
+      p-label="Hide Toolbar Actions "
+      [p-options]="toolbarHideActionsOptions"
+      [(ngModel)]="toolbarHideActions"
+      p-placeholder="color"
+    >
+    </po-multiselect>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoCheckboxGroupOption } from '@po-ui/ng-components';
+import { PoCheckboxGroupOption, PoMultiselectOption, PoRichTextToolbarActions } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-rich-text-labs',
@@ -16,12 +16,22 @@ export class SamplePoRichTextLabsComponent implements OnInit {
   properties: Array<string>;
   richText: string;
 
+  toolbarHideActions = [PoRichTextToolbarActions.Link];
+
+  public readonly toolbarHideActionsOptions: Array<PoMultiselectOption> = [
+    { value: PoRichTextToolbarActions.Align, label: 'align' },
+    { value: PoRichTextToolbarActions.Color, label: 'color' },
+    { value: PoRichTextToolbarActions.Format, label: 'format' },
+    { value: PoRichTextToolbarActions.Link, label: 'link' },
+    { value: PoRichTextToolbarActions.List, label: 'list' },
+    { value: PoRichTextToolbarActions.Media, label: 'media' }
+  ];
+
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'optional', label: 'Optional' },
     { value: 'readonly', label: 'Read Only' },
     { value: 'required', label: 'Required' },
-    { value: 'showRequired', label: 'Show Required' },
-    { value: 'disabledTextAlign', label: 'Disabled Text Align' }
+    { value: 'showRequired', label: 'Show Required' }
   ];
 
   ngOnInit() {


### PR DESCRIPTION
**PO-RICHTEXT**

**DTHFUI-9923**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Hoje existe somente a possibilidade de ocultar o alinhamento de texto.

**Qual o novo comportamento?**
Implementação da propriedade 'p-hide-toolbar-actions'. Com essa propriedade, será possível passar os botões do toolbar que serão ocultados do toolbar. Se for passado todas as opções existentes ('color', 'align', 'format', 'list', 'link', 'media'), a toolbar não será exibida.

**Simulação**
> buildar o po-style e adicionar no po-angular, via `.tgz`, `verdaccio` ou `copiando o dist`.

- Testar Portal po-ui / exemplo LABS do Richtext
```
npm run build:ui // build po-ui
npm run build:portal // build portal
npm run start portal // iniciar o portal
```
- Testar o app [simulação.zip](https://github.com/user-attachments/files/17663267/simulacao.zip)

```
// descompactar o app e colocar dentro do po-angular `po-angular\projects\app\src\app`
npm run build // build po-ui
npm run start app // iniciar o app
```