### PR TITLE
feat(tabs): adiciona o token --background-item-default

### DIFF
--- a/projects/ui/src/lib/components/po-tabs/po-tabs-base.component.ts
+++ b/projects/ui/src/lib/components/po-tabs/po-tabs-base.component.ts
@@ -30,8 +30,10 @@ import { convertToBoolean } from '../../utils/util';
  * | Propriedade                            | Descrição                                                                       | Valor Padrão                                      |
  * |----------------------------------------|---------------------------------------------------------------------------------|---------------------------------------------------|
  * | **Default Values**                     |                                                                                 |                                                   |
- * | `--background`                         | Cor de background                                                               | `var(--color-neutral-light-00)`                   |
+ * | `--background`                         | Cor de background                                                               | `var(--color-transparent)`                        |
+ * | `--background-item-default`            | Cor de background do item padrão                                                | `var(--color-transparent)`                        |
  * | `--border-radius`                      | Contém o valor do raio dos cantos do elemento&nbsp;                             | `var(--border-radius-md)`                         |
+ * | `--color`                              | Cor da fonte padrão                                                             | `var(--color-action-default)`                     |
  * | `--color-baseline`                     | Cor para box-shadow                                                             | `var(--color-neutral-light-20)`                   |
  * | `--font-family`                        | Família tipográfica usada                                                       | `var(--font-family-theme)`                        |
  * | `--font-size`                          | Tamanho da fonte                                                                | `var(--font-size-default)`                        |
@@ -50,7 +52,7 @@ import { convertToBoolean } from '../../utils/util';
  * | `--color-hover`                        | Cor principal no estado hover                                                   | `var(--color-brand-01-darkest)`                   |
  * | `--background-item-hover`              | Cor de background no estado de hover                                            | `var(--color-brand-01-lightest)`                  |
  * | **Selected**                           |                                                                                 |                                                   |
- * | `--background-item-selected`           | Cor de background do ítem selecionado                                           | `var(--color-neutral-light-10)`                   |
+ * | `--background-item-selected`           | Cor de background do item selecionado                                           | `var(--color-brand-01-lightest)`                  |
  *
  */
 @Directive()


### PR DESCRIPTION
O componente po-tabs implementa apenas o token --background, que altera a cor de fundo do componente por inteiro. Adiciona o token --background-item-default para permitir a customização da cor de fundo do item padrão separadamente da cor de fundo de todo o po-tabs.

Fixes: DTHFUI-10947

**po-tabs**

**DTHFUI-10947**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente não é possível alterar a cor de fundo dos botões padrão de forma dinâmica e separada da cor de fundo do container do po-tabs, alterando por completo o fundo do componente.

**Qual o novo comportamento?**
Adiciona o token --background-item-default para customizar apenas a cor de fundo dos itens padrões renderizados no po-tabs.

**Simulação**
[app_DTHFUI-10947.zip](https://github.com/user-attachments/files/19488312/app_DTHFUI-10947.zip)