### PR TITLE
fix(dynamic-form): adiciona interface de multiselect em optionsService

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -7,6 +7,7 @@ import {
   PoDatepickerRangeLiterals,
   PoLookupFilter,
   PoLookupLiterals,
+  PoMultiselectFilter,
   PoMultiselectFilterMode,
   PoMultiselectLiterals,
   PoSwitchLabelPosition,
@@ -78,7 +79,7 @@ export interface PoDynamicFormField extends PoDynamicField {
    *  > Para que funcione corretamente, é importante que o serviço siga o
    *  [guia de API do PO UI](https://po-ui.io/guides/api).
    */
-  optionsService?: string | PoComboFilter;
+  optionsService?: string | PoComboFilter | PoMultiselectFilter;
 
   /**
    * Serviço que será utilizado para realizar a busca avançada. Pode ser utilizado em conjunto com a propriedade `columns`.

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -942,6 +942,22 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
       expect(component['isMultiselect'](field)).toBe(true);
     });
 
+    it('isMultiselect: should return `true` if `optionsMulti` is true and `optionsService` is defined service', () => {
+      const options = [
+        { label: '1', value: 1 },
+        { label: '2', value: 2 },
+        { label: '3', value: 3 },
+        { label: '4', value: 4 }
+      ];
+      const optionsService = {
+        getFilteredData: null,
+        getObjectByValue: null
+      };
+      const field = { optionsService, property: 'products', options, optionsMulti: true };
+
+      expect(component['isMultiselect'](field)).toBeTruthy();
+    });
+
     it('isMultiselect: should return false if `optionsMulti` is false', () => {
       const options = [
         { label: '1', value: 1 },


### PR DESCRIPTION
Dynamic-Form

DTHFUI-10180
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A propriedade optionsService nao aceita ser tipada com a interface PoMultiselectFilter

**Qual o novo comportamento?**
A propriedade optionsService aceita ser tipada com a interface PoMultiselectFilter

**Simulação**

[app (13).zip](https://github.com/user-attachments/files/17819155/app.13.zip)

