### PR TITLE
fix(multiselect): corrige remoção da tag para value 0

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -415,6 +415,20 @@ describe('PoMultiselectComponent:', () => {
     expect(component.selectedOptions[0].value).toBe(1);
   });
 
+  it('closeTag: should handle value 0 correctly', () => {
+    component.visibleTags = [{ label: 'label0', value: 0 }];
+    component.selectedOptions = [{ label: 'label0', value: 0 }];
+
+    spyOn(component, 'updateVisibleItems');
+    spyOn(component, 'callOnChange');
+
+    component['closeTag'](0, 'click');
+
+    expect(component.updateVisibleItems).toHaveBeenCalled();
+    expect(component.callOnChange).toHaveBeenCalled();
+    expect(component.selectedOptions.some(opt => opt.value === 0)).toBeFalse();
+  });
+
   describe('showAdditionalHelp:', () => {
     it('should toggle `displayAdditionalHelp` from false to true', () => {
       component.displayAdditionalHelp = false;

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -453,7 +453,7 @@ export class PoMultiselectComponent
   closeTag(value, event) {
     let index;
     this.enterCloseTag = true;
-    if (!value || (typeof value === 'string' && value.includes('+'))) {
+    if (value === null || value === undefined || (typeof value === 'string' && value.includes('+'))) {
       index = null;
       const itemsNotInVisibleTags = this.selectedOptions.filter(option => !this.visibleTags.includes(option));
       for (const option of this.visibleTags) {


### PR DESCRIPTION
Corrige remoção de opção do po-multiselect para valor falsy.

Fixes DTHFUI-9922

_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
