### PR TITLE
fix(table): corrige posição do ícone arrow para coluna detalhe

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -278,9 +278,12 @@
             </ng-container>
           </td>
 
-          <!-- Valida se a origem do detail é pelo input do po-table -->
+          <!-- Valida se a origem do detail é pelo input do po-table ou pela diretiva -->
           <td
-            *ngIf="columnMasterDetail && !hideDetail && !hasRowTemplate"
+            *ngIf="
+              (columnMasterDetail && !hideDetail && !hasRowTemplate) ||
+              (hasRowTemplate && !hasRowTemplateWithArrowDirectionRight)
+            "
             class="po-table-column-detail-toggle"
             (click)="toggleDetail(row)"
           >
@@ -298,19 +301,6 @@
             [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
           >
           </ng-template>
-
-          <!-- Valida se a origem do detail é pela diretiva -->
-          <td
-            *ngIf="hasRowTemplate && !hasRowTemplateWithArrowDirectionRight"
-            class="po-table-column-detail-toggle"
-            (click)="toggleDetail(row)"
-          >
-            <ng-template
-              [ngTemplateOutlet]="poTableColumnDetail"
-              [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-            >
-            </ng-template>
-          </td>
 
           <td
             *ngFor="let column of mainColumns; let columnIndex = index; trackBy: trackBy"
@@ -631,9 +621,12 @@
               </ng-container>
             </td>
 
-            <!-- Valida se a origem do detail é pelo input do po-table -->
+            <!-- Valida se a origem do detail é pelo input do po-table ou pela diretiva -->
             <td
-              *ngIf="columnMasterDetail && !hideDetail && !hasRowTemplate"
+              *ngIf="
+                (columnMasterDetail && !hideDetail && !hasRowTemplate) ||
+                (hasRowTemplate && !hasRowTemplateWithArrowDirectionRight)
+              "
               class="po-table-column-detail-toggle"
               (click)="toggleDetail(row)"
             >
@@ -651,19 +644,6 @@
               [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
             >
             </ng-template>
-
-            <!-- Valida se a origem do detail é pela diretiva -->
-            <td
-              *ngIf="hasRowTemplate && !hasRowTemplateWithArrowDirectionRight"
-              class="po-table-column-detail-toggle"
-              (click)="toggleDetail(row)"
-            >
-              <ng-template
-                [ngTemplateOutlet]="poTableColumnDetail"
-                [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-              >
-              </ng-template>
-            </td>
 
             <td
               *ngFor="let column of mainColumns; let columnIndex = index; trackBy: trackBy"


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-9372**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao definir uma tabela que contenha uma coluna do tipo detalhe, embutida em um ngTemplate, há diferença de posicionamento do ícone arrow se comparado a uma tabela que possui a coluna de detalhes apenas definida no Array de objetos do (p-columns).

**Qual o novo comportamento?**
Não há evidencia no figma do PoTable que informe que deva ter esta diferença de posicionamento do ícone arrow. Lá está definido que deve estar a esquerda do ícone de ações da respectiva linha;
Ajustado a lógica no template do componente para que em ambos os casos o ícone arrow seja posicionado a esquerda do ícone de ações;

**Simulação**
No app em anexo consta os dois cenários em que é possível simular o problema.
[app.zip](https://github.com/user-attachments/files/18773191/app.26.zip)



















