### PR TITLE
fix(rich-text): alteracao de cor parcial no mac

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.html
@@ -21,7 +21,7 @@
           class="po-rich-text-toolbar-color-picker-input"
           type="color"
           [disabled]="readonly"
-          (change)="changeTextColor($event.target.value)"
+          (input)="changeTextColor($event.target.value)"
           [attr.aria-label]="literals.textColor"
         />
       </button>


### PR DESCRIPTION
**< COMPONENTE >**
rich-text

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**

O problema pode ser replicado no Chrome + MacOS.

Se eu tenho um texto no rich-text, seleciono uma palavra no meio do texto, e tento alterar a cor dela utilizando o color picker a nova cor nao eh aplicada.

O problema ocorre porque o evento `change` eh disparado quando o usuario clica fora do dialog do color picker, porem no MacOS ao clicar fora o texto eh deselecionado antes do `change` disparar, dessa forma a cor do texto nao eh alterada.





**Qual o novo comportamento?**

A correcao proposta apenas altera o evento do color picker de `change` para `input`, dessa forma a nova cor eh aplicada no momento que ela eh selecionada no color picker, e nao quando o usuario clica fora do color picker.


**Simulação**
