### PR TITLE
feat(upload): cria propriedade p-disabled-remove-file

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
@@ -1,14 +1,14 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component } from '@angular/core';
-import { UntypedFormControl, FormsModule } from '@angular/forms';
 import { HttpClient, HttpHandler } from '@angular/common/http';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, UntypedFormControl } from '@angular/forms';
 
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 import * as utilsFunctions from '../../../utils/util';
 import * as ValidatorsFunctions from '../validators';
-import { PoLanguageService } from '../../../services/po-language/po-language.service';
-import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
 
 import { PoUploadBaseComponent, poUploadLiteralsDefault } from './po-upload-base.component';
 import { PoUploadFile } from './po-upload-file';
@@ -679,6 +679,18 @@ describe('PoUploadBaseComponent:', () => {
       const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
 
       expectPropertiesValues(component, 'directory', invalidValues, false);
+    });
+
+    it('disabledRemoveFile: should set `disabledRemoveFile` with valid values', () => {
+      component.disabledRemoveFile = utilsFunctions.convertToBoolean(1);
+
+      expect(component.disabledRemoveFile).toBe(true);
+    });
+
+    it('disabledRemoveFile: should set `disabledRemoveFile` to false with invalid values', () => {
+      component.disabledRemoveFile = utilsFunctions.convertToBoolean(3);
+
+      expect(component.disabledRemoveFile).toBe(false);
     });
 
     it('directory: should apply true to `canHandleDirectory` if directory is true and `isIE` plus `isMobile` return false', () => {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -196,6 +196,17 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * @description
    *
+   * Desabilita botão de remover o(s) arquivo(s) selecionado(s).
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-disabled-remove-file', transform: convertToBoolean }) disabledRemoveFile: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Define se a indicação de campo opcional será exibida.
    *
    * > Não será exibida a indicação se:

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
@@ -63,6 +63,7 @@
           <div [ngClass]="{ 'po-upload-progress-container-area po-pt-2 po-pl-1': hasMoreThanFourItems }">
             <po-progress
               *ngFor="let file of currentFiles; trackBy: trackByFn"
+              [p-disabled-cancel]="disabledRemoveFile"
               [p-info]="infoByUploadStatus[file.status]?.text(file.percent)"
               [p-info-icon]="infoByUploadStatus[file.status]?.icon"
               [p-status]="progressStatusByFileStatus[file.status]"

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
@@ -5,6 +5,7 @@
   [p-directory]="properties.includes('directory')"
   [p-disabled]="properties.includes('disabled')"
   [p-required-url]="properties.includes('requiredUrl')"
+  [p-disabled-remove-file]="properties.includes('disabledRemoveFile')"
   [p-drag-drop]="properties.includes('dragDrop')"
   [p-drag-drop-height]="dragDropHeight"
   [p-form-field]="formField"

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
@@ -28,6 +28,7 @@ export class SamplePoUploadLabsComponent implements OnInit {
     { value: 'autoupload', label: 'Automatic upload' },
     { value: 'directory', label: 'Directory' },
     { value: 'disabled', label: 'Disabled' },
+    { value: 'disabledRemoveFile', label: 'Disabled Remove File' },
     { value: 'dragDrop', label: 'Drag Drop' },
     { value: 'requiredUrl', label: 'required Url' },
     { value: 'multiple', label: 'Multiple upload' },

--- a/projects/ui/src/lib/components/po-progress/po-progress-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-progress/po-progress-base.component.spec.ts
@@ -1,4 +1,5 @@
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
+import { convertToBoolean } from '../../utils/util';
 
 import { PoProgressBaseComponent } from './po-progress-base.component';
 
@@ -10,6 +11,18 @@ describe('PoProgressBaseComponent:', () => {
   });
 
   describe('Properties:', () => {
+    it('p-disabled-cancel: should update property with `true` if valid values', () => {
+      component.disabledCancel = convertToBoolean(1);
+
+      expect(component.disabledCancel).toBe(true);
+    });
+
+    it('p-disabled-cancel: should update property with `false` if invalid values', () => {
+      component.disabledCancel = convertToBoolean(3);
+
+      expect(component.disabledCancel).toBe(false);
+    });
+
     it('p-indeterminate: should update property with `true` if valid values', () => {
       const validValues = [true, 'true', 1, ''];
 

--- a/projects/ui/src/lib/components/po-progress/po-progress-base.component.ts
+++ b/projects/ui/src/lib/components/po-progress/po-progress-base.component.ts
@@ -41,6 +41,20 @@ export class PoProgressBaseComponent {
    *
    * @description
    *
+   * Desabilita botão de cancelamento na parte inferior da barra de progresso.
+   *
+   * > Se nenhuma função for passada para o evento `(p-cancel)` ou a barra de progresso estiver com o status `PoProgressStatus.Success`,
+   * o ícone de cancelamento não será exibido.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-disabled-cancel', transform: convertToBoolean }) disabledCancel: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Informação adicional que aparecerá abaixo da barra de progresso ao lado direito.
    */
   @Input('p-info') info?: string;

--- a/projects/ui/src/lib/components/po-progress/po-progress.component.html
+++ b/projects/ui/src/lib/components/po-progress/po-progress.component.html
@@ -33,6 +33,7 @@
         p-icon="ICON_CLOSE"
         (p-click)="emitCancellation()"
         p-kind="secondary"
+        [p-disabled]="disabledCancel"
         [p-aria-label]="literals.cancel"
         [p-danger]="true"
       ></po-button>

--- a/projects/ui/src/lib/components/po-progress/samples/sample-po-progress-labs/sample-po-progress-labs.component.html
+++ b/projects/ui/src/lib/components/po-progress/samples/sample-po-progress-labs/sample-po-progress-labs.component.html
@@ -1,4 +1,5 @@
 <po-progress
+  [p-disabled-cancel]="properties.includes('disabledCancel')"
   [p-indeterminate]="properties.includes('indeterminate')"
   [p-show-percentage]="properties.includes('showPercentage')"
   [p-info]="info"

--- a/projects/ui/src/lib/components/po-progress/samples/sample-po-progress-labs/sample-po-progress-labs.component.ts
+++ b/projects/ui/src/lib/components/po-progress/samples/sample-po-progress-labs/sample-po-progress-labs.component.ts
@@ -24,6 +24,7 @@ export class SamplePoProgressLabsComponent implements OnInit {
   ];
 
   propertiesOptions: Array<PoCheckboxGroupOption> = [
+    { label: 'Disabled Cancel', value: 'disabledCancel' },
     { label: 'Indeterminate', value: 'indeterminate' },
     { label: 'Show percentage', value: 'showPercentage' }
   ];


### PR DESCRIPTION
Upload e Progress
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
N/A

**Qual o novo comportamento?**
Cria nova propriedade p-disabled-remove-file que permite desabilitar o botão de remover o arquivo no po-upload.
Cria nova propriedade p-disabled-cancel que permite desabilitar o botão no canto inferior direito do po-progresso que dispara o evento de p-cancel

**Simulação**
[app.zip](https://github.com/user-attachments/files/17806425/app.zip)
