### PR TITLE
fix(table): corrige warnings indesejados ao utilizar po-column-template

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -2901,6 +2901,16 @@ describe('PoTableComponent:', () => {
 
       expect(res).toEqual(tableColumnTemplate.templateRef);
     });
+
+    it('getTemplate: should return null if component is not initialized', () => {
+      component.initialized = false;
+
+      const column: PoTableColumn = { property: 'status' };
+
+      const res = component.getTemplate(column);
+
+      expect(res).toBeNull();
+    });
   });
 
   it('hasRowTemplateWithArrowDirectionRight: should be false if tableRowTemplateArrowDirection is left', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -698,13 +698,16 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     const template: PoTableColumnTemplateDirective = this.tableColumnTemplates?.find(
       tableColumnTemplate => tableColumnTemplate.targetProperty === column.property
     );
-    if (!template) {
+    if (!this.initialized) return null;
+
+    if (template) {
+      return template.templateRef;
+    } else {
       console.warn(
         `Não foi possível encontrar o template para a coluna: ${column.property}, por gentileza informe a propriedade [p-property]`
       );
       return null;
     }
-    return template.templateRef;
   }
 
   public getWidthColumnManager() {


### PR DESCRIPTION
Ocorriam diversos warnings no console do navegador ao utilizar o po-table com po-column-template, mesmo quando as propriedades estavam sendo alimentadas corretamente.

Agora, a exibição dos warnings ocorre apenas quando necessário, garantindo que o componente opere de forma correta e sem mensagens indesejadas no console.

Fixes DTHFUI-9561

_____________________________________________________________________________


**Qual o comportamento atual?**
Ocorriam diversos warnings no console do navegador ao utilizar o po-table com po-column-template, mesmo quando as propriedades estavam sendo alimentadas corretamente.

**Qual o novo comportamento?**
Agora, a exibição dos warnings ocorre apenas quando necessário, garantindo que o componente opere de forma correta e sem mensagens indesejadas no console.

**Simulação**
APP
[appDTHFUI-9561.zip](https://github.com/user-attachments/files/18833942/appDTHFUI-9561.zip)
