### PR TITLE
fix(chart): corrige espaço em branco

### DIFF
--- a/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
@@ -378,6 +378,12 @@ describe('PoChartComponent:', () => {
 
       expect(component['getAxisXLabelArea'](axisXLabel)).toBe(56);
     });
+
+    it('getAxisXLabelArea: should calculate and return width for a decimal number', () => {
+      const axisXLabel = 12.111111111111;
+
+      expect(component['getAxisXLabelArea'](axisXLabel)).toBe(56);
+    });
   });
 
   describe('Template', () => {

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.ts
@@ -181,7 +181,9 @@ export class PoChartComponent extends PoChartBaseComponent implements AfterViewI
     const spanElement = this.renderer.createElement('span');
 
     this.renderer.addClass(spanElement, 'po-chart-axis-x-label');
-    spanElement.innerHTML = axisXLabel;
+
+    const formattedLabel = typeof axisXLabel === 'number' ? axisXLabel.toFixed(2) : axisXLabel;
+    spanElement.innerHTML = formattedLabel;
 
     this.renderer.appendChild(this.elementRef.nativeElement, spanElement);
     const axisXLabelWidth = Math.ceil(spanElement.offsetWidth) + labelPoChartPadding;


### PR DESCRIPTION
**PO-CHART**

**DTHFUI-10263**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o novo comportamento?**
Corrige espaço em branco gerado ao atribuir números quebrados nas séries dentro de um po-widget.

**Simulação**
[DTHFUI-10263.zip](https://github.com/user-attachments/files/17847588/DTHFUI-10263.zip)