### PR TITLE
feat(dynamic-table): cria nova propriedade p-visible-filter-disclaimers

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
@@ -162,6 +162,18 @@ describe('PoPageDynamicSearchBaseComponent:', () => {
 
       expectPropertiesValues(component, 'quickSearchWidth', invalidValues, undefined);
     });
+
+    it('visibleFilterDisclaimers: should update property `p-visible-filter-disclaimers` to `false` when valid boolean value is given', () => {
+      component.visibleFilterDisclaimers = false;
+
+      expect(component.visibleFilterDisclaimers).toBe(false);
+    });
+
+    it('visibleFilterDisclaimers: should update property `p-visible-filter-disclaimers` to `true` when valid boolean value is given', () => {
+      component.visibleFilterDisclaimers = true;
+
+      expect(component.visibleFilterDisclaimers).toBe(true);
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
@@ -254,6 +254,26 @@ export abstract class PoPageDynamicSearchBaseComponent {
    *
    * @description
    *
+   * Controla a visibilidade dos disclaimers de filtro na página.
+   *
+   * - Quando `true` (defualt), os disclaimers de filtro são exibidos, permitindo que o usuário visualize e remova individualmente os filtros aplicados.
+   * - Quando `false`, os disclaimers de filtro são ocultados, desativando a opção de visualização e remoção de filtros diretamente na interface.
+   *
+   * Esta propriedade é útil para ajustar a experiência do usuário em relação aos filtros aplicados, especialmente em casos onde não se deseja exibir os disclaimers de filtro na interface.
+   *
+   * **Exemplo de uso:**
+   * ```html
+   * <!-- Para ocultar os disclaimers de filtro -->
+   * <po-page-dynamic-table [p-visible-filter-disclaimers]="false"></po-page-dynamic-table>
+   * ```
+   */
+  @Input('p-visible-filter-disclaimers') visibleFilterDisclaimers: boolean = true;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Lista dos campos usados na busca avançada. Caso o mesmo não seja passado a busca avançada não será exibida.
    */
   @Input('p-filters') set filters(filters: Array<PoPageDynamicSearchFilters>) {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.html
@@ -6,6 +6,7 @@
   [p-filter]="filterSettings"
   [p-title]="title"
   [p-quick-search-value]="quickSearchValue"
+  [p-visible-filter-disclaimers]="visibleFilterDisclaimers"
 >
   <po-advanced-filter
     [p-filters]="filters"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -9,6 +9,7 @@
   [p-hide-remove-all-disclaimer]="hideRemoveAllDisclaimer"
   [p-quick-search-width]="quickSearchWidth"
   [p-title]="title"
+  [p-visible-filter-disclaimers]="visibleFilterDisclaimers"
   (p-advanced-search)="onAdvancedSearch($event)"
   (p-change-disclaimers)="onChangeDisclaimers($event)"
   (p-quick-search)="onQuickSearch($event)"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -182,6 +182,18 @@ describe('PoPageDynamicTableComponent:', () => {
       component.virtualScroll = true;
       expect(component.virtualScroll).toBe(true);
     });
+
+    it('visibleFilterDisclaimers: should update property `p-visible-filter-disclaimers` to `false` when valid boolean value is given', () => {
+      component.visibleFilterDisclaimers = false;
+
+      expect(component.visibleFilterDisclaimers).toBe(false);
+    });
+
+    it('visibleFilterDisclaimers: should update property `p-visible-filter-disclaimers` to `true` when valid boolean value is given', () => {
+      component.visibleFilterDisclaimers = true;
+
+      expect(component.visibleFilterDisclaimers).toBe(true);
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -444,6 +444,26 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     this._hideCloseDisclaimers = Array.isArray(value) ? value : [];
   }
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Controla a visibilidade dos disclaimers de filtro na página.
+   *
+   * - Quando `true` (defualt), os disclaimers de filtro são exibidos, permitindo que o usuário visualize e remova individualmente os filtros aplicados.
+   * - Quando `false`, os disclaimers de filtro são ocultados, desativando a opção de visualização e remoção de filtros diretamente na interface.
+   *
+   * Esta propriedade é útil para ajustar a experiência do usuário em relação aos filtros aplicados, especialmente em casos onde não se deseja exibir os disclaimers de filtro na interface.
+   *
+   * **Exemplo de uso:**
+   * ```html
+   * <!-- Para ocultar os disclaimers de filtro -->
+   * <po-page-dynamic-table [p-visible-filter-disclaimers]="false"></po-page-dynamic-table>
+   * ```
+   */
+  @Input('p-visible-filter-disclaimers') visibleFilterDisclaimers: boolean = true;
+
   get hideCloseDisclaimers(): Array<string> {
     return this._hideCloseDisclaimers;
   }

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.spec.ts
@@ -141,5 +141,17 @@ describe('PoPageListBaseComponent:', () => {
 
       expect(component.poPageContent.recalculateHeaderSize).toHaveBeenCalled();
     }));
+
+    it('visibleFilterDisclaimers: should update property `p-visible-filter-disclaimers` to `false` when valid boolean value is given', () => {
+      component.visibleFilterDisclaimers = false;
+
+      expect(component.visibleFilterDisclaimers).toBe(false);
+    });
+
+    it('visibleFilterDisclaimers: should update property `p-visible-filter-disclaimers` to `true` when valid boolean value is given', () => {
+      component.visibleFilterDisclaimers = true;
+
+      expect(component.visibleFilterDisclaimers).toBe(true);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.ts
@@ -182,6 +182,26 @@ export abstract class PoPageListBaseComponent {
    */
   @Input('p-subtitle') subtitle: string;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Controla a visibilidade dos disclaimers de filtro na página.
+   *
+   * - Quando `true` (defualt), os disclaimers de filtro são exibidos, permitindo que o usuário visualize e remova individualmente os filtros aplicados.
+   * - Quando `false`, os disclaimers de filtro são ocultados, desativando a opção de visualização e remoção de filtros diretamente na interface.
+   *
+   * Esta propriedade é útil para ajustar a experiência do usuário em relação aos filtros aplicados, especialmente em casos onde não se deseja exibir os disclaimers de filtro na interface.
+   *
+   * **Exemplo de uso:**
+   * ```html
+   * <!-- Para ocultar os disclaimers de filtro -->
+   * <po-page-list [p-visible-filter-disclaimers]="false"></po-page-list>
+   * ```
+   */
+  @Input('p-visible-filter-disclaimers') visibleFilterDisclaimers: boolean = true;
+
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();
   }

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.html
@@ -95,7 +95,7 @@
 
       <!-- DISCLAIMER -->
       <po-disclaimer-group
-        *ngIf="!!disclaimerGroup"
+        *ngIf="!!disclaimerGroup && visibleFilterDisclaimers"
         [class.po-page-list-disclaimer-group]="!!disclaimerGroup?.disclaimers?.length"
         [p-disclaimers]="disclaimerGroup?.disclaimers"
         [p-hide-remove-all]="disclaimerGroup?.hideRemoveAll"


### PR DESCRIPTION
Foi criado a nova propriedade para visibleFilterDisclaimers opcional do tipo boolean com valor default 'true' que permite exibir ou não o filtro fixo nos disclaimer

dynamic-table/DTHFUI-7112