### PR TITLE
fix(table): corrige requisição de múltiplas tabelas

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -67,7 +67,7 @@ describe('PoTableComponent:', () => {
   let tableHeaderElement;
   let tableElement;
   let tableFooterElement;
-  let poTableService: PoTableService;
+  let poTableService: jasmine.SpyObj<PoTableService> = jasmine.createSpyObj('PoTableService', ['scrollListener']);
 
   // mocks
   let actions: Array<PoTableAction>;
@@ -236,7 +236,7 @@ describe('PoTableComponent:', () => {
         PoDateService,
         DecimalPipe,
         PoColorPaletteService,
-        PoTableService,
+        { provide: PoTableService, useValue: poTableService },
         { provide: CdkVirtualScrollViewport, useValue: mockViewPort },
         { provide: changeDetector, useValue: changeDetector },
         provideHttpClient(withInterceptorsFromDi()),
@@ -257,7 +257,7 @@ describe('PoTableComponent:', () => {
 
     component.infiniteScroll = false;
 
-    poTableService = TestBed.inject(PoTableService);
+    // poTableService = TestBed.inject(PoTableService);
 
     nativeElement = fixture.debugElement.nativeElement;
 
@@ -2933,7 +2933,7 @@ describe('PoTableComponent:', () => {
     component.height = 100;
     component.infiniteScroll = true;
 
-    component['subscriptionScrollEvent'] = poTableService.scrollListener(dummyElement).subscribe();
+    component['subscriptionScrollEvent'] = component['defaultService'].scrollListener(dummyElement).subscribe();
 
     component['removeListeners']();
 
@@ -3022,7 +3022,7 @@ describe('PoTableComponent:', () => {
 
     component.tableScrollable = new ElementRef(mockScrollableElement);
 
-    const spyScrollListener = spyOn(poTableService, 'scrollListener').and.returnValue(
+    const spyScrollListener = spyOn(component['defaultService'], 'scrollListener').and.returnValue(
       of({ target: { offsetHeight: 100, scrollTop: 100, scrollHeight: 1 } })
     );
 
@@ -3045,7 +3045,7 @@ describe('PoTableComponent:', () => {
 
     component.tableVirtualScroll = mockTableVirtualScroll;
 
-    const spyScrollListener = spyOn(poTableService, 'scrollListener').and.returnValue(
+    const spyScrollListener = spyOn(component['defaultService'], 'scrollListener').and.returnValue(
       of({ target: { offsetHeight: 100, scrollTop: 100, scrollHeight: 1 } })
     );
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -101,7 +101,7 @@ import { PoTableService } from './services/po-table.service';
 @Component({
   selector: 'po-table',
   templateUrl: './po-table.component.html',
-  providers: [PoDateService],
+  providers: [PoDateService, PoTableService],
   standalone: false
 })
 export class PoTableComponent extends PoTableBaseComponent implements AfterViewInit, DoCheck, OnDestroy, OnInit {

--- a/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
+++ b/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
@@ -11,7 +11,7 @@ describe('PoTableService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
-      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting(), PoTableService]
     });
     service = TestBed.inject(PoTableService);
   });

--- a/projects/ui/src/lib/components/po-table/services/po-table.service.ts
+++ b/projects/ui/src/lib/components/po-table/services/po-table.service.ts
@@ -6,9 +6,7 @@ import { isTypeof } from '../../../utils/util';
 import { PoTableFilter } from '../interfaces/po-table-filter.interface';
 import { PoTableFilteredItemsParams } from '../interfaces/po-table-filtered-items-params.interface';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable()
 export class PoTableService implements PoTableFilter {
   readonly headers: HttpHeaders = new HttpHeaders({
     'X-PO-No-Message': 'true'


### PR DESCRIPTION
Ao utilizar mais de uma po-table com serviço habilitado e endpoints diferentes, o botão de carregar mais de todas as tabelas estava requisitando no mesmo serviço.

Agora, cada po-table requisita corretamente ao endpoint configurado no componente, sem interferência nas demais.

Comportamento esperado:
- Cada po-table com serviço habilitado deve chamar corretamente o endpoint configurado ao clicar em 'Carregar mais'.
- O botão de carregar mais não interfere nas requisições das outras tabelas."

Fixes DTHFUI-10553