### PR TITLE
fix(accordion): corrige eventos de teclado e alinha tag ao título

### DIFF
--- a/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.html
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-item-header/po-accordion-item-header.component.html
@@ -5,6 +5,7 @@
     [attr.aria-label]="label"
     [attr.aria-expanded]="expanded || false"
     class="po-accordion-item-header-button po-clickable"
+    type="button"
     (click)="onClick()"
   >
     <div class="po-accordion-item-header-button-content" [p-tooltip]="getTooltip()">

--- a/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.html
+++ b/projects/ui/src/lib/components/po-accordion/po-accordion-manager/po-accordion-manager.component.html
@@ -2,6 +2,7 @@
   <button
     #accordionHeaderButtonManagerElement
     class="po-accordion-manager-button po-clickable"
+    type="button"
     (click)="onClick()"
     [attr.aria-expanded]="expandedAllItems"
     [p-tooltip]="getTooltip()"

--- a/projects/ui/src/lib/components/po-accordion/samples/sample-po-accordion-labs/sample-po-accordion-labs.component.html
+++ b/projects/ui/src/lib/components/po-accordion/samples/sample-po-accordion-labs/sample-po-accordion-labs.component.html
@@ -43,7 +43,7 @@
   </po-radio-group>
   <po-checkbox-group
     class="po-md-6"
-    p-label="Propetie Accordion Item"
+    p-label="Properties Accordion Item"
     name="disabledItem"
     [p-options]="disabledOption"
     [(ngModel)]="disabledItem"


### PR DESCRIPTION
Adicionado o controle sobre o evento emitido pela tecla Enter no corpo de dados do accordion-item para o mesmo parmenecer aberto quando o usuário apertar a tecla Enter em outros campos dentro do accordion-item O evento de abrir/fechar o accordion permanece funcionando quando o foco está no cabeçalho Ajusta o posicionamento da tag em relação ao título fixes DTHFUI-10166

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
