### PR TITLE
fix(dynamic-form): ajusta emissão de evento para p-validate

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
@@ -161,11 +161,8 @@ export class PoDynamicFormBaseComponent {
    * - `function`: Método que será executado.
    *
    * Ao ser executado, irá receber como parâmetro um objeto com o nome da propriedade
-   * alterada e o novo valor, conforme a interface `PoDynamicFormFieldChanged`:
+   * alterada e os valores atualizados do formulario, conforme a interface `PoDynamicFormFieldChanged`
    *
-   * ```
-   * { property: 'property name', value: 'new value' }
-   * ```
    *
    * O retorno desta função deve ser do tipo [PoDynamicFormValidation](documentation/po-dynamic-form#po-dynamic-form-validation),
    * onde o usuário poderá determinar as novas atualizações dos campos.

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgForm, ReactiveFormsModule } from '@angular/forms';
-import { SimpleChange } from '@angular/core';
+import { SimpleChange, SimpleChanges } from '@angular/core';
 
 import { of } from 'rxjs';
 
@@ -82,6 +82,19 @@ describe('PoDynamicFormFieldsComponent: ', () => {
       component.ngOnChanges(fieldsChange);
 
       expect(component['hasChangeContainer']).toHaveBeenCalled();
+    });
+
+    it('ngOnChanges: should update `previousValue` with the changes in `p-value`', () => {
+      const value = { name: 'name' };
+      component.value = value;
+
+      const changes: SimpleChanges = {
+        value: new SimpleChange(null, value, true)
+      };
+
+      component.ngOnChanges(changes);
+
+      expect(component['previousValue']).toEqual(value);
     });
 
     it('trackBy: should return index', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -51,6 +51,10 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
         this.setContainerFields();
       }
     }
+
+    if (changes.value) {
+      this.updatePreviousValue();
+    }
   }
 
   focus(property: string) {


### PR DESCRIPTION
Corrige a emissão do evento para p-validate em campos do tipo lookup.

**DYNAMIC-FORM**

**DTHFUI-10917**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao setar `p-value` para um `dynamic-form` que tenha um `po-lookup`, `p-vaidate` era disparado

**Qual o novo comportamento?**
Ao setar `p-value` para um `dynamic-form` que tenha um `po-lookup`, `p-vaidate` não deve ser disparado

**Simulação**
[app.zip](https://github.com/user-attachments/files/19059596/app.zip)

