### PR TITLE
feat(combo): considera p-remove-initial-filter junto ao p-filter-service

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -814,4 +814,15 @@ export interface PoDynamicFormField extends PoDynamicField {
    * **Componente compatível**: `po-upload`
    */
   onUpload?: Function;
+
+  /**
+   *
+   * Define que o filtro no primeiro clique será removido.
+   *
+   * > Caso o combo tenha um valor padrão de inicialização, o primeiro clique
+   * no componente retornará todos os itens da lista e não apenas o item inicialiazado.
+   *
+   * **Componente compatível**: `po-combo`
+   */
+  removeInitialFilter?: boolean;
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -304,6 +304,7 @@
       [p-debounce-time]="field.debounceTime"
       [p-change-on-enter]="field.changeOnEnter"
       (p-additional-help)="field.additionalHelp?.($event)"
+      [p-remove-initial-filter]="field.removeInitialFilter"
     >
     </po-combo>
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -931,6 +931,14 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     if (validValue(value) && !this.service && this.comboOptionsList && this.comboOptionsList.length) {
       const option = this.getOptionFromValue(value, this.comboOptionsList);
       this.updateSelectedValue(option);
+
+      this.comboOptionsList = this.comboOptionsList.map((option: any) => {
+        if (this.isEqual(option[this.dynamicValue], value)) {
+          return { ...option, selected: true };
+        }
+        return option;
+      });
+
       this.updateComboList();
       this.removeInitialFilter = false;
       return;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -374,6 +374,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   applyFilter(value: string, reset: boolean = false, isArrowDown?: boolean) {
+    if (this.removeInitialFilter) {
+      this.defaultService.hasNext = true;
+    }
+
     if (this.defaultService.hasNext) {
       this.controlComboVisibility(false, reset);
       this.isServerSearching = true;
@@ -408,8 +412,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
 
     if (this.isFirstFilter) {
       this.isFirstFilter = !this.isFirstFilter;
-
-      this.cacheOptions = this.comboOptionsList;
+      this.updateCacheOptions();
     }
   }
 
@@ -467,7 +470,9 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   applyFilterInFirstClick() {
-    if (this.isFirstFilter && !this.selectedValue) {
+    const isEmptyFirstFilter = this.isFirstFilter && !this.selectedValue;
+
+    if (this.removeInitialFilter || isEmptyFirstFilter) {
       this.options = [];
       const scrollingControl = this.setScrollingControl();
       this.applyFilter('', scrollingControl);
@@ -596,6 +601,12 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   clearAndFocus() {
     this.clear(null);
     this.inputEl.nativeElement.focus();
+  }
+
+  updateCacheOptions(): void {
+    this.cacheOptions = this.comboOptionsList.map(item =>
+      item.value === this.selectedValue ? { ...item, selected: true } : item
+    );
   }
 
   private adjustContainerPosition() {

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.spec.ts
@@ -32,6 +32,35 @@ describe('PoItemListComponent', () => {
   });
 
   describe('Methods:', () => {
+    describe('shouldUpdateSelected', () => {
+      it('should return true when searchValue and label from changes exist and have equal values', () => {
+        const changes = {
+          searchValue: { currentValue: 'test', previousValue: null, firstChange: true, isFirstChange: () => true },
+          label: { currentValue: 'test', previousValue: null, firstChange: true, isFirstChange: () => true }
+        };
+        component.ngOnChanges(<any>changes);
+
+        expect(component['shouldUpdateSelected'](changes)).toBeTrue();
+      });
+
+      it('should return false when searchValue and label from changes exist but have different values', () => {
+        const changes = {
+          searchValue: { currentValue: 'test', previousValue: null, firstChange: true, isFirstChange: () => true },
+          label: { currentValue: 'different', previousValue: null, firstChange: true, isFirstChange: () => true }
+        };
+
+        expect(component['shouldUpdateSelected'](changes)).toBeFalse();
+      });
+
+      it('should return false when searchValue is not present in changes', () => {
+        const changes = {
+          label: { currentValue: 'test', previousValue: null, firstChange: true, isFirstChange: () => true }
+        };
+
+        expect(component['shouldUpdateSelected'](changes)).toBeFalse();
+      });
+    });
+
     describe('onSelectItem:', () => {
       it('should emit tabsItem when tabHide or disabled is changed', () => {
         component.isTabs = true;

--- a/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-item-list/po-item-list.component.ts
@@ -23,7 +23,14 @@ export class PoItemListComponent extends PoItemListBaseComponent implements OnCh
     super();
   }
 
+  private shouldUpdateSelected(changes: SimpleChanges): boolean {
+    return !!(changes.searchValue && changes.label && changes.searchValue.currentValue === changes.label.currentValue);
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
+    if (this.shouldUpdateSelected(changes)) {
+      this.selected = true;
+    }
     if (this.isTabs) {
       if (changes.tabHide?.currentValue || changes.disabled?.currentValue) {
         this.tabsItem.emit(this.item);


### PR DESCRIPTION
**PO-COMBO**

**DTHFUI-10068**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente a propriedade p-remove-initial-filter aplica-se apenas ao p-options, sendo assim, quando montado uma lista de ítens pelo p-filter-service não é considerado a funcionalidade de p-remove-initial-filter.

**Qual o novo comportamento?**
Ajustado para que p-remove-initial-filter funcione tanto com p-options como para p-filter-service.
Também repassado para po-dynamic-form-field a propriedade removeInitialFilter para atuar com a funcionalidade p-remove-initial-filter.

**Simulação**
[app.zip](https://github.com/user-attachments/files/18233106/app.zip)

