### PR TITLE
feat(components): implementa help adicional ao p-help

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-field.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-field.interface.ts
@@ -6,6 +6,8 @@ import { PoDynamicFormField } from '@po-ui/ng-components';
  * @description
  *
  * Interface dos fields usados para compor o template `po-page-dynamic-edit`.
+ * Herda as definições da interface
+ * [PoDynamicFormField](https://po-ui.io/documentation/po-dynamic-form).
  */
 export interface PoPageDynamicEditField extends PoDynamicFormField {
   /** Indica se o campo será duplicado caso seja executada a ação de duplicação. */

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.ts
@@ -37,7 +37,14 @@ export class SamplePoPageDynamicEditUserComponent {
     { property: 'name', divider: 'Personal data', required: true },
     { property: 'nickname' },
     { property: 'email', label: 'E-mail' },
-    { property: 'birthdate', label: 'Birth date', type: 'date' },
+    {
+      property: 'birthdate',
+      label: 'Birth date',
+      type: 'date',
+      errorMessage: 'Invalid date.',
+      help: 'Enter or select a valid date.',
+      additionalHelpTooltip: 'Please enter a valid date in the format MMDDYYYY.'
+    },
     { property: 'genre', options: ['female', 'male', 'others'], gridLgColumns: 6 },
     { property: 'nationality' },
     { property: 'birthPlace', label: 'Place of birth' },

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -37,6 +37,41 @@ import { PoDynamicField } from '../po-dynamic-field.interface';
  */
 export interface PoDynamicFormField extends PoDynamicField {
   /**
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   *
+   * **Componentes compatíveis:** `po-checkbox`, `po-checkbox-group`, `po-combo`, `po-datepicker`, `po-datepicker-range`,
+   * `po-decimal`, `po-email`, `po-input`, `po-login`, `po-lookup`, `po-multiselect`, `po-number`, `po-password`,
+   * `po-radio-group`, `po-rich-text`, `po-select`, `po-switch`, `po-textarea`, `po-upload`, `po-url`.
+   */
+  additionalHelp?: Function;
+
+  /**
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   *
+   * **Componentes compatíveis:** `po-checkbox`, `po-checkbox-group`, `po-combo`, `po-datepicker`, `po-datepicker-range`,
+   * `po-decimal`, `po-email`, `po-input`, `po-login`, `po-lookup`, `po-multiselect`, `po-number`, `po-password`,
+   * `po-radio-group`, `po-rich-text`, `po-select`, `po-switch`, `po-textarea`, `po-upload`, `po-url`.
+   */
+  additionalHelpTooltip?: string;
+
+  /**
+   * Define que o `listbox` e/ou tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) serão incluídos no body da
+   * página e não dentro do componente. Essa opção é necessária para cenários com containers que possuem scroll ou
+   * overflow escondido, garantindo o posicionamento correto de ambos próximo ao elemento.
+   *
+   * > O uso dessa propriedade pode acarretar na perda sequencial da tabulação da página.
+   * Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * **Componentes compatíveis:** `po-checkbox`, `po-checkbox-group`, `po-combo`, `po-datepicker`, `po-datepicker-range`,
+   * `po-decimal`, `po-email`, `po-input`, `po-login`, `po-lookup`, `po-multiselect`, `po-number`, `po-password`,
+   * `po-radio-group`, `po-rich-text`, `po-select`, `po-switch`, `po-textarea`, `po-upload`, `po-url`.
+   */
+  appendBox?: boolean;
+
+  /**
    * Define as colunas para utilização da busca avançada. Usada somente em conjunto com a propriedade `searchService`,
    * essa propriedade deve receber um array de objetos que implementam a interface [`PoLookupColumn`](/documentation/po-lookup).
    *
@@ -297,8 +332,6 @@ export interface PoDynamicFormField extends PoDynamicField {
    * @default `false`
    */
   errorLimit?: boolean;
-
-  errorAppendBox?: boolean;
 
   /**
    * Função executada para realizar a validação assíncrona personalizada.

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -10,13 +10,14 @@
 <ng-template #poContent let-fields>
   <ng-container *ngFor="let field of fields; trackBy: trackBy">
     <po-divider *ngIf="field?.divider?.trim()" class="po-sm-12" [p-label]="field.divider"> </po-divider>
-
     <po-datepicker
       #component
       *ngIf="compareTo(field.control, 'datepicker')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-clean]="field.clean"
       [p-disabled]="isDisabled(field)"
       [p-error-pattern]="field.errorMessage"
@@ -38,6 +39,7 @@
       [p-show-required]="field.showRequired"
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
+      (p-additional-help)="field.additionalHelp?.($event)"
     >
     </po-datepicker>
 
@@ -47,6 +49,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-clean]="field.clean"
       [p-disabled]="isDisabled(field)"
       [p-auto-focus]="field.focus"
@@ -62,6 +66,7 @@
       [p-field-error-message]="field.errorMessage"
       [p-error-limit]="field.errorLimit"
       [p-show-required]="field.showRequired"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
     >
     </po-datepicker-range>
@@ -72,6 +77,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-clean]="field.clean"
       [p-disabled]="isDisabled(field)"
       [p-error-pattern]="field.errorMessage"
@@ -90,6 +97,7 @@
       [p-required]="field.required"
       [p-required-field-error-message]="field.requiredFieldErrorMessage"
       [p-show-required]="field.showRequired"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-icon]="field.icon"
@@ -104,6 +112,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-clean]="field.clean"
       [p-disabled]="isDisabled(field)"
       [p-error-pattern]="field.errorMessage"
@@ -123,6 +133,7 @@
       [p-required]="field.required"
       [p-required-field-error-message]="field.requiredFieldErrorMessage"
       [p-show-required]="field.showRequired"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-icon]="field.icon"
@@ -136,6 +147,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-clean]="field.clean"
       [p-error-pattern]="field.errorMessage"
       [p-error-limit]="field.errorLimit"
@@ -158,6 +171,7 @@
       [p-required]="field.required"
       [p-required-field-error-message]="field.requiredFieldErrorMessage"
       [p-show-required]="field.showRequired"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-placeholder]="field.placeholder"
@@ -170,6 +184,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-field-label]="field.fieldLabel"
       [p-field-value]="field.fieldValue"
       [p-disabled]="isDisabled(field)"
@@ -181,6 +197,7 @@
       [p-field-error-message]="field.errorMessage"
       [p-error-limit]="field.errorLimit"
       [p-show-required]="field.showRequired"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
       [p-readonly]="field.readonly"
@@ -193,6 +210,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-columns]="field.columns || 3"
       [p-auto-focus]="field.focus"
       [p-disabled]="isDisabled(field)"
@@ -204,6 +223,7 @@
       [p-field-error-message]="field.errorMessage"
       [p-error-limit]="field.errorLimit"
       [p-show-required]="field.showRequired"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
     >
     </po-radio-group>
@@ -214,6 +234,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-disabled]="isDisabled(field)"
       [p-format-model]="field.formatModel"
       [p-help]="field.help"
@@ -222,6 +244,7 @@
       [p-label-on]="field.booleanTrue"
       [p-label-position]="field.labelPosition"
       [p-hide-label-status]="field.hideLabelStatus"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
     >
     </po-switch>
@@ -232,10 +255,13 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-auto-focus]="field.focus"
       [p-disabled]="isDisabled(field)"
       [p-label]="field.label"
       [p-size]="field.size"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
     >
     </po-checkbox>
@@ -247,6 +273,8 @@
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
       p-emit-object-value
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-auto-focus]="field.focus"
       [p-clean]="field.clean"
       [p-disabled]="isDisabled(field)"
@@ -275,6 +303,7 @@
       [p-disabled-tab-filter]="field.disabledTabFilter"
       [p-debounce-time]="field.debounceTime"
       [p-change-on-enter]="field.changeOnEnter"
+      (p-additional-help)="field.additionalHelp?.($event)"
     >
     </po-combo>
 
@@ -286,6 +315,8 @@
       p-field-label="label"
       p-field-value="value"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-clean]="field.clean"
       [p-columns]="field.columns"
       [p-disabled]="isDisabled(field)"
@@ -310,6 +341,7 @@
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
       [p-advanced-filters]="field.advancedFilters"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change-visible-columns)="field.changeVisibleColumns?.($event)"
       (p-restore-column-manager)="field.columnRestoreManager?.($event)"
     >
@@ -321,6 +353,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-columns]="field.columns || 3"
       [p-auto-focus]="field.focus"
       [p-disabled]="isDisabled(field)"
@@ -332,6 +366,7 @@
       [p-show-required]="field.showRequired"
       [p-field-error-message]="field.errorMessage"
       [p-error-limit]="field.errorLimit"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
     >
     </po-checkbox-group>
@@ -342,6 +377,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-disabled]="isDisabled(field)"
       [p-auto-focus]="field.focus"
       [p-auto-height]="field.autoHeight"
@@ -365,6 +402,7 @@
       [p-placeholder-search]="field.placeholderSearch"
       [p-hide-search]="field.hideSearch"
       [p-hide-select-all]="field.hideSelectAll"
+      (p-additional-help)="field.additionalHelp?.($event)"
     >
     </po-multiselect>
 
@@ -374,6 +412,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-disabled]="isDisabled(field)"
       [p-auto-focus]="field.focus"
       [p-help]="field.help"
@@ -387,6 +427,7 @@
       [p-error-limit]="field.errorLimit"
       [p-show-required]="field.showRequired"
       [p-rows]="field.rows"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-placeholder]="field.placeholder"
@@ -399,6 +440,8 @@
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-clean]="field.clean"
       [p-disabled]="isDisabled(field)"
       [p-error-pattern]="field.errorMessage"
@@ -418,6 +461,7 @@
       [p-required]="field.required"
       [p-required-field-error-message]="field.requiredFieldErrorMessage"
       [p-show-required]="field.showRequired"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-placeholder]="field.placeholder"
@@ -429,6 +473,8 @@
       *ngIf="compareTo(field.control, 'upload')"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
+      [additionalHelpEventTrigger]="field.additionalHelp ? 'event' : 'noEvent'"
+      [p-additional-help-tooltip]="field.additionalHelpTooltip"
       [p-auto-upload]="field.autoUpload"
       [p-directory]="field.directory"
       [p-disabled]="isDisabled(field)"
@@ -453,6 +499,7 @@
       [p-optional]="field.optional"
       [p-required]="field.required"
       [p-show-required]="field.showRequired"
+      (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
       [p-url]="field.url"

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-container/sample-po-dynamic-form-container.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-container/sample-po-dynamic-form-container.component.ts
@@ -41,7 +41,9 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
       gridSmColumns: 12,
       maxValue: '2010-01-01',
       errorMessage: 'The date must be before the year 2010.',
-      order: -1
+      order: -1,
+      help: 'Enter or select a valid date.',
+      additionalHelpTooltip: 'Please enter a valid date in the format MMDDYYYY.'
     },
     { property: 'cpf', label: 'CPF', mask: '999.999.999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
     { property: 'cnpj', label: 'CNPJ', mask: '99.999.999/9999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
@@ -61,7 +63,9 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
       secret: true,
       pattern: '[a-zA]{5}[Z0-9]{3}',
       errorMessage: 'At least 5 alphabetic and 3 numeric characters are required.',
-      placeholder: 'Type your password'
+      placeholder: 'Type your password',
+      help: 'Password must include a combination of letters and numbers.',
+      additionalHelpTooltip: 'At least 5 alphabetic and 3 numeric characters are required.'
     },
     {
       property: 'rememberSecretKey',
@@ -111,7 +115,9 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
       container: 'Work data',
       range: true,
       gridColumns: 5,
-      gridSmColumns: 12
+      gridSmColumns: 12,
+      help: 'Enter or select a valid date range.',
+      additionalHelpTooltip: 'Ensure the start date is earlier than or equal to the end date.'
     },
     {
       property: 'entryTime',

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
@@ -41,6 +41,35 @@ const poCheckboxGroupColumnsTotalLength: number = 12;
  */
 @Directive()
 export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Validator {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) será incluído no body da página e não
+   * dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou overflow
+   * escondido, garantindo o posicionamento correto do tooltip próximo ao elemento.
+   *
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
   /**
    * @optional
    *
@@ -89,6 +118,15 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
    *
    */
   @Input('p-field-error-message') fieldErrorMessage: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.html
@@ -1,13 +1,12 @@
 <po-field-container
   [p-disabled]="disabled"
-  [p-help]="help"
   [p-label]="label"
   [p-optional]="optional"
   [p-required]="required"
   [p-show-required]="showRequired"
 >
-  <div role="group" [attr.aria-label]="label" class="po-field-container-content po-checkbox-group-content">
-    <ul class="po-row po-pt-2 po-pb-1">
+  <div role="group" [attr.aria-label]="label" class="po-checkbox-group-content">
+    <ul class="po-row">
       <li
         *ngFor="let option of checkboxGroupOptionsView; trackBy: trackByFn"
         class="po-checkbox-group-item po-md-{{ mdColumns }} po-lg-{{ columns }}"
@@ -28,7 +27,13 @@
   </div>
 
   <po-field-container-bottom
-    [p-error-pattern]="getErrorPattern()"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
+    [p-help]="help"
+    [p-disabled]="disabled"
     [p-error-limit]="errorLimit"
+    [p-error-pattern]="getErrorPattern()"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.spec.ts
@@ -50,10 +50,6 @@ describe('PoCheckboxGroupComponent:', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have help', () => {
-    expect(nativeElement.querySelector('.po-field-help').innerHTML).toContain('Help');
-  });
-
   it('should create 2 checkbox options', () => {
     expect(nativeElement.querySelectorAll('po-checkbox').length).toBe(2);
   });
@@ -83,6 +79,26 @@ describe('PoCheckboxGroupComponent:', () => {
       component.ngAfterViewInit();
 
       expect(spyFocus).not.toHaveBeenCalled();
+    });
+
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
     });
 
     describe('focus:', () => {
@@ -170,6 +186,35 @@ describe('PoCheckboxGroupComponent:', () => {
 
         expect(component.checkboxLabels[0].checkboxLabel.nativeElement.focus).not.toHaveBeenCalled();
         expect(component.checkboxLabels[1].checkboxLabel.nativeElement.focus).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
       });
     });
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
@@ -72,6 +72,12 @@ export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent imple
     }
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
   /**
    * Função que atribui foco ao componente.
    *
@@ -99,6 +105,10 @@ export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent imple
     }
   }
 
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
+  }
+
   getErrorPattern() {
     return this.fieldErrorMessage && this.hasInvalidClass() ? this.fieldErrorMessage : '';
   }
@@ -119,7 +129,18 @@ export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent imple
     }
   }
 
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
   trackByFn(index) {
     return index;
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.html
@@ -1,6 +1,7 @@
 <po-checkbox-group
   name="checkboxGroup"
   [(ngModel)]="checkboxGroup"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-columns]="columns"
   [p-disabled]="properties.includes('disabled')"
   [p-help]="help"
@@ -27,61 +28,66 @@
 <hr />
 
 <form #fOption="ngForm">
+  <po-input class="po-md-6" name="optionValue" [(ngModel)]="option.value" p-clean p-label="Option Value" p-required>
+  </po-input>
+
+  <po-input class="po-md-6" name="optionLabel" [(ngModel)]="option.label" p-clean p-label="Option Label" p-required>
+  </po-input>
+
+  <po-switch class="po-md-6" name="disabled" [(ngModel)]="option.disabled" p-label="Option Disabled"> </po-switch>
+
   <div class="po-row">
-    <po-input class="po-lg-4" name="optionValue" [(ngModel)]="option.value" p-clean p-label="Option Value" p-required>
-    </po-input>
-
-    <po-input class="po-lg-4" name="optionLabel" [(ngModel)]="option.label" p-clean p-label="Option Label" p-required>
-    </po-input>
-
-    <po-switch class="po-lg-4" name="disabled" [(ngModel)]="option.disabled" p-label="Option Disabled"> </po-switch>
-
-    <po-button class="po-lg-3" p-label="Add option" [p-disabled]="fOption.invalid" (p-click)="addOption()"> </po-button>
+    <po-button class="po-lg-3 po-md-4" p-label="Add option" [p-disabled]="fOption.invalid" (p-click)="addOption()">
+    </po-button>
   </div>
 </form>
 
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-lg-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
-    <po-input class="po-lg-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
-  <div class="po-row">
-    <po-input
-      class="po-md-6"
-      name="fieldErrorMessage"
-      [(ngModel)]="fieldErrorMessage"
-      p-clean
-      p-label="Field Error Message"
-    >
-    </po-input>
-  </div>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="fieldErrorMessage"
+    [(ngModel)]="fieldErrorMessage"
+    p-clean
+    p-label="Field Error Message"
+  >
+  </po-input>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+
+  <po-radio-group
+    class="po-md-12"
+    name="columns"
+    [(ngModel)]="columns"
+    p-columns="4"
+    p-label="Columns"
+    [p-options]="columnOptions"
+  >
+  </po-radio-group>
 
   <div class="po-row">
-    <po-radio-group
-      class="po-md-6"
-      name="columns"
-      [(ngModel)]="columns"
-      p-columns="3"
-      p-label="Columns"
-      [p-options]="columnOptions"
-    >
-    </po-radio-group>
-
-    <po-checkbox-group
-      class="po-md-6"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="3"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption, PoRadioGroupOption } from '@po-ui/ng-components'
   standalone: false
 })
 export class SamplePoCheckboxGroupLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   checkboxGroup: object;
   columns: number;
   disabled: boolean;
@@ -50,6 +51,7 @@ export class SamplePoCheckboxGroupLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.checkboxGroup = undefined;
     this.columns = undefined;
     this.disabled = false;

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -47,6 +47,42 @@ import { PoCheckboxSize } from './po-checkbox-size.enum';
  */
 @Directive()
 export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o tooltip (`p-additional-help-tooltip`) será incluído no body da página e não dentro do componente. Essa
+   * opção pode ser necessária em cenários com containers que possuem scroll ou overflow escondido, garantindo o
+   * posicionamento correto do tooltip próximo ao elemento.
+   *
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Texto de apoio do campo */
+  @Input('p-help') help?: string;
+
   /** Define o nome do *checkbox*. */
   @Input('name') name: string;
 
@@ -65,6 +101,15 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
 
   /** Texto de exibição do *checkbox*. */
   @Input('p-label') label?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
@@ -1,36 +1,48 @@
-<div
-  class="container-po-checkbox"
-  [attr.checked]="checkboxValue"
-  (click)="checkOption(checkboxValue)"
-  (keydown)="onKeyDown($event, checkboxValue)"
->
-  <div
-    #checkboxLabel
-    role="checkbox"
-    class="po-checkbox-outline"
-    [attr.p-size]="size"
-    [tabindex]="disabled || disabladTabindex ? -1 : 0"
-    [attr.aria-checked]="checkboxValue"
-  >
-    <span
-      [attr.aria-checked]="checkboxValue"
-      aria-label=" "
-      [id]="id"
-      class="po-checkbox"
-      [ngClass]="iconNameLib === 'AnimaliaIcon' ? 'po-checkbox-phosphor' : 'po-checkbox-poicon'"
-      [attr.aria-disabled]="disabled"
-      [attr.required]="checkBoxRequired"
+<po-field-container [p-disabled]="disabled">
+  <div class="po-field-container-content">
+    <div
+      class="container-po-checkbox"
+      [attr.checked]="checkboxValue"
+      (click)="checkOption(checkboxValue)"
+      (keydown)="onKeyDown($event, checkboxValue)"
     >
-    </span>
+      <div
+        #checkboxLabel
+        role="checkbox"
+        class="po-checkbox-outline"
+        [attr.p-size]="size"
+        [tabindex]="disabled || disabladTabindex ? -1 : 0"
+        [attr.aria-checked]="checkboxValue"
+      >
+        <span
+          [attr.aria-checked]="checkboxValue"
+          aria-label=" "
+          [id]="id"
+          class="po-checkbox"
+          [ngClass]="iconNameLib === 'AnimaliaIcon' ? 'po-checkbox-phosphor' : 'po-checkbox-poicon'"
+          [attr.aria-disabled]="disabled"
+          [attr.required]="checkBoxRequired"
+        >
+        </span>
 
-    <po-label
-      *ngIf="label"
-      class="po-checkbox-label"
-      tabindex="-1"
-      [p-disabled]="disabled"
-      [p-for]="id"
-      [p-label]="label"
-    >
-    </po-label>
+        <po-label
+          *ngIf="label"
+          class="po-checkbox-label"
+          tabindex="-1"
+          [p-disabled]="disabled"
+          [p-for]="id"
+          [p-label]="label"
+        >
+        </po-label>
+      </div>
+    </div>
   </div>
-</div>
+  <po-field-container-bottom
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
+    [p-disabled]="disabled"
+    [p-help]="help"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
+  ></po-field-container-bottom>
+</po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
@@ -78,6 +78,55 @@ describe('PoCheckboxComponent:', () => {
       });
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
+      });
+    });
+
     describe('onKeyDown:', () => {
       let fakeEvent: any;
 
@@ -147,6 +196,27 @@ describe('PoCheckboxComponent:', () => {
       component['changeModelValue'](true);
 
       expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
+    });
+
+    describe('isAdditionalHelpEventTriggered:', () => {
+      it('should return true when additionalHelpEventTrigger is "event"', () => {
+        component.additionalHelpEventTrigger = 'event';
+        expect((component as any).isAdditionalHelpEventTriggered()).toBeTrue();
+      });
+
+      it('should return true when additionalHelpEventTrigger is undefined and additionalHelp is observed', () => {
+        component.additionalHelpEventTrigger = undefined;
+        component.additionalHelp = {
+          observed: true
+        } as any;
+
+        expect((component as any).isAdditionalHelpEventTriggered()).toBeTrue();
+      });
+
+      it('should return false when additionalHelpEventTrigger is not "event" and additionalHelp is not observed', () => {
+        component.additionalHelpEventTrigger = 'noEvent';
+        expect((component as any).isAdditionalHelpEventTriggered()).toBeFalse();
+      });
     });
 
     it('onBlur: should call `onTouched` on blur', () => {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.ts
@@ -98,12 +98,26 @@ export class PoCheckboxComponent extends PoCheckboxBaseComponent implements Afte
     }
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
+  }
+
   onKeyDown(event: KeyboardEvent, value: boolean | string) {
     if (event.which === PoKeyCodeEnum.space || event.keyCode === PoKeyCodeEnum.space) {
       this.checkOption(value);
 
       event.preventDefault();
     }
+  }
+
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
   }
 
   protected changeModelValue(value: boolean | null | string) {
@@ -113,6 +127,13 @@ export class PoCheckboxComponent extends PoCheckboxBaseComponent implements Afte
       this.checkboxValue = typeof value === 'boolean' || value === null ? value : false;
     }
     this.changeDetector.detectChanges();
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 
   get iconNameLib() {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.module.ts
@@ -4,10 +4,11 @@ import { CommonModule } from '@angular/common';
 
 import { PoCheckboxComponent } from './po-checkbox.component';
 import { PoLabelModule } from '../../po-label/po-label.module';
+import { PoFieldContainerModule } from '../po-field-container/po-field-container.module';
 
 @NgModule({
   declarations: [PoCheckboxComponent],
   exports: [PoCheckboxComponent],
-  imports: [CommonModule, FormsModule, PoLabelModule]
+  imports: [CommonModule, FormsModule, PoLabelModule, PoFieldContainerModule]
 })
 export class PoCheckboxModule {}

--- a/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.html
@@ -1,7 +1,9 @@
 <po-checkbox
   name="checkbox"
   [(ngModel)]="checkbox"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-disabled]="disabled"
+  [p-help]="help"
   [p-label]="label"
   [p-size]="size ? 'large' : 'medium'"
   (p-change)="changeEvent('p-change')"
@@ -21,6 +23,17 @@
 <form #f="ngForm">
   <div class="po-row">
     <po-input class="po-sm-6" name="label" [(ngModel)]="label" p-label="Label"> </po-input>
+
+    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+
+    <po-input
+      class="po-md-6"
+      name="additionalHelpTooltip"
+      [(ngModel)]="additionalHelpTooltip"
+      p-clean
+      p-label="Additional Help Tooltip"
+    >
+    </po-input>
 
     <po-switch class="po-sm-3" name="disabled" [(ngModel)]="disabled" p-label="Disabled"> </po-switch>
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.ts
@@ -6,8 +6,10 @@ import { Component, OnInit } from '@angular/core';
   standalone: false
 })
 export class SamplePoCheckboxLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   checkbox: boolean | null;
   disabled: boolean;
+  help: string;
   size: boolean;
   event: string;
   label: string;
@@ -21,9 +23,11 @@ export class SamplePoCheckboxLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.checkbox = undefined;
     this.disabled = false;
     this.event = undefined;
+    this.help = '';
     this.label = undefined;
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -14,7 +14,6 @@ import { PoComboOptionGroup } from './interfaces/po-combo-option-group.interface
 import { PoComboOption } from './interfaces/po-combo-option.interface';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
 import { PoComboFilterService } from './po-combo-filter.service';
-import { Subscription } from 'rxjs';
 
 const PO_COMBO_DEBOUNCE_TIME_DEFAULT = 400;
 const PO_COMBO_FIELD_LABEL_DEFAULT = 'label';
@@ -76,6 +75,20 @@ const PO_COMBO_FIELD_VALUE_DEFAULT = 'value';
  */
 @Directive()
 export abstract class PoComboBaseComponent implements ControlValueAccessor, OnInit, Validator {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
   /**
    * @optional
    *
@@ -255,6 +268,15 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * @optional
    *
    * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
    *
    * Limita a exibição da mensagem de erro a duas linhas e exibe um tooltip com o texto completo.
    *
@@ -264,8 +286,6 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * @default `false`
    */
   @Input('p-error-limit') errorLimit: boolean = false;
-
-  @Input({ alias: 'p-error-append-in-body', transform: convertToBoolean }) errorAppendBox?: boolean = false;
 
   /**
    * @optional
@@ -675,10 +695,12 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @description
    *
-   * Define que o dropdown do combo será incluido no body da página e não suspenso com a caixa de texto do componente.
-   * Opção necessária para o caso de uso do componente em páginas que necessitam renderizar o combo fora do conteúdo principal.
+   * Define que o `listbox` e/ou tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) serão incluídos no body da
+   * página e não dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou
+   * overflow escondido,garantindo o posicionamento correto de ambos próximo ao elemento.
    *
-   * > Obs: O uso dessa propriedade pode acarretar na perda sequencial da tabulação da página
+   * > O uso dessa propriedade pode acarretar na perda sequencial da tabulação da página. Quando utilizado com
+   * `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
    *
    * @default `false`
    */

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -85,11 +85,14 @@
     </ng-template>
 
     <po-field-container-bottom
+      [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+      [p-append-in-body]="appendBox"
       [p-help]="help"
       [p-disabled]="disabled"
       [p-error-pattern]="getErrorPattern()"
       [p-error-limit]="errorLimit"
-      [p-append-in-body]="errorAppendBox"
+      [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+      (p-additional-help)="emitAdditionalHelp()"
     ></po-field-container-bottom>
   </po-field-container>
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -371,6 +371,35 @@ describe('PoComboComponent:', () => {
       expect(component.inputEl.nativeElement.focus).toHaveBeenCalled();
     });
 
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
+      });
+    });
+
     it('onBlur: should be called when blur event', () => {
       component['onModelTouched'] = () => {};
       spyOn(component, <any>'onModelTouched');
@@ -1698,6 +1727,26 @@ describe('PoComboComponent - with service:', () => {
 
       expect(component['unsubscribeKeyupObservable']).not.toHaveBeenCalled();
       expect(component['initInputObservable']).not.toHaveBeenCalled();
+    });
+
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
     });
 
     it(`searchOnEnterOrArrow: should call 'controlApplyFilter' if has a service,

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -196,6 +196,12 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
   /**
    * Função que atribui foco ao componente.
    *
@@ -217,6 +223,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     if (!this.disabled) {
       this.inputEl.nativeElement.focus();
     }
+  }
+
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
   }
 
   onBlur() {
@@ -571,6 +581,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }
   }
 
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
   showMoreInfiniteScroll(): void {
     if (this.defaultService.hasNext) {
       this.infiniteLoading = true;
@@ -625,6 +639,13 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     });
 
     window.addEventListener('scroll', this.onScroll, true);
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 
   private onErrorGetObjectByValue() {

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -2,6 +2,7 @@
   class="po-md-12"
   name="combo"
   [(ngModel)]="combo"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-change-on-enter]="properties.includes('changeOnEnter')"
   [p-clean]="properties.includes('clean')"
   [p-debounce-time]="debounceTime"
@@ -44,7 +45,7 @@
 
   <div class="po-row">
     <po-switch
-      class="po-md-2"
+      class="po-lg-4 po-md-12"
       name="comboOptionGroupSwitch"
       [(ngModel)]="comboOptionGroupSwitch"
       p-label="Combo options group"
@@ -52,7 +53,7 @@
     </po-switch>
 
     <po-select
-      class="po-md-5"
+      class="po-lg-4 po-md-6"
       name="selectedsOptionsGroup"
       [(ngModel)]="selectedOptionsGroup"
       p-label="Options group list"
@@ -63,7 +64,7 @@
     </po-select>
 
     <po-input
-      class="po-md-5"
+      class="po-lg-4 po-md-6"
       name="optionsGroup"
       [(ngModel)]="optionsGroup"
       p-label="New Options Group"
@@ -84,7 +85,7 @@
   </div>
 
   <div class="po-row">
-    <po-button class="po-md-6 po-lg-3" p-label="Add Option" [p-disabled]="fOption.form.invalid" (p-click)="addOption()">
+    <po-button class="po-lg-3 po-md-4" p-label="Add Option" [p-disabled]="fOption.form.invalid" (p-click)="addOption()">
     </po-button>
   </div>
 </form>
@@ -92,50 +93,56 @@
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
 
-    <po-input
-      class="po-md-6"
-      name="fieldErrorMessage"
-      [(ngModel)]="fieldErrorMessage"
-      p-clean
-      p-label="Field Error Message"
-    >
-    </po-input>
-  </div>
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="fieldErrorMessage"
+    [(ngModel)]="fieldErrorMessage"
+    p-clean
+    p-label="Field Error Message"
+  >
+  </po-input>
 
   <div class="po-row">
     <po-checkbox-group
-      class="po-lg-4"
+      class="po-md-12"
       name="properties"
       [(ngModel)]="properties"
-      p-columns="2"
+      p-columns="4"
       p-label="Properties"
       [p-options]="propertiesOptions"
     >
     </po-checkbox-group>
 
     <po-radio-group
-      class="po-md-6 po-lg-4"
+      class="po-md-12"
       name="icon"
       [(ngModel)]="icon"
-      p-columns="1"
+      p-columns="4"
       p-label="Icon"
       [p-options]="iconsOptions"
     >
     </po-radio-group>
 
     <po-radio-group
-      class="po-md-6 po-lg-4"
+      class="po-md-12"
       name="filterMode"
       [(ngModel)]="filterMode"
-      p-columns="1"
+      p-columns="4"
       p-label="Filter Mode"
       [p-options]="filterModeOptions"
     >
@@ -144,7 +151,7 @@
 
   <div class="po-row">
     <po-input
-      class="po-md-6"
+      class="po-md-12 po-lg-6"
       name="filterService"
       [(ngModel)]="filterService"
       p-clean
@@ -154,7 +161,7 @@
     </po-input>
 
     <po-input
-      class="po-lg-6"
+      class="po-md-12 po-lg-6"
       name="literals"
       [(ngModel)]="literals"
       p-help='Ex.: {"noData": "Sem dados a serem exibidos"}'
@@ -179,6 +186,6 @@
   </div>
 
   <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
@@ -15,6 +15,7 @@ import {
   standalone: false
 })
 export class SamplePoComboLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   combo: string;
   comboOptionGroupSwitch: boolean;
   customLiterals: PoComboLiterals;
@@ -92,6 +93,7 @@ export class SamplePoComboLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.combo = undefined;
     this.comboOptionGroupSwitch = false;
     this.customLiterals = undefined;

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -60,6 +60,35 @@ import { Subscription, switchMap } from 'rxjs';
  */
 @Directive()
 export abstract class PoDatepickerRangeBaseComponent implements ControlValueAccessor, Validator, OnDestroy {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o `calendar` e/ou tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) serão incluídos no body da
+   * página e não dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou
+   * overflow escondido, garantindo o posicionamento correto de ambos próximo ao elemento.
+   *
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
   /**
    * @optional
    *
@@ -117,6 +146,15 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    *
    */
   @Input('p-field-error-message') fieldErrorMessage: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
@@ -72,10 +72,15 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorMessage"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>
 </po-field-container>
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
@@ -211,6 +211,26 @@ describe('PoDatepickerRangeComponent:', () => {
       expect(removeListener).toHaveBeenCalled();
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
     it('ngOnInit: should set `poMaskObject` with `buildMask` return', () => {
       component['poMaskObject'] = undefined;
       const buildMaskReturn = new PoMask(undefined, false);
@@ -300,6 +320,26 @@ describe('PoDatepickerRangeComponent:', () => {
       expect(component.endDateInputValue).toBe('');
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
     it('eventOnClick: should click when select text and edit model', () => {
       fixture.detectChanges();
       spyOn(component['poMaskObject'], 'click');
@@ -337,6 +377,35 @@ describe('PoDatepickerRangeComponent:', () => {
       component.focus();
 
       expect(component.startDateInput.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
+      });
     });
 
     it('onBlur: should call `removeFocusFromDatePickerRangeField` and `updateModelByScreen` with `true`', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -205,6 +205,12 @@ export class PoDatepickerRangeComponent
     this.updateModel(this.dateRange);
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
   eventOnClick($event: any) {
     this.poMaskObject.click($event);
   }
@@ -230,6 +236,10 @@ export class PoDatepickerRangeComponent
     if (!this.disabled) {
       this.startDateInput.nativeElement.focus();
     }
+  }
+
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
   }
 
   onBlur(event: any) {
@@ -288,6 +298,10 @@ export class PoDatepickerRangeComponent
   resetDateRangeInputValidation() {
     this.isStartDateRangeInputValid = true;
     this.isDateRangeInputFormatValid = true;
+  }
+
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
   }
 
   toggleCalendar() {
@@ -400,6 +414,13 @@ export class PoDatepickerRangeComponent
     });
 
     window.addEventListener('scroll', this.onScroll, true);
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 
   private isEqualBeforeValue(startDate: string, endDate: string): boolean {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
@@ -2,6 +2,7 @@
   class="po-sm-12"
   name="datepickerRange"
   [(ngModel)]="datepickerRange"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-clean]="properties.includes('clean')"
   [p-disabled]="properties.includes('disabled')"
   [p-end-date]="endDate"
@@ -34,71 +35,58 @@
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
 
-  <div class="po-row">
-    <po-datepicker
-      class="po-md-6"
-      name="minDate"
-      [(ngModel)]="minDate"
-      p-clean
-      p-label="Min date"
-      [p-max-date]="maxDate"
-    >
-    </po-datepicker>
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
 
-    <po-datepicker
-      class="po-md-6"
-      name="maxDate"
-      [(ngModel)]="maxDate"
-      p-clean
-      p-label="Max date"
-      [p-min-date]="minDate"
-    >
-    </po-datepicker>
-  </div>
+  <po-datepicker class="po-md-6" name="minDate" [(ngModel)]="minDate" p-clean p-label="Min date" [p-max-date]="maxDate">
+  </po-datepicker>
 
-  <div class="po-row">
-    <po-input
-      class="po-md-6"
-      name="literals"
-      [(ngModel)]="literals"
-      p-help='Ex.: { "invalidFormat": "Date in inconsistent format", "startDateGreaterThanEndDate": "End date less than start date" }'
-      p-label="Literals"
-      (p-change)="changeLiterals()"
-    >
-    </po-input>
+  <po-datepicker class="po-md-6" name="maxDate" [(ngModel)]="maxDate" p-clean p-label="Max date" [p-min-date]="minDate">
+  </po-datepicker>
 
-    <po-input
-      class="po-md-6"
-      name="fieldErrorMessage"
-      [(ngModel)]="fieldErrorMessage"
-      p-clean
-      p-label="Field Error Message"
-    >
-    </po-input>
-  </div>
+  <po-input
+    class="po-md-12 po-lg-6"
+    name="literals"
+    [(ngModel)]="literals"
+    p-help='Ex.: { "invalidFormat": "Date in inconsistent format", "startDateGreaterThanEndDate": "End date less than start date" }'
+    p-label="Literals"
+    (p-change)="changeLiterals()"
+  >
+  </po-input>
 
-  <div class="po-row">
-    <po-checkbox-group
-      class="po-md-6"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="3"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
+  <po-input
+    class="po-md-6"
+    name="fieldErrorMessage"
+    [(ngModel)]="fieldErrorMessage"
+    p-clean
+    p-label="Field Error Message"
+  >
+  </po-input>
 
-    <po-select class="po-md-6" name="locale" p-label="Locale" [(ngModel)]="locale" [p-options]="localeOptions">
-    </po-select>
-  </div>
+  <po-select class="po-md-6" name="locale" p-label="Locale" [(ngModel)]="locale" [p-options]="localeOptions">
+  </po-select>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
 
   <div class="po-row">
-    <po-button class="po-md-3" name="restore" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" name="restore" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.ts
@@ -13,6 +13,7 @@ import {
   standalone: false
 })
 export class SamplePoDatepickerRangeLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   clean: boolean;
   customLiterals: PoDatepickerRangeLiterals;
   datepickerRange: PoDatepickerRange;
@@ -67,6 +68,7 @@ export class SamplePoDatepickerRangeLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.clean = undefined;
     this.customLiterals = undefined;
     this.endDate = undefined;

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -95,6 +95,20 @@ const poDatepickerFormatDefault: string = 'dd/mm/yyyy';
  */
 @Directive()
 export abstract class PoDatepickerBaseComponent implements ControlValueAccessor, OnInit, OnDestroy, Validator {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
   /**
    * @optional
    *
@@ -162,8 +176,6 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    */
   @Input('p-error-limit') errorLimit: boolean = false;
 
-  @Input({ alias: 'p-error-append-in-body', transform: convertToBoolean }) errorAppendBox?: boolean = false;
-
   /**
    * @optional
    *
@@ -176,6 +188,15 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    * @default `false`
    */
   @Input('p-required-field-error-message') showErrorMessageRequired: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp: EventEmitter<any> = new EventEmitter<any>();
 
   /**
    * @optional
@@ -439,11 +460,11 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    *
    * @description
    *
-   * Define que o calendário do DatePicker será incluído no body da página, em vez de suspenso junto ao campo de entrada do componente.
-   * Essa opção é útil em cenários onde o DatePicker precisa ser renderizado fora do conteúdo principal da página,
-   * como em formulários que utilizam scroll ou containers com overflow escondido.
+   * Define que o `calendar` e/ou tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) serão incluídos no body da
+   * página e não dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou
+   * overflow escondido, garantindo o posicionamento correto de ambos próximo ao elemento.
    *
-   * > Obs: O uso dessa propriedade pode interferir na sequência de tabulação da página, especialmente em formulários longos.
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
    *
    * @default `false`
    */

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
@@ -79,10 +79,14 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
-    [p-append-in-body]="errorAppendBox"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -492,6 +492,26 @@ describe('PoDatepickerComponent:', () => {
       expect(component['subscriptionValidator'].unsubscribe).toHaveBeenCalled();
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
     it('focus: should call `focus` of datepicker', () => {
       component.inputEl = {
         nativeElement: {
@@ -519,6 +539,35 @@ describe('PoDatepickerComponent:', () => {
       component.focus();
 
       expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
+      });
     });
 
     it('addListener: should call wasClickedOnPicker when click in document', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -180,6 +180,12 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
     this.removeListeners();
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
   /**
    * Função que atribui foco ao componente.
    *
@@ -201,6 +207,10 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
     if (!this.disabled) {
       this.inputEl.nativeElement.focus();
     }
+  }
+
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
   }
 
   togglePicker() {
@@ -383,6 +393,10 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
     return element.classList.contains('po-datepicker-calendar-overlay');
   }
 
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
   verifyErrorAsync(value) {
     if (this.errorPattern !== '' && this.errorAsync) {
       const errorAsync = this.errorAsync(value);
@@ -456,6 +470,13 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
     });
 
     window.addEventListener('scroll', this.onScroll, true);
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 
   private onScroll = (): void => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
@@ -2,6 +2,7 @@
   class="po-sm-12"
   name="datepicker"
   [(ngModel)]="datepicker"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-clean]="properties.includes('clean')"
   [p-disabled]="properties.includes('disabled')"
   [p-max-date]="maxDate"
@@ -36,88 +37,86 @@
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
 
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
 
-    <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern">
-    </po-input>
-  </div>
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
 
-  <div class="po-row">
-    <po-datepicker
-      class="po-md-6"
-      name="minDate"
-      [(ngModel)]="minDate"
-      p-clean
-      p-label="Min date"
-      [p-max-date]="maxDate"
-      [p-format]="format"
-    >
-    </po-datepicker>
+  <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern"> </po-input>
 
-    <po-datepicker
-      class="po-md-6"
-      name="maxDate"
-      [(ngModel)]="maxDate"
-      p-clean
-      p-label="Max date"
-      [p-format]="format"
-      [p-min-date]="minDate"
-    >
-    </po-datepicker>
-  </div>
+  <po-datepicker
+    class="po-md-6"
+    name="minDate"
+    [(ngModel)]="minDate"
+    p-clean
+    p-label="Min date"
+    [p-max-date]="maxDate"
+    [p-format]="format"
+  >
+  </po-datepicker>
 
-  <div class="po-row">
-    <po-radio-group
-      class="po-md-6"
-      name="format"
-      [(ngModel)]="format"
-      p-columns="3"
-      p-label="Format"
-      [p-options]="formatOptions"
-    >
-    </po-radio-group>
+  <po-datepicker
+    class="po-md-6"
+    name="maxDate"
+    [(ngModel)]="maxDate"
+    p-clean
+    p-label="Max date"
+    [p-format]="format"
+    [p-min-date]="minDate"
+  >
+  </po-datepicker>
 
-    <po-radio-group
-      class="po-md-6"
-      name="locale"
-      [(ngModel)]="locale"
-      p-columns="3"
-      p-label="Locale"
-      [p-options]="localeOptions"
-    >
-    </po-radio-group>
-  </div>
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
 
-  <div class="po-row">
-    <po-radio-group
-      class="po-md-4"
-      name="isoFormat"
-      [(ngModel)]="isoFormat"
-      p-columns="1"
-      p-label="Iso Format"
-      [p-options]="isoFormatOptions"
-    >
-    </po-radio-group>
+  <po-radio-group
+    class="po-md-12"
+    name="locale"
+    [(ngModel)]="locale"
+    p-columns="4"
+    p-label="Locale"
+    [p-options]="localeOptions"
+  >
+  </po-radio-group>
 
-    <po-checkbox-group
-      class="po-sm-8"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="3"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
+  <po-radio-group
+    class="po-md-12"
+    name="format"
+    [(ngModel)]="format"
+    p-columns="4"
+    p-label="Format"
+    [p-options]="formatOptions"
+  >
+  </po-radio-group>
+
+  <po-radio-group
+    class="po-md-12"
+    name="isoFormat"
+    [(ngModel)]="isoFormat"
+    p-columns="4"
+    p-label="Iso Format"
+    [p-options]="isoFormatOptions"
+  >
+  </po-radio-group>
 
   <div class="po-row">
-    <po-button class="po-md-3" name="restore" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" name="restore" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption, PoDatepickerIsoFormat, PoRadioGroupOption } from
   standalone: false
 })
 export class SamplePoDatepickerLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   datepicker: string | Date;
   maxDate: string | Date;
   errorPattern: string;
@@ -60,6 +61,7 @@ export class SamplePoDatepickerLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.datepicker = undefined;
     this.maxDate = undefined;
     this.event = undefined;

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
@@ -45,11 +45,14 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
     [p-error-limit]="errorLimit"
     [p-error-pattern]="getErrorPatternMessage()"
-    [p-append-in-body]="errorAppendBox"
-  >
-  </po-field-container-bottom>
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
+  ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
@@ -2,6 +2,7 @@
   class="po-md-12"
   name="decimal"
   [(ngModel)]="decimal"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-clean]="properties.includes('clean')"
   [p-decimals-length]="decimalsLength"
   [p-disabled]="properties.includes('disabled')"
@@ -37,77 +38,74 @@
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
 
-  <div class="po-row">
-    <po-number
-      class="po-md-4"
-      name="decimalsLength"
-      [(ngModel)]="decimalsLength"
-      p-clean
-      p-help="By default is equal 2, check the behavior in doc."
-      p-label="Decimals max length"
-      p-min="0"
-      [p-max]="maxDecimalsLength"
-    >
-    </po-number>
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
 
-    <po-number
-      class="po-md-4"
-      name="thousandMaxlength"
-      [(ngModel)]="thousandMaxlength"
-      p-clean
-      p-help="By default is equal 13, check the behavior in doc."
-      p-label="Thousand max length"
-      p-min="0"
-      [p-max]="maxThousandMaxlength"
-    >
-    </po-number>
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
 
-    <po-select
-      class="po-md-4"
-      name="locale"
-      [(ngModel)]="locale"
-      p-clean
-      p-help="By default is equal your browser locale"
-      p-label="Locale"
-      [p-options]="localeOptions"
-    ></po-select>
-  </div>
+  <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern"> </po-input>
 
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+  <po-select class="po-md-6 po-lg-3" name="icon" [(ngModel)]="icon" p-clean p-label="Icon" [p-options]="iconOptions">
+  </po-select>
 
-    <po-select class="po-md-6" name="icon" [(ngModel)]="icon" p-clean p-label="Icon" [p-options]="iconOptions">
-    </po-select>
-  </div>
+  <po-number class="po-md-6 po-lg-3" name="min" [(ngModel)]="min" p-clean p-label="Min"> </po-number>
 
-  <div class="po-row">
-    <po-number class="po-md-6 po-lg-3" name="min" [(ngModel)]="min" p-clean p-label="Min"> </po-number>
+  <po-number class="po-md-6 po-lg-3" name="max" [(ngModel)]="max" p-clean p-label="Max"> </po-number>
 
-    <po-number class="po-md-6 po-lg-3" name="max" [(ngModel)]="max" p-clean p-label="Max"> </po-number>
+  <po-select
+    class="po-md-6 po-lg-3"
+    name="locale"
+    [(ngModel)]="locale"
+    p-clean
+    p-label="Locale"
+    [p-options]="localeOptions"
+  ></po-select>
 
-    <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern">
-    </po-input>
-  </div>
+  <po-number
+    class="po-md-6 po-lg-3"
+    name="decimalsLength"
+    [(ngModel)]="decimalsLength"
+    p-clean
+    p-help="Máximo 15"
+    p-label="Decimals max length"
+    p-min="0"
+    [p-max]="maxDecimalsLength"
+  >
+  </po-number>
 
-  <div class="po-row">
-    <po-checkbox-group
-      class="po-md-12"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="4"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
+  <po-number
+    class="po-md-6 po-lg-3"
+    name="thousandMaxlength"
+    [(ngModel)]="thousandMaxlength"
+    p-clean
+    p-help="Máximo 13"
+    p-label="Thousand max length"
+    p-min="0"
+    [p-max]="maxThousandMaxlength"
+  >
+  </po-number>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
 
   <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption, PoSelectOption } from '@po-ui/ng-components';
   standalone: false
 })
 export class SamplePoDecimalLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   decimal: number;
   decimalsLength: number;
   event: string;
@@ -64,6 +65,7 @@ export class SamplePoDecimalLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.decimal = undefined;
     this.decimalsLength = undefined;
     this.event = '';

--- a/projects/ui/src/lib/components/po-field/po-email/samples/sample-po-email-labs/sample-po-email-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-email/samples/sample-po-email-labs/sample-po-email-labs.component.html
@@ -1,6 +1,7 @@
 <po-email
   name="email"
   [(ngModel)]="email"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-clean]="properties.includes('clean')"
   [p-disabled]="properties.includes('disabled')"
   [p-error-pattern]="errorPattern"
@@ -34,38 +35,38 @@
 <hr />
 
 <form #f="ngForm">
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+
+  <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern"> </po-input>
+
+  <po-number class="po-md-6 po-lg-3" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
+
+  <po-number class="po-md-6 po-lg-3" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+
   <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
-
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
-
-    <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern">
-    </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-number class="po-md-6" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
-
-    <po-number class="po-md-6" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
-  </div>
-
-  <div class="po-row">
-    <po-checkbox-group
-      class="po-md-12"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="4"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-email/samples/sample-po-email-labs/sample-po-email-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-email/samples/sample-po-email-labs/sample-po-email-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption } from '@po-ui/ng-components';
   standalone: false
 })
 export class SamplePoEmailLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   email: string;
   errorPattern: string;
   event: string;
@@ -34,6 +35,7 @@ export class SamplePoEmailLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.properties = [];
 
     this.label = undefined;

--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.component.html
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.component.html
@@ -18,8 +18,19 @@
       {{ errorPattern }}
     </span>
   </div>
-
-  <span *ngIf="help && !errorPattern" class="po-field-container-bottom-help-text">
-    {{ help }}
-  </span>
+  <div *ngIf="!errorPattern" class="po-field-container-bottom-help-text">
+    <span *ngIf="help">
+      {{ help }}
+    </span>
+    <div *ngIf="showAdditionalHelpIcon" class="po-icon-container">
+      <po-icon
+        class="po-icon-additional-help"
+        [class.po-clickable]="!additionalHelpTooltip"
+        p-icon="an an-fill an an-info"
+        [p-append-in-body]="appendBox"
+        [p-tooltip]="additionalHelpTooltip"
+        (click)="additionalHelp.emit()"
+      ></po-icon>
+    </div>
+  </div>
 </div>

--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { convertToBoolean } from '../../../../utils/util';
 
 /**
@@ -16,6 +16,14 @@ import { convertToBoolean } from '../../../../utils/util';
   standalone: false
 })
 export class PoFieldContainerBottomComponent {
+  /** Texto exibido no tooltip do ícone de ajuda adicional. */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string = '';
+
+  /** Define se o tooltip será inserido no `body` em vez do componente. */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox: boolean = false;
+
+  @Input('p-disabled') disabled: boolean = false;
+
   /**
    * Mensagem que será apresentada quando o pattern ou a máscara não for satisfeita.
    * Obs: Esta mensagem não é apresentada quando o campo estiver vazio, mesmo que ele seja requerido.
@@ -27,9 +35,11 @@ export class PoFieldContainerBottomComponent {
    */
   @Input('p-error-limit') errorLimit: boolean = false;
 
-  @Input('p-disabled') disabled: boolean = false;
-
   @Input('p-help') help?: string;
 
-  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+  /** Exibe o ícone de ajuda adicional. */
+  @Input('p-show-additional-help-icon') showAdditionalHelpIcon: boolean = false;
+
+  /** Evento disparado ao clicar no ícone de ajuda adicional. */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 }

--- a/projects/ui/src/lib/components/po-field/po-field-validate.model.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-validate.model.ts
@@ -49,8 +49,6 @@ export abstract class PoFieldValidateModel<T> extends PoFieldModel<T> implements
    */
   @Input('p-field-error-message') fieldErrorMessage: string;
 
-  @Input({ alias: 'p-error-append-in-body', transform: convertToBoolean }) errorAppendBox?: boolean = false;
-
   /**
    * @optional
    *

--- a/projects/ui/src/lib/components/po-field/po-field.model.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.model.spec.ts
@@ -70,10 +70,59 @@ describe('PoFieldModel', () => {
     expect(spyOnWriteValue).toHaveBeenCalledWith(expectedValue);
   });
 
+  describe('emitAdditionalHelp:', () => {
+    it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+      spyOn(component.additionalHelp, 'emit');
+      spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+      component.emitAdditionalHelp();
+
+      expect(component.additionalHelp.emit).toHaveBeenCalled();
+    });
+
+    it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+      spyOn(component.additionalHelp, 'emit');
+      spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+      component.emitAdditionalHelp();
+
+      expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+    });
+  });
+
   it('should emit change', () => {
     spyOn(component.change, 'emit');
     component.emitChange('test');
 
     expect(component.change.emit).toHaveBeenCalled();
+  });
+
+  describe('getAdditionalHelpTooltip:', () => {
+    it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+      spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+      const result = component.getAdditionalHelpTooltip();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+      const tooltip = 'Test Tooltip';
+      component.additionalHelpTooltip = tooltip;
+      spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+      const result = component.getAdditionalHelpTooltip();
+
+      expect(result).toBe(tooltip);
+    });
+
+    it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+      component.additionalHelpTooltip = undefined;
+      spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+      const result = component.getAdditionalHelpTooltip();
+
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-field.model.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.model.ts
@@ -5,6 +5,35 @@ import { convertToBoolean } from '../../utils/util';
 
 @Directive()
 export abstract class PoFieldModel<T> implements ControlValueAccessor {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) será incluído no body da página e não
+   * dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou overflow
+   * escondido, garantindo o posicionamento correto do tooltip próximo ao elemento.
+   *
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox: boolean = false;
+
   /** Rótulo exibido pelo componente. */
   @Input('p-label') label: string;
 
@@ -24,6 +53,15 @@ export abstract class PoFieldModel<T> implements ControlValueAccessor {
    * @default `false`
    */
   @Input({ alias: 'p-disabled', transform: convertToBoolean }) disabled: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * @optional
@@ -60,8 +98,28 @@ export abstract class PoFieldModel<T> implements ControlValueAccessor {
     this.onWriteValue(value);
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
   emitChange(value) {
     this.change.emit(value);
+  }
+
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
+  }
+
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 
   protected updateModel(value: T) {

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
@@ -437,6 +437,55 @@ describe('PoInputBase:', () => {
       expect(component.changeModel.emit).toHaveBeenCalledWith(newModelValue);
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
+      });
+    });
+
     it('validateModel: shouldn`t call `validatorChange` when it is falsy', () => {
       component['validateModel']();
 

--- a/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
@@ -46,10 +46,14 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
-    [p-append-in-body]="errorAppendBox"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
@@ -1,6 +1,7 @@
 <po-input
   name="input"
   [(ngModel)]="input"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-clean]="properties?.includes('clean')"
   [p-disabled]="properties?.includes('disabled')"
   [p-error-pattern]="errorPattern"
@@ -40,63 +41,61 @@
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
 
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
 
-    <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern">
-    </po-input>
-  </div>
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
 
-  <div class="po-row">
-    <po-input
-      class="po-md-6"
-      name="mask"
-      [(ngModel)]="mask"
-      p-clean
-      p-help="Ex.: Zip code: '99999-999'; License plate: '@@@-9999'"
-      p-label="Mask"
-    >
-    </po-input>
+  <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern"> </po-input>
 
-    <po-input
-      class="po-lg-6 po-md-12"
-      name="pattern"
-      [(ngModel)]="pattern"
-      p-clean
-      p-help="Ex.: '^(2[0-3]|[01][0-9]):?([0-5][0-9])$'"
-      p-label="Pattern (Regex)"
-    >
-    </po-input>
-  </div>
+  <po-input
+    class="po-md-12 po-lg-6"
+    name="mask"
+    [(ngModel)]="mask"
+    p-clean
+    p-help="Ex.: Zip code: '99999-999'; License plate: '@@@-9999'"
+    p-label="Mask"
+  >
+  </po-input>
 
-  <div class="po-row">
-    <po-number class="po-md-6" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
+  <po-input
+    class="po-md-12 po-lg-6"
+    name="pattern"
+    [(ngModel)]="pattern"
+    p-clean
+    p-help="Ex.: '^(2[0-3]|[01][0-9]):?([0-5][0-9])$'"
+    p-label="Pattern (Regex)"
+  >
+  </po-input>
 
-    <po-number class="po-md-6" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
-  </div>
+  <po-number class="po-md-6 po-lg-3" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
 
-  <div class="po-row">
-    <po-select class="po-lg-6" name="icon" [(ngModel)]="icon" p-clean p-label="Icon" [p-options]="iconOptions">
-    </po-select>
+  <po-number class="po-md-6 po-lg-3" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
 
-    <po-checkbox-group
-      class="po-lg-6 po-md-12"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="2"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
+  <po-select class="po-md-6" name="icon" [(ngModel)]="icon" p-clean p-label="Icon" [p-options]="iconOptions">
+  </po-select>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
 
   <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="f.reset(); this.restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="f.reset(); this.restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption, PoSelectOption } from '@po-ui/ng-components';
   standalone: false
 })
 export class SamplePoInputLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   input: string;
   errorPattern: string;
   event: string;
@@ -51,6 +52,7 @@ export class SamplePoInputLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.input = undefined;
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-login/po-login.component.html
+++ b/projects/ui/src/lib/components/po-field/po-login/po-login.component.html
@@ -45,10 +45,14 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
     [p-help]="help"
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   >
   </po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.html
@@ -1,6 +1,7 @@
 <po-login
   name="login"
   [(ngModel)]="login"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-clean]="properties.includes('clean')"
   [p-disabled]="properties.includes('disabled')"
   [p-error-pattern]="errorPattern"
@@ -35,55 +36,57 @@
 <hr />
 
 <form #f="ngForm">
+  <po-input class="po-md-6 po-lg-4" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+
+  <po-input class="po-md-6 po-lg-4" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+
+  <po-input class="po-md-6 po-lg-4" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder">
+  </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="pattern"
+    [(ngModel)]="pattern"
+    p-clean
+    p-help="Ex.: '[a-zA]{5}[Z0-9]{3}'"
+    p-label="Pattern (Regex)"
+  >
+  </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="errorPattern"
+    [(ngModel)]="errorPattern"
+    p-clean
+    p-help="Ex.: Required field"
+    p-label="Error pattern"
+  >
+  </po-input>
+
+  <po-number class="po-md-6 po-lg-3" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min length"> </po-number>
+
+  <po-number class="po-md-6 po-lg-3" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max length"> </po-number>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+
   <div class="po-row">
-    <po-input class="po-md-4" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
-
-    <po-input class="po-md-4" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-
-    <po-input class="po-md-4" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-input
-      class="po-md-6"
-      name="pattern"
-      [(ngModel)]="pattern"
-      p-clean
-      p-help="Ex.: '[a-zA]{5}[Z0-9]{3}'"
-      p-label="Pattern (Regex)"
-    >
-    </po-input>
-
-    <po-input
-      class="po-md-6"
-      name="errorPattern"
-      [(ngModel)]="errorPattern"
-      p-clean
-      p-help="Ex.: Required field"
-      p-label="Error pattern"
-    >
-    </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-number class="po-md-6" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min length"> </po-number>
-
-    <po-number class="po-md-6" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max length"> </po-number>
-  </div>
-
-  <div class="po-row">
-    <po-checkbox-group
-      class="po-md-12"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="4"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption } from '@po-ui/ng-components';
   standalone: false
 })
 export class SamplePoLoginLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   errorPattern: string;
   event: string;
   help: string;
@@ -40,6 +41,7 @@ export class SamplePoLoginLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.errorPattern = '';
     this.event = '';
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -14,18 +14,10 @@ import {
   Output,
   SimpleChanges
 } from '@angular/core';
-import {
-  AbstractControl,
-  ControlValueAccessor,
-  NgControl,
-  UntypedFormControl,
-  Validator,
-  Validators
-} from '@angular/forms';
+import { AbstractControl, ControlValueAccessor, NgControl, UntypedFormControl, Validator } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
-import { InputBoolean } from '../../../decorators';
 import { convertToBoolean, isTypeof } from '../../../utils/util';
 import { requiredFailed } from '../validators';
 import { PoLookupAdvancedFilter } from './interfaces/po-lookup-advanced-filter.interface';
@@ -77,6 +69,36 @@ export abstract class PoLookupBaseComponent
 {
   private _literals?: PoLookupLiterals;
   private language: string;
+
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) será incluído no body da página e não
+   * dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou overflow
+   * escondido, garantindo o posicionamento correto do tooltip próximo ao elemento.
+   *
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
   /**
    * @optional
    *
@@ -356,8 +378,6 @@ export abstract class PoLookupBaseComponent
    */
   @Input('p-error-limit') errorLimit: boolean = false;
 
-  @Input({ alias: 'p-error-append-in-body', transform: convertToBoolean }) errorAppendBox?: boolean = false;
-
   /**
    * @optional
    *
@@ -401,6 +421,15 @@ export abstract class PoLookupBaseComponent
    * @default `true`
    */
   @Input({ alias: 'p-virtual-scroll', transform: convertToBoolean }) virtualScroll?: boolean = true;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * Evento será disparado quando ocorrer algum erro na requisição de busca do item.

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
@@ -56,11 +56,14 @@
     </div>
   </div>
   <po-field-container-bottom
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
-    [p-append-in-body]="errorAppendBox"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>
 </po-field-container>
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -277,6 +277,55 @@ describe('PoLookupComponent:', () => {
       expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
+      });
+    });
+
     it('openLookup: should call `openModal` if `isAllowedOpenModal` return true', inject(
       [LookupFilterService],
       (lookupFilterService: LookupFilterService) => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -228,6 +228,16 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
     }
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
+  }
+
   openLookup(): void {
     if (this.isAllowedOpenModal()) {
       const {
@@ -420,6 +430,17 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
     }
 
     this.visibleDisclaimers = [...newDisclaimers];
+  }
+
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 
   private isAllowedOpenModal(): boolean {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -1,6 +1,7 @@
 <po-lookup
   name="lookup"
   [(ngModel)]="lookup"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-advanced-filters]="customAdvancedFilters"
   [p-auto-height]="properties.includes('autoHeight')"
   [p-clean]="properties.includes('clean')"
@@ -45,121 +46,123 @@
 <hr />
 
 <form #f="ngForm">
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+
+  <po-checkbox-group
+    class="po-md-12 po-lg-6"
+    name="columnsName"
+    [(ngModel)]="columnsName"
+    p-columns="3"
+    p-label="Columns"
+    [p-options]="columnsOptions"
+    (p-change)="updateColumns()"
+  >
+  </po-checkbox-group>
+
+  <po-select
+    class="po-md-6 po-lg-12"
+    name="fieldLabel"
+    [(ngModel)]="fieldLabel"
+    p-label="Field Label"
+    p-required
+    [p-options]="fieldLabelOptions"
+  >
+  </po-select>
+
+  <po-select
+    class="po-md-6"
+    name="fieldValue"
+    [(ngModel)]="fieldValue"
+    p-label="Field Value"
+    p-required
+    [p-options]="fieldValueOptions"
+  >
+  </po-select>
+
+  <po-input
+    class="po-md-12 po-lg-6"
+    name="filterService"
+    [(ngModel)]="filterService"
+    p-clean
+    p-help="https://po-sample-api.onrender.com/v1/people"
+    p-label="Filter Service"
+  >
+  </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="fieldErrorMessage"
+    [(ngModel)]="fieldErrorMessage"
+    p-clean
+    p-label="Field Error Message"
+  >
+  </po-input>
+
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+
+  <po-input
+    class="po-lg-6"
+    name="literals"
+    [(ngModel)]="literals"
+    p-help='Ex.: { "modalTitle": "Select a register", "modalPrimaryActionLabel": "Select", "modalPlaceholder": "Search Value" }'
+    p-label="Literals"
+    (p-change)="changeLiterals()"
+  >
+  </po-input>
+
+  <po-input
+    name="formatField"
+    [(ngModel)]="formatField"
+    class="po-lg-6"
+    p-label="Field Format"
+    p-help='Ex.: ["id", "name"]'
+    (p-change)="onFieldFormatChange($event)"
+  >
+  </po-input>
+
+  <po-checkbox-group
+    class="po-lg-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+
+  <po-radio-group
+    class="po-lg-12"
+    name="spacing"
+    [(ngModel)]="spacing"
+    p-columns="4"
+    p-label="Spacing"
+    [p-options]="typeSpacing"
+  >
+  </po-radio-group>
+
+  <po-textarea
+    class="po-md-12 po-lg-12"
+    name="advancedFilters"
+    [(ngModel)]="advancedFilters"
+    (p-change)="changeAdvancedFilters()"
+    p-help='Ex.: [{"property":"name","divider":"PERSONAL DATA","required":true,"gridColumns":6},{"property":"id","optional":true,"gridColumns":6}]'
+    p-label="Advanced Filters"
+    p-rows="4"
+  >
+  </po-textarea>
+
   <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
-
-    <po-checkbox-group
-      class="po-md-6"
-      name="columnsName"
-      [(ngModel)]="columnsName"
-      p-columns="4"
-      p-label="Columns"
-      [p-options]="columnsOptions"
-      (p-change)="updateColumns()"
-    >
-    </po-checkbox-group>
-  </div>
-
-  <div class="po-row">
-    <po-select
-      class="po-md-6"
-      name="fieldLabel"
-      [(ngModel)]="fieldLabel"
-      p-label="Field Label"
-      p-required
-      [p-options]="fieldLabelOptions"
-    >
-    </po-select>
-
-    <po-select
-      class="po-md-6"
-      name="fieldValue"
-      [(ngModel)]="fieldValue"
-      p-label="Field Value"
-      p-required
-      [p-options]="fieldValueOptions"
-    >
-    </po-select>
-  </div>
-
-  <div class="po-row">
-    <po-input
-      class="po-md-6"
-      name="filterService"
-      [(ngModel)]="filterService"
-      p-clean
-      p-help="https://po-sample-api.onrender.com/v1/people"
-      p-label="Filter Service"
-    >
-    </po-input>
-
-    <po-input
-      class="po-md-6"
-      name="fieldErrorMessage"
-      [(ngModel)]="fieldErrorMessage"
-      p-clean
-      p-label="Field Error Message"
-    >
-    </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-input class="po-lg-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-
-    <po-input class="po-lg-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-input
-      class="po-lg-6"
-      name="literals"
-      [(ngModel)]="literals"
-      p-help='Ex.: { "modalTitle": "Select a register", "modalPrimaryActionLabel": "Select", "modalPlaceholder": "Search Value" }'
-      p-label="Literals"
-      (p-change)="changeLiterals()"
-    >
-    </po-input>
-
-    <po-input
-      name="formatField"
-      [(ngModel)]="formatField"
-      class="po-lg-6"
-      p-label="Field Format"
-      p-help='Ex.: ["id", "name"]'
-      (p-change)="onFieldFormatChange($event)"
-    >
-    </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-checkbox-group
-      class="po-lg-6"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="2"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-
-    <po-radio-group class="po-lg-6" name="spacing" [(ngModel)]="spacing" p-label="Spacing" [p-options]="typeSpacing">
-    </po-radio-group>
-  </div>
-
-  <div class="po-row">
-    <po-textarea
-      class="po-md-6"
-      name="advancedFilters"
-      [(ngModel)]="advancedFilters"
-      (p-change)="changeAdvancedFilters()"
-      p-help='Ex.: [{"property":"name","divider":"PERSONAL DATA","required":true,"gridColumns":6},{"property":"id","optional":true,"gridColumns":6}]'
-      p-label="Advanced Filters"
-      p-rows="4"
-    >
-    </po-textarea>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
@@ -20,6 +20,7 @@ import { SamplePoLookupService } from '../sample-po-lookup.service';
   standalone: false
 })
 export class SamplePoLookupLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   columns: Array<PoLookupColumn>;
   columnsName: Array<string>;
   customLiterals: PoLookupLiterals;
@@ -119,6 +120,7 @@ export class SamplePoLookupLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.columnsName = ['id', 'name'];
     this.customLiterals = undefined;
     this.updateColumns();

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -1,5 +1,5 @@
 import { Directive, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { AbstractControl, ControlValueAccessor, Validator, Validators } from '@angular/forms';
+import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 
 import { Observable, Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs/operators';
@@ -112,6 +112,20 @@ export const poMultiselectLiteralsDefault = {
  */
 @Directive()
 export abstract class PoMultiselectBaseComponent implements ControlValueAccessor, OnInit, Validator {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
   /**
    * @optional
    *
@@ -190,6 +204,15 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * @optional
    *
    * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
    *
    * Limita a exibição da mensagem de erro a duas linhas e exibe um tooltip com o texto completo.
    *
@@ -214,16 +237,16 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    *
    * @description
    *
-   * Define que o dropdown do multiselect será incluido no body da página e não suspenso com a caixa de texto do componente.
-   * Opção necessária para o caso de uso do componente em páginas que necessitam renderizar o multiselect fora do conteúdo principal.
+   * Define que o `listbox` e/ou tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) serão incluídos no body da
+   * página e não dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou
+   * overflow escondido, garantindo o posicionamento correto de ambos próximo ao elemento.
    *
-   * > Obs: O uso dessa propriedade pode acarretar na perda sequencial da tabulação da página
+   * > O uso dessa propriedade pode interferir na sequência de tabulação da página. Quando utilizado com
+   * `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
    *
    * @default `false`
    */
   @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
-
-  @Input({ alias: 'p-error-append-in-body', transform: convertToBoolean }) errorAppendBox?: boolean = false;
 
   selectedOptions: Array<PoMultiselectOption | any> = [];
   visibleOptionsDropdown: Array<PoMultiselectOption | any> = [];

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -65,11 +65,14 @@
     </ng-template>
 
     <po-field-container-bottom
+      [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+      [p-append-in-body]="appendBox"
       [p-help]="help"
       [p-disabled]="disabled"
       [p-error-pattern]="getErrorPattern()"
       [p-error-limit]="errorLimit"
-      [p-append-in-body]="errorAppendBox"
+      [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+      (p-additional-help)="emitAdditionalHelp()"
     ></po-field-container-bottom>
   </po-field-container>
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -514,6 +514,26 @@ describe('PoMultiselectComponent:', () => {
       expect(fnDestroy).not.toThrow();
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
     it('Should call `setService` if a change occurs in `filterService` and contain `filterService`', () => {
       const changes = { filterService: 'filterServiceURL' };
       component.filterService = 'http://localhost:4200/test';
@@ -581,6 +601,35 @@ describe('PoMultiselectComponent:', () => {
       component.focus();
 
       expect(component.inputElement.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
+      });
     });
 
     it(`calculateVisibleItems: should calc visible items and not set 'isCalculateVisibleItems' to false when

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -191,6 +191,12 @@ export class PoMultiselectComponent
     this.subscription.unsubscribe();
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
   /**
    * Função que atribui foco ao componente.
    *
@@ -212,6 +218,10 @@ export class PoMultiselectComponent
     if (!this.disabled) {
       this.inputElement.nativeElement.focus();
     }
+  }
+
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
   }
 
   getInputWidth() {
@@ -455,6 +465,10 @@ export class PoMultiselectComponent
     }, 300);
   }
 
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
   wasClickedOnToggle(event: MouseEvent): void {
     if (
       this.dropdownOpen &&
@@ -615,6 +629,13 @@ export class PoMultiselectComponent
     });
 
     window.addEventListener('scroll', this.onScroll, true);
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 
   private onScroll = (): void => {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
@@ -3,6 +3,7 @@
     class="po-md-12"
     name="PO Multiselect"
     [(ngModel)]="multiselect"
+    [p-additional-help-tooltip]="additionalHelpTooltip"
     [p-auto-height]="properties.includes('autoHeight')"
     [p-disabled]="properties.includes('disabled')"
     [p-field-label]="fieldLabel"
@@ -48,7 +49,7 @@
   </div>
 
   <div class="po-row">
-    <po-button class="po-md-6 po-lg-3" p-label="Add Option" [p-disabled]="fOption.form.invalid" (p-click)="addOption()">
+    <po-button class="po-md-4 po-lg-3" p-label="Add Option" [p-disabled]="fOption.form.invalid" (p-click)="addOption()">
     </po-button>
   </div>
 </form>
@@ -56,88 +57,85 @@
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
 
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
 
-    <po-input
-      class="po-md-6"
-      name="placeholderSearch"
-      [(ngModel)]="placeholderSearch"
-      p-clean
-      p-label="Placeholder Search"
-    >
-    </po-input>
-  </div>
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
 
-  <div class="po-row">
-    <po-input
-      class="po-md-6"
-      name="literals"
-      [(ngModel)]="literals"
-      p-help='Ex.: {"noData": "Sem dados a serem exibidos", "placeholderSearch": "Buscar"}'
-      p-label="Literals"
-      (p-change)="changeLiterals()"
-    >
-    </po-input>
+  <po-input
+    class="po-md-6"
+    name="placeholderSearch"
+    [(ngModel)]="placeholderSearch"
+    p-clean
+    p-label="Placeholder Search"
+  >
+  </po-input>
 
-    <po-input
-      class="po-md-6"
-      name="fieldErrorMessage"
-      [(ngModel)]="fieldErrorMessage"
-      p-clean
-      p-label="Field Error Message"
-    >
-    </po-input>
-  </div>
+  <po-input
+    class="po-md-6"
+    name="fieldErrorMessage"
+    [(ngModel)]="fieldErrorMessage"
+    p-clean
+    p-label="Field Error Message"
+  >
+  </po-input>
 
-  <div class="po-row">
-    <po-input
-      class="po-md-12"
-      name="filterService"
-      [(ngModel)]="filterService"
-      p-clean
-      p-help="https://po-sample-api.onrender.com/v1/heroes"
-      p-label="Filter Service"
-    >
-    </po-input>
-  </div>
+  <po-input
+    class="po-md-12 po-lg-6"
+    name="literals"
+    [(ngModel)]="literals"
+    p-help='Ex.: {"noData": "Sem dados a serem exibidos", "placeholderSearch": "Buscar"}'
+    p-label="Literals"
+    (p-change)="changeLiterals()"
+  >
+  </po-input>
 
-  <div class="po-row">
-    <po-input class="po-md-6" name="fieldValue" [(ngModel)]="fieldValue" p-clean p-label="Field Value"> </po-input>
+  <po-input
+    class="po-md-12"
+    name="filterService"
+    [(ngModel)]="filterService"
+    p-clean
+    p-help="https://po-sample-api.onrender.com/v1/heroes"
+    p-label="Filter Service"
+  >
+  </po-input>
 
-    <po-input class="po-md-6" name="fieldLabel" [(ngModel)]="fieldLabel" p-clean p-label="Field Label"> </po-input>
-  </div>
+  <po-input class="po-md-6" name="fieldValue" [(ngModel)]="fieldValue" p-clean p-label="Field Value"> </po-input>
 
-  <div class="po-row">
-    <po-checkbox-group
-      class="po-md-7"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="3"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
+  <po-input class="po-md-6" name="fieldLabel" [(ngModel)]="fieldLabel" p-clean p-label="Field Label"> </po-input>
 
-    <po-radio-group
-      class="po-md-5"
-      name="filterMode"
-      [(ngModel)]="filterMode"
-      p-columns="3"
-      p-label="Filter mode"
-      [p-disabled]="properties.includes('hideSearch')"
-      [p-options]="filterModeOptions"
-    >
-    </po-radio-group>
-  </div>
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+
+  <po-radio-group
+    class="po-md-12"
+    name="filterMode"
+    [(ngModel)]="filterMode"
+    p-columns="4"
+    p-label="Filter mode"
+    [p-disabled]="properties.includes('hideSearch')"
+    [p-options]="filterModeOptions"
+  >
+  </po-radio-group>
 
   <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
@@ -13,6 +13,7 @@ import {
   standalone: false
 })
 export class SamplePoMultiselectLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   customLiterals: PoMultiselectLiterals;
   event: string;
   filterMode: string;
@@ -70,6 +71,7 @@ export class SamplePoMultiselectLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.customLiterals = undefined;
     this.help = '';
     this.filterMode = undefined;

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
@@ -46,11 +46,15 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
     [p-error-limit]="errorLimit"
     [p-error-pattern]="getErrorPatternMessage()"
-    [p-append-in-body]="errorAppendBox"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   >
   </po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.html
@@ -2,6 +2,7 @@
   class="po-md-12"
   name="PO number"
   [(ngModel)]="number"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-clean]="properties.includes('clean')"
   [p-disabled]="properties.includes('disabled')"
   [p-error-pattern]="messageErrorPattern"
@@ -37,57 +38,54 @@
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
 
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
 
-    <po-input
-      class="po-md-6"
-      name="messageErrorPattern"
-      [(ngModel)]="messageErrorPattern"
-      p-clean
-      p-label="Message error pattern"
-    >
-    </po-input>
-  </div>
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
 
-  <div class="po-row">
-    <po-number class="po-md-6 po-lg-3" name="min" [(ngModel)]="min" p-clean p-label="Min"> </po-number>
+  <po-input
+    class="po-md-6"
+    name="messageErrorPattern"
+    [(ngModel)]="messageErrorPattern"
+    p-clean
+    p-label="Message error pattern"
+  >
+  </po-input>
 
-    <po-number class="po-md-6 po-lg-3" name="minlength" [(ngModel)]="minlength" p-clean p-label="Minlength">
-    </po-number>
+  <po-number class="po-md-6 po-lg-3" name="min" [(ngModel)]="min" p-clean p-label="Min"> </po-number>
 
-    <po-number class="po-md-6 po-lg-3" name="max" [(ngModel)]="max" p-clean p-label="Max"> </po-number>
+  <po-number class="po-md-6 po-lg-3" name="minlength" [(ngModel)]="minlength" p-clean p-label="Minlength"> </po-number>
 
-    <po-number class="po-md-6 po-lg-3" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Maxlength">
-    </po-number>
-  </div>
+  <po-number class="po-md-6 po-lg-3" name="max" [(ngModel)]="max" p-clean p-label="Max"> </po-number>
 
-  <div class="po-row">
-    <po-number class="po-md-6" name="step" [(ngModel)]="step" p-clean p-label="Step"> </po-number>
+  <po-number class="po-md-6 po-lg-3" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Maxlength"> </po-number>
 
-    <po-select class="po-lg-6" name="icon" [(ngModel)]="icon" p-clean p-label="Icon" [p-options]="iconOptions">
-    </po-select>
-  </div>
+  <po-number class="po-md-6 po-lg-3" name="step" [(ngModel)]="step" p-clean p-label="Step"> </po-number>
 
-  <div class="po-row">
-    <po-checkbox-group
-      class="po-md-6"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="3"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
+  <po-select class="po-md-6 po-lg-3" name="icon" [(ngModel)]="icon" p-clean p-label="Icon" [p-options]="iconOptions">
+  </po-select>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
 
   <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption, PoSelectOption } from '@po-ui/ng-components';
   standalone: false
 })
 export class SamplePoNumberLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   event: string;
   messageErrorPattern: string;
   help: string;
@@ -49,6 +50,7 @@ export class SamplePoNumberLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.number = undefined;
     this.max = undefined;
     this.maxlength = undefined;

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.html
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.html
@@ -56,10 +56,14 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
     [p-help]="help"
     [p-disabled]="disabled"
-    [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
+    [p-error-pattern]="getErrorPattern()"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   >
   </po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.html
@@ -1,6 +1,7 @@
 <po-password
   name="password"
   [(ngModel)]="password"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-clean]="properties.includes('clean')"
   [p-disabled]="properties.includes('disabled')"
   [p-error-pattern]="errorPattern"
@@ -36,50 +37,48 @@
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
 
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
 
-    <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern">
-    </po-input>
-  </div>
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
 
-  <div class="po-row">
-    <po-input
-      class="po-md-12"
-      name="pattern"
-      [(ngModel)]="pattern"
-      p-clean
-      p-help="Ex.: '[a-zA]{5}[Z0-9]{3}'"
-      p-label="Pattern (Regex)"
-    >
-    </po-input>
-  </div>
+  <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern"> </po-input>
 
-  <div class="po-row">
-    <po-number class="po-md-6" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
+  <po-input
+    class="po-md-6"
+    name="pattern"
+    [(ngModel)]="pattern"
+    p-clean
+    p-help="Ex.: '[a-zA]{5}[Z0-9]{3}'"
+    p-label="Pattern (Regex)"
+  >
+  </po-input>
 
-    <po-number class="po-md-6" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
-  </div>
+  <po-number class="po-md-6 po-lg-3" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
 
-  <div class="po-row">
-    <po-checkbox-group
-      class="po-md-12"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="4"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
+  <po-number class="po-md-6 po-lg-3" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
 
   <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption } from '@po-ui/ng-components';
   standalone: false
 })
 export class SamplePoPasswordLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   errorPattern: string;
   event: string;
   help: string;
@@ -42,6 +43,7 @@ export class SamplePoPasswordLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.errorPattern = undefined;
     this.event = undefined;
     this.help = undefined;

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
@@ -60,6 +60,35 @@ const poRadioGroupColumnsTotalLength: number = 12;
 
 @Directive()
 export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor, Validator {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) será incluído no body da página e não
+   * dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou overflow
+   * escondido, garantindo o posicionamento correto do tooltip próximo ao elemento.
+   *
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
   /**
    * @optional
    *
@@ -102,6 +131,15 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
    *
    */
   @Input('p-field-error-message') fieldErrorMessage: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.html
@@ -1,6 +1,5 @@
 <po-field-container
   [p-disabled]="disabled"
-  [p-help]="help"
   [p-label]="label"
   [p-optional]="optional"
   [p-required]="required"
@@ -24,9 +23,16 @@
         </po-radio>
       </div>
     </div>
+
+    <po-field-container-bottom
+      [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+      [p-append-in-body]="appendBox"
+      [p-disabled]="disabled"
+      [p-error-limit]="errorLimit"
+      [p-error-pattern]="getErrorPattern()"
+      [p-help]="help"
+      [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+      (p-additional-help)="emitAdditionalHelp()"
+    ></po-field-container-bottom>
   </div>
-  <po-field-container-bottom
-    [p-error-pattern]="getErrorPattern()"
-    [p-error-limit]="errorLimit"
-  ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
@@ -145,6 +145,26 @@ describe('PoRadioGroupComponent:', () => {
       });
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
     describe('focus:', () => {
       it('should call `focus` of radio', () => {
         component.options = [
@@ -208,6 +228,35 @@ describe('PoRadioGroupComponent:', () => {
         component.focus();
 
         expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
       });
     });
 

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
@@ -100,6 +100,12 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
     this.cd.markForCheck();
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
   eventClick(value: any, disabled: any) {
     if (!disabled) {
       this.onTouched?.();
@@ -134,6 +140,10 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
     }
   }
 
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
+  }
+
   getElementByValue(value) {
     return this.inputEl.nativeElement.querySelector(`input[value='${value}']`);
   }
@@ -154,6 +164,17 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
     if (this.isArrowKey(key)) {
       this.changeValue(value);
     }
+  }
+
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 
   private isArrowKey(key: number) {

--- a/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.html
@@ -1,6 +1,7 @@
 <po-radio-group
   name="radioGroupLabs"
   [(ngModel)]="radioGroup"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-columns]="columns"
   [p-disabled]="properties.includes('disabled')"
   [p-help]="help"
@@ -52,48 +53,59 @@
 <hr />
 
 <form #propertiesForm="ngForm">
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="fieldErrorMessage"
+    [(ngModel)]="fieldErrorMessage"
+    p-clean
+    p-label="Field Error Message"
+  >
+  </po-input>
+
+  <po-radio-group
+    class="po-md-12"
+    name="columns"
+    [(ngModel)]="columns"
+    p-columns="4"
+    p-label="Columns"
+    [p-options]="columnOptions"
+  >
+  </po-radio-group>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+  <po-radio-group
+    class="po-md-12"
+    name="size"
+    [(ngModel)]="size"
+    p-columns="4"
+    p-label="Size"
+    [p-options]="sizesOptions"
+  >
+  </po-radio-group>
+
   <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
-
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-radio-group
-      class="po-lg-6 po-md-12"
-      name="columns"
-      [(ngModel)]="columns"
-      p-columns="3"
-      p-label="Columns"
-      [p-options]="columnOptions"
-    >
-    </po-radio-group>
-
-    <po-checkbox-group
-      class="po-lg-6 po-md-12"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="3"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
-  <div class="po-row">
-    <po-radio-group class="po-lg-6 po-md-12" name="size" [(ngModel)]="size" p-label="Size" [p-options]="sizesOptions">
-    </po-radio-group>
-
-    <po-input
-      class="po-md-6"
-      name="fieldErrorMessage"
-      [(ngModel)]="fieldErrorMessage"
-      p-clean
-      p-label="Field Error Message"
-    >
-    </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (click)="propertiesForm.reset(); restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (click)="propertiesForm.reset(); restore()">
+    </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption, PoRadioGroupOption } from '@po-ui/ng-components'
   standalone: false
 })
 export class SamplePoRadioGroupLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   columns: number;
   event: string;
   help: string;
@@ -53,11 +54,12 @@ export class SamplePoRadioGroupLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.event = '';
     this.radioGroup = undefined;
     this.properties = [];
     this.fieldErrorMessage = '';
-
+    this.size = 'medium';
     this.option = this.getNewOption();
     this.options = [];
   }

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
@@ -21,6 +21,32 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
    * @optional
    *
    * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) será incluído no body da página e não
+   * dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou overflow
+   * escondido, garantindo o posicionamento correto do tooltip próximo ao elemento.
+   *
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
    *
    * Aplica foco no elemento ao ser iniciado.
    *
@@ -130,6 +156,15 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
   get hideToolbarActions(): Array<PoRichTextToolbarActions> {
     return this._hideToolbarActions;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
@@ -28,8 +28,13 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="additionalHelp.observed ? null : additionalHelpTooltip"
+    [p-append-in-body]="appendBox"
     [p-help]="help"
-    [p-error-pattern]="errorMsg"
     [p-error-limit]="errorLimit"
+    [p-error-pattern]="errorMsg"
+    [p-show-additional-help-icon]="!!additionalHelpTooltip || additionalHelp.observed"
+    (p-additional-help)="additionalHelp.emit()"
   ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
@@ -1,6 +1,7 @@
 <po-rich-text
   name="richText"
   [(ngModel)]="richText"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-error-message]="errorMessage"
   [p-height]="height"
   [p-help]="help"
@@ -20,7 +21,8 @@
 <po-divider></po-divider>
 
 <div class="po-row">
-  <po-textarea class="po-md-6" name="model" [(ngModel)]="richText" p-label="Model" p-readonly p-rows="8"> </po-textarea>
+  <po-textarea class="po-lg-6 po-md-12" name="model" [(ngModel)]="richText" p-label="Model" p-readonly p-rows="8">
+  </po-textarea>
 
   <po-info class="po-md-6" p-label="Event" [p-value]="event"> </po-info>
 </div>
@@ -28,44 +30,46 @@
 <po-divider p-label="Properties"></po-divider>
 
 <form #f="ngForm">
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+
+  <po-input class="po-md-6" name="errorMessage" [(ngModel)]="errorMessage" p-clean p-label="Error Message"> </po-input>
+
+  <po-number class="po-md-6 po-lg-3" name="height" [(ngModel)]="height" p-label="Height"> </po-number>
+
+  <po-multiselect
+    class="po-md-6 po-lg-3"
+    name="multiselect"
+    p-label="Hide Toolbar Actions "
+    [p-options]="toolbarHideActionsOptions"
+    [(ngModel)]="toolbarHideActions"
+    p-placeholder="color"
+  >
+  </po-multiselect>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+
   <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
-
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
-
-    <po-input class="po-md-6" name="errorMessage" [(ngModel)]="errorMessage" p-clean p-label="Error Message">
-    </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-number class="po-md-1" name="height" [(ngModel)]="height" p-label="Height"> </po-number>
-
-    <po-checkbox-group
-      class="po-md-5"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="4"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-
-    <po-multiselect
-      class="po-md-6"
-      name="multiselect"
-      p-label="Hide Toolbar Actions "
-      [p-options]="toolbarHideActionsOptions"
-      [(ngModel)]="toolbarHideActions"
-      p-placeholder="color"
-    >
-    </po-multiselect>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption, PoMultiselectOption, PoRichTextToolbarActions } 
   standalone: false
 })
 export class SamplePoRichTextLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   errorMessage: string;
   event: string;
   help: string;
@@ -16,7 +17,6 @@ export class SamplePoRichTextLabsComponent implements OnInit {
   placeholder: string;
   properties: Array<string>;
   richText: string;
-
   toolbarHideActions = [PoRichTextToolbarActions.Link];
 
   public readonly toolbarHideActionsOptions: Array<PoMultiselectOption> = [
@@ -45,6 +45,7 @@ export class SamplePoRichTextLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.errorMessage = '';
     this.help = '';
     this.label = '';

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
@@ -53,10 +53,14 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
-    [p-append-in-body]="errorAppendBox"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.html
@@ -2,6 +2,7 @@
   class="po-md-12"
   name="select"
   [(ngModel)]="select"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-disabled]="properties.includes('disabled')"
   [p-help]="help"
   [p-label]="label"
@@ -35,7 +36,7 @@
 
   <div class="po-row">
     <po-switch
-      class="po-md-2"
+      class="po-lg-2 po-md-12"
       name="selectOptionGroupSwitch"
       (p-change)="restoreSwitch($event)"
       [(ngModel)]="selectOptionGroupSwitch"
@@ -44,7 +45,7 @@
     </po-switch>
 
     <po-select
-      class="po-md-5"
+      class="po-lg-4 po-md-6"
       name="selectedsOptionsGroup"
       [(ngModel)]="selectedOptionsGroup"
       p-label="Options group list"
@@ -55,7 +56,7 @@
     </po-select>
 
     <po-input
-      class="po-md-5"
+      class="po-lg-4 po-md-6"
       name="optionsGroup"
       [(ngModel)]="optionsGroup"
       p-label="New Options Group"
@@ -75,7 +76,7 @@
   </div>
 
   <div class="po-row">
-    <po-button class="po-md-6 po-lg-3" p-label="Add Option" [p-disabled]="fOption.invalid" (p-click)="addOption()">
+    <po-button class="po-lg-3 po-md-4" p-label="Add Option" [p-disabled]="fOption.invalid" (p-click)="addOption()">
     </po-button>
   </div>
 </form>
@@ -83,38 +84,42 @@
 <hr />
 
 <form #f="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-label="Label"> </po-input>
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-label="Label"> </po-input>
 
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-label="Help"> </po-input>
-  </div>
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-label="Placeholder"> </po-input>
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-label="Help"> </po-input>
 
-    <po-input
-      class="po-md-6"
-      name="fieldErrorMessage"
-      [(ngModel)]="fieldErrorMessage"
-      p-clean
-      p-label="Field Error Message"
-    >
-    </po-input>
-  </div>
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-label="Placeholder"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="fieldErrorMessage"
+    [(ngModel)]="fieldErrorMessage"
+    p-clean
+    p-label="Field Error Message"
+  >
+  </po-input>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
 
   <div class="po-row">
-    <po-checkbox-group
-      class="po-md-12"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="4"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
-
-  <div class="po-row">
-    <div class="po-md-3">
+    <div class="po-lg-3 po-md-6">
       <po-button p-label="Sample Restore" (p-click)="restore()"> </po-button>
     </div>
   </div>

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption, PoSelectOption, PoSelectOptionGroup } from '@po-
   standalone: false
 })
 export class SamplePoSelectLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   event: string;
   help: string;
   label: string;
@@ -52,6 +53,7 @@ export class SamplePoSelectLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.event = '';
     this.help = undefined;
     this.label = undefined;

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
@@ -31,5 +31,12 @@
     </div>
   </div>
 
-  <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
+  <po-field-container-bottom
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
+    [p-help]="help"
+    [p-disabled]="disabled"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
+  ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.html
@@ -1,6 +1,7 @@
 <po-switch
   name="switch"
   [(ngModel)]="switch"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-disabled]="properties.includes('disabled')"
   [p-help]="help"
   [p-label]="label"
@@ -16,61 +17,65 @@
 <hr />
 
 <div class="po-row">
-  <po-info class="po-lg-6" p-label="Model" [p-value]="switch"> </po-info>
+  <po-info class="po-md-6" p-label="Model" [p-value]="switch"> </po-info>
 
-  <po-info class="po-lg-6" p-label="Event" [p-value]="event"> </po-info>
+  <po-info class="po-md-6" p-label="Event" [p-value]="event"> </po-info>
 </div>
 
 <hr />
 
 <form #f="ngForm">
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-label="Label"> </po-input>
+
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-label="Help"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="labelOff"
+    [(ngModel)]="labelOff"
+    p-help="Text displayed when PO Switch is set to 'false'"
+    p-label="Label Off"
+  >
+  </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="labelOn"
+    [(ngModel)]="labelOn"
+    p-help="Text displayed when PO Switch is set to 'true'"
+    p-label="Label On"
+  >
+  </po-input>
+
+  <po-checkbox-group
+    class="po-lg-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+
+  <po-radio-group
+    class="po-lg-6"
+    name="labelPosition"
+    [(ngModel)]="labelPosition"
+    p-label="Label Position"
+    [p-options]="labelPositionOptions"
+  >
+  </po-radio-group>
+
   <div class="po-row">
-    <po-input class="po-lg-6" name="label" [(ngModel)]="label" p-label="Label"> </po-input>
-
-    <po-input class="po-lg-6" name="help" [(ngModel)]="help" p-label="Help"> </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-input
-      class="po-lg-6"
-      name="labelOff"
-      [(ngModel)]="labelOff"
-      p-help="Text displayed when PO Switch is set to 'false'"
-      p-label="Label Off"
-    >
-    </po-input>
-
-    <po-input
-      class="po-lg-6"
-      name="labelOn"
-      [(ngModel)]="labelOn"
-      p-help="Text displayed when PO Switch is set to 'true'"
-      p-label="Label On"
-    >
-    </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-radio-group
-      class="po-lg-6"
-      name="labelPosition"
-      [(ngModel)]="labelPosition"
-      p-label="Label Position"
-      [p-options]="labelPositionOptions"
-    >
-    </po-radio-group>
-
-    <po-checkbox-group
-      class="po-lg-6"
-      name="properties"
-      [(ngModel)]="properties"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption, PoRadioGroupOption, PoSwitchLabelPosition } from
   standalone: false
 })
 export class SamplePoSwitchLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   event: string;
   help: string;
   label: string;
@@ -37,6 +38,7 @@ export class SamplePoSwitchLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.event = '';
     this.help = undefined;
     this.label = undefined;

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -34,6 +34,35 @@ import { maxlengpoailed, minlengpoailed, requiredFailed } from '../validators';
  */
 @Directive()
 export abstract class PoTextareaBaseComponent implements ControlValueAccessor, Validator {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o tooltip (`p-additional-help-tooltip` e/ou `p-error-limit`) será incluído no body da página e não
+   * dentro do componente. Essa opção pode ser necessária em cenários com containers que possuem scroll ou overflow
+   * escondido, garantindo o posicionamento correto do tooltip próximo ao elemento.
+   *
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
   /**
    * @optional
    *
@@ -82,6 +111,15 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
    *
    */
   @Input('p-field-error-message') fieldErrorMessage: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.html
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.html
@@ -24,9 +24,14 @@
   </div>
 
   <po-field-container-bottom
+    *ngIf="!readonly"
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
@@ -157,6 +157,26 @@ describe('PoTextareaComponent:', () => {
       });
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
     it('focus: should call `focus` of textarea', () => {
       component.inputEl = {
         nativeElement: {
@@ -184,6 +204,35 @@ describe('PoTextareaComponent:', () => {
       component.focus();
 
       expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
+      });
     });
 
     it('writeValueModel: should call change if value exists', () => {
@@ -248,6 +297,27 @@ describe('PoTextareaComponent:', () => {
         component.fieldErrorMessage = undefined;
         expect(component.getErrorPattern()).toBe('');
       });
+    });
+  });
+
+  describe('isAdditionalHelpEventTriggered:', () => {
+    it('should return true when additionalHelpEventTrigger is "event"', () => {
+      component.additionalHelpEventTrigger = 'event';
+      expect((component as any).isAdditionalHelpEventTriggered()).toBeTrue();
+    });
+
+    it('should return true when additionalHelpEventTrigger is undefined and additionalHelp is observed', () => {
+      component.additionalHelpEventTrigger = undefined;
+      component.additionalHelp = {
+        observed: true
+      } as any;
+
+      expect((component as any).isAdditionalHelpEventTriggered()).toBeTrue();
+    });
+
+    it('should return false when additionalHelpEventTrigger is not "event" and additionalHelp is not observed', () => {
+      component.additionalHelpEventTrigger = 'noEvent';
+      expect((component as any).isAdditionalHelpEventTriggered()).toBeFalse();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
@@ -71,6 +71,12 @@ export class PoTextareaComponent extends PoTextareaBaseComponent implements Afte
     super(cd);
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
   /**
    * Função que atribui foco ao componente.
    *
@@ -98,6 +104,10 @@ export class PoTextareaComponent extends PoTextareaBaseComponent implements Afte
     if (this.autoFocus) {
       this.focus();
     }
+  }
+
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
   }
 
   getErrorPattern() {
@@ -160,5 +170,16 @@ export class PoTextareaComponent extends PoTextareaBaseComponent implements Afte
     if (elementValue !== this.valueBeforeChange) {
       this.change.emit(elementValue);
     }
+  }
+
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.html
@@ -1,6 +1,7 @@
 <po-textarea
   name="textarea"
   [(ngModel)]="textarea"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-disabled]="properties.includes('disabled')"
   [p-help]="help"
   [p-label]="label"
@@ -32,46 +33,47 @@
 <hr />
 
 <form #f="ngForm">
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="fieldErrorMessage"
+    [(ngModel)]="fieldErrorMessage"
+    p-clean
+    p-label="Field Error Message"
+  >
+  </po-input>
+
+  <po-number class="po-md-6 po-lg-3" name="rows" [(ngModel)]="rows" p-clean p-label="Rows" p-min="3"> </po-number>
+
+  <po-number class="po-md-6 po-lg-3" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
+
+  <po-number class="po-md-6 po-lg-3" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+
   <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
-
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
-
-    <po-number class="po-md-6" name="rows" [(ngModel)]="rows" p-clean p-label="Rows" p-min="3"> </po-number>
-  </div>
-
-  <div class="po-row">
-    <po-number class="po-md-6" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
-
-    <po-number class="po-md-6" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
-  </div>
-
-  <div class="po-row">
-    <po-input
-      class="po-md-6"
-      name="fieldErrorMessage"
-      [(ngModel)]="fieldErrorMessage"
-      p-clean
-      p-label="Field Error Message"
-    >
-    </po-input>
-
-    <po-checkbox-group
-      class="po-md-6"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="4"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption } from '@po-ui/ng-components';
   standalone: false
 })
 export class SamplePoTextareaLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   event: string;
   help: string;
   label: string;
@@ -37,6 +38,7 @@ export class SamplePoTextareaLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.textarea = undefined;
     this.label = undefined;
     this.help = undefined;

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -141,6 +141,35 @@ const poUploadMinFileSize = 0;
  */
 @Directive()
 export abstract class PoUploadBaseComponent implements ControlValueAccessor, Validator {
+  // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
+  @Input() additionalHelpEventTrigger: string | undefined;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
+   * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
+   * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
+   * > Requer um recuo mínimo de 8px se o componente estiver próximo à lateral da tela.
+   */
+  @Input('p-additional-help-tooltip') additionalHelpTooltip?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define que o tooltip (`p-additional-help-tooltip`) será incluído no body da página e não dentro do componente. Essa
+   * opção pode ser necessária em cenários com containers que possuem scroll ou overflow escondido, garantindo o
+   * posicionamento correto do tooltip próximo ao elemento.
+   *
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   *
+   * @default `false`
+   */
+  @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
   /**
    * @optional
    *
@@ -239,6 +268,15 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
   @HostBinding('attr.p-required-url')
   @Input({ alias: 'p-required-url', transform: convertToBoolean })
   requiredUrl: boolean = true;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
@@ -90,5 +90,12 @@
       ></po-button>
     </div>
   </div>
-  <po-field-container-bottom [p-help]="help" [p-disabled]="disabled"></po-field-container-bottom>
+  <po-field-container-bottom
+    [p-additional-help-tooltip]="getAdditionalHelpTooltip()"
+    [p-append-in-body]="appendBox"
+    [p-help]="help"
+    [p-disabled]="disabled"
+    [p-show-additional-help-icon]="showAdditionalHelpIcon()"
+    (p-additional-help)="emitAdditionalHelp()"
+  ></po-field-container-bottom>
 </po-field-container>

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
@@ -431,6 +431,26 @@ describe('PoUploadComponent:', () => {
       expect(component['cleanInputValue']).toHaveBeenCalled();
     });
 
+    describe('emitAdditionalHelp:', () => {
+      it('should emit additionalHelp when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit additionalHelp when isAdditionalHelpEventTriggered returns false', () => {
+        spyOn(component.additionalHelp, 'emit');
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        component.emitAdditionalHelp();
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+      });
+    });
+
     describe('focus:', () => {
       it('should call `uploadButton.focus` if `uploadButton` is defined', () => {
         component.hideSelectButton = false;
@@ -496,6 +516,35 @@ describe('PoUploadComponent:', () => {
         component.focus();
 
         expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getAdditionalHelpTooltip:', () => {
+      it('should return null when isAdditionalHelpEventTriggered returns true', () => {
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(true);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeNull();
+      });
+
+      it('should return additionalHelpTooltip when isAdditionalHelpEventTriggered returns false', () => {
+        const tooltip = 'Test Tooltip';
+        component.additionalHelpTooltip = tooltip;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBe(tooltip);
+      });
+
+      it('should return undefined when additionalHelpTooltip is undefined and isAdditionalHelpEventTriggered returns false', () => {
+        component.additionalHelpTooltip = undefined;
+        spyOn(component as any, 'isAdditionalHelpEventTriggered').and.returnValue(false);
+
+        const result = component.getAdditionalHelpTooltip();
+
+        expect(result).toBeUndefined();
       });
     });
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
@@ -191,6 +191,12 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
     this.cleanInputValue();
   }
 
+  emitAdditionalHelp() {
+    if (this.isAdditionalHelpEventTriggered()) {
+      this.additionalHelp.emit();
+    }
+  }
+
   /**
    * Função que atribui foco ao componente.
    *
@@ -219,6 +225,10 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
         this.poUploadDragDropComponent.focus();
       }
     }
+  }
+
+  getAdditionalHelpTooltip() {
+    return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
   }
 
   // Verifica se existe algum arquivo sendo enviado ao serviço.
@@ -306,6 +316,10 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
     }
   }
 
+  showAdditionalHelpIcon() {
+    return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
   // Caso o componente estiver no modo AutoUpload, o arquivo também será removido da lista.
   stopUpload(file: PoUploadFile) {
     this.uploadService.stopRequestByFile(file, () => {
@@ -357,6 +371,13 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
     this.calledByCleanInputValue = true;
     this.inputFile.nativeElement.value = '';
     this.cd.detectChanges();
+  }
+
+  private isAdditionalHelpEventTriggered(): boolean {
+    return (
+      this.additionalHelpEventTrigger === 'event' ||
+      (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
+    );
   }
 
   // função disparada na resposta do sucesso ou error

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
@@ -1,6 +1,7 @@
 <po-upload
   name="upload"
   [(ngModel)]="upload"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-auto-upload]="properties.includes('autoupload')"
   [p-directory]="properties.includes('directory')"
   [p-disabled]="properties.includes('disabled')"
@@ -40,13 +41,13 @@
 
 <hr />
 
-<form #fRestrictions="ngForm">
-  <div class="po-row">
+<div class="po-row">
+  <form #fRestrictions="ngForm">
     <po-input
       class="po-md-6"
       name="allowedExtensions"
       [(ngModel)]="allowedExtensions"
-      p-help="Enter the allowed extensions separated by comma"
+      p-help="Digite as extensões permitidas separadas por vírgula"
       p-label="Allowed Extensions"
       p-placeholder=".png, .jpeg, .jpg"
       (p-change)="onChangeExtension()"
@@ -54,71 +55,70 @@
     </po-input>
 
     <po-number
-      class="po-md-6"
+      class="po-md-6 po-lg-3"
       name="maxFiles"
       [(ngModel)]="maxFiles"
       p-clean
-      p-help="Requires that the 'p-multiple' property be enabled"
+      p-help="Requer p-multiple habilitado"
       p-label="Max Files"
       (p-change)="onChangeMaxFiles(maxFiles)"
     >
     </po-number>
-  </div>
 
-  <div class="po-row">
     <po-number
-      class="po-md-4"
+      class="po-md-6 po-lg-3"
       name="dragDropHeight"
       [(ngModel)]="dragDropHeight"
       p-clean
-      p-help="Height of drag drop area"
+      p-help="Altura da área de arrastar e soltar"
       p-label="Drag Drop Height"
       p-min="160"
     >
     </po-number>
 
     <po-number
-      class="po-md-4"
+      class="po-md-6 po-lg-3"
       name="minSize"
       [(ngModel)]="minSize"
       p-clean
-      p-help="In megabytes"
+      p-help="Em megabytes"
       p-label="Min File Size"
       (p-change)="onChangeMinSize(minSize)"
     >
     </po-number>
 
     <po-number
-      class="po-md-4"
+      class="po-md-6 po-lg-3"
       name="maxSize"
       [(ngModel)]="maxSize"
       p-clean
-      p-help="In megabytes"
+      p-help="Em megabytes"
       p-label="Max File Size"
       (p-change)="onChangeMaxSize(maxSize)"
     >
     </po-number>
-  </div>
-</form>
 
-<hr />
+    <hr />
 
-<form #f="ngForm">
-  <div class="po-row">
     <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
 
     <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
 
-  <div class="po-row">
-    <po-input class="po-md-6" name="formField" [(ngModel)]="formField" p-clean p-label="Form Field"> </po-input>
-
-    <po-input class="po-md-6" name="url" [(ngModel)]="url" p-clean p-label="URL" p-required> </po-input>
-  </div>
-
-  <div class="po-row">
     <po-input
       class="po-md-6"
+      name="additionalHelpTooltip"
+      [(ngModel)]="additionalHelpTooltip"
+      p-clean
+      p-label="Additional Help Tooltip"
+    >
+    </po-input>
+
+    <po-input class="po-md-6" name="formField" [(ngModel)]="formField" p-clean p-label="Form Field"> </po-input>
+
+    <po-input class="po-md-12 po-lg-6" name="url" [(ngModel)]="url" p-clean p-label="URL" p-required> </po-input>
+
+    <po-input
+      class="po-md-12 po-lg-6"
       name="headers"
       [(ngModel)]="headersLabs"
       p-help='Ex.: {"Authorization": "12312414"}'
@@ -128,7 +128,7 @@
     </po-input>
 
     <po-input
-      class="po-md-6"
+      class="po-md-12 po-lg-6"
       name="literals"
       [(ngModel)]="literals"
       p-help='Ex.: {"selectFile": "Select file", "deleteFile": "Delete file", "cancel": "Cancel sending"}'
@@ -147,21 +147,21 @@
       [p-options]="propertiesOptions"
     >
     </po-checkbox-group>
-  </div>
 
-  <div *ngIf="properties.includes('showCustomAction')">
-    <po-widget p-title="Action Button">
-      <form [formGroup]="actionForm" class="po-row">
-        <po-input class="po-sm-6 po-md-4" formControlName="label" p-label="Label" />
-        <po-select class="po-sm-6 po-md-2" formControlName="icon" p-label="Icon" [p-options]="iconOptions" />
-        <po-select class="po-sm-6 po-md-2" formControlName="type" p-label="Type" [p-options]="typeOptions" />
-        <po-switch class="po-sm-6 po-md-2" formControlName="disabled" p-label="Disabled" />
-        <po-switch class="po-sm-6 po-md-2" formControlName="visible" p-label="Visible" />
-      </form>
-    </po-widget>
-  </div>
+    <div *ngIf="properties.includes('showCustomAction')">
+      <po-widget p-title="Action Button">
+        <form [formGroup]="actionForm" class="po-row">
+          <po-input class="po-sm-6 po-md-4" formControlName="label" p-label="Label" />
+          <po-select class="po-sm-6 po-md-2" formControlName="icon" p-label="Icon" [p-options]="iconOptions" />
+          <po-select class="po-sm-6 po-md-2" formControlName="type" p-label="Type" [p-options]="typeOptions" />
+          <po-switch class="po-sm-6 po-md-2" formControlName="disabled" p-label="Disabled" />
+          <po-switch class="po-sm-6 po-md-2" formControlName="visible" p-label="Visible" />
+        </form>
+      </po-widget>
+    </div>
 
-  <div class="po-row po-mt-1">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
-  </div>
-</form>
+    <div class="po-row po-mt-1">
+      <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    </div>
+  </form>
+</div>

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
@@ -15,6 +15,7 @@ import {
   standalone: false
 })
 export class SamplePoUploadLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   allowedExtensions: string;
   customLiterals: PoUploadLiterals;
   dragDropHeight: number;
@@ -126,6 +127,7 @@ export class SamplePoUploadLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.allowedExtensions = undefined;
     this.customLiterals = undefined;
     this.dragDropHeight = undefined;

--- a/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.html
@@ -1,6 +1,7 @@
 <po-url
   name="url"
   [(ngModel)]="url"
+  [p-additional-help-tooltip]="additionalHelpTooltip"
   [p-clean]="properties.includes('clean')"
   [p-disabled]="properties.includes('disabled')"
   [p-error-pattern]="errorPattern"
@@ -34,38 +35,38 @@
 <hr />
 
 <form #f="ngForm">
+  <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
+
+  <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
+
+  <po-input
+    class="po-md-6"
+    name="additionalHelpTooltip"
+    [(ngModel)]="additionalHelpTooltip"
+    p-clean
+    p-label="Additional Help Tooltip"
+  >
+  </po-input>
+
+  <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
+
+  <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern"> </po-input>
+
+  <po-number class="po-md-6 po-lg-3" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
+
+  <po-number class="po-md-6 po-lg-3" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="properties"
+    [(ngModel)]="properties"
+    p-columns="4"
+    p-label="Properties"
+    [p-options]="propertiesOptions"
+  >
+  </po-checkbox-group>
+
   <div class="po-row">
-    <po-input class="po-md-6" name="label" [(ngModel)]="label" p-clean p-label="Label"> </po-input>
-
-    <po-input class="po-md-6" name="help" [(ngModel)]="help" p-clean p-label="Help"> </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-input class="po-md-6" name="placeholder" [(ngModel)]="placeholder" p-clean p-label="Placeholder"> </po-input>
-
-    <po-input class="po-md-6" name="errorPattern" [(ngModel)]="errorPattern" p-clean p-label="Error Pattern">
-    </po-input>
-  </div>
-
-  <div class="po-row">
-    <po-number class="po-md-6" name="minlength" [(ngModel)]="minlength" p-clean p-label="Min Length"> </po-number>
-
-    <po-number class="po-md-6" name="maxlength" [(ngModel)]="maxlength" p-clean p-label="Max Length"> </po-number>
-  </div>
-
-  <div class="po-row">
-    <po-checkbox-group
-      class="po-md-12"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="4"
-      p-label="Properties"
-      [p-options]="propertiesOptions"
-    >
-    </po-checkbox-group>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-md-3" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
   </div>
 </form>

--- a/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.ts
@@ -8,6 +8,7 @@ import { PoCheckboxGroupOption } from '@po-ui/ng-components';
   standalone: false
 })
 export class SamplePoUrlLabsComponent implements OnInit {
+  additionalHelpTooltip: string;
   errorPattern: string;
   event: string;
   help: string;
@@ -39,6 +40,7 @@ export class SamplePoUrlLabsComponent implements OnInit {
   }
 
   restore() {
+    this.additionalHelpTooltip = '';
     this.properties = [];
 
     this.label = undefined;
@@ -48,7 +50,6 @@ export class SamplePoUrlLabsComponent implements OnInit {
 
     this.minlength = undefined;
     this.maxlength = undefined;
-
     this.url = '';
     this.event = '';
   }


### PR DESCRIPTION
**DTHFUI-10443**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o novo comportamento?**
Implementa help adicional ao p-help, permitindo exibir um tooltip ou disparar um evento.

**Simulação**
Labs

**Custom:**
```
po-input po-field-container-bottom,
po-checkbox po-field-container-bottom,
po-checkbox-group po-field-container-bottom,
po-combo po-field-container-bottom,
po-datepicker po-field-container-bottom,
po-datepicker-range po-field-container-bottom,
po-lookup po-field-container-bottom,
po-multiselect po-field-container-bottom,
po-number po-field-container-bottom,
po-password po-field-container-bottom,
po-radio-group po-field-container-bottom,
po-rich-text po-field-container-bottom,
po-select po-field-container-bottom,
po-switch po-field-container-bottom,
po-textarea po-field-container-bottom,
po-upload po-field-container-bottom {
  /* Help text */
  --font-size: 20px;
  --line-height: 24px;
  --text-color-help: gold;

  /* Disabled */
  --text-color-help-disabled: blue;

  /* Error */
  --text-color-error: green;
  --color-icon-error: purple;
}
```