### PR TITLE
fix(page-job-scheduler): corrige erro quando 'firstExecution' undefined

### DIFF
--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.component.spec.ts
@@ -786,4 +786,22 @@ describe('PoPageJobSchedulerComponent:', () => {
       expect(executionElementHiddenAttribute).toBeFalsy();
     });
   });
+
+  it(`getSteps: should use 'literals' when the parameterization step title is not defined`, () => {
+    const mock = Object.assign(new QueryList(), {
+      _results: [{}, {}],
+      length: 1
+    }) as QueryList<PoJobSchedulerParametersTemplateDirective>;
+
+    component.parametersTemplate = mock;
+    component['getSteps']();
+
+    const result = component['steps'].slice(1, -1);
+    const resultExpected = [
+      { label: `${component['literals']['parameterization']} 1` },
+      { label: `${component['literals']['parameterization']} 2` }
+    ];
+
+    expect(result).toEqual(resultExpected);
+  });
 });

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.spec.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.spec.ts
@@ -379,6 +379,84 @@ describe('PoPageJobSchedulerService:', () => {
       expect(poPageJobSchedulerService['removeInvalidKeys']).toHaveBeenCalledWith(jobSchedulerInternal);
     });
 
+    it(`convertToJobScheduler: should ignore when 'firstExecutionHour' is set but 'firstExecution' is not set`, () => {
+      const jobSchedulerInternal = {
+        executionParameter: 'value',
+        firstExecution: undefined,
+        firstExecutionHour: '15:30',
+        processID: '1'
+      };
+
+      const jobSchedulerInternalExpected = {
+        executionParameter: 'value',
+        firstExecution: undefined,
+        processID: '1'
+      };
+
+      const result = <any>poPageJobSchedulerService['convertToJobScheduler'](jobSchedulerInternal);
+
+      expect(result).toEqual(jobSchedulerInternalExpected);
+    });
+
+    it(`convertToJobScheduler: should ignore when 'firstExecutionHour' is set but 'firstExecution' is set date invalid`, () => {
+      const jobSchedulerInternal = {
+        executionParameter: 'value',
+        firstExecution: 'XPTO',
+        firstExecutionHour: '99',
+        processID: '1'
+      };
+
+      const jobSchedulerInternalExpected = {
+        executionParameter: 'value',
+        firstExecution: 'XPTO',
+        processID: '1'
+      };
+
+      const result = <any>poPageJobSchedulerService['convertToJobScheduler'](jobSchedulerInternal);
+
+      expect(result).toEqual(jobSchedulerInternalExpected);
+    });
+
+    it(`convertToJobScheduler: should ignore when 'firstExecutionHour' is set but 'firstExecution' is set string in format yyyy-mm-dd`, () => {
+      const jobSchedulerInternal = {
+        executionParameter: 'value',
+        firstExecution: 'XPTO-XP-TO',
+        firstExecutionHour: '15:30',
+        processID: '1'
+      };
+
+      const jobSchedulerInternalExpected = {
+        executionParameter: 'value',
+        firstExecution: 'XPTO-XP-TO',
+        processID: '1'
+      };
+
+      const result = <any>poPageJobSchedulerService['convertToJobScheduler'](jobSchedulerInternal);
+
+      expect(result).toEqual(jobSchedulerInternalExpected);
+    });
+
+    it(`convertToJobScheduler: should ignore 'firstExecutionHour' when thrown error`, () => {
+      const jobSchedulerInternal = {
+        executionParameter: 'value',
+        firstExecution: '2024-12-30',
+        firstExecutionHour: '15:30',
+        processID: '1'
+      };
+
+      const jobSchedulerInternalExpected = {
+        executionParameter: 'value',
+        firstExecution: '2024-12-30',
+        processID: '1'
+      };
+
+      spyOn(utilsFunctions, 'convertDateToISOExtended').and.throwError('Convert Date');
+
+      const result = <any>poPageJobSchedulerService['convertToJobScheduler'](jobSchedulerInternal);
+
+      expect(result).toEqual(jobSchedulerInternalExpected);
+    });
+
     it(`convertToJobSchedulerInternal: should set 'jobSchedulerInternal.firstExecutionHour' with 'getHourFirstExecution'
       return if 'firstExecution' is defined`, () => {
       const jobSchedulerInternal = {
@@ -483,6 +561,7 @@ describe('PoPageJobSchedulerService:', () => {
 
       expect(result).toEqual(jobSchedulerInternalExpected);
     });
+
     it(`convertToJobSchedulerInternal: should return the merge between 'jobSchedulerInternal' and
       the return from 'convertToPeriodicityInternal'`, () => {
       const jobSchedulerInternal = {
@@ -786,6 +865,15 @@ describe('PoPageJobSchedulerService:', () => {
       expect(poPageJobSchedulerService['replaceHourFirstExecution'](initialDate, timeToReplace).substring(0, 19)).toBe(
         result
       );
+    });
+
+    it(`replaceHourFirstExecution: should replace hour add time zone`, () => {
+      const stringDate = new Date().toString();
+      const timeZone = `${stringDate.substring(28, 31)}:${stringDate.substring(31, 33)}`;
+
+      const result = `2025-12-24T23:59:00${timeZone}`;
+
+      expect(poPageJobSchedulerService['replaceHourFirstExecution']('2025-12-24', '23:59')).toBe(result);
     });
 
     it('returnValidExecutionParameter: should remove keys that have undefined value', () => {

--- a/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.ts
+++ b/projects/templates/src/lib/components/po-page-job-scheduler/po-page-job-scheduler.service.ts
@@ -232,18 +232,35 @@ export class PoPageJobSchedulerService {
   }
 
   private replaceHourFirstExecution(date: string, time: string): string {
-    const dateSplited = date.split('-');
-    const year = parseInt(dateSplited[0]);
-    const monthIndex = parseInt(dateSplited[1]) - 1;
-    const day = parseInt(dateSplited[2]);
+    try {
+      if (!date) {
+        return date;
+      }
 
-    const timeSplited = time.split(':');
-    const hours = parseInt(timeSplited[0], 10);
-    const minutes = parseInt(timeSplited[1], 10);
+      const dateSplited = date.split('-');
+      const timeSplited = time.split(':');
 
-    const firstExecutionDate = new Date(year, monthIndex, day, hours, minutes);
+      if (dateSplited.length < 2 || timeSplited.length < 1) {
+        return date;
+      }
 
-    return convertDateToISOExtended(firstExecutionDate);
+      const year = parseInt(dateSplited[0]);
+      const monthIndex = parseInt(dateSplited[1]) - 1;
+      const day = parseInt(dateSplited[2]);
+
+      const hours = parseInt(timeSplited[0], 10);
+      const minutes = parseInt(timeSplited[1], 10);
+
+      const firstExecutionDate = new Date(year, monthIndex, day, hours, minutes);
+
+      if (!(firstExecutionDate instanceof Date && !isNaN(firstExecutionDate.getTime()))) {
+        return date;
+      }
+
+      return convertDateToISOExtended(firstExecutionDate);
+    } catch {
+      return date;
+    }
   }
 
   private returnValidExecutionParameter(parameter: object) {


### PR DESCRIPTION
Corrigo erro quando 'firstExecution' é definido como undefined

fixes DTHFUI-10385

**page-job-scheduler**

**DTHFUI-10385**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao definir `firstExecution` como undefined um erro é apresentado no console

**Qual o novo comportamento?**
Ao definir `firstExecution` como undefined não deve ser apresentado no console

**Simulação**
[DTHFUI-10385.zip](https://github.com/user-attachments/files/18030031/DTHFUI-10385.zip)
