### PR TITLE
fix(accordion): ajusta tipo do botão para evitar envio de formulário

### DIFF
--- a/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.html
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.html
@@ -5,6 +5,7 @@
     [attr.aria-label]="label"
     [attr.aria-expanded]="expanded || false"
     class="po-accordion-item-header-button po-clickable"
+    type="button"
     (click)="onClick()"
   >
     <div class="po-accordion-item-header-button-content" [p-tooltip]="getTooltip()">

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.html
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.html
@@ -2,6 +2,7 @@
   <button
     #accordionHeaderButtonManagerElement
     class="po-accordion-manager-button po-clickable"
+    type="button"
     (click)="onClick()"
     [attr.aria-expanded]="expandedAllItems"
     [p-tooltip]="getTooltip()"

--- a/projects/ui/src/lib/components/po-accordion/samples/sample-po-accordion-labs/sample-po-accordion-labs.component.html
+++ b/projects/ui/src/lib/components/po-accordion/samples/sample-po-accordion-labs/sample-po-accordion-labs.component.html
@@ -43,7 +43,7 @@
   </po-radio-group>
   <po-checkbox-group
     class="po-md-6"
-    p-label="Propetie Accordion Item"
+    p-label="Properties Accordion Item"
     name="disabledItem"
     [p-options]="disabledOption"
     [(ngModel)]="disabledItem"


### PR DESCRIPTION
Alterado o tipo do botão dentro do componente accordion-item-body de submit para button, evitando que o formulário seja enviado ao pressionar a tecla Enter.
Essa alteração impede que o Accordion feche inesperadamente quando a tecla Enter é pressionada em campos de entrada.
fixes DTHFUI-10166

**Qual o comportamento atual?**
Ao pressionar a tecla Enter em um input que está dentro do componente accordion-item-body o Componente Accordion realiza o evento de fechar todos os itens.

**Qual o novo comportamento?**
A tecla Enter não dispara o envio do formulário, pois o botão foi alterado para o tipo button, mantendo os itens do Accordion abertos.

**Simulação**
Samples no portal.
[app_dthfui10166.zip](https://github.com/user-attachments/files/18430027/app_dthfui10166.zip)

