### PR TITLE
fix(dynamic-form): ajusta emissão de evento para p-validate

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -29,7 +29,7 @@ describe('PoDynamicFormFieldsComponent: ', () => {
 
     fixture = TestBed.createComponent(PoDynamicFormFieldsComponent);
     component = fixture.componentInstance;
-    component['form'] = <any>{ touched: true };
+    component['form'] = <any>{ dirty: true };
 
     fixture.detectChanges();
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -68,8 +68,8 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
       this.objectValue.emit(objectValue);
     }
 
-    // verifica se o formulario esta touched para não disparar o validate ao carregar a tela.
-    if ((this.form.touched || isBooleanType) && isChangedValueField) {
+    // verifica se o formulario esta dirty para não disparar o validate ao carregar a tela.
+    if ((this.form.dirty || isBooleanType) && isChangedValueField) {
       const { changedField, changedFieldIndex } = this.getField(property);
 
       if (changedField.validate) {


### PR DESCRIPTION
**PO-DYNAMIC-FORM**

**DTHFUI-10604**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Componentes po-lookup e po-datepicker-range não estão emitindo evento para p-validate quando a alteração de valor é feita através da interação com o botão.

**Qual o novo comportamento?**
Corrige a emissão do evento para p-validate em campos com alteração de valor através de interações com botões.

**Simulação**
[DTHFUI-10604_simulacao.zip](https://github.com/user-attachments/files/18440072/DTHFUI-10604_simulacao.zip)
