### PR TITLE
fix(dynamic-view): corrige utilização de optionsService em container

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-view/po-dynamic-view-base.component.ts
@@ -213,14 +213,22 @@ export class PoDynamicViewBaseComponent extends PoDynamicSharedBase {
               this.service = field.optionsService as PoMultiselectFilterService;
             } else {
               this.service = this.multiselectFilterService;
-              this.service.configProperties(field.optionsService, field.fieldLabel, field.fieldValue);
+              this.service.configProperties(
+                field.optionsService,
+                field.fieldLabel || 'label',
+                field.fieldValue || 'value'
+              );
             }
           } else {
             if (typeof field.optionsService === 'object') {
               this.service = field.optionsService as PoComboFilterService;
             } else {
               this.service = this.comboFilterService;
-              this.service.configProperties(field.optionsService, field.fieldLabel, field.fieldValue);
+              this.service.configProperties(
+                field.optionsService,
+                field.fieldLabel || 'label',
+                field.fieldValue || 'value'
+              );
             }
           }
         }
@@ -281,6 +289,7 @@ export class PoDynamicViewBaseComponent extends PoDynamicSharedBase {
       const oldFieldIndex = newFields.indexOf(newFields.find(field => field === oldField));
       newFields.splice(oldFieldIndex, 1, allValues);
       sortFields(newFields);
+      this.setContainerFields();
     });
   }
 


### PR DESCRIPTION
Corrige o comportamento da exibição do value ao
utilizar optionsService em campos com container.

Fixes DTHFUI-10548

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
