### PR TITLE
fix(i18n): corrigido conflito de literais entre app e lib no PO UI

### DIFF
--- a/projects/ui/src/lib/services/po-i18n/index.ts
+++ b/projects/ui/src/lib/services/po-i18n/index.ts
@@ -1,4 +1,5 @@
 export * from './interfaces/po-i18n-config.interface';
+export * from './interfaces/po-i18n-config-context.interface';
 export * from './interfaces/po-i18n-config-default.interface';
 export * from './interfaces/po-i18n-literals.interface';
 export * from './po-i18n.pipe';

--- a/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config-context.interface.ts
+++ b/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config-context.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * @description
+ *
+ * <a id="poI18nConfigContext"></a>
+ *
+ * Interface para a configuração dos contextos do módulo `PoI18nModule`.
+ *
+ * @usedBy PoI18nModule
+ */
+export interface PoI18nConfigContext {
+  [name: string]: { [language: string]: { [literal: string]: string } } | { url: string };
+}

--- a/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
+++ b/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
@@ -1,4 +1,5 @@
 import { PoI18nConfigDefault } from './po-i18n-config-default.interface';
+import { PoI18nConfigContext } from './po-i18n-config-context.interface';
 
 /**
  * @description
@@ -76,5 +77,5 @@ export interface PoI18nConfig {
    * ```
    * > Caso a constante contenha alguma literal que o serviço não possua será utilizado a literal da constante.
    */
-  contexts: object;
+  contexts: PoI18nConfigContext;
 }

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.spec.ts
@@ -1,6 +1,6 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpRequest } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 import { of } from 'rxjs';
 
@@ -43,7 +43,8 @@ describe('PoI18nService:', () => {
 
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, PoLanguageModule, PoI18nModule.config(config)]
+        imports: [PoLanguageModule, PoI18nModule.config(config)],
+        providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
       }).compileComponents();
 
       service = TestBed.inject(PoI18nService);
@@ -61,21 +62,39 @@ describe('PoI18nService:', () => {
       });
     });
 
-    it('should get specific literals passing parameters', done => {
+    it('should get specific literals passing parameters', () => {
       service.getLiterals({ literals: ['text'] }).subscribe((literals: any) => {
-        expect(literals['text']).toBeTruthy();
-
-        done();
+        expect(literals['text']).toBe('texto');
       });
     });
 
-    it('should get specific literals from unexist language', done => {
-      // Procura em ingles, se não acho busca em pt-br
+    it('should get pt-br literals from unexist language', () => {
       service.getLiterals({ literals: ['text'], language: 'en-us' }).subscribe((literals: any) => {
         expect(literals['text']).toBeTruthy();
-
-        done();
       });
+    });
+
+    it('should call getLiteralsFromContextService when servicesContext[context] exists', () => {
+      const observerMock = {
+        next: jasmine.createSpy('next'),
+        error: jasmine.createSpy('error'),
+        complete: jasmine.createSpy('complete')
+      };
+
+      service['servicesContext'] = { meuContexto: {} };
+
+      spyOn(service, <any>'getLiteralsFromContextService').and.callFake(() => {
+        observerMock.complete();
+      });
+
+      service.getLiterals({ context: 'meuContexto', language: 'pt' }).subscribe(observerMock);
+
+      expect(service['getLiteralsFromContextService']).toHaveBeenCalledWith(
+        'pt',
+        'meuContexto',
+        [],
+        jasmine.any(Object)
+      );
     });
 
     it('should get literals with specific context', () => {
@@ -314,79 +333,30 @@ describe('PoI18nService:', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, PoLanguageModule, PoI18nModule.config(config)]
+        imports: [PoLanguageModule, PoI18nModule.config(config)],
+        providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
       });
 
       service = TestBed.inject(PoI18nService);
       httpMock = TestBed.inject(HttpTestingController);
-    });
 
-    it('should get all literals from service', done => {
-      spyOn(service, 'getLanguage').and.returnValue('pt');
-
-      service.getLiterals().subscribe((literals: any) => {
-        expect(literals['developer']).toBeTruthy();
-        expect(literals['task']).toBeTruthy();
-
-        done();
+      spyOn(localStorage, 'getItem').and.callFake((key: string) => {
+        const mockStorage = {
+          'en-general-label1': 'Label 1',
+          'en-general-label2': 'Label 2'
+        };
+        return mockStorage[key] || null;
       });
-
-      httpMock.expectOne((req: HttpRequest<any>) => req.method === 'GET').flush(mockResponse);
-    });
-
-    it('should return empty object when not found specific literals from service', done => {
-      spyOn(service, 'getLanguage').and.returnValue('pt');
-
-      service.getLiterals({ literals: ['teste'] }).subscribe((literals: any) => {
-        expect(Object.keys(literals).length).toBe(0);
-
-        done();
-      });
-
-      httpMock.expectOne((req: HttpRequest<any>) => req.method === 'GET').flush({});
-    });
-
-    it('should get specific literals from localStorage', done => {
-      const developerTranslation = 'desenvolvedor';
-      const taskTranslation = 'tarefa';
-
-      const language = 'en';
-
-      spyOn(service, 'getLanguage').and.returnValue(language);
-
-      localStorage.setItem(`${language}-general-developer`, developerTranslation);
-      localStorage.setItem(`${language}-general-task`, taskTranslation);
-
-      service.getLiterals({ literals: ['developer', 'task'] }).subscribe((literals: any) => {
-        expect(literals['developer']).toEqual(developerTranslation);
-        expect(literals['task']).toEqual(taskTranslation);
-
-        done();
-      });
-
-      localStorage.clear();
-    });
-
-    it('should get literals from localStorage, selecting context, literals and language', done => {
-      const carTranslation = 'carro';
-      const testTranslation = 'teste';
-
-      localStorage.setItem('pt-br-general-car', carTranslation);
-      localStorage.setItem('pt-br-another-test', testTranslation);
-
-      service
-        .getLiterals({ context: 'general', literals: ['car', 'test'], language: 'pt-br' })
-        .subscribe((literals: any) => {
-          expect(literals['car']).toEqual(carTranslation);
-          expect(literals['test']).toBeUndefined();
-
-          done();
-        });
-
-      localStorage.clear();
     });
 
     describe('Methods: ', () => {
+      describe('getHttpService', () => {
+        it('should return a http servic', () => {
+          const httpService = service['getHttpService']('/', 'pt', ['text']);
+          expect(httpService).toBeTruthy();
+        });
+      });
+
       describe('getLiteralsFromContextService', () => {
         it(`should call 'observer.next' with translations if translations keys length is greater than 0
           and call 'getLiteralsLocalStorageAndCache'`, () => {
@@ -417,6 +387,74 @@ describe('PoI18nService:', () => {
           expect(spyObserverNext).not.toHaveBeenCalled();
           expect(spyMergeObject).toHaveBeenCalled();
           expect(spyGetLiteralsLocalStorageAndCache).toHaveBeenCalled();
+        });
+
+        it('should assign languageAlternative to languageSearch when languageAlternative is provided', () => {
+          const language = 'en';
+          const languageAlternative = 'es';
+          const context = 'general';
+          const literals = ['label1', 'label2'];
+          const observer = { next: jasmine.createSpy('next') };
+          const translations = {};
+
+          spyOn(service as any, 'mergeObject').and.callThrough();
+          spyOn(service, 'searchInVarI18n' as keyof PoI18nService).and.returnValue('');
+          spyOn(service, 'countObject' as keyof PoI18nService).and.returnValue('0');
+          spyOn(service, 'getLiteralsLocalStorageAndCache' as keyof PoI18nService);
+
+          service['getLiteralsFromContextService'](
+            language,
+            context,
+            literals,
+            observer,
+            translations,
+            languageAlternative
+          );
+
+          expect(service['getLiteralsLocalStorageAndCache']).toHaveBeenCalledWith(
+            languageAlternative,
+            context,
+            literals,
+            observer,
+            translations,
+            languageAlternative
+          );
+        });
+      });
+
+      describe('searchInLocalStorage', () => {
+        it('should return translations when literals exist in localStorage', () => {
+          const language = 'en';
+          const context = 'general';
+          const literals = ['label1', 'label2'];
+
+          const result = service['searchInLocalStorage'](language, context, literals);
+
+          expect(result).toEqual({
+            label1: 'Label 1',
+            label2: 'Label 2'
+          });
+        });
+
+        it('should return an empty object when literals are not found in localStorage', () => {
+          const language = 'en';
+          const context = 'general';
+          const literals = ['label3', 'label4']; // Literais não presentes no mockStorage
+
+          const result = service['searchInLocalStorage'](language, context, literals);
+
+          expect(result).toEqual({});
+        });
+
+        it('should return an empty object when literals array is empty', () => {
+          const language = 'en';
+          const context = 'general';
+          const literals: Array<string> = [];
+
+          const result = service['searchInLocalStorage'](language, context, literals);
+
+          expect(result).toEqual({});
+          expect(localStorage.getItem).not.toHaveBeenCalled();
         });
       });
 
@@ -551,6 +589,21 @@ describe('PoI18nService:', () => {
         expect(mergedObject).toEqual({ ...obj2, ...obj1 });
         expect(mergedObject.people).toBe(expectedPeopleTranslation);
         expect(Object.keys(mergedObject).length).toBe(2);
+      });
+
+      it('updateLocalStorage: should store values in localStorage when useCache is true', () => {
+        service['useCache'] = true;
+
+        spyOn(localStorage, 'setItem').and.callFake(() => {});
+        const language = 'en';
+        const context = 'general';
+        const data = { label1: 'Label 1', label2: 'Label 2' };
+
+        service['updateLocalStorage'](language, context, data);
+
+        expect(localStorage.setItem).toHaveBeenCalledTimes(2);
+        expect(localStorage.setItem).toHaveBeenCalledWith('en-general-label1', 'Label 1');
+        expect(localStorage.setItem).toHaveBeenCalledWith('en-general-label2', 'Label 2');
       });
     });
   });

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
@@ -191,7 +191,7 @@ export class PoI18nBaseService {
     const context = options['context'] ? options['context'] : this.contextDefault;
     const literals: Array<string> = options['literals'] ? options['literals'] : [];
 
-    return new Observable(observer => {
+    return new Observable<any>(observer => {
       if (this.servicesContext[context]) {
         // Faz o processo de busca de um contexto que contém serviço
         this.getLiteralsFromContextService(language, context, literals, observer);

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-config-injection-token.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-config-injection-token.ts
@@ -2,4 +2,4 @@ import { InjectionToken } from '@angular/core';
 
 import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 
-export const I18N_CONFIG = new InjectionToken<PoI18nConfig>('I18N_CONFIG');
+export const I18N_CONFIG = new InjectionToken<Array<PoI18nConfig>>('I18N_CONFIG');

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
@@ -144,7 +144,6 @@ import { PoLanguageModule } from '../po-language/po-language.module';
  * Para aplicações que utilizem a abordagem de módulos com carregamento *lazy loading*, caso seja
  * definida outra configuração do `PoI18nModule`, deve-se atentar os seguintes detalhes:
  *
- * - Caso existam literais comuns na aplicação, estas devem ser reimportadas;
  * - Não defina outra *default language* para este módulo. Caso for definida, será sobreposta para
  * toda a aplicação;
  * - Caso precise de módulos carregados via *lazy loading* com linguagens diferentes, utilize o
@@ -162,7 +161,8 @@ export class PoI18nModule {
       providers: [
         {
           provide: I18N_CONFIG,
-          useValue: config
+          useValue: config,
+          multi: true
         },
         {
           provide: APP_INITIALIZER,
@@ -180,12 +180,12 @@ export class PoI18nModule {
   }
 }
 
-export function initializeLanguageDefault(config: PoI18nConfig, languageService: PoLanguageService) {
-  // eslint-disable-next-line sonarjs/prefer-immediate-return
-  const setDefaultLanguage = () => {
-    if (config.default.language) {
+export function initializeLanguageDefault(configs: Array<PoI18nConfig>, languageService: PoLanguageService) {
+  const config = configs.find(c => c.default); // Busca a configuração com `default`
+
+  return () => {
+    if (config?.default.language) {
       languageService.setLanguageDefault(config.default.language);
     }
   };
-  return setDefaultLanguage;
 }

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.service.spec.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.service.spec.ts
@@ -1,0 +1,74 @@
+import { mergePoI18nConfigs } from './po-i18n.service';
+
+describe('mergePoI18nConfigs', () => {
+  it('should correctly merge the default configuration, prioritizing the first one found', () => {
+    const input = [
+      { default: { title: 'Hello' }, contexts: {} },
+      { default: { title: 'Olá' }, contexts: {} }
+    ];
+
+    const result = mergePoI18nConfigs(input);
+
+    expect(result.default).toEqual({ title: 'Hello' });
+  });
+
+  it('should return correctly merge contexts and languages', () => {
+    const input = [
+      {
+        default: { title: 'Hello' },
+        contexts: {
+          home: {
+            en: { welcome: 'Welcome' },
+            pt: { welcome: 'Bem-vindo' }
+          }
+        }
+      },
+      {
+        contexts: {
+          home: {
+            en: { goodbye: 'Goodbye' },
+            es: { welcome: 'Bienvenido' }
+          },
+          about: {
+            en: { info: 'Information' }
+          }
+        }
+      }
+    ];
+
+    const result = mergePoI18nConfigs(input);
+
+    expect(result.contexts).toEqual({
+      home: {
+        en: { welcome: 'Welcome', goodbye: 'Goodbye' },
+        pt: { welcome: 'Bem-vindo' },
+        es: { welcome: 'Bienvenido' }
+      },
+      about: {
+        en: { info: 'Information' }
+      }
+    });
+  });
+
+  it('should return an empty object if the input is an empty array', () => {
+    const result = mergePoI18nConfigs([]);
+    expect(result).toEqual({ contexts: {} });
+  });
+
+  it('should return handle null or undefined values', () => {
+    const input = [
+      { default: { title: 'Hello' }, contexts: null },
+      { contexts: undefined },
+      { default: { title: 'Olá' }, contexts: { home: { en: { greeting: 'Hi' } } } }
+    ];
+
+    const result = mergePoI18nConfigs(input);
+
+    expect(result.default).toEqual({ title: 'Hello' });
+    expect(result.contexts).toEqual({
+      home: {
+        en: { greeting: 'Hi' }
+      }
+    });
+  });
+});

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
@@ -14,6 +14,42 @@ import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 export class PoI18nService extends PoI18nBaseService {}
 
 // Função usada para retornar instância para o módulo po-i18n.module
-export function returnPoI18nService(config: PoI18nConfig, http: HttpClient, languageService: PoLanguageService) {
-  return new PoI18nService(config, http, languageService);
+export function returnPoI18nService(
+  configs: Array<PoI18nConfig>,
+  http: HttpClient,
+  languageService: PoLanguageService
+) {
+  const validatedConfigs = configs.map(config => ({
+    ...config,
+    contexts: config.contexts,
+    default: config.default
+  }));
+
+  const mergedObject = mergePoI18nConfigs(validatedConfigs);
+
+  return new PoI18nService(mergedObject, http, languageService);
+}
+
+export function mergePoI18nConfigs(objects: Array<any>): any {
+  return objects.reduce(
+    (acc, current) => {
+      if (!acc.default) {
+        acc.default = { ...current.default };
+      }
+
+      Object.entries(current.contexts || {}).forEach(([context, languages]) => {
+        acc.contexts[context] = acc.contexts[context] || {};
+
+        Object.entries(languages).forEach(([lang, translations]) => {
+          acc.contexts[context][lang] = {
+            ...acc.contexts[context][lang],
+            ...translations
+          };
+        });
+      });
+
+      return acc;
+    },
+    { contexts: {} }
+  );
 }


### PR DESCRIPTION
Resolvido problema onde os literais da lib não eram carregados quando a lib era adicionada em um app que também utiliza i18n.
Habilitado o I18N_CONFIG com multi: true
Conforme previso na documentação, informava-se: "Caso existam literais comuns na aplicação, estas devem ser reimportadas".
A partir deste commit foi implementado o provider I18N_CONFIG com multi: true, permitindo que múltiplas configurações de internacionalização (i18n) sejam injetadas como um array de configurações, ao invés de sobrescrever uma única configuração.
Desta forma, se no app, determinado literal não for definido, será considerado o literal da lib.
Fixes DTHFUI-10440