### PR TITLE
feat(stepper): cria a propriedade `p-disable-click`

### DIFF
--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
@@ -284,6 +284,17 @@ export class PoStepperBaseComponent {
    */
   @Input('p-step-icon-active') iconActive?: string | TemplateRef<void>;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Desabilita o clique nos steps.
+   *
+   * @default `false`
+   */
+  @Input('p-disable-click') disabledClick: boolean = false;
+
   private initializeSteps(): void {
     const hasStatus = this._steps.some(step => step.status !== PoStepperStatus.Default);
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.html
@@ -1,7 +1,8 @@
 <div
   #labelElement
   class="po-stepper-label"
-  [class.po-link]="status !== 'disabled'"
+  [class.po-link]="status !== 'disabled' && !this.disabledClick"
+  [class.po-stepper-disabled-click]="this.disabledClick"
   [class.po-stepper-label-active]="status === 'active' || status === 'error'"
   [class.po-stepper-label-done]="status === 'done'"
   [class.po-stepper-label-vertical]="isVerticalOrientation"

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-label/po-stepper-label.component.ts
@@ -37,6 +37,8 @@ export class PoStepperLabelComponent implements AfterViewInit, OnChanges {
 
   @ViewChild('labelElement') labelElement: ElementRef;
 
+  @Input('p-disable-click') disabledClick: boolean = false;
+
   displayedContent: string;
   tooltipContent: string;
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.html
@@ -2,10 +2,11 @@
   class="po-stepper-step"
   [ngClass]="getStatusClass(status)"
   role="tab"
-  [tabindex]="status === 'disabled' ? -1 : 0"
+  [tabindex]="status === 'disabled' || disabledClick ? -1 : 0"
   [attr.aria-selected]="status === 'active'"
   [attr.aria-disabled]="status === 'disabled'"
   [attr.aria-required]="status === 'error'"
+  [class.po-stepper-disabled-click]="disabledClick"
   (click)="onClick()"
   (keydown.enter)="onEnter()"
 >
@@ -35,6 +36,7 @@
       [p-status]="status"
       [p-vertical-orientation]="isVerticalOrientation"
       [attr.aria-label]="label"
+      [p-disable-click]="disabledClick"
     >
     </po-stepper-label>
   </div>

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.spec.ts
@@ -194,6 +194,15 @@ describe('PoStepperStepComponent:', () => {
       expect(component.click.emit).not.toHaveBeenCalled();
     });
 
+    it('onClick: shouldn´t call `click.emit` if `disabledClick` is `true`.', () => {
+      component.status = PoStepperStatus.Active;
+      component.disabledClick = true;
+      spyOn(component.click, 'emit');
+      component.onClick();
+
+      expect(component.click.emit).not.toHaveBeenCalled();
+    });
+
     it('onEnter: should call `click.emit` if `status` is different of `disabled`.', () => {
       component.status = PoStepperStatus.Active;
 
@@ -206,6 +215,15 @@ describe('PoStepperStepComponent:', () => {
     it('onEnter: shouldn´t call `click.emit` if `status` is `disabled`.', () => {
       component.status = PoStepperStatus.Disabled;
 
+      spyOn(component.enter, 'emit');
+      component.onEnter();
+
+      expect(component.enter.emit).not.toHaveBeenCalled();
+    });
+
+    it('onEnter: shouldn´t call `click.emit` if `disabledClick` is `true`.', () => {
+      component.status = PoStepperStatus.Active;
+      component.disabledClick = true;
       spyOn(component.enter, 'emit');
       component.onEnter();
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-step/po-stepper-step.component.ts
@@ -114,6 +114,8 @@ export class PoStepperStepComponent implements OnChanges {
   // Evento que será emitido ao focar no *step* e pressionar a tecla *enter*.
   @Output('p-enter') enter = new EventEmitter<any>();
 
+  @Input('p-disable-click') disabledClick: boolean = false;
+
   readonly literals = {
     ...poStepLiteralsDefault[poLocaleDefault],
     ...poStepLiteralsDefault[getShortBrowserLanguage()]
@@ -169,13 +171,13 @@ export class PoStepperStepComponent implements OnChanges {
   }
 
   onClick(): void {
-    if (this.status !== PoStepperStatus.Disabled) {
+    if (this.status !== PoStepperStatus.Disabled && !this.disabledClick) {
       this.click.emit();
     }
   }
 
   onEnter(): void {
-    if (this.status !== PoStepperStatus.Disabled) {
+    if (this.status !== PoStepperStatus.Disabled && !this.disabledClick) {
       this.enter.emit();
     }
   }

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.html
@@ -27,6 +27,7 @@
           [p-step-icon-active]="iconActive"
           [p-step-icon-done]="iconDone"
           [p-vertical-orientation]="isVerticalOrientation"
+          [p-disable-click]="disabledClick"
           (p-activated)="onStepActive(step)"
           (p-click)="changeStep(index, step)"
           (p-enter)="changeStep(index, step)"

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.html
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.html
@@ -6,6 +6,7 @@
     [p-step-size]="properties.stepSize"
     [p-step-icon-active]="properties.iconActive"
     [p-step-icon-done]="properties.iconDone"
+    [p-disable-click]="properties.disabledClick"
     (p-change-step)="changeStep('change')"
   >
     <po-step *ngFor="let step of steps" [p-label]="step.label" [p-icon-default]="step.iconDefault">

--- a/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/samples/sample-po-stepper-labs/sample-po-stepper-labs.component.ts
@@ -53,6 +53,11 @@ export class SamplePoStepperLabsComponent implements OnInit {
       help: 'Ex.: ph ph-check-fat',
       gridLgColumns: 4,
       property: 'iconDone'
+    },
+    {
+      property: 'disabledClick',
+      label: 'Disabled click',
+      type: 'boolean'
     }
   ];
 


### PR DESCRIPTION
Cria propriedade `p-disable-click` para desabilitar o clique no step

DTHFUI-9924

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

