### PR TITLE
fix(dynamic-form): corrige erro de visibilidade campos no container

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
@@ -50,7 +50,7 @@ export class PoDynamicFormBaseComponent {
    * o `po-textarea`, caso o valor da propriedade `rows` seja menor que 3 o componente criado será o `po-input`.
    * - Caso seja informada a propriedade `secret` o componente criado será o `po-password`.
    * - Caso o *type* informado seja *string* o componente criado será o `po-input`.
-   * > Ao alterar o valor das `properties` e/ou agrupamentos via container, os `fields` que utilizam serviço podem refazer as chamadas para as API's.
+   * > Ao alterar o valor das `properties`, visibilidade e/ou agrupamentos via container, os `fields` que utilizam serviço podem refazer as chamadas para as API's.
    * @default `[]`
    */
   @Input('p-fields') fields: Array<PoDynamicFormField>;

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -669,6 +669,57 @@ describe('PoDynamicFormFieldsComponent: ', () => {
       expect(component.setContainerFields).toHaveBeenCalled();
     });
 
+    it('hasChangeContainer: should call `setContainerFields` if there is a change in hidden fields', () => {
+      const fieldPrevious: Array<PoDynamicFormField> = [
+        { property: 'campo 1', visible: false },
+        { property: 'campo 2' }
+      ];
+      const fieldCurrent: Array<PoDynamicFormField> = [{ property: 'campo 1', visible: true }, { property: 'campo 2' }];
+
+      component.visibleFields = fieldCurrent;
+
+      spyOn(component, <any>'setContainerFields');
+
+      component['hasChangeContainer'](fieldPrevious, fieldCurrent);
+
+      expect(component['setContainerFields']).toHaveBeenCalled();
+    });
+
+    it('hasChangeContainer: if there is a change in the visible fields', () => {
+      const fieldPrevious: Array<PoDynamicFormField> = [{ property: 'campo 1' }, { property: 'campo 2' }];
+      const fieldCurrent: Array<PoDynamicFormField> = [
+        { property: 'campo 1' },
+        { property: 'campo 2' },
+        { property: 'campo 3', visible: false }
+      ];
+
+      component.visibleFields = fieldCurrent.filter(x => x.visible === false);
+
+      spyOn(component, <any>'setContainerFields');
+
+      component['hasChangeContainer'](fieldPrevious, fieldCurrent);
+
+      expect(component['setContainerFields']).toHaveBeenCalled();
+    });
+
+    it('hasChangeContainer: should call "handleChange Container" if there is a change of fields to visible', () => {
+      const fieldPrevious: Array<PoDynamicFormField> = [
+        { property: 'campo 1', visible: true },
+        { property: 'campo 2', visible: false }
+      ];
+      const fieldCurrent: Array<PoDynamicFormField> = [
+        { property: 'campo 1', visible: false },
+        { property: 'campo 2', visible: true }
+      ];
+
+      spyOn(component, <any>'getVisibleFields').and.returnValue(fieldCurrent.filter(x => x.visible === true));
+      spyOn(component, <any>'handleChangesContainer');
+
+      component['hasChangeContainer'](fieldPrevious, fieldCurrent);
+
+      expect(component['handleChangesContainer']).toHaveBeenCalled();
+    });
+
     it('handleChangesContainer: should not call `setContainerFields` if order had its value changed', () => {
       const previous: Array<PoDynamicFormField> = [{ property: 'property1', order: 1 }, { property: 'property2' }];
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -165,14 +165,16 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
       container: item.container || null,
       property: item.property,
       index,
-      order: item.order
+      order: item.order,
+      visible: item.visible ?? true
     }));
 
     const currArray = current.map((item, index) => ({
       container: item.container || null,
       property: item.property,
       index,
-      order: item.order
+      order: item.order,
+      visible: item.visible ?? true
     }));
 
     const prevContainers = prevArray.filter(item => item.container);
@@ -180,6 +182,12 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
 
     const prevOrder = prevArray.filter(item => item.order);
     const currOrder = currArray.filter(item => item.order);
+
+    const prevVisibleTrue = prevArray.filter(item => item.visible === true);
+    const currVisibleTrue = currArray.filter(item => item.visible === true);
+
+    const prevVisibleFalse = prevArray.filter(item => !item.visible);
+    const currVisibleFalse = currArray.filter(item => !item.visible);
 
     // Verifica mudança na quantidade de containers
     if (prevContainers.length !== currContainers.length) {
@@ -193,12 +201,32 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
       return;
     }
 
+    // Verifica mudança na quantidade de visible
+    if (prevVisibleTrue.length !== currVisibleTrue.length) {
+      this.setContainerFields();
+      return;
+    }
+
+    // Verifica mudança na quantidade de visible
+    if (prevVisibleFalse.length !== currVisibleFalse.length) {
+      this.setContainerFields();
+      return;
+    }
+
     if (currContainers.length) {
       this.handleChangesContainer(prevContainers, currContainers, 'container');
     }
 
     if (currOrder.length) {
       this.handleChangesContainer(prevOrder, currOrder, 'order');
+    }
+
+    if (currVisibleTrue.length) {
+      this.handleChangesContainer(prevVisibleTrue, currVisibleTrue, 'visible');
+    }
+
+    if (currVisibleFalse.length) {
+      this.handleChangesContainer(prevVisibleFalse, currVisibleFalse, 'visible');
     }
 
     //atualiza container sem mudança na estrutura da interface


### PR DESCRIPTION
Corrige erro ao setar visibilidade nos campos quando dentro de um container

fixes DTHFUI-10270

**dynamic-form**

**DTHFUI-10270**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao setar a visibilidade de um campo dentro de um container não era respeitado está configuração

**Qual o novo comportamento?**
Ao setar a visibilidade de um campo dentro de um container respeita está configuração

**Simulação**
[DTHFUI-10270.zip](https://github.com/user-attachments/files/17815578/DTHFUI-10270.zip)
