### PR TITLE
feat(components): habilita exibição do help adicional através de atalho

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -465,6 +465,15 @@ describe('PoPageDynamicEditComponent: ', () => {
       expect(spy).toHaveBeenCalled();
     });
 
+    it('showAdditionalHelp: should call `fieldsComponent.showAdditionalHelp` with the given property', () => {
+      const property = 'name';
+      const dynamicFormMock = jasmine.createSpyObj('PoDynamicFormComponent', ['showAdditionalHelp']);
+      component.dynamicForm = dynamicFormMock;
+      component.showAdditionalHelp(property);
+
+      expect(dynamicFormMock.showAdditionalHelp).toHaveBeenCalledWith(property);
+    });
+
     describe('ngOnInit:', () => {
       it('should call `loadData` with `paramId` and `duplicate` if `activatedRoute.snapshot.data.serviceApi` is falsy', () => {
         const id = 1;

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -510,6 +510,38 @@ export class PoPageDynamicEditComponent implements OnInit, OnDestroy {
     this.gridDetail.insertRow();
   }
 
+  /**
+   * Método que exibe `additionalHelpTooltip` ou executa a ação definida em `additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `keydown`.
+   *
+   * ```
+   * import { PoPageDynamicEditModule } from '@po-ui/ng-templates';
+   * ...
+   * @ViewChild('dynamicEdit', { static: true }) dynamicEdit: PoPageDynamicEditComponent;
+   *
+   * fields: Array<PoPageDynamicEditField> = [
+   *  {
+   *    property: 'name',
+   *    ...
+   *    help: 'Mensagem de ajuda.',
+   *    additionalHelpTooltip: 'Mensagem de ajuda complementar.',
+   *    keydown: this.onKeyDown.bind(this, 'name')
+   *  },
+   * ]
+   *
+   * onKeyDown(property: string, event: KeyboardEvent): void {
+   *  if (event.code === 'F9') {
+   *    this.dynamicEdit.showAdditionalHelp(property);
+   *  }
+   * }
+   * ```
+   *
+   * @param { string } property Identificador da coluna.
+   */
+  showAdditionalHelp(property: string) {
+    this.dynamicForm.showAdditionalHelp(property);
+  }
+
   get duplicates() {
     return [...this._duplicates];
   }

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.html
@@ -1,4 +1,5 @@
 <po-page-dynamic-edit
+  #dynamicEdit
   [p-auto-router]="true"
   p-title="User edit"
   [p-actions]="actions"

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/samples/sample-po-page-dynamic-edit-user/sample-po-page-dynamic-edit-user.component.ts
@@ -1,8 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 
 import { PoBreadcrumb, PoDynamicFormField } from '@po-ui/ng-components';
 
-import { PoPageDynamicEditActions, PoPageDynamicEditLiterals } from '@po-ui/ng-templates';
+import { PoPageDynamicEditActions, PoPageDynamicEditComponent, PoPageDynamicEditLiterals } from '@po-ui/ng-templates';
 
 @Component({
   selector: 'sample-po-page-dynamic-edit-user',
@@ -10,6 +10,8 @@ import { PoPageDynamicEditActions, PoPageDynamicEditLiterals } from '@po-ui/ng-t
   standalone: false
 })
 export class SamplePoPageDynamicEditUserComponent {
+  @ViewChild('dynamicEdit', { static: true }) dynamicEdit: PoPageDynamicEditComponent;
+
   public readonly serviceApi = 'https://po-sample-api.onrender.com/v1/people';
 
   public readonly actions: PoPageDynamicEditActions = {
@@ -43,7 +45,8 @@ export class SamplePoPageDynamicEditUserComponent {
       type: 'date',
       errorMessage: 'Invalid date.',
       help: 'Enter or select a valid date.',
-      additionalHelpTooltip: 'Please enter a valid date in the format MMDDYYYY.'
+      additionalHelpTooltip: 'Please enter a valid date in the format MMDDYYYY.',
+      keydown: this.onKeyDown.bind(this, 'birthdate')
     },
     { property: 'genre', options: ['female', 'male', 'others'], gridLgColumns: 6 },
     { property: 'nationality' },
@@ -76,4 +79,10 @@ export class SamplePoPageDynamicEditUserComponent {
       gridColumns: 4
     }
   ];
+
+  onKeyDown(property: string, event: KeyboardEvent): void {
+    if (event.code === 'F9') {
+      this.dynamicEdit.showAdditionalHelp(property);
+    }
+  }
 }

--- a/projects/ui/src/lib/components/po-button/po-button-base.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button-base.component.ts
@@ -117,6 +117,9 @@ export class PoButtonBaseComponent {
    */
   @Input('p-type') type?: PoButtonType = PoButtonType.Button;
 
+  // Evento disparado ao sair do campo.
+  @Output('p-blur') blur: EventEmitter<any> = new EventEmitter();
+
   /** Ação que será executada quando o usuário clicar sobre o `po-button`. */
   @Output('p-click') click = new EventEmitter<null>();
 

--- a/projects/ui/src/lib/components/po-button/po-button.component.html
+++ b/projects/ui/src/lib/components/po-button/po-button.component.html
@@ -7,6 +7,7 @@
   [attr.p-danger]="danger"
   [disabled]="disabled || loading"
   [attr.aria-label]="ariaLabel"
+  (blur)="onBlur()"
   (click)="onClick()"
 >
   <div *ngIf="loading" class="po-button-loading-icon">

--- a/projects/ui/src/lib/components/po-button/po-button.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button/po-button.component.spec.ts
@@ -59,6 +59,14 @@ describe('PoButtonComponent: ', () => {
     expect(nativeElement.querySelector('i.po-icon.po-icon-news')).toBeTruthy();
   });
 
+  it('should simulate button blur.', () => {
+    spyOn(component.blur, 'emit');
+
+    component.onBlur();
+
+    expect(component.blur.emit).toHaveBeenCalled();
+  });
+
   it('should simulate button click.', () => {
     spyOn(component.click, 'emit');
 

--- a/projects/ui/src/lib/components/po-button/po-button.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button.component.ts
@@ -35,6 +35,10 @@ import { PoButtonBaseComponent } from './po-button-base.component';
 export class PoButtonComponent extends PoButtonBaseComponent {
   @ViewChild('button', { static: true }) buttonElement: ElementRef;
 
+  onBlur(): void {
+    this.blur.emit();
+  }
+
   /**
    * Função que atribui foco ao componente.
    *

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -39,10 +39,6 @@ export interface PoDynamicFormField extends PoDynamicField {
   /**
    * Evento disparado ao clicar no ícone de ajuda adicional.
    * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
-   *
-   * **Componentes compatíveis:** `po-checkbox`, `po-checkbox-group`, `po-combo`, `po-datepicker`, `po-datepicker-range`,
-   * `po-decimal`, `po-email`, `po-input`, `po-login`, `po-lookup`, `po-multiselect`, `po-number`, `po-password`,
-   * `po-radio-group`, `po-rich-text`, `po-select`, `po-switch`, `po-textarea`, `po-upload`, `po-url`.
    */
   additionalHelp?: Function;
 
@@ -50,10 +46,6 @@ export interface PoDynamicFormField extends PoDynamicField {
    * Exibe um ícone de ajuda adicional ao `p-help`, com o texto desta propriedade no tooltip.
    * Se o evento `p-additional-help` estiver definido, o tooltip não será exibido.
    * **Como boa prática, indica-se utilizar um texto com até 140 caracteres.**
-   *
-   * **Componentes compatíveis:** `po-checkbox`, `po-checkbox-group`, `po-combo`, `po-datepicker`, `po-datepicker-range`,
-   * `po-decimal`, `po-email`, `po-input`, `po-login`, `po-lookup`, `po-multiselect`, `po-number`, `po-password`,
-   * `po-radio-group`, `po-rich-text`, `po-select`, `po-switch`, `po-textarea`, `po-upload`, `po-url`.
    */
   additionalHelpTooltip?: string;
 
@@ -64,10 +56,6 @@ export interface PoDynamicFormField extends PoDynamicField {
    *
    * > O uso dessa propriedade pode acarretar na perda sequencial da tabulação da página.
    * Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
-   *
-   * **Componentes compatíveis:** `po-checkbox`, `po-checkbox-group`, `po-combo`, `po-datepicker`, `po-datepicker-range`,
-   * `po-decimal`, `po-email`, `po-input`, `po-login`, `po-lookup`, `po-multiselect`, `po-number`, `po-password`,
-   * `po-radio-group`, `po-rich-text`, `po-select`, `po-switch`, `po-textarea`, `po-upload`, `po-url`.
    */
   appendBox?: boolean;
 
@@ -81,6 +69,12 @@ export interface PoDynamicFormField extends PoDynamicField {
    * **Componentes compatíveis:** `po-radio-group`, `po-lookup`, `po-checkbox-group`.
    */
   columns?: Array<PoLookupColumn> | number;
+
+  /**
+   * Função executada quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  keydown?: Function;
 
   /** Define a obrigatoriedade do campo. */
   required?: boolean;

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -40,6 +40,7 @@
       (p-change)="onChangeField(field)"
       [p-placeholder]="field.placeholder"
       (p-additional-help)="field.additionalHelp?.($event)"
+      (p-keydown)="field.keydown?.($event)"
     >
     </po-datepicker>
 
@@ -68,6 +69,7 @@
       [p-show-required]="field.showRequired"
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
+      (p-keydown)="field.keydown?.($event)"
     >
     </po-datepicker-range>
 
@@ -100,6 +102,7 @@
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
+      (p-keydown)="field.keydown?.($event)"
       [p-icon]="field.icon"
       [p-placeholder]="field.placeholder"
       [p-readonly]="field.readonly"
@@ -136,6 +139,7 @@
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
+      (p-keydown)="field.keydown?.($event)"
       [p-icon]="field.icon"
       [p-placeholder]="field.placeholder"
     >
@@ -174,6 +178,7 @@
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
+      (p-keydown)="field.keydown?.($event)"
       [p-placeholder]="field.placeholder"
     >
     </po-decimal>
@@ -199,6 +204,7 @@
       [p-show-required]="field.showRequired"
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
+      (p-keydown)="field.keydown?.($event)"
       [p-placeholder]="field.placeholder"
       [p-readonly]="field.readonly"
     >
@@ -225,6 +231,7 @@
       [p-show-required]="field.showRequired"
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
+      (p-keydown)="field.keydown?.($event)"
     >
     </po-radio-group>
 
@@ -246,6 +253,7 @@
       [p-hide-label-status]="field.hideLabelStatus"
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
+      (p-keydown)="field.keydown?.($event)"
     >
     </po-switch>
 
@@ -263,6 +271,7 @@
       [p-size]="field.size"
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
+      (p-keydown)="field.keydown?.($event)"
     >
     </po-checkbox>
 
@@ -305,6 +314,7 @@
       [p-change-on-enter]="field.changeOnEnter"
       (p-additional-help)="field.additionalHelp?.($event)"
       [p-remove-initial-filter]="field.removeInitialFilter"
+      (p-keydown)="field.keydown?.($event)"
     >
     </po-combo>
 
@@ -344,6 +354,7 @@
       [p-advanced-filters]="field.advancedFilters"
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change-visible-columns)="field.changeVisibleColumns?.($event)"
+      (p-keydown)="field.keydown?.($event)"
       (p-restore-column-manager)="field.columnRestoreManager?.($event)"
     >
     </po-lookup>
@@ -369,6 +380,7 @@
       [p-error-limit]="field.errorLimit"
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
+      (p-keydown)="field.keydown?.($event)"
     >
     </po-checkbox-group>
 
@@ -404,6 +416,7 @@
       [p-hide-search]="field.hideSearch"
       [p-hide-select-all]="field.hideSelectAll"
       (p-additional-help)="field.additionalHelp?.($event)"
+      (p-keydown)="field.keydown?.($event)"
     >
     </po-multiselect>
 
@@ -431,6 +444,7 @@
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
+      (p-keydown)="field.keydown?.($event)"
       [p-placeholder]="field.placeholder"
     >
     </po-textarea>
@@ -465,6 +479,7 @@
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
+      (p-keydown)="field.keydown?.($event)"
       [p-placeholder]="field.placeholder"
     >
     </po-password>
@@ -503,6 +518,7 @@
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-change)="onChangeField(field)"
       (p-change-model)="onChangeFieldModel(field)"
+      (p-keydown)="field.keydown?.($event)"
       [p-url]="field.url"
     >
     </po-upload>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -364,6 +364,26 @@ describe('PoDynamicFormFieldsComponent: ', () => {
       });
     });
 
+    describe('showAdditionalHelp:', () => {
+      it('should call `showAdditionalHelp` if find component.', () => {
+        const fieldComponent = { showAdditionalHelp: jasmine.createSpy(), name: 'name' };
+        component.components = <any>[fieldComponent];
+
+        component.showAdditionalHelp('name');
+
+        expect(fieldComponent.showAdditionalHelp).toHaveBeenCalled();
+      });
+
+      it('should not call `showAdditionalHelp` if component is not found', () => {
+        const fieldComponent = { showAdditionalHelp: jasmine.createSpy(), name: 'name' };
+        component.components = <any>[fieldComponent];
+
+        component.showAdditionalHelp('nickname');
+
+        expect(fieldComponent.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+    });
+
     it('applyFieldValidation: should merge fields and validatedFields and apply new value to `fields` and `value``', () => {
       const index = 1;
       const validatedField = { field: { property: 'test2', required: false, visible: true }, value: 'expected value' };

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -22,7 +22,11 @@ import { PoDynamicFormFieldsBaseComponent } from './po-dynamic-form-fields-base.
   standalone: false
 })
 export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseComponent implements OnChanges {
-  @ViewChildren('component') components: QueryList<{ name: string; focus: () => void }>;
+  @ViewChildren('component') components: QueryList<{
+    name: string;
+    focus: () => void;
+    showAdditionalHelp: () => void;
+  }>;
 
   private previousValue = {};
 
@@ -89,6 +93,13 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
       const { property } = visibleField;
       const { changedFieldIndex } = this.getField(property);
       this.triggerValidationOnForm(changedFieldIndex);
+    }
+  }
+
+  showAdditionalHelp(property: string) {
+    const foundComponent = this.components.find(component => component.name === property);
+    if (foundComponent) {
+      foundComponent.showAdditionalHelp();
     }
   }
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
@@ -80,6 +80,15 @@ describe('PoDynamicFormComponent:', () => {
       expect(spyFieldsComponentFocus).toHaveBeenCalled();
     });
 
+    it('showAdditionalHelp: should call `fieldsComponent.showAdditionalHelp` with the given property', () => {
+      const property = 'name';
+      spyOn(component.fieldsComponent, 'showAdditionalHelp');
+
+      component.showAdditionalHelp(property);
+
+      expect(component.fieldsComponent.showAdditionalHelp).toHaveBeenCalledWith(property);
+    });
+
     it('validateForm: should call sendFormChange with validate, field and value', () => {
       const updatedField = { property: 'test', disabled: true };
       component.validate = 'http://fakeUrlPo.com';

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.ts
@@ -40,9 +40,14 @@ import { PoDynamicFormValidationService } from './po-dynamic-form-validation/po-
   standalone: false
 })
 export class PoDynamicFormComponent extends PoDynamicFormBaseComponent implements OnInit, OnDestroy {
-  @ViewChild('fieldsComponent') fieldsComponent: { focus: (property: string) => void; updatePreviousValue: () => void };
+  @ViewChild('fieldsComponent') fieldsComponent: {
+    focus: (property: string) => void;
+    updatePreviousValue: () => void;
+    showAdditionalHelp: (property: string) => void;
+  };
 
   disabledForm: boolean;
+  displayAdditionalHelp: boolean = false;
 
   private _form: NgForm;
 
@@ -119,6 +124,38 @@ export class PoDynamicFormComponent extends PoDynamicFormBaseComponent implement
 
   sendObjectValue(objectValue: any) {
     this.comboOptionSubject.next(objectValue);
+  }
+
+  /**
+   * Método que exibe `additionalHelpTooltip` ou executa a ação definida em `additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `keydown`.
+   *
+   * ```
+   * import { PoDynamicModule } from '@po-ui/ng-components';
+   * ...
+   * @ViewChild('dynamicForm', { static: true }) dynamicForm: PoDynamicFormComponent;
+   *
+   * fields: Array<PoDynamicFormField> = [
+   *  {
+   *    property: 'name',
+   *    ...
+   *    help: 'Mensagem de ajuda.',
+   *    additionalHelpTooltip: 'Mensagem de ajuda complementar.',
+   *    keydown: this.onKeyDown.bind(this, 'name')
+   *  },
+   * ]
+   *
+   * onKeyDown(property: string, event: KeyboardEvent): void {
+   *  if (event.code === 'F9') {
+   *    this.dynamicForm.showAdditionalHelp(property);
+   *  }
+   * }
+   * ```
+   *
+   * @param { string } property Identificador da coluna.
+   */
+  showAdditionalHelp(property: string) {
+    this.fieldsComponent.showAdditionalHelp(property);
   }
 
   validateForm(field: PoDynamicFormField) {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-container/sample-po-dynamic-form-container.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-container/sample-po-dynamic-form-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 
 import {
   PoDynamicFormField,
@@ -6,7 +6,8 @@ import {
   PoDynamicFormValidation,
   PoNotificationService,
   ForceBooleanComponentEnum,
-  PoUploadFile
+  PoUploadFile,
+  PoDynamicFormComponent
 } from '@po-ui/ng-components';
 import { PoDynamicFormContainerService } from './sample-po-dynamic-form-container.service';
 
@@ -17,6 +18,7 @@ import { PoDynamicFormContainerService } from './sample-po-dynamic-form-containe
   standalone: false
 })
 export class SamplePoDynamicFormContainerComponent implements OnInit {
+  @ViewChild('dynamicForm', { static: true }) dynamicForm: PoDynamicFormComponent;
   person = {};
   validateFields: Array<string> = ['state'];
 
@@ -43,7 +45,8 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
       errorMessage: 'The date must be before the year 2010.',
       order: -1,
       help: 'Enter or select a valid date.',
-      additionalHelpTooltip: 'Please enter a valid date in the format MMDDYYYY.'
+      additionalHelpTooltip: 'Please enter a valid date in the format MMDDYYYY.',
+      keydown: this.onKeyDown.bind(this, 'birthday')
     },
     { property: 'cpf', label: 'CPF', mask: '999.999.999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
     { property: 'cnpj', label: 'CNPJ', mask: '99.999.999/9999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
@@ -65,7 +68,8 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
       errorMessage: 'At least 5 alphabetic and 3 numeric characters are required.',
       placeholder: 'Type your password',
       help: 'Password must include a combination of letters and numbers.',
-      additionalHelpTooltip: 'At least 5 alphabetic and 3 numeric characters are required.'
+      additionalHelpTooltip: 'At least 5 alphabetic and 3 numeric characters are required.',
+      keydown: this.onKeyDown.bind(this, 'secretKey')
     },
     {
       property: 'rememberSecretKey',
@@ -117,7 +121,8 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
       gridColumns: 5,
       gridSmColumns: 12,
       help: 'Enter or select a valid date range.',
-      additionalHelpTooltip: 'Ensure the start date is earlier than or equal to the end date.'
+      additionalHelpTooltip: 'Ensure the start date is earlier than or equal to the end date.',
+      keydown: this.onKeyDown.bind(this, 'vacation')
     },
     {
       property: 'entryTime',
@@ -237,6 +242,12 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
         }
       ]
     };
+  }
+
+  onKeyDown(property: string, event: KeyboardEvent): void {
+    if (event.code === 'F9') {
+      this.dynamicForm.showAdditionalHelp(property);
+    }
   }
 
   onLoadFields(value: any) {

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
@@ -123,15 +123,6 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
    * @optional
    *
    * @description
-   * Evento disparado ao clicar no ícone de ajuda adicional.
-   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
-   */
-  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
-
-  /**
-   * @optional
-   *
-   * @description
    *
    * Limita a exibição da mensagem de erro a duas linhas e exibe um tooltip com o texto completo.
    *
@@ -163,14 +154,33 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
    * @optional
    *
    * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
    *
    * Evento disparado ao alterar valor do campo
    */
   @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
   checkboxGroupOptionsView: Array<PoCheckboxGroupOptionView>;
   checkedOptions: any = {};
   checkedOptionsList: any = [];
+  displayAdditionalHelp: boolean = false;
   mdColumns: number = poCheckboxGroupColumnsDefaultLength;
   propagateChange: any;
   validatorChange: any;

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.html
@@ -16,8 +16,9 @@
           #checkboxLabel
           [p-label]="option.label"
           [p-disabled]="option.disabled || disabled"
+          (p-blur)="onBlur(checkboxLabel)"
           (click)="checkOption(option)"
-          (keydown)="onKeyDown($event, option)"
+          (keydown)="onKeyDown($event, option, checkboxLabel)"
           [p-checkboxValue]="checkedOptions[option.value] === null ? 'mixed' : checkedOptions[option.value]"
           [p-required]="required"
         >
@@ -33,6 +34,7 @@
     [p-disabled]="disabled"
     [p-error-limit]="errorLimit"
     [p-error-pattern]="getErrorPattern()"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
@@ -72,6 +72,12 @@ export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent imple
     }
   }
 
+  onBlur(checkbox: PoCheckboxComponent) {
+    if (!this.isCheckboxOptionFocused(checkbox) && this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+  }
+
   emitAdditionalHelp() {
     if (this.isAdditionalHelpEventTriggered()) {
       this.additionalHelp.emit();
@@ -119,7 +125,7 @@ export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent imple
     );
   }
 
-  onKeyDown(event: KeyboardEvent, option: PoCheckboxGroupOption) {
+  onKeyDown(event: KeyboardEvent, option: PoCheckboxGroupOption, checkbox?: PoCheckboxComponent) {
     const spaceBar = 32;
 
     if (event.which === spaceBar || event.keyCode === spaceBar) {
@@ -127,6 +133,36 @@ export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent imple
 
       event.preventDefault();
     }
+
+    if (this.isCheckboxOptionFocused(checkbox)) {
+      this.keydown.emit(event);
+    }
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-checkbox-group
+   *  #checkboxGroup
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, checkboxGroup)"
+   * ></po-checkbox-group>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoCheckboxGroupComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   showAdditionalHelpIcon() {
@@ -142,5 +178,9 @@ export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent imple
       this.additionalHelpEventTrigger === 'event' ||
       (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
     );
+  }
+
+  private isCheckboxOptionFocused(checkbox: PoCheckboxComponent): boolean {
+    return document.activeElement === checkbox.checkboxLabel.nativeElement;
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.html
@@ -14,6 +14,7 @@
   [p-error-limit]="properties?.includes('errorLimit')"
   [p-show-required]="properties.includes('showRequired')"
   (p-change)="changeEvent('p-change')"
+  (p-keydown)="changeEvent('p-keydown')"
 >
 </po-checkbox-group>
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -111,6 +111,9 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
    */
   @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
+  // Evento disparado ao sair do campo.
+  @Output('p-blur') blur: EventEmitter<any> = new EventEmitter();
+
   /**
    * @optional
    *
@@ -119,6 +122,15 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
    * Evento disparado quando o valor do *checkbox* for alterado.
    */
   @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
 
   //propriedade interna recebida do checkbox-group para verificar se o checkbox está ativo, inativo ou indeterminate
   @Input('p-checkboxValue') checkboxValue: boolean | null | string;
@@ -129,6 +141,7 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
   //propriedade interna recebida para desabilitar o tabindex do checkbox na utilização dentro de um list-box
   @Input({ alias: 'p-disabled-tabindex', transform: convertToBoolean }) disabladTabindex: boolean = false;
 
+  displayAdditionalHelp: boolean = false;
   id = uuid();
   propagateChange: any;
   onTouched;

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.html
@@ -13,6 +13,7 @@
         [attr.p-size]="size"
         [tabindex]="disabled || disabladTabindex ? -1 : 0"
         [attr.aria-checked]="checkboxValue"
+        (blur)="onBlur()"
       >
         <span
           [attr.aria-checked]="checkboxValue"
@@ -42,6 +43,7 @@
     [p-append-in-body]="appendBox"
     [p-disabled]="disabled"
     [p-help]="help"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
@@ -172,6 +172,57 @@ describe('PoCheckboxComponent:', () => {
         expect(spyOnCheckOption).toHaveBeenCalledWith(component.checkboxValue);
         expect(spyOnPreventDefault).toHaveBeenCalled();
       });
+
+      it('should emit event when field is focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.checkboxLabel = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(component.checkboxLabel.nativeElement);
+
+        component.onKeyDown(fakeEvent, component.checkboxValue);
+
+        expect(component.keydown.emit).toHaveBeenCalledWith(fakeEvent);
+      });
+
+      it('should not emit event when field is not focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.checkboxLabel = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(document.createElement('div'));
+        component.onKeyDown(fakeEvent, component.checkboxValue);
+
+        expect(component.keydown.emit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('showAdditionalHelp:', () => {
+      it('should toggle `displayAdditionalHelp` from false to true', () => {
+        component.displayAdditionalHelp = false;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeTrue();
+        expect(component.displayAdditionalHelp).toBeTrue();
+      });
+
+      it('should toggle `displayAdditionalHelp` from true to false', () => {
+        component.displayAdditionalHelp = true;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeFalse();
+        expect(component.displayAdditionalHelp).toBeFalse();
+      });
     });
 
     it('changeModelValue: should update `changeModelValue` with property values', () => {
@@ -219,21 +270,52 @@ describe('PoCheckboxComponent:', () => {
       });
     });
 
-    it('onBlur: should call `onTouched` on blur', () => {
-      component.onTouched = value => {};
+    describe('onBlur:', () => {
+      let setupTest;
 
-      spyOn(component, 'onTouched');
-      component.onBlur();
+      beforeEach(() => {
+        setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
+          component.additionalHelpTooltip = tooltip;
+          component.displayAdditionalHelp = displayHelp;
+          component.additionalHelp = additionalHelpEvent;
+          spyOn(component, 'showAdditionalHelp');
+        };
+      });
 
-      expect(component.onTouched).toHaveBeenCalledWith();
-    });
+      it('should call `onTouched` on blur', () => {
+        component.onTouched = value => {};
 
-    it('onBlur: shouldn´t throw error if onTouched is falsy', () => {
-      component['onTouched'] = null;
+        spyOn(component, 'onTouched');
+        component.onBlur();
 
-      const fnError = () => component.onBlur();
+        expect(component.onTouched).toHaveBeenCalledWith();
+      });
 
-      expect(fnError).not.toThrow();
+      it('shouldn´t throw error if onTouched is falsy', () => {
+        component['onTouched'] = null;
+
+        const fnError = () => component.onBlur();
+
+        expect(fnError).not.toThrow();
+      });
+
+      it('should call showAdditionalHelp when the tooltip is displayed', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when tooltip is not displayed', () => {
+        setupTest('Mensagem de apoio adicional.', false, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when additionalHelp event is true', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: true });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.ts
@@ -90,6 +90,10 @@ export class PoCheckboxComponent extends PoCheckboxBaseComponent implements Afte
 
   onBlur() {
     this.onTouched?.();
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+    this.blur.emit();
   }
 
   ngAfterViewInit() {
@@ -109,11 +113,43 @@ export class PoCheckboxComponent extends PoCheckboxBaseComponent implements Afte
   }
 
   onKeyDown(event: KeyboardEvent, value: boolean | string) {
+    const isFieldFocused = document.activeElement === this.checkboxLabel.nativeElement;
+
     if (event.which === PoKeyCodeEnum.space || event.keyCode === PoKeyCodeEnum.space) {
       this.checkOption(value);
 
       event.preventDefault();
     }
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
+    }
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-checkbox
+   *  #checkbox
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, checkbox)"
+   * ></po-checkbox>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoCheckboxComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   showAdditionalHelpIcon() {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.html
@@ -7,6 +7,7 @@
   [p-label]="label"
   [p-size]="size ? 'large' : 'medium'"
   (p-change)="changeEvent('p-change')"
+  (p-keydown)="changeEvent('p-keydown')"
 >
 </po-checkbox>
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -302,6 +302,15 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * @optional
    *
    * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
+  /**
+   * @optional
+   *
+   * @description
    *
    * Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
    *
@@ -341,6 +350,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   page: number = 1;
   pageSize: number = 10;
   loading: boolean = false;
+  displayAdditionalHelp: boolean = false;
   dynamicLabel: string = 'label';
   dynamicValue: string = 'value';
   shouldApplyFocus: boolean = false;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -91,6 +91,7 @@
       [p-disabled]="disabled"
       [p-error-pattern]="getErrorPattern()"
       [p-error-limit]="errorLimit"
+      [p-show-additional-help]="displayAdditionalHelp"
       [p-show-additional-help-icon]="showAdditionalHelpIcon()"
       (p-additional-help)="emitAdditionalHelp()"
     ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -231,11 +231,15 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
 
   onBlur() {
     this.onModelTouched?.();
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
   }
 
   onKeyDown(event?: any) {
-    const key = event.keyCode;
-    const inputValue = event.target.value;
+    const key = event?.keyCode;
+    const inputValue = event?.target?.value;
+    const isFieldFocused = document.activeElement === this.inputEl.nativeElement;
 
     if (event.shiftKey && key === PoKeyCodeEnum.tab) {
       this.controlComboVisibility(false);
@@ -291,6 +295,10 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     }
 
     this.lastKey = event.keyCode;
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
+    }
   }
 
   onKeyUp(event?: any) {
@@ -534,6 +542,32 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     if (value === null) {
       this.cleanListbox();
     }
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-combo
+   *  #combo
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, combo)"
+   * ></po-combo>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoComboComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   wasClickedOnToggle(event: MouseEvent): void {

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -26,6 +26,7 @@
   [p-show-required]="properties.includes('showRequired')"
   [p-sort]="properties.includes('sort')"
   (p-change)="changeEvent('p-change')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-combo>

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -63,6 +63,9 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
   @Input() additionalHelpEventTrigger: string | undefined;
 
+  /* Nome do componente. */
+  @Input('name') name: string;
+
   /**
    * @optional
    *
@@ -179,8 +182,18 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    */
   @Output('p-change') onChange: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<any>();
+
   errorMessage: string = '';
   dateRange: PoDatepickerRange = { start: '', end: '' };
+  displayAdditionalHelp: boolean = false;
 
   protected format: any = 'dd/mm/yyyy';
   protected isDateRangeInputFormatValid: boolean = true;

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
@@ -79,6 +79,7 @@
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorMessage"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -244,6 +244,10 @@ export class PoDatepickerRangeComponent
 
   onBlur(event: any) {
     this.onTouchedModel?.();
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+
     const isStartDateTargetEvent = event.target.name === this.startDateInputName;
 
     this.updateModelByScreen(isStartDateTargetEvent);
@@ -271,6 +275,9 @@ export class PoDatepickerRangeComponent
   }
 
   onKeydown(event?: any) {
+    const isStartDateFocused = document.activeElement === this.startDateInput.nativeElement;
+    const isEndDateFocused = document.activeElement === this.endDateInput.nativeElement;
+    const isFieldFocused = isStartDateFocused || isEndDateFocused;
     if (this.readonly) {
       return;
     }
@@ -280,6 +287,10 @@ export class PoDatepickerRangeComponent
       this.setFocusOnBackspace();
     } else {
       this.poMaskObject.keydown(event);
+    }
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
     }
   }
 
@@ -302,6 +313,32 @@ export class PoDatepickerRangeComponent
 
   showAdditionalHelpIcon() {
     return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-datepicker-range
+   *  #datepickerRange
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, datepickerRange)"
+   * ></po-datepicker-range>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoDatepickerRangeComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   toggleCalendar() {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
@@ -20,6 +20,7 @@
   [p-start-date]="startDate"
   [p-locale]="locale"
   (p-change)="changeEvent('p-change')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-datepicker-range>

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -216,6 +216,15 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    */
   @Output('p-change') onchange: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
   offset: number;
   protected firstStart = true;
   protected hour: string = 'T00:00:00-00:00';

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
@@ -27,6 +27,7 @@
           [required]="required"
           (blur)="eventOnBlur($event)"
           (click)="eventOnClick($event)"
+          (keydown)="onKeyDown($event)"
         />
         <div class="po-field-icon-container-right">
           <po-clean
@@ -86,6 +87,7 @@
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -92,6 +92,7 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
   /** Texto de apoio do campo. */
   @Input('p-help') help?: string;
 
+  displayAdditionalHelp: boolean = false;
   el: ElementRef;
   declare hour: string;
   id = `po-datepicker[${uuid()}]`;
@@ -277,6 +278,11 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
 
   eventOnBlur($event: any) {
     this.onTouchedModel?.();
+
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+
     const date = this.inputEl.nativeElement.value;
     const newDate = date ? this.getDateFromString(date) : undefined;
     this.objMask.blur($event);
@@ -310,6 +316,14 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
     }
   }
 
+  onKeyDown(event: KeyboardEvent): void {
+    const isFieldFocused = document.activeElement === this.inputEl.nativeElement;
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
+    }
+  }
+
   onKeyPress(event: any) {
     if (isKeyCodeEnter(event) || isKeyCodeSpace(event)) {
       this.togglePicker();
@@ -334,6 +348,32 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
     if (value) {
       this.inputEl.nativeElement.value = this.formatToDate(value);
     }
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-datepicker
+   *  #datepicker
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, datepicker)"
+   * ></po-datepicker>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoDatepickerComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   // Função implementada do ControlValueAccessor

--- a/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
@@ -22,6 +22,7 @@
   [p-show-required]="properties.includes('showRequired')"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-datepicker>

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.html
@@ -31,6 +31,7 @@
       (focus)="onFocus($event)"
       (input)="onInput($event)"
       (keypress)="onKeyPress($event)"
+      (keydown)="onKeyDown($event)"
     />
 
     <div class="po-field-icon-container-right">
@@ -52,6 +53,7 @@
     [p-disabled]="disabled"
     [p-error-limit]="errorLimit"
     [p-error-pattern]="getErrorPatternMessage()"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -1272,35 +1272,72 @@ describe('PoDecimalComponent:', () => {
       });
     });
 
-    it(`onBlur: should call 'setViewValue' with empty string and 'callOnChange' with undefined if 'target.value'
-      contains more than one comma`, () => {
-      fixture.detectChanges();
-      const fakeEvent = {
-        target: {
-          value: '1,200,50'
-        }
-      };
-      component['onTouched'] = () => {};
+    describe('onBlur:', () => {
+      let setupTest;
 
-      spyOn(component, <any>'setViewValue');
-      spyOn(component, <any>'callOnChange');
-      spyOn(component, <any>'onTouched');
+      beforeEach(() => {
+        setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
+          component.additionalHelpTooltip = tooltip;
+          component.displayAdditionalHelp = displayHelp;
+          component.additionalHelp = additionalHelpEvent;
+          spyOn(component, 'showAdditionalHelp');
+        };
+      });
 
-      component.onBlur(fakeEvent);
+      it(`onBlur: should call 'setViewValue' with empty string and 'callOnChange' with undefined if 'target.value'
+        contains more than one comma`, () => {
+        fixture.detectChanges();
+        const fakeEvent = {
+          target: {
+            value: '1,200,50'
+          }
+        };
+        component['onTouched'] = () => {};
 
-      expect(component['onTouched']).toHaveBeenCalled();
-      expect(component['setViewValue']).toHaveBeenCalledWith('');
-      expect(component['callOnChange']).toHaveBeenCalledWith(undefined);
-    });
+        spyOn(component, <any>'setViewValue');
+        spyOn(component, <any>'callOnChange');
+        spyOn(component, <any>'onTouched');
 
-    it('onBlur: shouldn´t throw error if onTouched is falsy', () => {
-      const fakeEvent = { target: { value: '' } };
+        component.onBlur(fakeEvent);
 
-      component['onTouched'] = null;
+        expect(component['onTouched']).toHaveBeenCalled();
+        expect(component['setViewValue']).toHaveBeenCalledWith('');
+        expect(component['callOnChange']).toHaveBeenCalledWith(undefined);
+      });
 
-      const fnError = () => component.onBlur(fakeEvent);
+      it('onBlur: shouldn´t throw error if onTouched is falsy', () => {
+        const fakeEvent = { target: { value: '' } };
 
-      expect(fnError).not.toThrow();
+        component['onTouched'] = null;
+
+        const fnError = () => component.onBlur(fakeEvent);
+
+        expect(fnError).not.toThrow();
+      });
+
+      it('should call showAdditionalHelp when the tooltip is displayed', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: false });
+        const fakeEvent = { target: { value: '' } };
+
+        component.onBlur(fakeEvent);
+        expect(component.showAdditionalHelp).toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when tooltip is not displayed', () => {
+        setupTest('Mensagem de apoio adicional.', false, { observed: false });
+        const fakeEvent = { target: { value: '' } };
+
+        component.onBlur(fakeEvent);
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when additionalHelp event is true', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: true });
+        const fakeEvent = { target: { value: '' } };
+
+        component.onBlur(fakeEvent);
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
     });
 
     describe('containsMoreThanOneDecimalSeparator:', () => {
@@ -1437,6 +1474,39 @@ describe('PoDecimalComponent:', () => {
 
       expect(component['setViewValue']).not.toHaveBeenCalled();
       expect(component['setCursorInput']).not.toHaveBeenCalled();
+    });
+
+    describe('onKeyDown:', () => {
+      it('should emit event when field is focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.inputEl = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(component.inputEl.nativeElement);
+
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).toHaveBeenCalledWith(fakeEvent);
+      });
+
+      it('should not emit event when field is not focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.inputEl = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(document.createElement('div'));
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).not.toHaveBeenCalled();
+      });
     });
 
     it('hasLetters: should return true with numbers.', () => {

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -85,7 +85,6 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
   @ViewChild('inp', { read: ElementRef, static: true }) inputEl: ElementRef;
 
   id = `po-decimal[${uuid()}]`;
-
   private _decimalsLength?: number = poDecimalDefaultDecimalsLength;
   private _thousandMaxlength?: number = poDecimalDefaultThousandMaxlength;
   private _locale?: string;
@@ -354,9 +353,14 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
     return !this.hasLetters(keyValue) && this.hasNotSpace(keyValue) && validKey;
   }
 
-  // função responsável por adicionar os zeroes com as casa decimais ao sair do campo.
+  // função responsável por adicionar os zeros com as casa decimais ao sair do campo.
   onBlur(event: any) {
     this.onTouched?.();
+
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+
     const value = event.target.value;
 
     if (value) {
@@ -434,6 +438,14 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
       if (this.isValidKey(event, key)) {
         this.setViewValue(inputValue);
       }
+    }
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    const isFieldFocused = document.activeElement === this.inputEl.nativeElement;
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-decimal/samples/sample-po-decimal-labs/sample-po-decimal-labs.component.html
@@ -24,6 +24,7 @@
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-decimal>

--- a/projects/ui/src/lib/components/po-field/po-email/samples/sample-po-email-labs/sample-po-email-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-email/samples/sample-po-email-labs/sample-po-email-labs.component.html
@@ -20,6 +20,7 @@
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
   (p-enter)="changeEvent('p-enter')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-email>

--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { configureTestSuite } from './../../../../util-test/util-expect.spec';
 
 import { PoFieldContainerBottomComponent } from './po-field-container-bottom.component';
+import { SimpleChange, SimpleChanges } from '@angular/core';
 
 describe('PoFieldContainerBottomComponent', () => {
   let component: PoFieldContainerBottomComponent;
@@ -26,5 +27,45 @@ describe('PoFieldContainerBottomComponent', () => {
   it('should not show error pattern if no error pattern', () => {
     expect(fixture.debugElement.nativeElement.querySelector('.po-field-container-bottom-text-error')).toBeNull();
     expect(fixture.debugElement.nativeElement.querySelector('.po-field-container-icon-error')).toBeNull();
+  });
+
+  describe('Methods:', () => {
+    let changes: SimpleChanges;
+
+    beforeEach(() => {
+      changes = {
+        showAdditionalHelp: new SimpleChange(false, true, true)
+      };
+
+      component.poTooltip = { toggleTooltipVisibility: jasmine.createSpy() } as any;
+      spyOn(component.additionalHelp, 'emit');
+    });
+
+    describe('ngOnChanges', () => {
+      it('should emit `p-additional-help` event if `p-additional-help-tooltip` is not defined', () => {
+        (component as any).isInitialChange = false;
+        component.additionalHelpTooltip = null;
+        component.ngOnChanges(changes);
+
+        expect(component.additionalHelp.emit).toHaveBeenCalled();
+      });
+
+      it('should toggle the visibility of `p-additional-help-tooltip` is defined', () => {
+        (component as any).isInitialChange = false;
+        component.additionalHelpTooltip = 'Mensagem de apoio complementar.';
+        component.showAdditionalHelp = true;
+        component.ngOnChanges(changes);
+
+        expect(component.poTooltip.toggleTooltipVisibility).toHaveBeenCalledWith(true);
+      });
+
+      it('should not emit the `p-additional-help` event or display `p-additional-help-tooltip` at initialization', () => {
+        (component as any).isInitialChange = true;
+        component.ngOnChanges(changes);
+
+        expect(component.additionalHelp.emit).not.toHaveBeenCalled();
+        expect(component.poTooltip.toggleTooltipVisibility).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.component.ts
@@ -1,5 +1,18 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 import { convertToBoolean } from '../../../../utils/util';
+import { PoTooltipDirective } from '../../../../directives';
 
 /**
  * @docsPrivate
@@ -15,7 +28,9 @@ import { convertToBoolean } from '../../../../utils/util';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false
 })
-export class PoFieldContainerBottomComponent {
+export class PoFieldContainerBottomComponent implements OnChanges {
+  @ViewChild(PoTooltipDirective) poTooltip: PoTooltipDirective;
+
   /** Texto exibido no tooltip do ícone de ajuda adicional. */
   @Input('p-additional-help-tooltip') additionalHelpTooltip?: string = '';
 
@@ -37,9 +52,28 @@ export class PoFieldContainerBottomComponent {
 
   @Input('p-help') help?: string;
 
+  /** Ativa a exibição da ajuda adicional. */
+  @Input('p-show-additional-help') showAdditionalHelp: boolean = false;
+
   /** Exibe o ícone de ajuda adicional. */
   @Input('p-show-additional-help-icon') showAdditionalHelpIcon: boolean = false;
 
   /** Evento disparado ao clicar no ícone de ajuda adicional. */
   @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
+
+  private isInitialChange: boolean = true;
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.showAdditionalHelp) {
+      if (!this.isInitialChange) {
+        if (this.additionalHelpTooltip) {
+          this.poTooltip.toggleTooltipVisibility(this.showAdditionalHelp);
+        } else {
+          this.additionalHelp.emit();
+        }
+      } else {
+        this.isInitialChange = false;
+      }
+    }
+  }
 }

--- a/projects/ui/src/lib/components/po-field/po-field.model.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.model.spec.ts
@@ -125,4 +125,24 @@ describe('PoFieldModel', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe('showAdditionalHelp:', () => {
+    it('should toggle `displayAdditionalHelp` from false to true', () => {
+      component.displayAdditionalHelp = false;
+
+      const result = component.showAdditionalHelp();
+
+      expect(result).toBeTrue();
+      expect(component.displayAdditionalHelp).toBeTrue();
+    });
+
+    it('should toggle `displayAdditionalHelp` from true to false', () => {
+      component.displayAdditionalHelp = true;
+
+      const result = component.showAdditionalHelp();
+
+      expect(result).toBeFalse();
+      expect(component.displayAdditionalHelp).toBeFalse();
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-field/po-field.model.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.model.ts
@@ -72,6 +72,16 @@ export abstract class PoFieldModel<T> implements ControlValueAccessor {
    */
   @Output('p-change') change: EventEmitter<T> = new EventEmitter<T>();
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
+  displayAdditionalHelp: boolean = false;
   value: T;
 
   protected onTouched;
@@ -109,6 +119,32 @@ export abstract class PoFieldModel<T> implements ControlValueAccessor {
 
   getAdditionalHelpTooltip() {
     return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-nome-component
+   *  #component
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, component)"
+   * ></po-nome-component>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoNomeDoComponente): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   showAdditionalHelpIcon() {

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -36,7 +36,6 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
 
   @HostListener('keydown', ['$event']) onKeydown(e: any) {
     if (this.mask && !this.readonly && e.target.keyCode !== 229) {
-      this.eventOnBlur(e);
       this.objMask.keydown(e);
       if (this.passedWriteValue) {
         this.validateClassesForMask(true);
@@ -47,7 +46,6 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
   @HostListener('keyup', ['$event']) onKeyup(e: any) {
     if (this.mask && !this.readonly) {
       if (e.target.keyCode !== 229) {
-        this.eventOnBlur(e);
         this.objMask.keyup(e);
       }
       this.callOnChange(this.objMask.valueToModel);
@@ -75,6 +73,14 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
   focus() {
     if (!this.disabled) {
       this.inputEl.nativeElement.focus();
+    }
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    const isFieldFocused = document.activeElement === this.inputEl.nativeElement;
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
     }
   }
 
@@ -134,6 +140,11 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
 
   eventOnBlur(e: any) {
     this.onTouched?.();
+
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+
     if (this.mask) {
       this.objMask.blur(e);
     }

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
@@ -533,6 +533,26 @@ describe('PoInputBase:', () => {
       expect(component['validatorChange']).toBe(registerOnValidatorChangeFn);
     });
 
+    describe('showAdditionalHelp:', () => {
+      it('should toggle `displayAdditionalHelp` from false to true', () => {
+        component.displayAdditionalHelp = false;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeTrue();
+        expect(component.displayAdditionalHelp).toBeTrue();
+      });
+
+      it('should toggle `displayAdditionalHelp` from true to false', () => {
+        component.displayAdditionalHelp = true;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeFalse();
+        expect(component.displayAdditionalHelp).toBeFalse();
+      });
+    });
+
     it('validate: should call validatePatternOnWriteValue if pattern failed', () => {
       component.pattern = '[a-z]';
       component.getScreenValue = () => '2';

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -295,13 +295,23 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    */
   @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
 
-  type: string;
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
 
+  displayAdditionalHelp: boolean = false;
+  type: string;
   onChangePropagate: any = null;
   objMask: any;
   modelLastUpdate: any;
   isInvalid: boolean;
   hasValidatorRequired = false;
+
   private subscription: Subscription = new Subscription();
   protected onTouched: any = null;
 
@@ -563,6 +573,32 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
 
   showAdditionalHelpIcon() {
     return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-nome-component
+   *  #component
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, component)"
+   * ></po-nome-component>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoNomeDoComponente): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   updateModel(value: any) {

--- a/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input.component.html
@@ -32,6 +32,7 @@
       (click)="eventOnClick($event)"
       (focus)="eventOnFocus($event)"
       (input)="eventOnInput($event)"
+      (keydown)="onKeyDown($event)"
     />
 
     <div class="po-field-icon-container-right">
@@ -53,6 +54,7 @@
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-labs/sample-po-input-labs.component.html
@@ -26,6 +26,7 @@
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
   (p-enter)="changeEvent('p-enter')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-input>

--- a/projects/ui/src/lib/components/po-field/po-login/po-login.component.html
+++ b/projects/ui/src/lib/components/po-field/po-login/po-login.component.html
@@ -31,6 +31,7 @@
       (click)="eventOnClick($event)"
       (focus)="eventOnFocus($event)"
       (input)="eventOnInput($event)"
+      (keydown)="onKeyDown($event)"
     />
 
     <div class="po-field-icon-container-right">
@@ -51,6 +52,7 @@
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   >

--- a/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-login/samples/sample-po-login-labs/sample-po-login-labs.component.html
@@ -21,6 +21,7 @@
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
   (p-enter)="changeEvent('p-enter')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-login>

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -441,6 +441,15 @@ export abstract class PoLookupBaseComponent
    * @optional
    *
    * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
+  /**
+   * @optional
+   *
+   * @description
    *
    * Evento será disparado quando ocorrer alguma seleção.
    * Será passado por parâmetro o objeto com o valor selecionado.
@@ -479,6 +488,7 @@ export abstract class PoLookupBaseComponent
    */
   @Output('p-restore-column-manager') columnRestoreManager = new EventEmitter<Array<string>>();
 
+  displayAdditionalHelp: boolean = false;
   service: any;
 
   protected selectedOptions = [];

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
@@ -23,6 +23,7 @@
         [placeholder]="placeholder"
         [required]="required"
         (blur)="searchEvent()"
+        (keydown)="onKeyDown($event)"
       />
 
       <div class="po-field-icon-container-right po-lookup-buttons">
@@ -62,6 +63,7 @@
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>
@@ -78,6 +80,8 @@
       [class.po-lookup-input-static]="!autoHeight"
       [class.po-lookup-input-padding-button-clean]="clean"
       [class.po-lookup-input-disabled]="disabled"
+      (blur)="onBlur()"
+      (keydown)="onKeyDown($event)"
     >
       <span *ngIf="placeholder && !disclaimers?.length" class="po-lookup-input-placeholder">
         {{ placeholder }}

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -151,6 +151,37 @@ describe('PoLookupComponent:', () => {
       });
     });
 
+    describe('onBlur:', () => {
+      let setupTest;
+
+      beforeEach(() => {
+        setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
+          component.additionalHelpTooltip = tooltip;
+          component.displayAdditionalHelp = displayHelp;
+          component.additionalHelp = additionalHelpEvent;
+          spyOn(component, 'showAdditionalHelp');
+        };
+      });
+
+      it('should call showAdditionalHelp when the tooltip is displayed', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when tooltip is not displayed', () => {
+        setupTest('Mensagem de apoio adicional.', false, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when additionalHelp event is true', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: true });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+    });
+
     it('searchEvent: should call `searchById` when the current value isn`t equal to the old value.', inject(
       [LookupFilterService],
       (lookupFilterService: LookupFilterService) => {
@@ -957,6 +988,59 @@ describe('PoLookupComponent:', () => {
       component.calculateVisibleItems.call(fakeThis);
       expect(fakeThis.visibleDisclaimers.length).toBe(0);
       expect(fakeThis.isCalculateVisibleItems).toBeFalsy();
+    });
+
+    describe('onKeyDown:', () => {
+      it('should emit event when field is focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.inputEl = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(component.inputEl.nativeElement);
+
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).toHaveBeenCalledWith(fakeEvent);
+      });
+
+      it('should not emit event when field is not focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.inputEl = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(document.createElement('div'));
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('showAdditionalHelp:', () => {
+      it('should toggle `displayAdditionalHelp` from false to true', () => {
+        component.displayAdditionalHelp = false;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeTrue();
+        expect(component.displayAdditionalHelp).toBeTrue();
+      });
+
+      it('should toggle `displayAdditionalHelp` from true to false', () => {
+        component.displayAdditionalHelp = true;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeFalse();
+        expect(component.displayAdditionalHelp).toBeFalse();
+      });
     });
 
     it('setInputValueWipoieldFormat: should set `inputValue` and `oldValue` with value returned of `fieldFormat`', () => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -339,8 +339,17 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
     );
   }
 
-  searchEvent() {
+  onBlur(): void {
     this.onTouched?.();
+
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+  }
+
+  searchEvent() {
+    this.onBlur();
+
     const value = this.getViewValue();
 
     if (this.oldValue?.toString() !== value) {
@@ -430,6 +439,40 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
     }
 
     this.visibleDisclaimers = [...newDisclaimers];
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    const isFieldFocused = document.activeElement === this.inputEl.nativeElement;
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
+    }
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-lookup
+   *  #lookup
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, lookup)"
+   * ></po-lookup>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoLookupComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   showAdditionalHelpIcon() {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -28,6 +28,7 @@
   [p-virtual-scroll]="properties.includes('virtualScroll')"
   (p-change)="changeEvent('p-change')"
   (p-error)="changeEvent('p-error')"
+  (p-keydown)="changeEvent('p-keydown')"
   (p-selected)="changeEvent('p-selected')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -204,15 +204,6 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * @optional
    *
    * @description
-   * Evento disparado ao clicar no ícone de ajuda adicional.
-   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
-   */
-  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
-
-  /**
-   * @optional
-   *
-   * @description
    *
    * Limita a exibição da mensagem de erro a duas linhas e exibe um tooltip com o texto completo.
    *
@@ -227,10 +218,28 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * @optional
    *
    * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
    *
    * Pode ser informada uma função que será disparada quando houver alterações no ngModel.
    */
   @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
 
   /**
    * @optional
@@ -256,6 +265,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   filterSubject = new Subject();
   service: PoMultiselectFilterService;
   defaultService: PoMultiselectFilterService;
+  displayAdditionalHelp: boolean = false;
 
   // eslint-disable-next-line
   protected onModelTouched: any = null;

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -71,6 +71,7 @@
       [p-disabled]="disabled"
       [p-error-pattern]="getErrorPattern()"
       [p-error-limit]="errorLimit"
+      [p-show-additional-help]="displayAdditionalHelp"
       [p-show-additional-help-icon]="showAdditionalHelpIcon()"
       (p-additional-help)="emitAdditionalHelp()"
     ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -330,6 +330,10 @@ export class PoMultiselectComponent
   }
 
   onBlur() {
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+
     if (
       typeof this.inputElement.nativeElement.getAttribute('aria-label') === 'string' &&
       this.inputElement.nativeElement.getAttribute('aria-label').includes('Unselected')
@@ -340,6 +344,8 @@ export class PoMultiselectComponent
   }
 
   onKeyDown(event?: any) {
+    const isFieldFocused = document.activeElement === this.inputElement.nativeElement;
+
     if (event.shiftKey && event.keyCode === PoKeyCodeEnum.tab && !this.focusOnTag) {
       this.controlDropdownVisibility(false);
     }
@@ -379,6 +385,10 @@ export class PoMultiselectComponent
       this.toggleDropdownVisibility();
     }
     this.enterCloseTag = false;
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
+    }
   }
 
   toggleDropdownVisibility() {
@@ -463,6 +473,32 @@ export class PoMultiselectComponent
     setTimeout(() => {
       this.focusOnNextTag(index, event);
     }, 300);
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-multiselect
+   *  #multiselect
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, multiselect)"
+   * ></po-multiselect>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoMultiselectComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   showAdditionalHelpIcon() {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
@@ -24,6 +24,7 @@
     [p-show-required]="properties.includes('showRequired')"
     [p-sort]="properties.includes('sort')"
     (p-change)="changeEvent('p-change')"
+    (p-keydown)="changeEvent('p-keydown')"
     [p-error-limit]="properties?.includes('errorLimit')"
   >
   </po-multiselect>

--- a/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number-base.component.ts
@@ -36,6 +36,10 @@ export abstract class PoNumberBaseComponent extends PoInputGeneric {
     const target = event.target;
     this.invalidInputValueOnBlur = target.value === '' && !target.validity.valid;
 
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+
     if (this.invalidInputValueOnBlur) {
       this.callOnChange('Valor Inválido');
     }
@@ -44,9 +48,15 @@ export abstract class PoNumberBaseComponent extends PoInputGeneric {
   }
 
   onKeyDown(event) {
+    const isFieldFocused = document.activeElement === this.inputEl.nativeElement;
+
     if (!this.isKeyAllowed(event)) {
       event.stopPropagation();
       event.preventDefault();
+    }
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.html
@@ -53,6 +53,7 @@
     [p-disabled]="disabled"
     [p-error-limit]="errorLimit"
     [p-error-pattern]="getErrorPatternMessage()"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   >

--- a/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-number/samples/sample-po-number-labs/sample-po-number-labs.component.html
@@ -24,6 +24,7 @@
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-number>

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.html
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.html
@@ -33,6 +33,7 @@
       (click)="eventOnClick($event)"
       (focus)="eventOnFocus($event)"
       (input)="eventOnInput($event)"
+      (keydown)="onKeyDown($event)"
     />
 
     <div class="po-field-icon-container-right">
@@ -62,6 +63,7 @@
     [p-disabled]="disabled"
     [p-error-limit]="errorLimit"
     [p-error-pattern]="getErrorPattern()"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   >

--- a/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-password/samples/sample-po-password-labs/sample-po-password-labs.component.html
@@ -22,6 +22,7 @@
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
   (p-enter)="changeEvent('p-enter')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-password>

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
@@ -136,15 +136,6 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
    * @optional
    *
    * @description
-   * Evento disparado ao clicar no ícone de ajuda adicional.
-   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
-   */
-  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
-
-  /**
-   * @optional
-   *
-   * @description
    *
    * Limita a exibição da mensagem de erro a duas linhas e exibe um tooltip com o texto completo.
    *
@@ -159,11 +150,30 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
    * @optional
    *
    * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
    *
    * Evento ao alterar valor do campo.
    */
   @Output('p-change') change: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
+  displayAdditionalHelp: boolean = false;
   mdColumns: number = poRadioGroupColumnsDefaultLength;
   value: any;
 

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.html
@@ -17,6 +17,8 @@
           [p-required]="required"
           [p-size]="size"
           [p-value]="option.value"
+          (p-blur)="onBlur(inputRadio)"
+          (keydown)="onKeyDown($event, inputRadio)"
           (keyup)="onKeyUp($event, option.value)"
           (click)="eventClick(option.value, option.disabled === true || disabled)"
         >
@@ -31,6 +33,7 @@
       [p-error-limit]="errorLimit"
       [p-error-pattern]="getErrorPattern()"
       [p-help]="help"
+      [p-show-additional-help]="displayAdditionalHelp"
       [p-show-additional-help-icon]="showAdditionalHelpIcon()"
       (p-additional-help)="emitAdditionalHelp()"
     ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
@@ -260,6 +260,51 @@ describe('PoRadioGroupComponent:', () => {
       });
     });
 
+    describe('onBlur', () => {
+      let setupTest;
+      let radioMock;
+
+      beforeEach(() => {
+        setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
+          component.additionalHelpTooltip = tooltip;
+          component.displayAdditionalHelp = displayHelp;
+          component.additionalHelp = additionalHelpEvent;
+          spyOn(component, 'showAdditionalHelp');
+        };
+
+        radioMock = { radioInput: { nativeElement: document.createElement('input') } } as PoRadioComponent;
+      });
+      it('should call showAdditionalHelp when the tooltip is displayed', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: false });
+        component.onBlur(radioMock);
+        expect(component.showAdditionalHelp).toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when tooltip is not displayed', () => {
+        setupTest('Mensagem de apoio adicional.', false, { observed: false });
+        component.onBlur(radioMock);
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when additionalHelp event is true', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: true });
+        component.onBlur(radioMock);
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+    });
+
+    it('onKeyDown: should emit event when field is focused', () => {
+      const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+      spyOn(component.keydown, 'emit');
+
+      const radioMock = { radioInput: { nativeElement: document.createElement('input') } } as PoRadioComponent;
+      spyOnProperty(document, 'activeElement', 'get').and.returnValue(radioMock.radioInput.nativeElement);
+
+      component.onKeyDown(fakeEvent, radioMock);
+
+      expect(component.keydown.emit).toHaveBeenCalledWith(fakeEvent);
+    });
+
     describe('onKeyUp:', () => {
       it('should call `changeValue` when `isArrowKey` is true.', () => {
         spyOn(component, 'changeValue');
@@ -307,6 +352,26 @@ describe('PoRadioGroupComponent:', () => {
     it('isArrowKey: should return false when key is not between 37 and 40.', () => {
       expect(component['isArrowKey'](36)).toBeFalsy();
       expect(component['isArrowKey'](41)).toBeFalsy();
+    });
+
+    describe('showAdditionalHelp:', () => {
+      it('should toggle `displayAdditionalHelp` from false to true', () => {
+        component.displayAdditionalHelp = false;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeTrue();
+        expect(component.displayAdditionalHelp).toBeTrue();
+      });
+
+      it('should toggle `displayAdditionalHelp` from true to false', () => {
+        component.displayAdditionalHelp = true;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeFalse();
+        expect(component.displayAdditionalHelp).toBeFalse();
+      });
     });
   });
 

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
@@ -158,12 +158,50 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
     );
   }
 
+  onBlur(radio: PoRadioComponent): void {
+    if (!this.isRadioOptionFocused(radio) && this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+  }
+
+  onKeyDown(event: KeyboardEvent, radio?: PoRadioComponent): void {
+    if (this.isRadioOptionFocused(radio)) {
+      this.keydown.emit(event);
+    }
+  }
+
   onKeyUp(event: KeyboardEvent, value) {
     const key = event.keyCode || event.which;
 
     if (this.isArrowKey(key)) {
       this.changeValue(value);
     }
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-radio-group
+   *  #radioGroup
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, radioGroup)"
+   * ></po-radio-group>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoRadioGroupComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   showAdditionalHelpIcon() {
@@ -179,5 +217,9 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
 
   private isArrowKey(key: number) {
     return key >= 37 && key <= 40;
+  }
+
+  private isRadioOptionFocused(radio: PoRadioComponent): boolean {
+    return document.activeElement === radio.radioInput.nativeElement;
   }
 }

--- a/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.html
@@ -13,6 +13,7 @@
   [p-show-required]="properties.includes('showRequired')"
   [p-size]="size"
   (p-change)="changeEvent('p-change')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-radio-group>

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.html
@@ -9,6 +9,7 @@
       [name]="name ?? 'po-input-radio'"
       [required]="required"
       [value]="radioValue ?? ''"
+      (blur)="onBlur()"
     />
     <po-label *ngIf="label" [p-disabled]="disabled" [p-label]="label"></po-label>
   </label>

--- a/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio/po-radio.component.ts
@@ -64,6 +64,9 @@ export class PoRadioComponent extends PoFieldModel<boolean> {
   /** Define o status do *radio* */
   @Input('p-checked') checked: boolean = false;
 
+  // Evento disparado ao sair do campo.
+  @Output('p-blur') blur: EventEmitter<any> = new EventEmitter();
+
   /** Emite evento para a tabela ao selecionar ou desselecionar */
   @Output('p-change-selected') changeSelected: EventEmitter<any> = new EventEmitter<any>();
 
@@ -102,6 +105,7 @@ export class PoRadioComponent extends PoFieldModel<boolean> {
 
   onBlur() {
     this.onTouched?.();
+    this.blur.emit();
   }
 
   onKeyDown(event: KeyboardEvent) {

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
@@ -184,6 +184,16 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
    */
   @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
 
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
+  displayAdditionalHelp: boolean = false;
   invalid: boolean = false;
   onChangeModel: any = null;
   value: string;

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
@@ -305,6 +305,37 @@ describe('PoRichTextBodyComponent:', () => {
       expect(component.shortcutCommand.emit).not.toHaveBeenCalled();
     });
 
+    it('onKeyDown: should emit event when field is focused', () => {
+      const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+      component.bodyElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.keydown, 'emit');
+      spyOnProperty(document, 'activeElement', 'get').and.returnValue(component.bodyElement.nativeElement);
+
+      component.onKeyDown(fakeEvent);
+
+      expect(component.keydown.emit).toHaveBeenCalledWith(fakeEvent);
+    });
+
+    it('onKeyDown: should not emit event when field is not focused', () => {
+      const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+      component.bodyElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.keydown, 'emit');
+      spyOnProperty(document, 'activeElement', 'get').and.returnValue(document.createElement('div'));
+      component.onKeyDown(fakeEvent);
+
+      expect(component.keydown.emit).not.toHaveBeenCalled();
+    });
+
     it('onKeyUp: should call `toggleCursorOnLink` with `event` and `remove` before `updateModel`', () => {
       spyOn(component, <any>'toggleCursorOnLink');
       const updateModelSpy = spyOn(component, <any>'updateModel');

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
@@ -40,6 +40,8 @@ export class PoRichTextBodyComponent implements OnInit, OnDestroy {
 
   @Output('p-commands') commands = new EventEmitter<any>();
 
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
   @Output('p-selected-link') selectedLink = new EventEmitter<any>();
 
   @Output('p-shortcut-command') shortcutCommand = new EventEmitter<any>();
@@ -123,6 +125,7 @@ export class PoRichTextBodyComponent implements OnInit, OnDestroy {
   onKeyDown(event) {
     const keyK = event.keyCode === PoKeyCodeEnum.keyK;
     const isLinkShortcut = (keyK && event.ctrlKey) || (keyK && event.metaKey);
+    const isFieldFocused = document.activeElement === this.bodyElement.nativeElement;
 
     if (isLinkShortcut) {
       event.preventDefault();
@@ -130,6 +133,10 @@ export class PoRichTextBodyComponent implements OnInit, OnDestroy {
     }
 
     this.toggleCursorOnLink(event, 'add');
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
+    }
   }
 
   onKeyUp(event: any) {

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
@@ -13,6 +13,7 @@
       (p-shortcut-command)="richTextToolbar?.shortcutTrigger()"
       (p-value)="updateValue($event)"
       (p-blur)="onBlur()"
+      (p-keydown)="onKeyDown($event)"
     >
     </po-rich-text-body>
 
@@ -34,6 +35,7 @@
     [p-help]="help"
     [p-error-limit]="errorLimit"
     [p-error-pattern]="errorMsg"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="!!additionalHelpTooltip || additionalHelp.observed"
     (p-additional-help)="additionalHelp.emit()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.spec.ts
@@ -148,22 +148,72 @@ describe('PoRichTextComponent:', () => {
 
       expect(component.bodyElement.focus).toHaveBeenCalled();
     });
+    describe('onBlur', () => {
+      let setupTest;
 
-    it('onBlur: should be called when `po-rich-text-body` emit blur event', () => {
-      component['onTouched'] = () => {};
-      spyOn(component, <any>'onTouched');
+      beforeEach(() => {
+        setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
+          component.additionalHelpTooltip = tooltip;
+          component.displayAdditionalHelp = displayHelp;
+          component.additionalHelp = additionalHelpEvent;
+          spyOn(component, 'showAdditionalHelp');
+        };
+      });
 
-      component.onBlur();
+      it('should be called when `po-rich-text-body` emit blur event', () => {
+        component['onTouched'] = () => {};
+        spyOn(component, <any>'onTouched');
 
-      expect(component['onTouched']).toHaveBeenCalled();
+        component.onBlur();
+
+        expect(component['onTouched']).toHaveBeenCalled();
+      });
+
+      it('shouldn´t throw error if onTouched is falsy', () => {
+        component['onTouched'] = null;
+
+        const fnError = () => component.onBlur();
+
+        expect(fnError).not.toThrow();
+      });
+
+      it('should call showAdditionalHelp when the tooltip is displayed', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when tooltip is not displayed', () => {
+        setupTest('Mensagem de apoio adicional.', false, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when additionalHelp event is true', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: true });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
     });
 
-    it('onBlur: shouldn´t throw error if onTouched is falsy', () => {
-      component['onTouched'] = null;
+    describe('showAdditionalHelp:', () => {
+      it('should toggle `displayAdditionalHelp` from false to true', () => {
+        component.displayAdditionalHelp = false;
 
-      const fnError = () => component.onBlur();
+        const result = component.showAdditionalHelp();
 
-      expect(fnError).not.toThrow();
+        expect(result).toBeTrue();
+        expect(component.displayAdditionalHelp).toBeTrue();
+      });
+
+      it('should toggle `displayAdditionalHelp` from true to false', () => {
+        component.displayAdditionalHelp = true;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeFalse();
+        expect(component.displayAdditionalHelp).toBeFalse();
+      });
     });
 
     it('updateValue: should apply values to value, invalid and call updateModel', () => {
@@ -215,6 +265,15 @@ describe('PoRichTextComponent:', () => {
       component.onChangeValue('value');
 
       expect(component.change.emit).toHaveBeenCalledWith('value');
+    });
+
+    it('p-keydown: should emit event', () => {
+      const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+      spyOn(component.keydown, 'emit');
+
+      component.onKeyDown(fakeEvent);
+
+      expect(component.keydown.emit).toHaveBeenCalledWith(fakeEvent);
     });
 
     it('controlChangeModelEmitter: should emit changeModel and set modelLastUpdate value', () => {

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
@@ -139,10 +139,44 @@ export class PoRichTextComponent
 
   onBlur() {
     this.onTouched?.();
+
+    if (this.additionalHelp.observed ? null : this.additionalHelpTooltip && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
   }
 
   onChangeValue(value: any) {
     this.change.emit(value);
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    this.keydown.emit(event);
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-rich-text
+   *  #richtext
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, richtext)"
+   * ></po-rich-text>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoRichTextComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   updateValue(value: string) {

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-labs/sample-po-rich-text-labs.component.html
@@ -14,6 +14,7 @@
   [p-show-required]="properties.includes('showRequired')"
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-rich-text>

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
@@ -16,7 +16,9 @@
       [disabled]="disabled"
       [id]="id"
       [required]="required"
+      (blur)="onBlur()"
       (change)="onSelectChange($event.target.value)"
+      (keydown)="onKeyDown($event)"
     >
       <ng-container *ngIf="!isSafari">
         <option
@@ -60,6 +62,7 @@
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -335,6 +335,10 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
 
   onBlur() {
     this.onModelTouched?.();
+
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
   }
 
   // Altera o valor ao selecionar um item.
@@ -396,8 +400,40 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
     return false;
   }
 
+  onKeyDown(event: KeyboardEvent): void {
+    const isFieldFocused = document.activeElement === this.selectElement.nativeElement;
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
+    }
+  }
+
   registerOnTouched(fn: any): void {
     this.onModelTouched = fn;
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```html
+   * <po-select
+   *  #select
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, select)"
+   * ></po-select>
+   * ```
+   * ```typescript
+   * onKeyDown(event: KeyboardEvent, inp: PoSelectComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  override showAdditionalHelp(): boolean {
+    return super.showAdditionalHelp();
   }
 
   private isEqual(value: any, inputValue: any): boolean {

--- a/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/samples/sample-po-select-labs/sample-po-select-labs.component.html
@@ -17,6 +17,7 @@
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
   (p-enter)="changeEvent('p-enter')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-select>

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
@@ -36,6 +36,7 @@
     [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
@@ -130,24 +130,86 @@ describe('PoSwitchComponent', () => {
         expect(component.eventClick).not.toHaveBeenCalled();
         expect(fakeEvent.preventDefault).not.toHaveBeenCalled();
       });
+
+      it('should emit event when field is focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.switchContainer = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(component.switchContainer.nativeElement);
+
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).toHaveBeenCalledWith(fakeEvent);
+      });
+
+      it('should not emit event when field is not focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.switchContainer = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(document.createElement('div'));
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).not.toHaveBeenCalled();
+      });
     });
 
-    it('onBlur: should call `onTouched` on blur', () => {
-      component['onTouched'] = value => {};
+    describe('onBlur', () => {
+      let setupTest;
 
-      spyOn(component, <any>'onTouched');
+      beforeEach(() => {
+        setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
+          component.additionalHelpTooltip = tooltip;
+          component.displayAdditionalHelp = displayHelp;
+          component.additionalHelp = additionalHelpEvent;
+          spyOn(component, 'showAdditionalHelp');
+        };
+      });
 
-      component.onBlur();
+      it('should call `onTouched` on blur', () => {
+        component['onTouched'] = value => {};
 
-      expect(component['onTouched']).toHaveBeenCalledWith();
-    });
+        spyOn(component, <any>'onTouched');
 
-    it('onBlur: shouldn´t throw error if onTouched is falsy', () => {
-      component['onTouched'] = null;
+        component.onBlur();
 
-      const fnError = () => component.onBlur();
+        expect(component['onTouched']).toHaveBeenCalledWith();
+      });
 
-      expect(fnError).not.toThrow();
+      it('shouldn´t throw error if onTouched is falsy', () => {
+        component['onTouched'] = null;
+
+        const fnError = () => component.onBlur();
+
+        expect(fnError).not.toThrow();
+      });
+
+      it('should call showAdditionalHelp when the tooltip is displayed', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when tooltip is not displayed', () => {
+        setupTest('Mensagem de apoio adicional.', false, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when additionalHelp event is true', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: true });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
     });
 
     it('changeValue: shouldn`t call `change.emit` and `updateModel` if switch value is not changed', () => {

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
@@ -220,6 +220,10 @@ export class PoSwitchComponent extends PoFieldModel<any> {
 
   onBlur() {
     this.onTouched?.();
+
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
   }
 
   getLabelPosition() {
@@ -234,9 +238,15 @@ export class PoSwitchComponent extends PoFieldModel<any> {
   }
 
   onKeyDown(event) {
+    const isFieldFocused = document.activeElement === this.switchContainer.nativeElement;
+
     if (event.which === PoKeyCodeEnum.space || event.keyCode === PoKeyCodeEnum.space) {
       event.preventDefault();
       this.eventClick();
+    }
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.html
@@ -11,6 +11,7 @@
   [p-format-model]="properties.includes('formatModel')"
   [p-hide-label-status]="properties.includes('hideLabelStatus')"
   (p-change)="changeEvent('p-change')"
+  (p-keydown)="changeEvent('p-keydown')"
 >
 </po-switch>
 

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -116,15 +116,6 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
    * @optional
    *
    * @description
-   * Evento disparado ao clicar no ícone de ajuda adicional.
-   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
-   */
-  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
-
-  /**
-   * @optional
-   *
-   * @description
    *
    * Limita a exibição da mensagem de erro a duas linhas e exibe um tooltip com o texto completo.
    *
@@ -134,6 +125,15 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
    * @default `false`
    */
   @Input('p-error-limit') errorLimit: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao clicar no ícone de ajuda adicional.
+   * Este evento ativa automaticamente a exibição do ícone de ajuda adicional ao `p-help`.
+   */
+  @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
   /**
    * @optional
@@ -170,6 +170,17 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
    * Evento disparado ao alterar valor do model.
    */
   @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
+  displayAdditionalHelp: boolean = false;
 
   private _disabled: boolean = false;
   private _maxlength: number;

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.html
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.html
@@ -13,6 +13,7 @@
       (blur)="eventOnBlur()"
       (focus)="eventOnFocus()"
       (input)="eventOnInput($event)"
+      (keydown)="onKeyDown($event)"
       [attr.name]="name"
       [disabled]="disabled"
       [id]="id"
@@ -31,6 +32,7 @@
     [p-disabled]="disabled"
     [p-error-pattern]="getErrorPattern()"
     [p-error-limit]="errorLimit"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
@@ -92,12 +92,43 @@ describe('PoTextareaComponent:', () => {
     expect(component.controlChangeEmitter).toHaveBeenCalled();
   });
 
-  it('eventOnBlur: shouldn´t throw error if onTouched is falsy', () => {
-    component['onTouched'] = null;
+  describe('eventOnBlur', () => {
+    let setupTest;
 
-    const fnError = () => component.eventOnBlur();
+    beforeEach(() => {
+      setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
+        component.additionalHelpTooltip = tooltip;
+        component.displayAdditionalHelp = displayHelp;
+        component.additionalHelp = additionalHelpEvent;
+        spyOn(component, 'showAdditionalHelp');
+      };
+    });
 
-    expect(fnError).not.toThrow();
+    it('shouldn´t throw error if onTouched is falsy', () => {
+      component['onTouched'] = null;
+
+      const fnError = () => component.eventOnBlur();
+
+      expect(fnError).not.toThrow();
+    });
+
+    it('should call showAdditionalHelp when the tooltip is displayed', () => {
+      setupTest('Mensagem de apoio adicional.', true, { observed: false });
+      component.eventOnBlur();
+      expect(component.showAdditionalHelp).toHaveBeenCalled();
+    });
+
+    it('should not call showAdditionalHelp when tooltip is not displayed', () => {
+      setupTest('Mensagem de apoio adicional.', false, { observed: false });
+      component.eventOnBlur();
+      expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+    });
+
+    it('should not call showAdditionalHelp when additionalHelp event is true', () => {
+      setupTest('Mensagem de apoio adicional.', true, { observed: true });
+      component.eventOnBlur();
+      expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+    });
   });
 
   describe('Methods:', () => {
@@ -296,6 +327,80 @@ describe('PoTextareaComponent:', () => {
         component['el'].nativeElement.classList.add('ng-dirty');
         component.fieldErrorMessage = undefined;
         expect(component.getErrorPattern()).toBe('');
+      });
+    });
+
+    describe('onKeyDown:', () => {
+      it('should emit event when field is focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.inputEl = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(component.inputEl.nativeElement);
+
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).toHaveBeenCalledWith(fakeEvent);
+      });
+
+      it('should not emit event when field is not focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.inputEl = {
+          nativeElement: {
+            focus: () => {}
+          }
+        };
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(document.createElement('div'));
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('showAdditionalHelp:', () => {
+      it('should toggle `displayAdditionalHelp` from false to true', () => {
+        component.displayAdditionalHelp = false;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeTrue();
+        expect(component.displayAdditionalHelp).toBeTrue();
+      });
+
+      it('should toggle `displayAdditionalHelp` from true to false', () => {
+        component.displayAdditionalHelp = true;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeFalse();
+        expect(component.displayAdditionalHelp).toBeFalse();
+      });
+    });
+
+    describe('isAdditionalHelpEventTriggered:', () => {
+      it('should return true when additionalHelpEventTrigger is "event"', () => {
+        component.additionalHelpEventTrigger = 'event';
+        expect((component as any).isAdditionalHelpEventTriggered()).toBeTrue();
+      });
+
+      it('should return true when additionalHelpEventTrigger is undefined and additionalHelp is observed', () => {
+        component.additionalHelpEventTrigger = undefined;
+        component.additionalHelp = {
+          observed: true
+        } as any;
+
+        expect((component as any).isAdditionalHelpEventTriggered()).toBeTrue();
+      });
+
+      it('should return false when additionalHelpEventTrigger is not "event" and additionalHelp is not observed', () => {
+        component.additionalHelpEventTrigger = 'noEvent';
+        expect((component as any).isAdditionalHelpEventTriggered()).toBeFalse();
       });
     });
   });

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
@@ -162,6 +162,10 @@ export class PoTextareaComponent extends PoTextareaBaseComponent implements Afte
     this.onTouched?.();
     this.blur.emit();
     this.controlChangeEmitter();
+
+    if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
   }
 
   controlChangeEmitter() {
@@ -170,6 +174,40 @@ export class PoTextareaComponent extends PoTextareaBaseComponent implements Afte
     if (elementValue !== this.valueBeforeChange) {
       this.change.emit(elementValue);
     }
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    const isFieldFocused = document.activeElement === this.inputEl.nativeElement;
+
+    if (isFieldFocused) {
+      this.keydown.emit(event);
+    }
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-textarea
+   *  #textarea
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, textarea)"
+   * ></po-textarea>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoTextareaComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   showAdditionalHelpIcon() {

--- a/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-textarea/samples/sample-po-textarea-labs/sample-po-textarea-labs.component.html
@@ -18,6 +18,7 @@
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
   (p-enter)="changeEvent('p-enter')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-textarea>

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -362,6 +362,15 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    * @optional
    *
    * @description
+   * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
+   * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
+   */
+  @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
+  /**
+   * @optional
+   *
+   * @description
    *
    * Função que será executada no momento de realizar o envio do arquivo,
    * onde será possível adicionar informações ao parâmetro que será enviado na requisição.
@@ -422,6 +431,7 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
   currentFiles: Array<PoUploadFile>;
 
   canHandleDirectory: boolean;
+  displayAdditionalHelp: boolean = false;
   onModelChange: any;
 
   protected extensionNotAllowed = 0;

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
@@ -37,9 +37,11 @@
         #uploadButton
         class="po-upload-button"
         for="file"
+        (p-blur)="onBlur()"
         [p-disabled]="isDisabled"
         [p-label]="selectFileButtonLabel"
         (p-click)="selectFiles()"
+        (keydown)="onKeyDown($event)"
       >
       </po-button>
 
@@ -95,6 +97,7 @@
     [p-append-in-body]="appendBox"
     [p-help]="help"
     [p-disabled]="disabled"
+    [p-show-additional-help]="displayAdditionalHelp"
     [p-show-additional-help-icon]="showAdditionalHelpIcon()"
     (p-additional-help)="emitAdditionalHelp()"
   ></po-field-container-bottom>

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
@@ -21,6 +21,7 @@ import { PoUploadFileRestrictionsComponent } from './po-upload-file-restrictions
 import { PoUploadService } from './po-upload.service';
 import { PoUploadStatus } from './po-upload-status.enum';
 import { PoProgressAction } from '../../po-progress';
+import { PoButtonComponent } from '../../po-button';
 
 describe('PoUploadComponent:', () => {
   let component: PoUploadComponent;
@@ -558,6 +559,37 @@ describe('PoUploadComponent:', () => {
       expect(component['updateFiles']).toHaveBeenCalledWith(files);
     });
 
+    describe('onKeyDown:', () => {
+      beforeEach(() => {
+        component.uploadButton = {
+          buttonElement: {
+            nativeElement: document.createElement('button')
+          }
+        } as PoButtonComponent;
+      });
+
+      it('should emit event when field is focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(
+          component.uploadButton.buttonElement.nativeElement
+        );
+
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).toHaveBeenCalledWith(fakeEvent);
+      });
+
+      it('should not emit event when field is not focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(document.createElement('div'));
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).not.toHaveBeenCalled();
+      });
+    });
+
     it('removeFile: should be remove file from currentFiles', () => {
       const fakeThis = {
         currentFiles: [file],
@@ -761,6 +793,43 @@ describe('PoUploadComponent:', () => {
         component.uploadFiles.call(fakeThis, [file]);
 
         expect(fakeThis.responseHandler).toHaveBeenCalled();
+      });
+    });
+
+    describe('onBlur', () => {
+      let setupTest;
+
+      beforeEach(() => {
+        component.uploadButton = {
+          buttonElement: {
+            nativeElement: document.createElement('button')
+          }
+        } as PoButtonComponent;
+
+        setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
+          component.additionalHelpTooltip = tooltip;
+          component.displayAdditionalHelp = displayHelp;
+          component.additionalHelp = additionalHelpEvent;
+          spyOn(component, 'showAdditionalHelp');
+        };
+      });
+
+      it('should call showAdditionalHelp when the tooltip is displayed', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when tooltip is not displayed', () => {
+        setupTest('Mensagem de apoio adicional.', false, { observed: false });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+
+      it('should not call showAdditionalHelp when additionalHelp event is true', () => {
+        setupTest('Mensagem de apoio adicional.', true, { observed: true });
+        component.onBlur();
+        expect(component.showAdditionalHelp).not.toHaveBeenCalled();
       });
     });
 
@@ -1064,6 +1133,26 @@ describe('PoUploadComponent:', () => {
         'webkitdirectory'
       );
       expect(component.renderer.removeAttribute).toHaveBeenCalledTimes(1);
+    });
+
+    describe('showAdditionalHelp:', () => {
+      it('should toggle `displayAdditionalHelp` from false to true', () => {
+        component.displayAdditionalHelp = false;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeTrue();
+        expect(component.displayAdditionalHelp).toBeTrue();
+      });
+
+      it('should toggle `displayAdditionalHelp` from true to false', () => {
+        component.displayAdditionalHelp = true;
+
+        const result = component.showAdditionalHelp();
+
+        expect(result).toBeFalse();
+        expect(component.displayAdditionalHelp).toBeFalse();
+      });
     });
 
     it('customClick: should emit customActionClick with the provided file if customAction is defined', () => {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
@@ -76,7 +76,7 @@ import { PoUploadService } from './po-upload.service';
 export class PoUploadComponent extends PoUploadBaseComponent implements AfterViewInit {
   @ViewChild('inputFile', { read: ElementRef, static: true }) private inputFile: ElementRef;
   @ViewChild(PoUploadDragDropComponent) private poUploadDragDropComponent: PoUploadDragDropComponent;
-  @ViewChild('uploadButton') private uploadButton: PoButtonComponent;
+  @ViewChild('uploadButton') uploadButton: PoButtonComponent;
 
   id = `po-upload[${uuid()}]`;
 
@@ -245,6 +245,12 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
     return status !== PoUploadStatus.Uploaded;
   }
 
+  onBlur(): void {
+    if (!this.isUploadButtonFocused() && this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
+      this.showAdditionalHelp();
+    }
+  }
+
   // Função disparada ao selecionar algum arquivo.
   onFileChange(event): void {
     // necessário este tratamento quando para IE, pois nele o change é disparado quando o campo é limpado também
@@ -261,6 +267,12 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
 
   onFileChangeDragDrop(files) {
     this.updateFiles(files);
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    if (this.isUploadButtonFocused()) {
+      this.keydown.emit(event);
+    }
   }
 
   // Remove o arquivo passado por parâmetro da lista dos arquivos correntes.
@@ -314,6 +326,32 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
     } else {
       this.renderer.removeAttribute(this.inputFile.nativeElement, 'webkitdirectory');
     }
+  }
+
+  /**
+   * Método que exibe `p-additionalHelpTooltip` ou executa a ação definida em `p-additionalHelp`.
+   * Para isso, será necessário configurar uma tecla de atalho utilizando o evento `p-keydown`.
+   *
+   * ```
+   * <po-upload
+   *  #upload
+   *  ...
+   *  p-additional-help-tooltip="Mensagem de ajuda complementar"
+   *  (p-keydown)="onKeyDown($event, upload)"
+   * ></po-upload>
+   * ```
+   * ```
+   * ...
+   * onKeyDown(event: KeyboardEvent, inp: PoUploadComponent): void {
+   *  if (event.code === 'F9') {
+   *    inp.showAdditionalHelp();
+   *  }
+   * }
+   * ```
+   */
+  showAdditionalHelp(): boolean {
+    this.displayAdditionalHelp = !this.displayAdditionalHelp;
+    return this.displayAdditionalHelp;
   }
 
   showAdditionalHelpIcon() {
@@ -378,6 +416,10 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
       this.additionalHelpEventTrigger === 'event' ||
       (this.additionalHelpEventTrigger === undefined && this.additionalHelp.observed)
     );
+  }
+
+  private isUploadButtonFocused(): boolean {
+    return document.activeElement === this.uploadButton.buttonElement.nativeElement;
   }
 
   // função disparada na resposta do sucesso ou error

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
@@ -26,6 +26,7 @@
   [p-custom-action]="action"
   (p-custom-action-click)="changeEvent('p-custom-action-click')"
   (p-error)="changeEvent('p-error')"
+  (p-keydown)="changeEvent('p-keydown')"
   (p-success)="changeEvent('p-success')"
   (p-upload)="changeEvent('p-upload')"
 >

--- a/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-url/samples/sample-po-url-labs/sample-po-url-labs.component.html
@@ -20,6 +20,7 @@
   (p-change)="changeEvent('p-change')"
   (p-change-model)="changeEvent('p-change-model')"
   (p-enter)="changeEvent('p-enter')"
+  (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-url>

--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.spec.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.spec.ts
@@ -124,6 +124,45 @@ describe('PoTooltipDirective', () => {
 
       expect(spyaddTooltipAction).not.toHaveBeenCalled();
     });
+
+    describe('toggleTooltipVisibility', () => {
+      it('should call `removeTooltipAction` if `show` is false and `displayTooltip` is false', () => {
+        directive.displayTooltip = false;
+
+        const spyAddTooltipAction = spyOn(directive, <any>'addTooltipAction');
+        const spyRemoveTooltipAction = spyOn(directive, <any>'removeTooltipAction');
+
+        directive.toggleTooltipVisibility(false);
+
+        expect(spyRemoveTooltipAction).toHaveBeenCalled();
+        expect(spyAddTooltipAction).not.toHaveBeenCalled();
+      });
+
+      it('should call `addTooltipAction` if `show` is true and `displayTooltip` is false', () => {
+        directive.displayTooltip = false;
+
+        const spyAddTooltipAction = spyOn(directive, <any>'addTooltipAction');
+        const spyRemoveTooltipAction = spyOn(directive, <any>'removeTooltipAction');
+
+        directive.toggleTooltipVisibility(true);
+
+        expect(spyAddTooltipAction).toHaveBeenCalled();
+        expect(spyRemoveTooltipAction).not.toHaveBeenCalled();
+      });
+
+      it('should not call `addTooltipAction` or `removeTooltipAction` if `displayTooltip` is true', () => {
+        directive.displayTooltip = true;
+
+        const spyAddTooltipAction = spyOn(directive, <any>'addTooltipAction');
+        const spyRemoveTooltipAction = spyOn(directive, <any>'removeTooltipAction');
+
+        directive.toggleTooltipVisibility(true);
+        directive.toggleTooltipVisibility(false);
+
+        expect(spyAddTooltipAction).not.toHaveBeenCalled();
+        expect(spyRemoveTooltipAction).not.toHaveBeenCalled();
+      });
+    });
   });
 
   it('should call hideTooltip in ngOnDestroy', () => {

--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
@@ -94,6 +94,13 @@ export class PoTooltipDirective extends PoTooltipBaseDirective implements OnInit
     }
   }
 
+  // Controla a visibilidade do tooltip, criado para auxiliar a propriedade `p-additional-help-tooltip`.
+  toggleTooltipVisibility(show: boolean) {
+    if (!this.displayTooltip) {
+      show ? this.addTooltipAction() : this.removeTooltipAction();
+    }
+  }
+
   protected addTooltipAction() {
     setTimeout(() => {
       if (this.tooltip) {


### PR DESCRIPTION
**DTHFUI-10601**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o novo comportamento?**
Adiciona evento keydown para notificar sobre a tecla pressionada e o método showAdditionalHelp para exibir ou acionar additionalHelp.

**Simulação**
[DTHFUI-10601_components-po-ui_app.zip](https://github.com/user-attachments/files/18622006/DTHFUI-10601_components-po-ui_app.zip)
