### PR TITLE
fix(storage): sobrescreve dependência vulnerável @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,14 @@
     "typemoq": "^2.1.0",
     "typescript": "~5.6.3"
   },
+  "overrides": {
+    "custom-idle-queue": {
+      "@babel/runtime": "~7.26.10"
+    },
+    "@angular-devkit/build-angular": {
+      "@babel/runtime": "~7.26.10"
+    }
+  },
   "standard-version": {
     "skip": {
       "commit": true,


### PR DESCRIPTION
Os pacotes custom-idle-queue na versão 3.0.1 e @angular-devkit/build-angular na versão ~19.0.4 dependem de uma versão vulnerável do @babel/runtime. Adiciona o override em ambos os pacotes para utilizar o @babel/runtime ~7.26.10, primeira versão com a vulnerabilidade corrigida.

Fixes: DTHFUI-11004

**storage**

**DTHFUI-11004**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Dois pacotes do po-ui, "custom-idle-queue" e "@angular-devkit/build-angular" dependem da biblioteca @babel/runtime em uma [versão vulnerável](https://github.com/advisories/GHSA-968p-4wvh-cqc8), sendo acusado no comando "npm audit" e em processos de análise de código:
![image](https://github.com/user-attachments/assets/6b78d830-2ee6-4d01-9f2e-d5dee1b5140a)

**Qual o novo comportamento?**
Com a definição de dois overrides no "package.json" do projeto, a dependência "@babel/runtime" é instalada na primeira versão que possui a vulnerabilidade corrigida. **Esse mesmo processo de sobrescrita também precisa ser realizado pelo cliente, dado que os overrides não transferidos de projeto para projeto**.
![image](https://github.com/user-attachments/assets/89a362c9-600d-4e8a-81fa-8aa784f40403)
![image](https://github.com/user-attachments/assets/e5fe8064-5c70-46f2-ad84-21baa7811edc)

**Simulação**
https://github.com/luiz-s-vasconcellos/storage-test