### PR TITLE
fix(stepper): corrige navegação entre os steps

### DIFF
--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, Input, Output, Directive, TemplateRef } from '@angular/core';
 
-import { convertToBoolean } from '../../utils/util';
+import { convertToBoolean, uuid } from '../../utils/util';
 
 import { PoStepComponent } from './po-step/po-step.component';
 import { PoStepperItem } from './po-stepper-item.interface';
@@ -195,7 +195,10 @@ export class PoStepperBaseComponent {
    */
   @Input('p-steps') set steps(steps: Array<PoStepperItem>) {
     this._steps = Array.isArray(steps) ? steps : [];
-    this._steps.forEach(step => (step.status = step.status ?? PoStepperStatus.Default));
+    this._steps.forEach(step => {
+      step.status = step.status ?? PoStepperStatus.Default;
+      step.id = step.id ?? uuid();
+    });
     this.initializeSteps();
   }
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-item.interface.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-item.interface.ts
@@ -9,6 +9,9 @@ import { PoStepperStatus } from './enums/po-stepper-status.enum';
  * Interface para definição dos *steps* do componente `po-stepper` quando utilizada a propriedade `p-steps`.
  */
 export interface PoStepperItem {
+  /** Identificador único do step. */
+  id?: string;
+
   /** Define o ícone do *step* ativo. */
   iconActive?: string | TemplateRef<void>;
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
@@ -551,7 +551,7 @@ describe('PoStepperComponent:', () => {
         done();
       });
 
-      expect(spyOnCanActiveNextStep).toHaveBeenCalledWith(component['currentActiveStep'], nextStepIndex, undefined);
+      expect(spyOnCanActiveNextStep).toHaveBeenCalledWith(component['currentActiveStep'], nextStepIndex);
     });
 
     it('allowNextStep: should return false if `isBeforeStep` and `canActiveNextStep` are false', (done: DoneFn) => {
@@ -632,7 +632,7 @@ describe('PoStepperComponent:', () => {
         done();
       });
 
-      expect(component['checkAllowNextStep']).toHaveBeenCalledWith(nextStepIndex, undefined);
+      expect(component['checkAllowNextStep']).toHaveBeenCalledWith(nextStepIndex);
     });
 
     it('canActiveNextStep: should return true if `currentActiveStep.canActiveNextStep` function return true', (done: DoneFn) => {
@@ -1068,16 +1068,17 @@ describe('PoStepperComponent:', () => {
     });
   });
 
-  it('getCanActiveNextStepObservable: should return false if step.status is Done', (done: DoneFn) => {
+  it('getCanActiveNextStepObservable: should return result of canActiveNextStep', (done: DoneFn) => {
+    const canActivateNextStepResult = true;
     const currentActiveStep = {
-      canActiveNextStep: jasmine.createSpy()
+      canActiveNextStep: jasmine.createSpy().and.returnValue(canActivateNextStepResult)
     } as unknown as PoStepComponent;
 
     const step = { status: PoStepperStatus.Done } as unknown as PoStepComponent;
 
-    component['getCanActiveNextStepObservable'](currentActiveStep, step).subscribe(result => {
-      expect(result).toBe(false);
-      expect(currentActiveStep.canActiveNextStep).not.toHaveBeenCalled();
+    component['getCanActiveNextStepObservable'](currentActiveStep).subscribe(result => {
+      expect(result).toBe(canActivateNextStepResult);
+      expect(currentActiveStep.canActiveNextStep).toHaveBeenCalled();
       done();
     });
   });
@@ -1094,7 +1095,7 @@ describe('PoStepperComponent:', () => {
 
     const step = { status: PoStepperStatus.Active } as PoStepComponent;
 
-    component['getCanActiveNextStepObservable'](currentActiveStep, step).subscribe(result => {
+    component['getCanActiveNextStepObservable'](currentActiveStep).subscribe(result => {
       expect(result).toBe(true);
       expect(currentActiveStep.canActiveNextStep).toHaveBeenCalledWith(currentActiveStep);
       done();

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.ts
@@ -264,16 +264,12 @@ export class PoStepperComponent extends PoStepperBaseComponent implements AfterC
       return of(false);
     }
 
-    const isAllowNextStep$ = this.checkAllowNextStep(nextStepIndex, step);
+    const isAllowNextStep$ = this.checkAllowNextStep(nextStepIndex);
 
     return typeof isAllowNextStep$ === 'boolean' ? of(isAllowNextStep$) : isAllowNextStep$;
   }
 
-  private canActiveNextStep(
-    currentActiveStep = <PoStepComponent>{},
-    nextStepIndex?: number,
-    step?: PoStepComponent
-  ): Observable<boolean> {
+  private canActiveNextStep(currentActiveStep = <PoStepComponent>{}, nextStepIndex?: number): Observable<boolean> {
     const isCurrentStep = this.isCurrentStep(nextStepIndex);
 
     if (!currentActiveStep.canActiveNextStep) {
@@ -283,7 +279,7 @@ export class PoStepperComponent extends PoStepperBaseComponent implements AfterC
       return of(true);
     }
 
-    const canActiveNextStep$ = this.getCanActiveNextStepObservable(currentActiveStep, step);
+    const canActiveNextStep$ = this.getCanActiveNextStepObservable(currentActiveStep);
 
     return of(this.isBeforeStep(nextStepIndex)).pipe(
       mergeMap(isBefore => {
@@ -310,24 +306,14 @@ export class PoStepperComponent extends PoStepperBaseComponent implements AfterC
     );
   }
 
-  private checkAllowNextStep(nextStepIndex: number, step?: PoStepComponent): Observable<boolean> {
+  private checkAllowNextStep(nextStepIndex: number): Observable<boolean> {
     return this.usePoSteps
-      ? this.canActiveNextStep(this.currentActiveStep, nextStepIndex, step)
+      ? this.canActiveNextStep(this.currentActiveStep, nextStepIndex)
       : of(this.steps.slice(this.step, nextStepIndex).every(step => step.status === PoStepperStatus.Done));
   }
 
-  private getCanActiveNextStepObservable(
-    currentActiveStep: PoStepComponent,
-    step?: PoStepComponent
-  ): Observable<boolean> {
-    let canActiveNextStep: any;
-
-    if (step && step.status === PoStepperStatus.Done) {
-      canActiveNextStep = false;
-    } else {
-      canActiveNextStep = currentActiveStep.canActiveNextStep(currentActiveStep);
-    }
-
+  private getCanActiveNextStepObservable(currentActiveStep: PoStepComponent): Observable<boolean> {
+    const canActiveNextStep = currentActiveStep.canActiveNextStep(currentActiveStep);
     return canActiveNextStep instanceof Observable ? canActiveNextStep : of(canActiveNextStep);
   }
 


### PR DESCRIPTION
**PO-STEPPER**
[DTHFUI-10914]
_____________________________________________________________________________

**Qual o comportamento atual?**
Para navegação entre os steps utilizando o seletor po-step:
Quando o step selecionado é o último da lista,  ao retornar para o step anterior  o serviço configura a propriedade canActiveNextStep para o valor false. Essa ação impede a navegação para o próximo step já que o serviço entende que não pode habilitar o próximo step.

Para navegação entre os steps utilizando a lista p-steps:
Não é possível avançar para o próximo.

**Qual o novo comportamento?**
Navegação livre de bloqueios caso os formulários e as ativações dos steps estiverem válidos.

Para navegação entre os steps utilizando a lista p-steps:
Foi adicionado um id interno para validação e comparação dos steps antes da navegação.

**Simulação**
[app_steppers.zip](https://github.com/user-attachments/files/18999276/app_steppers.zip)
