### PR TITLE
fix(dynamic-view): ajusta renderização do multiselect

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.spec.ts
@@ -250,6 +250,36 @@ describe('PoDynamicViewComponent:', () => {
     });
 
     describe('setFieldValue:', () => {
+      it(`should return the labels of the selected options if options exist and a match is found`, () => {
+        const field = {
+          value: ['value1'],
+          optionsMulti: true,
+          options: [
+            { value: 'value1', label: 'label1' },
+            { value: 'value2', label: 'label2' },
+            { value: 'value3', label: 'label3' }
+          ]
+        };
+
+        field.value = ['value1', 'value2'];
+        expect(component.setFieldValue(field)).toEqual(['label1', 'label2']);
+      });
+
+      it(`should return the field values if options exist but no match is found'`, () => {
+        const field = {
+          value: ['value1'],
+          optionsMulti: true,
+          options: [
+            { value: 'value1', label: 'label1' },
+            { value: 'value2', label: 'label2' },
+            { value: 'value3', label: 'label3' }
+          ]
+        };
+
+        field.value = ['value4'];
+        expect(component.setFieldValue(field)).toEqual(['value4']);
+      });
+
       it(`should return the label of the selected option if options exist and a match is found`, () => {
         const field = {
           value: 'value1',

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view.component.ts
@@ -85,8 +85,15 @@ export class PoDynamicViewComponent extends PoDynamicViewBaseComponent implement
 
   setFieldValue(field) {
     if (field.options) {
-      const selectedOption = field.options.find(option => option.value === field.value);
-      return selectedOption ? selectedOption.label : field.value;
+      if (field.optionsMulti) {
+        const selectedOptions = field.options.filter(
+          option => Array.isArray(field.value) && field.value.some(value => value === option.value)
+        );
+        return selectedOptions.length ? selectedOptions.map(option => option.label) : field.value;
+      } else {
+        const selectedOption = field.options.find(option => option.value === field.value);
+        return selectedOption ? selectedOption.label : field.value;
+      }
     } else if (field.type === 'boolean' && 'booleanTrue' in field && 'booleanFalse' in field) {
       return field.value ? field.booleanTrue : field.booleanFalse;
     } else {


### PR DESCRIPTION
Ajusta renderização de campo com múltiplas opções.

Fixes #2308

**Dynamic-View**

**2308**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componente não renderiza corretamente campo com múltiplas opções selecionadas. 

**Qual o novo comportamento?**
Componente renderiza corretamente campo com múltiplas opções selecionadas. 

**Simulação**
Pode ser realizada com o [APP](https://github.com/user-attachments/files/17853471/app.zip)