### PR TITLE
feat(chart): inclusão propriedade `p-data-label` para chart tipo `line`

### DIFF
--- a/projects/ui/src/lib/components/po-chart/index.ts
+++ b/projects/ui/src/lib/components/po-chart/index.ts
@@ -3,6 +3,7 @@ export * from './interfaces/po-chart-serie.interface';
 export * from './enums/po-chart-type.enum';
 export * from './interfaces/po-chart-axis-options.interface';
 export * from './interfaces/po-chart-options.interface';
+export * from './interfaces/po-chart-serie-data-label.interface';
 
 export * from './po-chart.component';
 

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-path-coordinates.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-path-coordinates.interface.ts
@@ -25,4 +25,10 @@ export interface PoChartPathCoordinates {
 
   /** O texto de exibição no tooltip. */
   tooltipLabel?: string;
+
+  /** Indica se é elemento não está em foco. */
+  isBlur?: boolean;
+
+  /** Indica se o valor da série está mostrando fixado na tela. */
+  isFixed?: boolean;
 }

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-points-coordinates.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-points-coordinates.interface.ts
@@ -31,4 +31,7 @@ export interface PoChartPointsCoordinates {
 
   /** Coordenada vertical. */
   yCoordinate: number;
+
+  /** Indica se o valor da série está mostrando fixado na tela. */
+  isFixed?: boolean;
 }

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie-data-label.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie-data-label.interface.ts
@@ -1,0 +1,27 @@
+import { PoChartType } from '../enums/po-chart-type.enum';
+
+/**
+ * @usedBy PoChartComponent
+ *
+ * @description
+ *
+ * Interface que define as propriedades de exibição dos rótulos das séries no `po-chart`.
+ *
+ * > Aplicável apenas para gráficos do tipo `line`.
+ */
+export interface PoChartDataLabel {
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Indica se o texto associado aos pontos da série deve permanecer fixo na exibição do gráfico.
+   *
+   * - Quando definido como `true`:
+   *   - O *tooltip* não será exibido.
+   *   - As outras séries ficarão com opacidade reduzida ao passar o mouse sobre a série ativa.
+   *
+   * > Disponível apenas para o tipo de gráfico `PoChartType.Line`.
+   */
+  fixed?: boolean;
+}

--- a/projects/ui/src/lib/components/po-chart/po-chart-base.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-base.component.ts
@@ -7,6 +7,7 @@ import { PoChartType } from './enums/po-chart-type.enum';
 import { PoChartOptions } from './interfaces/po-chart-options.interface';
 import { PoChartSerie } from './interfaces/po-chart-serie.interface';
 import { PoColorService } from '../../services/po-color/po-color.service';
+import { PoChartDataLabel } from './interfaces/po-chart-serie-data-label.interface';
 
 const poChartDefaultHeight = 400;
 const poChartMinHeight = 200;
@@ -209,6 +210,30 @@ export abstract class PoChartBaseComponent implements OnChanges {
   get options() {
     return this._options;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Permite configurar as propriedades de exibição dos rótulos das séries no gráfico.
+   *
+   * Essa configuração possibilita fixar os valores das séries diretamente no gráfico, alterando o comportamento visual:
+   * - Os valores das séries permanecem visíveis, sem a necessidade de hover.
+   * - O *tooltip* não será exibido.
+   * - Os marcadores (*bullets*) terão seu estilo ajustado.
+   * - As outras séries ficarão com opacidade reduzida ao passar o mouse sobre a série ativa.
+   *
+   * > Disponível apenas para gráficos do tipo `line`.
+   *
+   * #### Exemplo de utilização:
+   * ```typescript
+   * dataLabel: PoChartDataLabel = {
+   *   fixed: true,
+   * };
+   * ```
+   */
+  @Input('p-data-label') dataLabel?: PoChartDataLabel;
 
   constructor(protected colorService: PoColorService) {}
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.html
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-container.component.html
@@ -5,6 +5,8 @@
   [attr.viewBox]="viewBox"
   [attr.width]="containerSize.svgWidth"
   [attr.height]="containerSize.svgHeight"
+  (mouseenter)="onChartMouseEnter()"
+  (mouseleave)="onChartMouseLeave()"
 >
   <!-- axis -->
   <svg:g
@@ -55,6 +57,8 @@
     [p-range]="range"
     [p-series]="seriesByType['line']"
     [p-container-size]="containerSize"
+    [p-data-label]="dataLabel"
+    [p-insideChart]="insideChart"
     (p-point-hover)="onSerieHover($event)"
     (p-point-click)="onSerieClick($event)"
   ></svg:g>

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line-base.component.spec.ts
@@ -103,8 +103,8 @@ describe('PoChartLineBaseComponent', () => {
         component['seriePathPointsDefinition'](component.containerSize, component.series, range);
 
         const expectedResult = [
-          { coordinates: ' M93 27 L136 26 L178 26', color: '#0C6C94', isActive: true },
-          { coordinates: ' M93 21 L136 14 L178 8', color: '#29B6C5', isActive: true }
+          { coordinates: ' M93 27 L136 26 L178 26', color: '#0C6C94', isActive: true, isFixed: undefined },
+          { coordinates: ' M93 21 L136 14 L178 8', color: '#29B6C5', isActive: true, isFixed: undefined }
         ];
 
         expect(component.seriesPathsCoordinates).toEqual(expectedResult);
@@ -113,6 +113,7 @@ describe('PoChartLineBaseComponent', () => {
 
       it('should apply apply value to `seriesPointsCoordinates`', () => {
         component.series = [{ label: 'Vancouver', data: [5, 10], type: PoChartType.Line, color: 'blue' }];
+        component.dataLabel = { fixed: true };
 
         component['seriePathPointsDefinition'](component.containerSize, component.series, range);
 
@@ -126,7 +127,8 @@ describe('PoChartLineBaseComponent', () => {
               data: 5,
               xCoordinate: 104,
               yCoordinate: 24,
-              isActive: true
+              isActive: true,
+              isFixed: true
             },
             {
               category: undefined,
@@ -136,7 +138,8 @@ describe('PoChartLineBaseComponent', () => {
               data: 10,
               xCoordinate: 168,
               yCoordinate: 21,
-              isActive: true
+              isActive: true,
+              isFixed: true
             }
           ]
         ];
@@ -149,6 +152,7 @@ describe('PoChartLineBaseComponent', () => {
       it('should apply apply only data to tooltipLabel if label is undefined', () => {
         const minMaxSeriesValues = { minValue: 5, maxValue: 10 };
         component.series = [{ label: undefined, data: [5, 10], type: PoChartType.Line, color: 'blue' }];
+        component.dataLabel = { fixed: true }; // Definir `dataLabel` para incluir `fixed`
 
         component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
 
@@ -162,7 +166,8 @@ describe('PoChartLineBaseComponent', () => {
               data: 5,
               xCoordinate: 104,
               yCoordinate: 28,
-              isActive: true
+              isActive: true,
+              isFixed: true // Adicione a propriedade esperada
             },
             {
               category: undefined,
@@ -172,7 +177,8 @@ describe('PoChartLineBaseComponent', () => {
               data: 10,
               xCoordinate: 168,
               yCoordinate: 8,
-              isActive: true
+              isActive: true,
+              isFixed: true // Adicione a propriedade esperada
             }
           ]
         ];
@@ -186,8 +192,7 @@ describe('PoChartLineBaseComponent', () => {
         const minMaxSeriesValues = { minValue: 5, maxValue: 10 };
         component.series = [{ label: 'Vancouver', data: [5, 10], type: PoChartType.Line, color: 'blue' }];
         component.categories = ['janeiro', 'fevereiro'];
-
-        component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
+        component.dataLabel = { fixed: true }; // Configurar o dataLabel
 
         const expectedResult = [
           [
@@ -199,7 +204,8 @@ describe('PoChartLineBaseComponent', () => {
               data: 5,
               xCoordinate: 104,
               yCoordinate: 28,
-              isActive: true
+              isActive: true,
+              isFixed: true // Adicionar isFixed
             },
             {
               category: 'fevereiro',
@@ -209,10 +215,13 @@ describe('PoChartLineBaseComponent', () => {
               data: 10,
               xCoordinate: 168,
               yCoordinate: 8,
-              isActive: true
+              isActive: true,
+              isFixed: true // Adicionar isFixed
             }
           ]
         ];
+
+        component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
 
         expect(component.seriesPointsCoordinates).toEqual(expectedResult);
         expect(component.seriesPointsCoordinates.length).toBe(1);
@@ -234,7 +243,8 @@ describe('PoChartLineBaseComponent', () => {
               data: 10,
               xCoordinate: 93,
               yCoordinate: 8,
-              isActive: true
+              isActive: true,
+              isFixed: undefined
             },
             {
               category: 'março',
@@ -244,7 +254,8 @@ describe('PoChartLineBaseComponent', () => {
               data: 12,
               xCoordinate: 178,
               yCoordinate: 0,
-              isActive: true
+              isActive: true,
+              isFixed: undefined
             }
           ]
         ];
@@ -253,7 +264,7 @@ describe('PoChartLineBaseComponent', () => {
 
         expect(component.seriesPointsCoordinates).toEqual(expectedPointsResult);
         expect(component.seriesPathsCoordinates).toEqual([
-          { coordinates: ' M93 8 L178 0', color: '#29B6C5', isActive: true }
+          { coordinates: ' M93 8 L178 0', color: '#29B6C5', isActive: true, isFixed: undefined }
         ]);
       });
 
@@ -274,7 +285,7 @@ describe('PoChartLineBaseComponent', () => {
 
         component['seriePathPointsDefinition'](component.containerSize, component.series, minMaxSeriesValues);
 
-        const expectedResult = [{ coordinates: ' M136 28', color: '#29B6C5', isActive: true }];
+        const expectedResult = [{ coordinates: ' M136 28', color: '#29B6C5', isActive: true, isFixed: undefined }];
 
         expect(component.seriesPathsCoordinates).toEqual(expectedResult);
         expect(component.seriesPathsCoordinates.length).toBe(1);
@@ -417,6 +428,20 @@ describe('PoChartLineBaseComponent', () => {
       component.range = <any>false;
 
       expect(spyseriePathPointsDefinition).not.toHaveBeenCalled();
+    });
+
+    describe('isFixed:', () => {
+      it('should include `isFixed` property in `pointCoordinates` when `dataLabel?.fixed` is true', () => {
+        component.dataLabel = { fixed: true };
+
+        component.series = [{ label: 'Test', data: [10], type: PoChartType.Line, color: 'blue' }];
+
+        component['seriePathPointsDefinition'](component.containerSize, component.series, range);
+
+        const point = component.seriesPointsCoordinates[0][0];
+
+        expect(point.isFixed).toBeTrue();
+      });
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line-base.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line-base.component.ts
@@ -9,6 +9,7 @@ import { PoChartMinMaxValues } from '../../interfaces/po-chart-min-max-values.in
 import { PoChartPathCoordinates } from '../../interfaces/po-chart-path-coordinates.interface';
 import { PoChartPointsCoordinates } from '../../interfaces/po-chart-points-coordinates.interface';
 import { PoChartSerie } from '../../interfaces/po-chart-serie.interface';
+import { PoChartDataLabel } from '../../interfaces/po-chart-serie-data-label.interface';
 
 @Directive()
 export abstract class PoChartLineBaseComponent {
@@ -19,6 +20,10 @@ export abstract class PoChartLineBaseComponent {
   @Input('p-categories-coordinates') categoriesCoordinates: Array<number>;
 
   @Input('p-svg-space') svgSpace;
+
+  @Input('p-data-label') dataLabel?: PoChartDataLabel;
+
+  @Input('p-insideChart') insideChart?: boolean;
 
   @Output('p-point-click') pointClick = new EventEmitter<any>();
 
@@ -42,7 +47,6 @@ export abstract class PoChartLineBaseComponent {
   @Input('p-range') set range(value: PoChartMinMaxValues) {
     if (value instanceof Object && !(value instanceof Array)) {
       this._range = value;
-
       this.seriePathPointsDefinition(this.containerSize, this._series, this._range);
     }
   }
@@ -153,7 +157,17 @@ export abstract class PoChartLineBaseComponent {
             const isActive = this.chartType === PoChartType.Line;
             pointCoordinates = [
               ...pointCoordinates,
-              { category, label, tooltipLabel, data: data, xCoordinate, yCoordinate, color, isActive }
+              {
+                category,
+                label,
+                tooltipLabel,
+                data: data,
+                xCoordinate,
+                yCoordinate,
+                color,
+                isActive,
+                isFixed: this.dataLabel?.fixed
+              }
             ];
             pathCoordinates += ` ${svgPathCommand}${xCoordinate} ${yCoordinate}`;
           }
@@ -163,7 +177,7 @@ export abstract class PoChartLineBaseComponent {
 
         this.seriesPointsCoordinates = [...this.seriesPointsCoordinates, pointCoordinates];
 
-        return { coordinates: pathCoordinates, color, isActive: true };
+        return { coordinates: pathCoordinates, color, isActive: true, isFixed: this.dataLabel?.fixed };
       }
     });
   }

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.spec.ts
@@ -70,5 +70,67 @@ describe('PoChartLineComponent', () => {
       expect(component.animate).toBeFalsy();
       expect(spyAppendChild).toHaveBeenCalled();
     });
+
+    it('ngOnChanges: should set `isBlur` to false for all items in `seriesPathsCoordinates` when `insideChart` is false', () => {
+      component.seriesPathsCoordinates = [
+        { coordinates: 'M10 10', color: '#29B6C5', isBlur: true },
+        { coordinates: 'M20 20', color: '#94DAE2', isBlur: true }
+      ];
+
+      const changes = {
+        insideChart: {
+          currentValue: false,
+          previousValue: true,
+          firstChange: false,
+          isFirstChange: () => false
+        }
+      };
+
+      component.ngOnChanges(changes);
+
+      expect(component.seriesPathsCoordinates[0].isBlur).toBeFalse();
+      expect(component.seriesPathsCoordinates[1].isBlur).toBeFalse();
+    });
+
+    it('onEnter: should update `selectedPath`, call `onLeave`, and set `isBlur` to true for non-selected paths if `dataLabel?.fixed` is true', () => {
+      const spyOnLeave = spyOn(component, 'onLeave').and.callThrough();
+      component.seriesPathsCoordinates = [
+        { coordinates: 'M10 10', color: '#29B6C5', isBlur: false },
+        { coordinates: 'M20 20', color: '#94DAE2', isBlur: false }
+      ];
+      component.dataLabel = { fixed: true };
+
+      component.onEnter(1);
+
+      expect(spyOnLeave).toHaveBeenCalledWith(1);
+      expect(component.selectedPath).toEqual(component.seriesPathsCoordinates[1]);
+      expect(component.seriesPathsCoordinates[0].isBlur).toBeTrue();
+      expect(component.seriesPathsCoordinates[1].isBlur).toBeFalse();
+    });
+
+    it('onLeave: should set `isBlur` to false for all items in `seriesPathsCoordinates` if `dataLabel?.fixed` is true', () => {
+      component.seriesPathsCoordinates = [
+        { coordinates: 'M10 10', color: '#29B6C5', isBlur: true },
+        { coordinates: 'M20 20', color: '#94DAE2', isBlur: true }
+      ];
+      component.dataLabel = { fixed: true };
+
+      component.onLeave(1);
+
+      expect(component.seriesPathsCoordinates[0].isBlur).toBeFalse();
+      expect(component.seriesPathsCoordinates[1].isBlur).toBeFalse();
+    });
+
+    it('ngOnChanges: should not modify `isBlur` if `insideChart` is true', () => {
+      component.insideChart = true;
+      component.seriesPathsCoordinates = [{ isBlur: true }, { isBlur: true }];
+
+      const changes = { insideChart: { currentValue: true, previousValue: false, firstChange: false } };
+
+      component.ngOnChanges(<any>changes);
+
+      // Verificar que `isBlur` permanece inalterado
+      expect(component.seriesPathsCoordinates.every(item => item.isBlur)).toBe(true);
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.svg
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.svg
@@ -1,7 +1,9 @@
 <svg:g #chartLine>
 
   <svg:g *ngFor="let item of seriesPathsCoordinates; let i = index; trackBy: trackBy"
+    class='po-chart-line-path-group'
     [class]="'po-chart-line-path-group-' + i"
+    [class.po-chart-line-path-blur]="item.isBlur"
     (mouseenter)="onEnter(i)"
     (mouseleave)="onLeave(i)"
   >
@@ -12,9 +14,9 @@
       [p-animate]="animate"
       [p-color]="item.color" 
       [p-coordinates]="item?.coordinates"
-      [p-is-active]="item.isActive"
+      [p-is-active]="item.isFixed"
       >
-      </svg:g>
+    </svg:g>
 
     <!-- SERIES POINTS -->
     <svg:g po-chart-series-point
@@ -23,6 +25,7 @@
       [p-color]="item.color"
       [p-coordinates]="seriesPointsCoordinates[i]"
       [p-is-active]="activeTooltip"
+      [p-is-fixed]="item.isFixed"
       [p-relative-to]="'po-chart-line-path-group-' + i" 
       [attr.key]="'po-chart-line-path-points-group-' + i"
       (p-point-click)="onSeriePointClick($event)"

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-line.component.ts
@@ -1,13 +1,16 @@
-import { Component, ElementRef, Renderer2 } from '@angular/core';
+import { Component, ElementRef, OnChanges, Renderer2, SimpleChanges } from '@angular/core';
 
 import { PoChartLineBaseComponent } from './po-chart-line-base.component';
 import { PoChartMathsService } from '../../services/po-chart-maths.service';
+import { PoChartPathCoordinates } from '../../interfaces/po-chart-path-coordinates.interface';
 
 @Component({
   selector: '[po-chart-line]',
   templateUrl: './po-chart-line.component.svg'
 })
-export class PoChartLineComponent extends PoChartLineBaseComponent {
+export class PoChartLineComponent extends PoChartLineBaseComponent implements OnChanges {
+  selectedPath: PoChartPathCoordinates;
+
   constructor(
     protected mathsService: PoChartMathsService,
     protected renderer: Renderer2,
@@ -15,11 +18,29 @@ export class PoChartLineComponent extends PoChartLineBaseComponent {
   ) {
     super(mathsService, renderer, elementRef);
   }
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.insideChart && !this.insideChart) {
+      this.seriesPathsCoordinates.forEach(item => (item.isBlur = false));
+    }
+  }
 
   onEnter(serieIndex: number) {
+    const newPath = this.seriesPathsCoordinates[serieIndex];
+    if (this.selectedPath !== newPath) {
+      this.onLeave(serieIndex);
+      this.selectedPath = newPath;
+    }
+    if (this.dataLabel?.fixed) {
+      this.seriesPathsCoordinates.filter(e => e !== this.selectedPath).map(e => (e.isBlur = true));
+    }
     return null;
   }
+
   onLeave(serieIndex: number) {
+    const newPath = this.seriesPathsCoordinates[serieIndex];
+    if (this.dataLabel?.fixed && this.selectedPath !== newPath) {
+      this.seriesPathsCoordinates.map(e => (e.isBlur = false));
+    }
     return null;
   }
 

--- a/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-series-point/po-chart-series-point.component.svg
+++ b/projects/ui/src/lib/components/po-chart/po-chart-container/po-chart-line/po-chart-series-point/po-chart-series-point.component.svg
@@ -1,7 +1,7 @@
 <svg:circle *ngFor="let item of coordinates$ | async; trackBy: trackBy" 
-  [p-tooltip]="item.tooltipLabel"
+  [p-tooltip]="!item.isFixed ? item.tooltipLabel : null"
   [p-append-in-body]='true'
-  [p-display-tooltip]="!chartLine && item.isActive"
+  [p-display-tooltip]="!chartLine && item.isActive && !item.isFixed"
   p-tooltip-position="top"
   class="po-chart-line-point"
   [class]="strokeColor?.includes('po-border-color') ? strokeColor : ''"
@@ -15,3 +15,28 @@
   (mouseleave)="onMouseLeave($event)"
   >
 </svg:circle>
+
+<ng-container *ngFor="let item of coordinates$ | async; trackBy: trackBy">
+
+  <svg:rect 
+    *ngIf="item.isFixed"
+    [attr.x]="item.xCoordinate - textWidth / 2 - 2"
+    [attr.y]="item.yCoordinate - radius - 5 - textHeight / 2 - 4"
+    [attr.width]="textWidth + 4"
+    [attr.height]="textHeight === 0 ? 0 : textHeight - 2"
+    class='po-chart-series-point-text-rect'
+    rx="2" ry="2"
+  ></svg:rect>
+
+  <svg:text 
+    *ngIf="item.isFixed"
+    [attr.x]="item.xCoordinate"
+    [attr.y]="item.yCoordinate - radius - 5"
+    class='po-chart-series-point-text'
+    [attr.data-id]="item.label"
+    [class]="strokeColor?.includes('po-border-color') ? strokeColor : ''"
+    text-anchor="middle">
+    {{ item.data }}
+  </svg:text>
+
+</ng-container>

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.html
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.html
@@ -9,6 +9,7 @@
     [p-series]="chartSeries"
     [p-categories]="categories"
     [p-container-size]="svgContainerSize"
+    [p-data-label]="dataLabel"
     (p-serie-click)="onSeriesClick($event)"
     (p-serie-hover)="onSeriesHover($event)"
   ></po-chart-container>

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.ts
@@ -45,6 +45,11 @@ import { PoChartMathsService } from './services/po-chart-maths.service';
  *  <file name="sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.html"> </file>
  *  <file name="sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts"> </file>
  * </example>
+ *
+ * <example name="po-chart-world-exports" title="PO Chart - World Exports">
+ *  <file name="sample-po-chart-world-exports/sample-po-chart-world-exports.component.html"> </file>
+ *  <file name="sample-po-chart-world-exports/sample-po-chart-world-exports.component.ts"> </file>
+ * </example>
  */
 @Component({
   selector: 'po-chart',

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
@@ -19,12 +19,24 @@
 <po-divider class="po-md-12" p-label="Properties"></po-divider>
 
 <form>
-  <po-select class="po-md-4" name="type" [(ngModel)]="type" p-columns="3" p-label="Type" [p-options]="typeOptions">
+  <po-select class="po-md-3" name="type" [(ngModel)]="type" p-columns="3" p-label="Type" [p-options]="typeOptions">
   </po-select>
 
-  <po-number class="po-md-4" name="height" [(ngModel)]="height" p-label="Height"> </po-number>
+  <po-number class="po-md-2" name="height" [(ngModel)]="height" p-label="Height"> </po-number>
 
   <po-input class="po-md-4" name="title" [(ngModel)]="title" p-label="Title"> </po-input>
+
+  <po-checkbox-group
+    *ngIf="isLineType()"
+    class="po-md-3"
+    name="dataLabel"
+    p-label="dataLabel"
+    p-help="only for Line Chart"
+    [(ngModel)]="dataLabel"
+    [p-options]="dataLabelOptions"
+    (p-change)="changeDataLabelOptions($event)"
+  >
+  </po-checkbox-group>
 </form>
 
 <form #chartSeries="ngForm">

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
@@ -1,6 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoChartSerie, PoChartType, PoSelectOption, PoChartOptions, PoCheckboxGroupOption } from '@po-ui/ng-components';
+import {
+  PoChartSerie,
+  PoChartType,
+  PoSelectOption,
+  PoChartOptions,
+  PoCheckboxGroupOption,
+  PoChartDataLabel
+} from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-chart-labs',
@@ -27,6 +34,7 @@ export class SamplePoChartLabsComponent implements OnInit {
       gridLines: undefined
     }
   };
+  dataLabel: PoChartDataLabel;
 
   readonly propertiesOptions: Array<PoCheckboxGroupOption> = [{ value: 'legend', label: 'Legend' }];
 
@@ -38,6 +46,8 @@ export class SamplePoChartLabsComponent implements OnInit {
     { label: 'Column', value: PoChartType.Column },
     { label: 'Bar', value: PoChartType.Bar }
   ];
+
+  readonly dataLabelOptions: Array<PoCheckboxGroupOption> = [{ value: 'fixed', label: 'Fixed' }];
 
   ngOnInit() {
     this.restore();
@@ -68,6 +78,14 @@ export class SamplePoChartLabsComponent implements OnInit {
     this.addOptions({ legend });
   }
 
+  isLineType(): boolean {
+    return this.type === PoChartType.Line;
+  }
+
+  changeDataLabelOptions() {
+    const fixed = this.dataLabel.fixed;
+  }
+
   changeEvent(eventName: string, serieEvent: PoChartSerie): void {
     this.event = `${eventName}: ${JSON.stringify(serieEvent)}`;
   }
@@ -87,6 +105,9 @@ export class SamplePoChartLabsComponent implements OnInit {
     this.allCategories = [];
     this.optionsActions = {
       legend: null
+    };
+    this.dataLabel = {
+      fixed: false
     };
     this.options = {
       ...this.optionsActions,

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-world-exports/sample-po-chart-world-exports.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-world-exports/sample-po-chart-world-exports.component.html
@@ -1,0 +1,12 @@
+<div class="po-row">
+  <po-chart
+    class="po-md-12"
+    p-title="Participation by country in world exports - %"
+    [p-options]="options"
+    [p-categories]="categories"
+    [p-series]="participationByCountryInWorldExports"
+    [p-type]="participationByCountryInWorldExportsType"
+    [p-data-label]="dataLabel"
+  >
+  </po-chart>
+</div>

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-world-exports/sample-po-chart-world-exports.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-world-exports/sample-po-chart-world-exports.component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+
+import { PoChartOptions, PoChartSerie, PoChartType } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-chart-world-exports',
+  templateUrl: './sample-po-chart-world-exports.component.html'
+})
+export class SamplePoChartWorldExportsComponent {
+  participationByCountryInWorldExportsType: PoChartType = PoChartType.Line;
+  options: PoChartOptions = {
+    axis: {
+      minRange: 0,
+      maxRange: 40,
+      gridLines: 5
+    }
+  };
+  dataLabel = { fixed: true };
+
+  categories: Array<string> = ['2010', '2011', '2012', '2013', '2014', '2015'];
+
+  participationByCountryInWorldExports: Array<PoChartSerie> = [
+    { label: 'Brazil', data: [35, 32, 27, 29, 33, 33] },
+    { label: 'Vietnam', data: [15, 17, 18, 19, 22, 18] },
+    { label: 'Colombia', data: [8, 7, 6, 9, 10, 11] }
+  ];
+}


### PR DESCRIPTION
**PO-CHART**

**DTHFUI-10134**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Hoje o gráfico do tipo line não tem a possibilidade do valor das series estarem sempre visiveis

**Qual o novo comportamento?**
Implementação da propriedade 'p-data-label', onde é possível passar a propriedade `fixed`. Com essa propriedade (fixed=tue), irar alterar o grafico do tipo line.
- O valor da series ficar sendo exibido fixado com uma background transparente.
- Não será mostrado o tooltip ao hover do bullet.
- Será adicionado uma opacidade a todas outras series quando selecionado uma delas.
- O hover da serie ficará ate selecionar outra ou sair do gráfico.

ex. funcionalidade
![DTHFUI-10134_sample](https://github.com/user-attachments/assets/3296b947-f73c-444a-88cc-41482d089058)

**Simulação**
[DTHFUI-10134_simulação.zip](https://github.com/user-attachments/files/17938262/DTHFUI-10134_simulacao.zip)

buildar o style e adicionar no projeto angular antes de rodar a simulação
testar também o portal, tanto o labs como o sample adicionado