### PR TITLE
fix(table): ajusta contagem de colunas extras na po-table

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -139,7 +139,7 @@
         </th>
 
         <th
-          *ngIf="(hasMasterDetailColumn || hasRowTemplate) && !hasRowTemplateWithArrowDirectionRight"
+          *ngIf="(hasMasterDetailColumn || hasRowTemplate) && hasMainColumns && !hasRowTemplateWithArrowDirectionRight"
           class="po-table-header-column po-table-header-master-detail"
         ></th>
 
@@ -250,7 +250,7 @@
         </ng-template>
 
         <th
-          *ngIf="hasRowTemplateWithArrowDirectionRight && (hasVisibleActions || hideColumnsManager)"
+          *ngIf="hasRowTemplateWithArrowDirectionRight && (hasVisibleActions || hideColumnsManager) && hasMainColumns"
           class="po-table-header-column po-table-header-master-detail"
         ></th>
 
@@ -488,7 +488,9 @@
           </th>
 
           <th
-            *ngIf="(hasMasterDetailColumn || hasRowTemplate) && !hasRowTemplateWithArrowDirectionRight"
+            *ngIf="
+              (hasMasterDetailColumn || hasRowTemplate) && hasMainColumns && !hasRowTemplateWithArrowDirectionRight
+            "
             class="po-table-header-column po-table-header-master-detail"
           ></th>
 
@@ -597,7 +599,7 @@
           </ng-template>
 
           <th
-            *ngIf="hasRowTemplateWithArrowDirectionRight && (hasVisibleActions || hideColumnsManager)"
+            *ngIf="hasRowTemplateWithArrowDirectionRight && hasMainColumns && (hasVisibleActions || hideColumnsManager)"
             class="po-table-header-column po-table-header-master-detail"
           ></th>
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -3317,4 +3317,74 @@ describe('PoTableComponent:', () => {
 
     expect(fakeTable.headerWidth).toBe(300);
   });
+
+  it('should return 0 if columnMasterDetail is defined', () => {
+    component['columnMasterDetail'] = { property: 'detail' } as any;
+    spyOnProperty(component, 'hasItems').and.returnValue(true);
+
+    const result = component['countExtraColumns']();
+
+    expect(result).toBe(0);
+  });
+
+  it('should return 1 if hasRowTemplate is true, hasRowTemplateWithArrowDirectionRight is false, and hasItems is true', () => {
+    component['columnMasterDetail'] = undefined;
+    spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
+    spyOnProperty(component, 'hasRowTemplateWithArrowDirectionRight').and.returnValue(false);
+    spyOnProperty(component, 'hasItems').and.returnValue(true);
+
+    const result = component['countExtraColumns']();
+
+    expect(result).toBe(1);
+  });
+
+  it('should return 1 if hasRowTemplateWithArrowDirectionRight is true, hasVisibleActions is true, and hasItems is true', () => {
+    component['columnMasterDetail'] = undefined;
+    spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
+    spyOnProperty(component, 'hasRowTemplateWithArrowDirectionRight').and.returnValue(true);
+    spyOnProperty(component, 'hasVisibleActions').and.returnValue(true);
+    spyOnProperty(component, 'hasItems').and.returnValue(true);
+
+    const result = component['countExtraColumns']();
+
+    expect(result).toBe(1);
+  });
+
+  it('should return 1 if hasRowTemplateWithArrowDirectionRight is true, hideColumnsManager is true, and hasItems is true', () => {
+    component['columnMasterDetail'] = undefined;
+    spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
+    spyOnProperty(component, 'hasRowTemplateWithArrowDirectionRight').and.returnValue(true);
+    component['hideColumnsManager'] = true;
+    spyOnProperty(component, 'hasItems').and.returnValue(true);
+
+    const result = component['countExtraColumns']();
+
+    expect(result).toBe(1);
+  });
+
+  it('should return 0 if no conditions are met and hasItems is true', () => {
+    component['columnMasterDetail'] = undefined;
+    spyOnProperty(component, 'hasRowTemplate').and.returnValue(false);
+    spyOnProperty(component, 'hasRowTemplateWithArrowDirectionRight').and.returnValue(false);
+    spyOnProperty(component, 'hasVisibleActions').and.returnValue(false);
+    component['hideColumnsManager'] = false;
+    spyOnProperty(component, 'hasItems').and.returnValue(true);
+
+    const result = component['countExtraColumns']();
+
+    expect(result).toBe(0);
+  });
+
+  it('should return 0 if hasItems is false, regardless of other conditions', () => {
+    component['columnMasterDetail'] = undefined;
+    spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
+    spyOnProperty(component, 'hasRowTemplateWithArrowDirectionRight').and.returnValue(true);
+    spyOnProperty(component, 'hasVisibleActions').and.returnValue(true);
+    component['hideColumnsManager'] = true;
+    spyOnProperty(component, 'hasItems').and.returnValue(false);
+
+    const result = component['countExtraColumns']();
+
+    expect(result).toBe(0);
+  });
 });

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -233,7 +233,8 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
       this.mainColumns.length +
       (this.actions.length > 0 ? 1 : 0) +
       (this.selectable ? 1 : 0) +
-      (!this.hideDetail && this.columnMasterDetail !== undefined ? 1 : 0);
+      (!this.hideDetail && this.columnMasterDetail !== undefined ? 1 : 0) +
+      this.countExtraColumns();
 
     return columnCount || 1;
   }
@@ -796,6 +797,29 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
       const columnLabel = this.getColumnLabel(row, column);
       return (this.tooltipText = columnLabel?.tooltip);
     }
+  }
+
+  private countExtraColumns(): number {
+    let extraColumns = 0;
+
+    if (!this.columnMasterDetail && this.hasItems) {
+      if (
+        (this.hasMasterDetailColumn || this.hasRowTemplate) &&
+        this.hasMainColumns &&
+        !this.hasRowTemplateWithArrowDirectionRight
+      ) {
+        extraColumns++;
+      }
+      if (
+        this.hasRowTemplateWithArrowDirectionRight &&
+        this.hasMainColumns &&
+        (this.hasVisibleActions || this.hideColumnsManager)
+      ) {
+        extraColumns++;
+      }
+    }
+
+    return extraColumns;
   }
 
   private debounceResize() {


### PR DESCRIPTION
Corrige alinhamento do texto "nenhum dado encontrado" sem dados. Adiciona função auxiliar para unificar condições extras de coluna. Mantém compatibilidade com temas e design tokens.

Fixes DTHFUI-8450