### PR TITLE
fix(lookup): corrige seleção de registros no modo múltiplo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
@@ -723,8 +723,8 @@ describe('PoLookupModalBaseComponent:', () => {
       expect(component.selecteds).toEqual(expectSelecteds);
     });
 
-    it('setDisclaimersItems: should set selecteds with [{ value: component.selectedItems }] if selectedItems isnt array', () => {
-      const expectSelecteds = [{ value: 123456789 }];
+    it('setDisclaimersItems: should set selecteds with [component.selectedItems] if selectedItems isnt array', () => {
+      const expectSelecteds = [123456789];
       component.multiple = true;
       component.selectedItems = 123456789;
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -431,13 +431,12 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
 
   //Método responsável por criar os disclaimers quando abre o modal.
   setDisclaimersItems() {
-    if (this.selectedItems && !Array.isArray(this.selectedItems)) {
-      this.multiple ? (this.selecteds = [{ value: this.selectedItems }]) : (this.selecteds = [this.selectedItems]);
-      return;
-    }
-
-    if (this.selecteds.length === 0 && this.selectedItems && this.selectedItems.length) {
+    if (this.selectedItems && Array.isArray(this.selectedItems) && this.selectedItems.length > 0) {
       this.selecteds = [...this.selectedItems];
+    } else if (this.selectedItems && !Array.isArray(this.selectedItems)) {
+      this.selecteds = [this.selectedItems];
+    } else {
+      this.selecteds = [];
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
@@ -241,14 +241,15 @@ describe('PoLookupModalComponent', () => {
 
     it('onSelect: should concat table item in selecteds', () => {
       component.multiple = true;
-      component.selecteds = [{ value: 'Doe', label: 'Jane' }];
+      component.selectedItems = [{ value: 'Doe', label: 'Jane' }];
+      component.selecteds = [...component.selectedItems];
 
-      component.fieldLabel = 'name';
-      component.fieldValue = 'value';
       const item = {
         name: 'John',
-        value: 'Lenon'
+        value: 'Lenon',
+        label: 'John'
       };
+
       component.onSelect(item);
 
       expect(component.selecteds).toEqual([
@@ -259,17 +260,32 @@ describe('PoLookupModalComponent', () => {
 
     it('onSelect: should override table item in selecteds', () => {
       component.multiple = false;
-      component.selecteds = [{ value: 'Doe', label: 'Jane' }];
 
-      component.fieldLabel = 'name';
-      component.fieldValue = 'value';
+      component.selectedItems = [{ value: 'Doe', label: 'Jane' }];
+      component.selecteds = [...component.selectedItems];
+
       const item = {
         name: 'John',
-        value: 'Lenon'
+        value: 'Lenon',
+        label: 'John'
       };
+
       component.onSelect(item);
 
-      expect(component.selecteds).toEqual([{ value: 'Lenon', label: 'John', name: 'John' }]);
+      expect(component.selecteds).toEqual([{ name: 'John', value: 'Lenon', label: 'John' }]);
+    });
+
+    it('onSelect: should initialize selectedItems with [selectedItem] when selectedItems is null or undefined', () => {
+      component.multiple = true;
+      component.selectedItems = null;
+
+      const selectedItem = { label: 'John', value: 1 };
+
+      component.onSelect(selectedItem);
+
+      expect(component.selectedItems).toEqual([selectedItem]);
+
+      expect(component.selecteds).toEqual([selectedItem]);
     });
 
     it('onAllUnselected: should be called and clean all items on table', () => {
@@ -282,6 +298,13 @@ describe('PoLookupModalComponent', () => {
     });
 
     it('onUnselectFromDisclaimer: should be called and remove disclaimer', () => {
+      component.selectedItems = [
+        { label: 'John', value: 1 },
+        { label: 'Paul', value: 2 }
+      ];
+
+      component.selecteds = [...component.selectedItems];
+
       spyOn(component['poTable'], 'unselectRowItem').and.callThrough();
 
       component.fieldValue = 'value';
@@ -294,24 +317,84 @@ describe('PoLookupModalComponent', () => {
       expect(component['poTable'].unselectRowItem).toHaveBeenCalled();
     });
 
-    it('onUnselect: should be called and unselect item', () => {
+    it('onUnselectFromDisclaimer: should be called and remove disclaimer, setting selecteds to an empty array when selectedItems becomes empty', () => {
+      component.selectedItems = [{ label: 'John', value: 1 }];
+      component.selecteds = [...component.selectedItems];
+
+      spyOn(component['poTable'], 'unselectRowItem').and.callThrough();
+
       component.fieldValue = 'value';
-      component.selecteds = [
+      fixture.detectChanges();
+
+      const removedDisclaimer = { label: 'John', value: 1 };
+
+      component.onUnselectFromDisclaimer(removedDisclaimer);
+
+      expect(component.selectedItems).toEqual([]);
+      expect(component.selecteds).toEqual([]);
+      expect(component['poTable'].unselectRowItem).toHaveBeenCalled();
+    });
+
+    it('onUnselect: should be called and unselect item', () => {
+      component.multiple = true;
+      component.selectedItems = [
         { label: 'John', value: 1 },
         { label: 'Paul', value: 2 },
         { label: 'George', value: 3 },
         { label: 'Ringo', value: 4 }
       ];
+      component.fieldValue = 'value';
+
+      component.selecteds = [...component.selectedItems];
 
       const unselectedItem = { label: 'Paul', value: 2 };
-      const expected = [
+      component.onUnselect(unselectedItem);
+
+      expect(component.selectedItems.length).toBe(3);
+      expect(component.selectedItems).toEqual([
         { label: 'John', value: 1 },
         { label: 'George', value: 3 },
         { label: 'Ringo', value: 4 }
+      ]);
+      expect(component.selecteds).toEqual(component.selectedItems);
+    });
+
+    it('onUnselect: should set selectedItems to an empty array when multiple is false', () => {
+      component.multiple = false;
+
+      component.selectedItems = [
+        { label: 'John', value: 1 },
+        { label: 'Paul', value: 2 }
       ];
 
+      component.selecteds = [...component.selectedItems];
+
+      const unselectedItem = { label: 'John', value: 1 };
+
       component.onUnselect(unselectedItem);
-      expect(component.selecteds).toEqual(expected);
+
+      expect(component.selectedItems).toEqual([]);
+
+      expect(component.selecteds).toEqual([]);
+    });
+
+    it('onUnselect: should set selectedItems to an empty array when multiple is false', () => {
+      component.multiple = false;
+
+      component.selectedItems = [
+        { label: 'John', value: 1 },
+        { label: 'Paul', value: 2 }
+      ];
+
+      component.selecteds = [...component.selectedItems];
+
+      const unselectedItem = { label: 'John', value: 1 };
+
+      component.onUnselect(unselectedItem);
+
+      expect(component.selectedItems).toEqual([]);
+
+      expect(component.selecteds).toEqual([]);
     });
 
     it('onAllSelected: should be called and select all visible itens', () => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
@@ -59,30 +59,49 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
 
   // Seleciona um item na tabela
   onSelect(item) {
+    const formattedItem = {
+      value: item[this.fieldValue],
+      label: item[this.fieldLabel],
+      ...item
+    };
     if (this.multiple) {
-      this.selecteds = [...this.selecteds, { value: item[this.fieldValue], label: item[this.fieldLabel], ...item }];
+      this.selectedItems = this.selectedItems ? [...this.selectedItems, formattedItem] : [formattedItem];
     } else {
-      this.selecteds = [{ value: item[this.fieldValue], label: item[this.fieldLabel], ...item }];
+      this.selectedItems = [formattedItem];
     }
+    this.selecteds = [...this.selectedItems];
   }
 
   // Remove a seleção de um item na tabela
   onUnselect(unselectedItem) {
-    this.selecteds = this.selecteds.filter(itemSelected => itemSelected.value !== unselectedItem[this.fieldValue]);
+    if (this.multiple) {
+      this.selectedItems = this.selectedItems.filter(item => item.value !== unselectedItem[this.fieldValue]);
+    } else {
+      this.selectedItems = [];
+    }
+    this.selecteds = [...this.selectedItems];
   }
 
   onUnselectFromDisclaimer(removedDisclaimer) {
+    this.selectedItems = this.selectedItems.filter(item => item.value !== removedDisclaimer.value);
+    if (this.selectedItems.length === 0) {
+      this.selecteds = [];
+    } else {
+      this.selecteds = [...this.selectedItems];
+    }
     this.poTable.unselectRowItem(item => item[this.fieldValue] === removedDisclaimer.value);
   }
 
   // Seleciona todos os itens visíveis na tabela
   onAllSelected(items) {
-    this.selecteds = items.map(item => ({ value: item[this.fieldValue], label: item[this.fieldLabel], ...item }));
+    this.selectedItems = items.map(item => ({ value: item[this.fieldValue], label: item[this.fieldLabel], ...item }));
+    this.selecteds = [...this.selectedItems];
   }
 
   // Remove a seleção de todos os itens visíveis na tabela
   onAllUnselected(items) {
     this.poTable.unselectRows();
+    this.selectedItems = [];
     this.selecteds = [];
   }
 


### PR DESCRIPTION
Corrige seleção de registros do lookup para o modo múltiplo.

Fixes DTHFUI-10695

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
