### PR TITLE
feat(input): inclusão da propriedade `p-mask-no-length-validation`

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
@@ -264,6 +264,153 @@ describe('PoInputBase:', () => {
       const validValues = [true, 'true', 1, ' '];
       expectPropertiesValues(component, 'noAutocomplete', validValues, true);
     });
+
+    describe('p-mask-no-length-validation:', () => {
+      describe('with p-maxlength:', () => {
+        it('validate: should return maxlength false when `maskNoLengthValidation` is false and value exceeds maxlength', () => {
+          component.maxlength = 5;
+          component.maskNoLengthValidation = false;
+          component.getScreenValue = () => '123456';
+
+          const result = component.validate(new FormControl('123456'));
+
+          expect(result).toEqual({
+            maxlength: {
+              valid: false
+            }
+          });
+        });
+
+        it('validate: should return null when `maskNoLengthValidation` is false and value is within maxlength', () => {
+          component.maxlength = 6;
+          component.maskNoLengthValidation = false;
+          component.getScreenValue = () => '123456';
+
+          const result = component.validate(new FormControl('123456'));
+
+          expect(result).toBeNull();
+        });
+
+        it('validate: should return maxlength false when `maskNoLengthValidation` is true, ignoring special characters, and value exceeds maxlength', () => {
+          component.maxlength = 5;
+          component.maskNoLengthValidation = true;
+          component.getScreenValue = () => '12-3456';
+
+          const result = component.validate(new FormControl('12-3456'));
+
+          expect(result).toEqual({
+            maxlength: {
+              valid: false
+            }
+          });
+        });
+
+        it('validate: should return null when `maskNoLengthValidation` is true and alphanumeric value is within maxlength ignoring special characters', () => {
+          component.maxlength = 6;
+          component.maskNoLengthValidation = true;
+          component.getScreenValue = () => '12-345';
+
+          const result = component.validate(new FormControl('12-345'));
+
+          expect(result).toBeNull();
+        });
+
+        it('validate: should handle special characters-only input correctly when `maskNoLengthValidation` is true', () => {
+          component.maxlength = 1;
+          component.maskNoLengthValidation = true;
+          component.getScreenValue = () => '---';
+
+          const result = component.validate(new FormControl('---'));
+
+          expect(result).toBeNull();
+        });
+
+        it('validate: should handle null or undefined values gracefully', () => {
+          component.maxlength = 5;
+          component.maskNoLengthValidation = true;
+
+          let result = component.validate(new FormControl(null));
+          expect(result).toBeNull();
+
+          result = component.validate(new FormControl(undefined));
+          expect(result).toBeNull();
+        });
+      });
+      describe('with p-minlength:', () => {
+        it('validate: should return minlength false when `maskNoLengthValidation` is false and value is below minlength', () => {
+          component.minlength = 5;
+          component.maskNoLengthValidation = false;
+          component.getScreenValue = () => '123';
+
+          const result = component.validate(new FormControl('123'));
+
+          expect(result).toEqual({
+            minlength: {
+              valid: false
+            }
+          });
+        });
+
+        it('validate: should return null when `maskNoLengthValidation` is false and value meets minlength', () => {
+          component.minlength = 3;
+          component.maskNoLengthValidation = false;
+          component.getScreenValue = () => '123';
+
+          const result = component.validate(new FormControl('123'));
+
+          expect(result).toBeNull();
+        });
+
+        it('validate: should return minlength false when `maskNoLengthValidation` is true, ignoring special characters, and value is below minlength', () => {
+          component.minlength = 5;
+          component.maskNoLengthValidation = true;
+          component.getScreenValue = () => '1-2-3';
+
+          const result = component.validate(new FormControl('1-2-3'));
+
+          expect(result).toEqual({
+            minlength: {
+              valid: false
+            }
+          });
+        });
+
+        it('validate: should return null when `maskNoLengthValidation` is true and alphanumeric value meets minlength ignoring special characters', () => {
+          component.minlength = 3;
+          component.maskNoLengthValidation = true;
+          component.getScreenValue = () => '1-2-3';
+
+          const result = component.validate(new FormControl('1-2-3'));
+
+          expect(result).toBeNull();
+        });
+
+        it('validate: should handle special characters-only input correctly when `maskNoLengthValidation` is true', () => {
+          component.minlength = 1;
+          component.maskNoLengthValidation = true;
+          component.getScreenValue = () => '---';
+
+          const result = component.validate(new FormControl('---'));
+
+          expect(result).toEqual({
+            minlength: {
+              valid: false
+            }
+          });
+        });
+
+        it('validate: should handle null or undefined values gracefully', () => {
+          component.minlength = 5;
+          component.maskNoLengthValidation = true;
+
+          let result = component.validate(new FormControl(null));
+          expect(result).toBeNull();
+
+          result = component.validate(new FormControl(undefined));
+          expect(result).toBeNull();
+        });
+      });
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Directive, EventEmitter, Input, OnDestroy, Output, TemplateRef } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, Validator, Validators } from '@angular/forms';
 
-import { Subject, Subscription, switchMap } from 'rxjs';
+import { Subscription, switchMap } from 'rxjs';
 import { convertToBoolean } from '../../../utils/util';
 import { ErrorAsyncProperties } from '../shared/interfaces/error-async-properties.interface';
 import { maxlengpoailed, minlengpoailed, patternFailed, requiredFailed } from './../validators';
@@ -172,6 +172,40 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    *
    */
   @Input({ alias: 'p-upper-case', transform: convertToBoolean }) upperCase: boolean = false;
+
+  _maskNoLengthValidation = false;
+  /**
+   * @description
+   *
+   * Define se os caracteres especiais da máscara devem ser ignorados ao validar os comprimentos mínimo (`minLength`) e máximo (`maxLength`) do campo.
+   *
+   * - Quando `true`, apenas os caracteres alfanuméricos serão contabilizados para a validação dos comprimentos.
+   * - Quando `false`, todos os caracteres, incluindo os especiais da máscara, serão considerados na validação.
+   *
+   * > Será ignorado essa propriedade , caso esteja utilizando junto com a propriedade `p-mask-format-model`.
+   *
+   * Exemplo:
+   * ```
+   * <po-input
+   *   p-mask="999-999"
+   *   p-maxlength="6"
+   *   p-minlength="4"
+   *   p-mask-no-length-validation="true"
+   * ></po-input>
+   * ```
+   * - Entrada: `123-456` → Validação será aplicada somente aos números, ignorando o caractere especial `-`.
+   *
+   * @default `false`
+   */
+  @Input('p-mask-no-length-validation') set maskNoLengthValidation(value: boolean) {
+    this._maskNoLengthValidation = convertToBoolean(value);
+
+    this.validateModel();
+  }
+
+  get maskNoLengthValidation() {
+    return this._maskNoLengthValidation;
+  }
 
   /**
    * @optional
@@ -487,7 +521,9 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
       };
     }
 
-    if (maxlengpoailed(this.maxlength, this.getScreenValue())) {
+    if (
+      maxlengpoailed(this.maxlength, this.getScreenValue(), this.maskFormatModel ? false : this.maskNoLengthValidation)
+    ) {
       this.isInvalid = true;
       return {
         maxlength: {
@@ -496,7 +532,9 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
       };
     }
 
-    if (minlengpoailed(this.minlength, this.getScreenValue())) {
+    if (
+      minlengpoailed(this.minlength, this.getScreenValue(), this.maskFormatModel ? false : this.maskNoLengthValidation)
+    ) {
       this.isInvalid = true;
       return {
         minlength: {

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
@@ -20,6 +20,7 @@
   [p-readonly]="properties?.includes('readonly')"
   [p-upper-case]="properties?.includes('uppercase')"
   [p-show-required]="properties?.includes('showRequired')"
+  [p-mask-no-length-validation]="properties?.includes('maskNoLengthValidation')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
@@ -36,7 +36,8 @@ export class SamplePoInputLabsComponent implements OnInit {
     { value: 'required', label: 'Required' },
     { value: 'requiredFieldErrorMessage', label: 'Required Field Error Message' },
     { value: 'uppercase', label: 'Upper Case' },
-    { value: 'showRequired', label: 'Show Required' }
+    { value: 'showRequired', label: 'Show Required' },
+    { value: 'maskNoLengthValidation', label: 'Mask No Length Validation' }
   ];
 
   ngOnInit() {

--- a/projects/ui/src/lib/components/po-field/validators.ts
+++ b/projects/ui/src/lib/components/po-field/validators.ts
@@ -7,16 +7,46 @@ export function requiredFailed(required: boolean, disabled: boolean, value: stri
   return required && !disabled && !valid;
 }
 
-export function maxlengpoailed(maxlength: number, value: string | number) {
-  const validMaxlength = maxlength || maxlength === 0;
-  const validValue = (value || value === 0) && value.toString();
-  return validMaxlength && validValue && validValue.length > Number(maxlength);
+export function maxlengpoailed(
+  maxlength: number,
+  value: string | number,
+  maskNoLengthValidation: boolean = false
+): boolean {
+  return validateLength(maxlength, value, 'max', maskNoLengthValidation);
 }
 
-export function minlengpoailed(minlength: number, value: string | number) {
-  const validMinlength = minlength || minlength === 0;
+export function minlengpoailed(
+  minlength: number,
+  value: string | number,
+  maskNoLengthValidation: boolean = false
+): boolean {
+  return validateLength(minlength, value, 'min', maskNoLengthValidation);
+}
+
+export function validateLength(
+  limit: number,
+  value: string | number,
+  comparison: 'max' | 'min',
+  maskNoLengthValidation: boolean = false
+): boolean {
+  if (!limit && limit !== 0) {
+    return false;
+  }
+
   const validValue = (value || value === 0) && value.toString();
-  return validMinlength && validValue && validValue.length < Number(minlength);
+  if (!validValue) {
+    return false;
+  }
+
+  const processedValue = maskNoLengthValidation ? validValue.replace(/[^\w]/g, '') : validValue;
+
+  if (comparison === 'max') {
+    return processedValue.length > Number(limit);
+  } else if (comparison === 'min') {
+    return processedValue.length < Number(limit);
+  }
+
+  return false;
 }
 
 export function patternFailed(pattern: string, value: string) {


### PR DESCRIPTION
**PO-INPUT**

**DTHFUI-10421**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Hoje ao passar uma mascara junto com comprimentos mínimos (minLength) ou máximos (maxLength), ele contabiliza os caracteres especiais ao valor do input incorretamente,


**Qual o novo comportamento?**
Adicionada a propriedade `p-mask-no-length-validation` ao componente `po-input` para permitir que caracteres especiais definidos na máscara sejam ignorados ao validar os comprimentos mínimos (minLength) e máximos (maxLength).

Essa funcionalidade garante maior flexibilidade ao lidar com máscaras, como no exemplo de números de telefone ou CEP, onde os caracteres especiais não devem interferir na validação do comprimento do valor.

**Simulação**
- Testar Portal (Labs)
- [app.zip](https://github.com/user-attachments/files/18117783/app.zip)
