### PR TITLE
feat(i18n): garantir merge correto de literais no PO UI e THF-Components

### DIFF
--- a/projects/ui/src/lib/services/po-i18n/index.ts
+++ b/projects/ui/src/lib/services/po-i18n/index.ts
@@ -1,4 +1,5 @@
 export * from './interfaces/po-i18n-config.interface';
+export * from './interfaces/po-i18n-config-context.interface';
 export * from './interfaces/po-i18n-config-default.interface';
 export * from './interfaces/po-i18n-literals.interface';
 export * from './po-i18n.pipe';

--- a/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config-context.interface.ts
+++ b/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config-context.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * @description
+ *
+ * <a id="poI18nConfigContext"></a>
+ *
+ * Interface para a configuração dos contextos do módulo `PoI18nModule`.
+ *
+ * @usedBy PoI18nModule
+ */
+export interface PoI18nConfigContext {
+  [name: string]: { [language: string]: { [literal: string]: string } } | { url: string };
+}

--- a/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
+++ b/projects/ui/src/lib/services/po-i18n/interfaces/po-i18n-config.interface.ts
@@ -1,4 +1,5 @@
 import { PoI18nConfigDefault } from './po-i18n-config-default.interface';
+import { PoI18nConfigContext } from './po-i18n-config-context.interface';
 
 /**
  * @description
@@ -76,5 +77,5 @@ export interface PoI18nConfig {
    * ```
    * > Caso a constante contenha alguma literal que o serviço não possua será utilizado a literal da constante.
    */
-  contexts: object;
+  contexts: PoI18nConfigContext;
 }

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
@@ -36,6 +36,24 @@ import { I18N_CONFIG } from './po-i18n-config-injection-token';
  * porém, nenhuma das propriedades são obrigatórias. Caso nenhum parâmetro seja passado, serão buscadas
  * todas as literais do contexto definido com padrão, no idioma definido como padrão.
  *
+ * * ## Alterações a partir da versão 19
+ * A partir da versão 19, para evitar conflitos com bibliotecas de terceiros que também utilizam i18n,
+ * é necessário passar explicitamente o contexto ao chamar `getLiterals`, garantindo a correta exibição das literais.
+ * Caso `getLiterals` seja chamado sem parâmetros, o retorno pode vir das configurações da biblioteca de terceiros.
+ *
+ * **Exemplo de chamada com contexto explícito:**
+ * ```typescript
+ * poI18nService.getLiterals({ context: 'general' }).subscribe(literals => console.log(literals));
+ * ```
+ *
+ * **Cenário de Contextos Iguais:**
+ * Caso tanto a aplicação quanto uma biblioteca de terceiros utilizem o mesmo nome de contexto,
+ * o PO UI fará um merge das literais, priorizando os valores definidos na aplicação cliente.
+ *
+ * **Recomendações:**
+ * - Sempre informar o contexto ao chamar `getLiterals` para evitar conflitos de literais.
+ * - Caso a aplicação utilize `lazy loading`, utilizar `setLanguage()` para garantir a correta configuração de idioma.
+ *
  * Exemplos de requisição:
  * ```
  * literals = {};
@@ -144,6 +162,7 @@ import { I18N_CONFIG } from './po-i18n-config-injection-token';
  *   }));
  *
  * });
+ *
  * ```
  */
 

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-config-injection-token.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-config-injection-token.ts
@@ -2,4 +2,4 @@ import { InjectionToken } from '@angular/core';
 
 import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 
-export const I18N_CONFIG = new InjectionToken<PoI18nConfig>('I18N_CONFIG');
+export const I18N_CONFIG = new InjectionToken<Array<PoI18nConfig>>('I18N_CONFIG');

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.module.ts
@@ -144,7 +144,6 @@ import { PoLanguageModule } from '../po-language/po-language.module';
  * Para aplicações que utilizem a abordagem de módulos com carregamento *lazy loading*, caso seja
  * definida outra configuração do `PoI18nModule`, deve-se atentar os seguintes detalhes:
  *
- * - Caso existam literais comuns na aplicação, estas devem ser reimportadas;
  * - Não defina outra *default language* para este módulo. Caso for definida, será sobreposta para
  * toda a aplicação;
  * - Caso precise de módulos carregados via *lazy loading* com linguagens diferentes, utilize o
@@ -162,7 +161,8 @@ export class PoI18nModule {
       providers: [
         {
           provide: I18N_CONFIG,
-          useValue: config
+          useValue: config,
+          multi: true
         },
         provideAppInitializer(() => {
           const initializerFn = initializeLanguageDefault(inject(I18N_CONFIG), inject(PoLanguageService));
@@ -178,12 +178,12 @@ export class PoI18nModule {
   }
 }
 
-export function initializeLanguageDefault(config: PoI18nConfig, languageService: PoLanguageService) {
-  // eslint-disable-next-line sonarjs/prefer-immediate-return
-  const setDefaultLanguage = () => {
-    if (config.default.language) {
+export function initializeLanguageDefault(configs: Array<PoI18nConfig>, languageService: PoLanguageService) {
+  const config = configs.find(c => c.default); // Busca a configuração com `default`
+
+  return () => {
+    if (config?.default.language) {
       languageService.setLanguageDefault(config.default.language);
     }
   };
-  return setDefaultLanguage;
 }

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.service.spec.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.service.spec.ts
@@ -1,0 +1,74 @@
+import { mergePoI18nConfigs } from './po-i18n.service';
+
+describe('mergePoI18nConfigs', () => {
+  it('should correctly merge the default configuration, prioritizing the first one found', () => {
+    const input = [
+      { default: { title: 'Hello' }, contexts: {} },
+      { default: { title: 'Olá' }, contexts: {} }
+    ];
+
+    const result = mergePoI18nConfigs(input);
+
+    expect(result.default).toEqual({ title: 'Hello' });
+  });
+
+  it('should return correctly merge contexts and languages', () => {
+    const input = [
+      {
+        default: { title: 'Hello' },
+        contexts: {
+          home: {
+            en: { welcome: 'Welcome' },
+            pt: { welcome: 'Bem-vindo' }
+          }
+        }
+      },
+      {
+        contexts: {
+          home: {
+            en: { goodbye: 'Goodbye' },
+            es: { welcome: 'Bienvenido' }
+          },
+          about: {
+            en: { info: 'Information' }
+          }
+        }
+      }
+    ];
+
+    const result = mergePoI18nConfigs(input);
+
+    expect(result.contexts).toEqual({
+      home: {
+        en: { welcome: 'Welcome', goodbye: 'Goodbye' },
+        pt: { welcome: 'Bem-vindo' },
+        es: { welcome: 'Bienvenido' }
+      },
+      about: {
+        en: { info: 'Information' }
+      }
+    });
+  });
+
+  it('should return an empty object if the input is an empty array', () => {
+    const result = mergePoI18nConfigs([]);
+    expect(result).toEqual({ contexts: {} });
+  });
+
+  it('should return handle null or undefined values', () => {
+    const input = [
+      { default: { title: 'Hello' }, contexts: null },
+      { contexts: undefined },
+      { default: { title: 'Olá' }, contexts: { home: { en: { greeting: 'Hi' } } } }
+    ];
+
+    const result = mergePoI18nConfigs(input);
+
+    expect(result.default).toEqual({ title: 'Hello' });
+    expect(result.contexts).toEqual({
+      home: {
+        en: { greeting: 'Hi' }
+      }
+    });
+  });
+});

--- a/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n.service.ts
@@ -16,6 +16,42 @@ import { PoI18nConfig } from './interfaces/po-i18n-config.interface';
 export class PoI18nService extends PoI18nBaseService {}
 
 // Função usada para retornar instância para o módulo po-i18n.module
-export function returnPoI18nService(config: PoI18nConfig, http: HttpClient, languageService: PoLanguageService) {
-  return new PoI18nService(config, http, languageService);
+export function returnPoI18nService(
+  configs: Array<PoI18nConfig>,
+  http: HttpClient,
+  languageService: PoLanguageService
+) {
+  const validatedConfigs = configs.map(config => ({
+    ...config,
+    contexts: config.contexts,
+    default: config.default
+  }));
+
+  const mergedObject = mergePoI18nConfigs(validatedConfigs);
+
+  return new PoI18nService(mergedObject, http, languageService);
+}
+
+export function mergePoI18nConfigs(objects: Array<any>): any {
+  return objects.reduce(
+    (acc, current) => {
+      if (!acc.default) {
+        acc.default = { ...current.default };
+      }
+
+      Object.entries(current.contexts || {}).forEach(([context, languages]) => {
+        acc.contexts[context] = acc.contexts[context] || {};
+
+        Object.entries(languages).forEach(([lang, translations]) => {
+          acc.contexts[context][lang] = {
+            ...acc.contexts[context][lang],
+            ...translations
+          };
+        });
+      });
+
+      return acc;
+    },
+    { contexts: {} }
+  );
 }


### PR DESCRIPTION
Ajustado `getLiterals()` para garantir que as literais sejam exibidas corretamente, independente da configuração utilizada. Agora, ao utilizar o PO UI e o THF-Components, o serviço i18n realiza o merge das literais da aplicação client e das bibliotecas de terceiros, evitando sobreposição indevida e garantindo a exibição esperada.

Fixes DTHFUI-10854