### PR TITLE
fix: ajuste na exibição das literais no Po UI e THF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [19.5.0](https://github.com/po-ui/po-angular/compare/v19.4.0...v19.5.0) (2025-03-10)
+
+
+### Features
+
+* **components:** adiciona nova propriedade 'p-control-value-with-label' ([a31728d](https://github.com/po-ui/po-angular/commit/a31728d05732716a7f6d5ba703d2e282624e8bdb))
+
+
+### Bug Fixes
+
+* **dynamic-form:** ajusta emissão de evento para p-validate ([70f4b8d](https://github.com/po-ui/po-angular/commit/70f4b8d0d057c0d13670d48af76aeadf5c6b917c))
+* **stepper:** corrige navegação entre os steps ([6f26e9a](https://github.com/po-ui/po-angular/commit/6f26e9a964f58e6ba6f290ac50116968c2bb4ec8))
+* **table:** corrige requisição de múltiplas tabelas ([006bb7b](https://github.com/po-ui/po-angular/commit/006bb7b0d5e9058acd21ad8bd25c13e4df6be7e8))
+
 ### [19.4.0](https://github.com/po-ui/po-angular/compare/v19.3.1...v19.4.0) (2025-02-24)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "po-ui-sources",
-  "version": "19.4.0",
+  "version": "19.5.0",
   "description": "PO UI",
   "homepage": "https://po-ui.io",
   "license": "MIT",
@@ -75,7 +75,7 @@
     "@angular/router": "~19.0.3",
     "@capacitor/core": "5.7.2",
     "@capacitor/network": "^5.0.7",
-    "@po-ui/style": "19.4.0",
+    "@po-ui/style": "19.5.0",
     "capitalize": "^2.0.4",
     "colors": "1.4.0",
     "core-js": "3.33.3",

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
@@ -161,11 +161,8 @@ export class PoDynamicFormBaseComponent {
    * - `function`: Método que será executado.
    *
    * Ao ser executado, irá receber como parâmetro um objeto com o nome da propriedade
-   * alterada e o novo valor, conforme a interface `PoDynamicFormFieldChanged`:
+   * alterada e os valores atualizados do formulario, conforme a interface `PoDynamicFormFieldChanged`
    *
-   * ```
-   * { property: 'property name', value: 'new value' }
-   * ```
    *
    * O retorno desta função deve ser do tipo [PoDynamicFormValidation](documentation/po-dynamic-form#po-dynamic-form-validation),
    * onde o usuário poderá determinar as novas atualizações dos campos.

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgForm, ReactiveFormsModule } from '@angular/forms';
-import { SimpleChange } from '@angular/core';
+import { SimpleChange, SimpleChanges } from '@angular/core';
 
 import { of } from 'rxjs';
 
@@ -82,6 +82,19 @@ describe('PoDynamicFormFieldsComponent: ', () => {
       component.ngOnChanges(fieldsChange);
 
       expect(component['hasChangeContainer']).toHaveBeenCalled();
+    });
+
+    it('ngOnChanges: should update `previousValue` with the changes in `p-value`', () => {
+      const value = { name: 'name' };
+      component.value = value;
+
+      const changes: SimpleChanges = {
+        value: new SimpleChange(null, value, true)
+      };
+
+      component.ngOnChanges(changes);
+
+      expect(component['previousValue']).toEqual(value);
     });
 
     it('trackBy: should return index', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -51,6 +51,10 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
         this.setContainerFields();
       }
     }
+
+    if (changes.value) {
+      this.updatePreviousValue();
+    }
   }
 
   focus(property: string) {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -559,6 +559,48 @@ describe('PoComboBaseComponent:', () => {
       expect(component.callModelChange).not.toHaveBeenCalled();
       expect(component['fromWriteValue']).toBe(false);
     });
+
+    describe('controlValueWithLabel', () => {
+      it('should return the object when controlValueWithLabel is true', () => {
+        const selectedOption = { value: 1, label: 'Xpto' };
+
+        component.controlValueWithLabel = true;
+
+        expect(component['getValueUpdate'](1, selectedOption)).toEqual(selectedOption);
+      });
+
+      it('should only return the value when controlValueWithLabel is false', () => {
+        const selectedOption = { value: 1, label: 'Xpto' };
+
+        component.controlValueWithLabel = false;
+
+        expect(component['getValueUpdate'](1, selectedOption)).toEqual(1);
+      });
+
+      it('should return a {value: any, label: any} object when controlValueWithLabel is true and both fieldValue and fieldLabel are set', () => {
+        const selectedOption = { value: 1, label: 'Xpto' };
+
+        component.controlValueWithLabel = true;
+        component.fieldValue = 'id';
+        component.fieldLabel = 'name';
+
+        expect(component['getValueUpdate'](null, selectedOption)).toEqual({ value: 1, label: 'Xpto' });
+      });
+
+      it('should only return the value when calling getValueWrite when controlValueWithLabel is true', () => {
+        component.controlValueWithLabel = true;
+        const option = { value: 1, label: 'Xpto' };
+
+        expect(component['getValueWrite'](option)).toEqual(1);
+      });
+
+      it('should return when calling getValueWrite when controlValueWithLabel is true and the object structure does not contain the value property', () => {
+        component.controlValueWithLabel = true;
+        const data = 1;
+
+        expect(component['getValueWrite'](data)).toEqual(data);
+      });
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -334,6 +334,13 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    */
   @Output('p-input-change') inputChange: EventEmitter<string> = new EventEmitter<string>();
 
+  /**
+   * @docsPrivate
+   *
+   * Determinar se o valor do compo deve retorna objeto do tipo {value: any, label: any}
+   */
+  @Input({ alias: 'p-control-value-with-label', transform: convertToBoolean }) controlValueWithLabel?: boolean = false;
+
   cacheOptions: Array<any> = [];
   defaultService: PoComboFilterService;
   firstInWriteValue: boolean = true;
@@ -936,6 +943,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
 
   // Recebe as alterações do model
   writeValue(value: any) {
+    value = this.getValueWrite(value);
     this.fromWriteValue = true;
 
     if (validValue(value) && !this.service && this.comboOptionsList && this.comboOptionsList.length) {
@@ -1067,6 +1075,27 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     };
   }
 
+  private getValueUpdate(data: any, selectedOption: any) {
+    const { [this.dynamicValue]: value, [this.dynamicLabel]: label } = selectedOption || {};
+
+    if (this.controlValueWithLabel && value) {
+      return {
+        value,
+        label
+      };
+    }
+
+    return data;
+  }
+
+  private getValueWrite(data: any) {
+    if (this.controlValueWithLabel && data?.value) {
+      return data?.value;
+    }
+
+    return data;
+  }
+
   private hasDuplicatedOption(options: Array<any>, currentOption: string, accumulatedGroupOptions?: Array<any>) {
     if (accumulatedGroupOptions) {
       return accumulatedGroupOptions.some(option => option[this.dynamicLabel] === currentOption);
@@ -1180,7 +1209,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   private updateModel(value: any): void {
     if (value !== this.selectedValue) {
       if (!this.fromWriteValue) {
-        this.callModelChange(value);
+        this.callModelChange(this.getValueUpdate(value, this.selectedOption));
       }
 
       this.change.emit(this.emitObjectValue ? this.selectedOption : value);

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -277,7 +277,8 @@ describe('PoMultiselectBaseComponent:', () => {
     const fakeThis = {
       onModelChange: v => {},
       eventChange: v => {},
-      getValuesFromOptions: v => []
+      getValuesFromOptions: v => [],
+      getValueUpdate: v => []
     };
 
     spyOn(fakeThis, 'onModelChange');
@@ -701,6 +702,49 @@ describe('PoMultiselectBaseComponent:', () => {
       component.debounceTime = 600;
 
       expect(component.debounceTime).toBe(600);
+    });
+  });
+
+  describe('controlValueWithLabel', () => {
+    it('should return the object when controlValueWithLabel is true', () => {
+      const selectedOptions = [{ value: 1, label: 'Xpto' }];
+
+      component.controlValueWithLabel = true;
+
+      expect(component['getValueUpdate'](selectedOptions)).toEqual(selectedOptions);
+    });
+
+    it('should only return the value when controlValueWithLabel is false', () => {
+      const selectedOptions = [{ value: 1, label: 'Xpto' }];
+
+      component.controlValueWithLabel = false;
+
+      expect(component['getValueUpdate'](selectedOptions)).toEqual([1]);
+    });
+
+    it('should return a {value: any, label: any} object when controlValueWithLabel is true and both fieldValue and fieldLabel are set', () => {
+      const selectedOptions = [{ id: 1, name: 'Xpto' }];
+
+      component.controlValueWithLabel = true;
+      component.fieldValue = 'id';
+      component.fieldLabel = 'name';
+
+      expect(component['getValueUpdate'](selectedOptions)).toEqual([{ value: 1, label: 'Xpto' }]);
+    });
+
+    it('should only return the value when calling getValueWrite when controlValueWithLabel is true', () => {
+      component.controlValueWithLabel = true;
+      const option = [{ value: 1, label: 'Xpto' }];
+
+      expect(component['getValueWrite'](option)).toEqual([1]);
+    });
+
+    it('should return when calling getValueWrite when controlValueWithLabel is true and the object structure does not contain the value property', () => {
+      const option = [{ id: 1, name: 'Xpto' }];
+
+      component.controlValueWithLabel = true;
+
+      expect(component['getValueWrite'](option)).toEqual(option);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -257,6 +257,13 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    */
   @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
 
+  /**
+   * @docsPrivate
+   *
+   * Determinar se o valor do compo deve retorna objeto do tipo {value: any, label: any}
+   */
+  @Input({ alias: 'p-control-value-with-label', transform: convertToBoolean }) controlValueWithLabel?: boolean = false;
+
   selectedOptions: Array<PoMultiselectOption | any> = [];
   visibleOptionsDropdown: Array<PoMultiselectOption | any> = [];
   visibleTags = [];
@@ -687,7 +694,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
 
   callOnChange(selectedOptions: Array<PoMultiselectOption | any>) {
     if (this.onModelChange) {
-      this.onModelChange(this.getValuesFromOptions(selectedOptions));
+      this.onModelChange(this.getValueUpdate(selectedOptions));
       this.eventChange(selectedOptions);
     }
   }
@@ -780,7 +787,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   }
 
   writeValue(values: any): void {
-    values = values || [];
+    values = this.getValueWrite(values) || [];
 
     if (this.service && values.length) {
       this.getObjectsByValuesSubscription = this.service.getObjectsByValues(values).subscribe(options => {
@@ -813,6 +820,22 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
 
   registerOnValidatorChange(fn: () => void) {
     this.validatorChange = fn;
+  }
+
+  private getValueUpdate(selectedOptions: Array<PoMultiselectOption | any>) {
+    if (this.controlValueWithLabel && selectedOptions?.length) {
+      return selectedOptions.map(option => ({ value: option[this.fieldValue], label: option[this.fieldLabel] }));
+    }
+
+    return this.getValuesFromOptions(selectedOptions);
+  }
+
+  private getValueWrite(data: any) {
+    if (this.controlValueWithLabel && data?.length && data.every(x => x?.value !== undefined)) {
+      return data.map(option => option.value);
+    }
+
+    return data;
   }
 
   private setLabelsAndValuesOptions() {

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import * as UtilsFunctions from '../../../utils/util';
-import { configureTestSuite, expectPropertiesValues, expectSettersMethod } from './../../../util-test/util-expect.spec';
+import { configureTestSuite, expectSettersMethod } from './../../../util-test/util-expect.spec';
 
 import { removeDuplicatedOptions, removeUndefinedAndNullOptions } from '../../../utils/util';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
@@ -16,9 +16,6 @@ describe('PoSelectComponent:', () => {
   let component: PoSelectComponent;
   let fixture: ComponentFixture<PoSelectComponent>;
   let nativeElement;
-  const booleanValidFalseValues = [false, 'false'];
-  const booleanValidTrueValues = [true, 'true', ''];
-  const booleanInvalidValues = [undefined, null, 2, 'string'];
 
   const event = new MouseEvent('click', { 'bubbles': false, 'cancelable': true });
 
@@ -152,7 +149,8 @@ describe('PoSelectComponent:', () => {
         selectedValue: '',
         displayValue: label => {},
         updateModel: value => {},
-        emitChange: value => {}
+        emitChange: value => {},
+        getValueUpdate: value => {}
       };
 
       spyOn(fakeThis, 'emitChange');
@@ -496,6 +494,48 @@ describe('PoSelectComponent:', () => {
       const defaultLabel = 'label';
       expectSettersMethod(component, 'fieldLabel', '', 'fieldLabel', defaultLabel);
       expect(component.fieldLabel).toEqual(defaultLabel);
+    });
+  });
+
+  describe('controlValueWithLabel', () => {
+    it('should return the object when controlValueWithLabel is true', () => {
+      const option = { value: 1, label: 'Xpto' };
+
+      component.controlValueWithLabel = true;
+
+      expect(component['getValueUpdate'](option)).toEqual(option);
+    });
+
+    it('should only return the value when controlValueWithLabel is false', () => {
+      const option = { value: 1, label: 'Xpto' };
+
+      component.controlValueWithLabel = false;
+
+      expect(component['getValueUpdate'](option)).toEqual(1);
+    });
+
+    it('should return a {value: any, label: any} object when controlValueWithLabel is true and both fieldValue and fieldLabel are set', () => {
+      const option = { id: 1, name: 'Xpto' };
+
+      component.controlValueWithLabel = true;
+      component.fieldValue = 'id';
+      component.fieldLabel = 'name';
+
+      expect(component['getValueUpdate'](option)).toEqual({ value: 1, label: 'Xpto' });
+    });
+
+    it('should only return the value when calling getValueWrite when controlValueWithLabel is true', () => {
+      component.controlValueWithLabel = true;
+      const option = { value: 1, label: 'Xpto' };
+
+      expect(component['getValueWrite'](option)).toEqual(1);
+    });
+
+    it('should return when calling getValueWrite when controlValueWithLabel is true and the object structure does not contain the value property', () => {
+      component.controlValueWithLabel = true;
+      const data = 1;
+
+      expect(component['getValueWrite'](data)).toEqual(data);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -274,6 +274,13 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
     }
   }
 
+  /**
+   * @docsPrivate
+   *
+   * Determinar se o valor do compo deve retorna objeto do tipo {value: any, label: any}
+   */
+  @Input({ alias: 'p-control-value-with-label', transform: convertToBoolean }) controlValueWithLabel?: boolean = false;
+
   get fieldValue() {
     return this._fieldValue;
   }
@@ -364,7 +371,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
     if (this.selectedValue !== option[this.fieldValue]) {
       this.selectedValue = option[this.fieldValue];
       this.selectElement.nativeElement.value = option[this.fieldValue];
-      this.updateModel(option[this.fieldValue]);
+      this.updateModel(this.getValueUpdate(option));
       this.displayValue = option[this.fieldLabel];
       this.emitChange(option[this.fieldValue]);
     }
@@ -372,6 +379,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
 
   // Recebe as alterações do model
   onWriteValue(value: any) {
+    value = this.getValueWrite(value);
     const optionFound: any = this.findOptionValue(value);
 
     if (optionFound) {
@@ -452,6 +460,25 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
     if (this.options) {
       return this.options.find(option => this.isEqual(option.value, value));
     }
+  }
+
+  private getValueUpdate(option: any) {
+    if (this.controlValueWithLabel) {
+      return {
+        value: option[this.fieldValue],
+        label: option[this.fieldLabel]
+      };
+    }
+
+    return option[this.fieldValue];
+  }
+
+  private getValueWrite(data: any) {
+    if (this.controlValueWithLabel && data?.value) {
+      return data?.value;
+    }
+
+    return data;
   }
 
   private transformInArray(objectWithArray: Array<any>): Array<PoSelectOptionGroup | any> {

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-base.component.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, Input, Output, Directive, TemplateRef } from '@angular/core';
 
-import { convertToBoolean } from '../../utils/util';
+import { convertToBoolean, uuid } from '../../utils/util';
 
 import { PoStepComponent } from './po-step/po-step.component';
 import { PoStepperItem } from './po-stepper-item.interface';
@@ -195,7 +195,10 @@ export class PoStepperBaseComponent {
    */
   @Input('p-steps') set steps(steps: Array<PoStepperItem>) {
     this._steps = Array.isArray(steps) ? steps : [];
-    this._steps.forEach(step => (step.status = step.status ?? PoStepperStatus.Default));
+    this._steps.forEach(step => {
+      step.status = step.status ?? PoStepperStatus.Default;
+      step.id = step.id ?? uuid();
+    });
     this.initializeSteps();
   }
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper-item.interface.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper-item.interface.ts
@@ -9,6 +9,9 @@ import { PoStepperStatus } from './enums/po-stepper-status.enum';
  * Interface para definição dos *steps* do componente `po-stepper` quando utilizada a propriedade `p-steps`.
  */
 export interface PoStepperItem {
+  /** Identificador único do step. */
+  id?: string;
+
   /** Define o ícone do *step* ativo. */
   iconActive?: string | TemplateRef<void>;
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.spec.ts
@@ -551,7 +551,7 @@ describe('PoStepperComponent:', () => {
         done();
       });
 
-      expect(spyOnCanActiveNextStep).toHaveBeenCalledWith(component['currentActiveStep'], nextStepIndex, undefined);
+      expect(spyOnCanActiveNextStep).toHaveBeenCalledWith(component['currentActiveStep'], nextStepIndex);
     });
 
     it('allowNextStep: should return false if `isBeforeStep` and `canActiveNextStep` are false', (done: DoneFn) => {
@@ -632,7 +632,7 @@ describe('PoStepperComponent:', () => {
         done();
       });
 
-      expect(component['checkAllowNextStep']).toHaveBeenCalledWith(nextStepIndex, undefined);
+      expect(component['checkAllowNextStep']).toHaveBeenCalledWith(nextStepIndex);
     });
 
     it('canActiveNextStep: should return true if `currentActiveStep.canActiveNextStep` function return true', (done: DoneFn) => {
@@ -1068,16 +1068,17 @@ describe('PoStepperComponent:', () => {
     });
   });
 
-  it('getCanActiveNextStepObservable: should return false if step.status is Done', (done: DoneFn) => {
+  it('getCanActiveNextStepObservable: should return result of canActiveNextStep', (done: DoneFn) => {
+    const canActivateNextStepResult = true;
     const currentActiveStep = {
-      canActiveNextStep: jasmine.createSpy()
+      canActiveNextStep: jasmine.createSpy().and.returnValue(canActivateNextStepResult)
     } as unknown as PoStepComponent;
 
     const step = { status: PoStepperStatus.Done } as unknown as PoStepComponent;
 
-    component['getCanActiveNextStepObservable'](currentActiveStep, step).subscribe(result => {
-      expect(result).toBe(false);
-      expect(currentActiveStep.canActiveNextStep).not.toHaveBeenCalled();
+    component['getCanActiveNextStepObservable'](currentActiveStep).subscribe(result => {
+      expect(result).toBe(canActivateNextStepResult);
+      expect(currentActiveStep.canActiveNextStep).toHaveBeenCalled();
       done();
     });
   });
@@ -1094,7 +1095,7 @@ describe('PoStepperComponent:', () => {
 
     const step = { status: PoStepperStatus.Active } as PoStepComponent;
 
-    component['getCanActiveNextStepObservable'](currentActiveStep, step).subscribe(result => {
+    component['getCanActiveNextStepObservable'](currentActiveStep).subscribe(result => {
       expect(result).toBe(true);
       expect(currentActiveStep.canActiveNextStep).toHaveBeenCalledWith(currentActiveStep);
       done();

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.ts
@@ -264,16 +264,12 @@ export class PoStepperComponent extends PoStepperBaseComponent implements AfterC
       return of(false);
     }
 
-    const isAllowNextStep$ = this.checkAllowNextStep(nextStepIndex, step);
+    const isAllowNextStep$ = this.checkAllowNextStep(nextStepIndex);
 
     return typeof isAllowNextStep$ === 'boolean' ? of(isAllowNextStep$) : isAllowNextStep$;
   }
 
-  private canActiveNextStep(
-    currentActiveStep = <PoStepComponent>{},
-    nextStepIndex?: number,
-    step?: PoStepComponent
-  ): Observable<boolean> {
+  private canActiveNextStep(currentActiveStep = <PoStepComponent>{}, nextStepIndex?: number): Observable<boolean> {
     const isCurrentStep = this.isCurrentStep(nextStepIndex);
 
     if (!currentActiveStep.canActiveNextStep) {
@@ -283,7 +279,7 @@ export class PoStepperComponent extends PoStepperBaseComponent implements AfterC
       return of(true);
     }
 
-    const canActiveNextStep$ = this.getCanActiveNextStepObservable(currentActiveStep, step);
+    const canActiveNextStep$ = this.getCanActiveNextStepObservable(currentActiveStep);
 
     return of(this.isBeforeStep(nextStepIndex)).pipe(
       mergeMap(isBefore => {
@@ -310,24 +306,14 @@ export class PoStepperComponent extends PoStepperBaseComponent implements AfterC
     );
   }
 
-  private checkAllowNextStep(nextStepIndex: number, step?: PoStepComponent): Observable<boolean> {
+  private checkAllowNextStep(nextStepIndex: number): Observable<boolean> {
     return this.usePoSteps
-      ? this.canActiveNextStep(this.currentActiveStep, nextStepIndex, step)
+      ? this.canActiveNextStep(this.currentActiveStep, nextStepIndex)
       : of(this.steps.slice(this.step, nextStepIndex).every(step => step.status === PoStepperStatus.Done));
   }
 
-  private getCanActiveNextStepObservable(
-    currentActiveStep: PoStepComponent,
-    step?: PoStepComponent
-  ): Observable<boolean> {
-    let canActiveNextStep: any;
-
-    if (step && step.status === PoStepperStatus.Done) {
-      canActiveNextStep = false;
-    } else {
-      canActiveNextStep = currentActiveStep.canActiveNextStep(currentActiveStep);
-    }
-
+  private getCanActiveNextStepObservable(currentActiveStep: PoStepComponent): Observable<boolean> {
+    const canActiveNextStep = currentActiveStep.canActiveNextStep(currentActiveStep);
     return canActiveNextStep instanceof Observable ? canActiveNextStep : of(canActiveNextStep);
   }
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -67,7 +67,7 @@ describe('PoTableComponent:', () => {
   let tableHeaderElement;
   let tableElement;
   let tableFooterElement;
-  let poTableService: PoTableService;
+  const poTableService: jasmine.SpyObj<PoTableService> = jasmine.createSpyObj('PoTableService', ['scrollListener']);
 
   // mocks
   let actions: Array<PoTableAction>;
@@ -236,7 +236,7 @@ describe('PoTableComponent:', () => {
         PoDateService,
         DecimalPipe,
         PoColorPaletteService,
-        PoTableService,
+        { provide: PoTableService, useValue: poTableService },
         { provide: CdkVirtualScrollViewport, useValue: mockViewPort },
         { provide: changeDetector, useValue: changeDetector },
         provideHttpClient(withInterceptorsFromDi()),
@@ -256,8 +256,6 @@ describe('PoTableComponent:', () => {
     fixture.detectChanges();
 
     component.infiniteScroll = false;
-
-    poTableService = TestBed.inject(PoTableService);
 
     nativeElement = fixture.debugElement.nativeElement;
 
@@ -2933,7 +2931,7 @@ describe('PoTableComponent:', () => {
     component.height = 100;
     component.infiniteScroll = true;
 
-    component['subscriptionScrollEvent'] = poTableService.scrollListener(dummyElement).subscribe();
+    component['subscriptionScrollEvent'] = component['defaultService'].scrollListener(dummyElement).subscribe();
 
     component['removeListeners']();
 
@@ -3022,7 +3020,7 @@ describe('PoTableComponent:', () => {
 
     component.tableScrollable = new ElementRef(mockScrollableElement);
 
-    const spyScrollListener = spyOn(poTableService, 'scrollListener').and.returnValue(
+    const spyScrollListener = spyOn(component['defaultService'], 'scrollListener').and.returnValue(
       of({ target: { offsetHeight: 100, scrollTop: 100, scrollHeight: 1 } })
     );
 
@@ -3045,7 +3043,7 @@ describe('PoTableComponent:', () => {
 
     component.tableVirtualScroll = mockTableVirtualScroll;
 
-    const spyScrollListener = spyOn(poTableService, 'scrollListener').and.returnValue(
+    const spyScrollListener = spyOn(component['defaultService'], 'scrollListener').and.returnValue(
       of({ target: { offsetHeight: 100, scrollTop: 100, scrollHeight: 1 } })
     );
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -101,7 +101,7 @@ import { PoTableService } from './services/po-table.service';
 @Component({
   selector: 'po-table',
   templateUrl: './po-table.component.html',
-  providers: [PoDateService],
+  providers: [PoDateService, PoTableService],
   standalone: false
 })
 export class PoTableComponent extends PoTableBaseComponent implements AfterViewInit, DoCheck, OnDestroy, OnInit {

--- a/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
+++ b/projects/ui/src/lib/components/po-table/services/po-table.service.spec.ts
@@ -11,7 +11,7 @@ describe('PoTableService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
-      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting(), PoTableService]
     });
     service = TestBed.inject(PoTableService);
   });

--- a/projects/ui/src/lib/components/po-table/services/po-table.service.ts
+++ b/projects/ui/src/lib/components/po-table/services/po-table.service.ts
@@ -6,9 +6,7 @@ import { isTypeof } from '../../../utils/util';
 import { PoTableFilter } from '../interfaces/po-table-filter.interface';
 import { PoTableFilteredItemsParams } from '../interfaces/po-table-filtered-items-params.interface';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable()
 export class PoTableService implements PoTableFilter {
   readonly headers: HttpHeaders = new HttpHeaders({
     'X-PO-No-Message': 'true'


### PR DESCRIPTION
Correção para garantir que as literais da aplicação sejam exibidas 
corretamente, independentemente da configuração utilizada. Ajuste 
aplicado para Po UI e THF-Components, evitando conflitos entre as 
literais do framework e da aplicação cliente.

Fixes DTHFUI-10854