### PR TITLE
build(ci): atualiza versão do action upload-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     - run: npm run build:portal:docs
     - run: npm run build:portal:prod
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: portal
         path: dist/portal


### PR DESCRIPTION
A versão v3 do action upload-artifact foi depreciada, impedindo a esteira CI.
Essa alteração atualiza para a versão mais recente seguindo a documentação de migração fornecida pelo action upload-artifact

< GitHub Actions CI>

< DTHFUI-10689 >
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

Qual o comportamento atual?
A versão v3 do action upload-artifact foi depreciada, impedindo a esteira CI.

Qual o novo comportamento?
Essa alteração atualiza para a versão mais recente seguindo a documentação de migração fornecida pelo action upload-artifact

Simulação
Esteira CI após criação de pull request nas branches master e 17.x.x