### PR TITLE
fix(datapicker): corrige validação do campo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -140,7 +140,7 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
 
   @HostListener('keyup', ['$event'])
   onKeyup($event: any) {
-    if (this.readonly) {
+    if (this.readonly || $event?.target !== this.inputEl?.nativeElement) {
       return;
     }
 


### PR DESCRIPTION
**PO Datepicker**

**DTHFUI-9953**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao atribuir um valor inválido no datepicker e pressionar a tecla TAB a mensagem de data inválida some tornando o campo válido novamente erroneamente.

**Qual o novo comportamento?**
Ao atribuir um valor inválido no datepicker e pressionar a tecla TAB a mensagem de data inválida é exibida e o campo permanece inválido.

**Simulação**
[app.component.zip](https://github.com/user-attachments/files/18994344/app.component.zip)
