### PR TITLE
fix(date-picker): corrige erro no console (17)

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input/po-mask.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-mask.spec.ts
@@ -473,6 +473,40 @@ describe('PoMask', () => {
     expect(fakeThis.finalPosition).toBe(fakeThis.initialPosition);
   });
 
+  it('resetPositions: should not call the function if the event does not have setSelectionRange', () => {
+    const mockEvent = {
+      target: {}
+    };
+
+    const fakeThis = mask;
+
+    expect(() => fakeThis.setPositions(mockEvent)).not.toThrow();
+  });
+
+  it('setSelectionRange: should not call the function if the event does not have setSelectionRange', () => {
+    const mockEvent = {
+      target: {}
+    };
+
+    const fakeThis = mask;
+    fakeThis.initialPosition = 2;
+    fakeThis.finalPosition = 1;
+
+    expect(() => fakeThis.setSelectionRange(mockEvent)).not.toThrow();
+  });
+
+  it('setSelectionRange: should not call the function if the event does not have setSelectionRange and final is larger than initial', () => {
+    const mockEvent = {
+      target: {}
+    };
+
+    const fakeThis = mask;
+    fakeThis.initialPosition = 1;
+    fakeThis.finalPosition = 2;
+
+    expect(() => fakeThis.setSelectionRange(mockEvent)).not.toThrow();
+  });
+
   it('should change the positions with a defined value', () => {
     const fakeThis = mask;
     fakeThis.initialPosition = 3;

--- a/projects/ui/src/lib/components/po-field/po-input/po-mask.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-mask.ts
@@ -100,9 +100,9 @@ export class PoMask {
 
   setSelectionRange($event: any) {
     if (this.initialPosition > this.finalPosition) {
-      $event.target.setSelectionRange(this.finalPosition, this.initialPosition);
+      $event.target.setSelectionRange?.(this.finalPosition, this.initialPosition);
     } else {
-      $event.target.setSelectionRange(this.initialPosition, this.finalPosition);
+      $event.target.setSelectionRange?.(this.initialPosition, this.finalPosition);
     }
   }
 
@@ -237,7 +237,7 @@ export class PoMask {
 
   // posiciona o cursor de acordo com o controle de posição
   setPositions($event: any) {
-    $event.target.setSelectionRange(this.initialPosition, this.finalPosition);
+    $event.target.setSelectionRange?.(this.initialPosition, this.finalPosition);
   }
 
   // muda a posição do cursor e atualiza o controle de posição


### PR DESCRIPTION
Corrige erro ao focar no botão e pressionar teclas diferentes de `enter` e `space`

DTHFUI-9908

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
