### PR TITLE
feat(po-listbox): adiciona opções de posição e altura

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/interfaces/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/interfaces/po-dynamic-form-field.interface.ts
@@ -221,6 +221,27 @@ export interface PoDynamicFormField extends PoDynamicField {
   formatModel?: boolean;
 
   /**
+   * Define a posição de abertura do `listbox`, permitindo forçar sua exibição acima (`top`) ou abaixo (`bottom`) do campo.
+   * Essa propriedade pode ser utilizada para garantir o posicionamento correto do dropdown em cenários com containers que possuem `scroll`,
+   * `overflow: hidden` ou `position: relative`, evitando que o conteúdo seja cortado.
+   *
+   * > Quando não definida, o componente calcula automaticamente a melhor posição com base no espaço disponível na tela.
+   *
+   * **Componentes compatíveis:** `po-multiselect`, `po-combo`.
+   */
+  listboxControlPosition?: 'top' | 'bottom';
+
+  /**
+   * Define a altura em pixels, do dropdown (`po-listbox`).
+   * Essa propriedade permite limitar a altura da lista de opções, evitando que ocupe toda a tela.
+   *
+   * > Caso não seja informada, será considerado o comportamento padrão de altura baseado na quantidade de itens.
+   *
+   * **Componentes compatíveis:** `po-multiselect`, `po-combo`.
+   */
+  listboxHeight?: number;
+
+  /**
    * Valor máximo a ser informado no componente, podendo ser utilizado quando o tipo de dado por *number*, *date* ou *dateTime*.
    *
    * **Componentes compatíveis:** `po-datepicker`, `po-datepicker-range`, `po-number`, `po-decimal`

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -324,6 +324,8 @@
       [p-size]="field.size || componentsSize"
       (p-keydown)="field.keydown?.($event)"
       (p-additional-help)="field.additionalHelp?.($event)"
+      [p-listbox-control-position]="field.listboxControlPosition"
+      [p-listbox-height]="field.listboxHeight"
     >
     </po-combo>
 
@@ -429,6 +431,8 @@
       [p-size]="field.size || componentsSize"
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-keydown)="field.keydown?.($event)"
+      [p-listbox-control-position]="field.listboxControlPosition"
+      [p-listbox-height]="field.listboxHeight"
     >
     </po-multiselect>
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -20,6 +20,7 @@ import { PoComboFilterService } from './po-combo-filter.service';
 const PO_COMBO_DEBOUNCE_TIME_DEFAULT = 400;
 const PO_COMBO_FIELD_LABEL_DEFAULT = 'label';
 const PO_COMBO_FIELD_VALUE_DEFAULT = 'value';
+const poMultiselectContainerPositionDefault = 'bottom';
 
 /**
  * @description
@@ -342,6 +343,35 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * Determinar se o valor do compo deve retorna objeto do tipo {value: any, label: any}
    */
   @Input({ alias: 'p-control-value-with-label', transform: convertToBoolean }) controlValueWithLabel?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define se o `listbox` será aberto acima (`top`) ou abaixo (`bottom`) do campo.
+   * Essa propriedade é útil para controlar manualmente o posicionamento do dropdown em situações com espaço de tela limitado,
+   * como em modais ou containers com rolagem, permitindo exibi-lo acima quando não houver espaço suficiente abaixo, por exemplo.
+   *
+   * Quando não definida, o componente calcula automaticamente a melhor posição com base no espaço disponível na tela.
+   */
+  @Input('p-listbox-control-position') listboxControlPosition: 'top' | 'bottom' = poMultiselectContainerPositionDefault;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a altura em pixels, do dropdown (`listbox`) exibido pelo componente.
+   * Essa propriedade permite limitar visualmente a altura da lista de opções, especialmente útil quando há muitos itens.
+   *
+   * Quando utilizada, o conteúdo excedente será rolável, preservando o espaço da interface e evitando que o dropdown ocupe
+   * toda a tela ou ultrapasse os limites visuais do container.
+   *
+   * > Se não for definida, a altura será ajustada automaticamente conforme a quantidade de itens disponíveis.
+   *
+   */
+  @Input('p-listbox-height') listboxHeight?: number;
 
   cacheOptions: Array<any> = [];
   defaultService: PoComboFilterService;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -139,6 +139,7 @@
         (p-update-infinite-scroll)="showMoreInfiniteScroll()"
         (p-close)="onCloseCombo()"
         [p-container-width]="containerWidth"
+        [p-height]="listboxHeight"
       ></po-listbox>
     </div>
   </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -33,7 +33,6 @@ import { PoComboFilterService } from './po-combo-filter.service';
 import { PoComboOptionTemplateDirective } from './po-combo-option-template/po-combo-option-template.directive';
 
 const poComboContainerOffset = 8;
-const poComboContainerPositionDefault = 'bottom';
 
 /**
  * @docsExtends PoComboBaseComponent
@@ -647,7 +646,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   private adjustContainerPosition() {
-    this.controlPosition.adjustPosition(poComboContainerPositionDefault);
+    this.controlPosition.adjustPosition(this.listboxControlPosition);
   }
 
   private close(reset: boolean) {

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -26,9 +26,11 @@
   [p-show-required]="properties.includes('showRequired')"
   [p-sort]="properties.includes('sort')"
   [p-size]="size"
+  [p-error-limit]="properties?.includes('errorLimit')"
+  [p-listbox-height]="listboxHeight"
+  [p-listbox-control-position]="listboxPosition"
   (p-change)="changeEvent('p-change')"
   (p-keydown)="changeEvent('p-keydown')"
-  [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-combo>
 
@@ -118,6 +120,18 @@
     p-label="Field Error Message"
   >
   </po-input>
+
+  <po-widget p-label="Propriedade do Listbox">
+    <po-radio-group
+      class="po-md-6"
+      name="listboxPosition"
+      [(ngModel)]="listboxPosition"
+      p-label="Listbox Position"
+      [p-options]="listboxPositionOptions"
+    ></po-radio-group>
+    <po-number class="po-md-6" name="listboxHeight" [(ngModel)]="listboxHeight" p-clean p-label="Listbox Height">
+    </po-number>
+  </po-widget>
 
   <div class="po-row">
     <po-checkbox-group

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
@@ -43,10 +43,18 @@ export class SamplePoComboLabsComponent implements OnInit {
   selectedOptionsGroup: string;
   size: string;
 
+  listboxPosition: string;
+  listboxHeight: number;
+
   public readonly filterModeOptions: Array<PoRadioGroupOption> = [
     { label: 'Starts With', value: 'startsWith' },
     { label: 'Contains', value: 'contains' },
     { label: 'Ends With', value: 'endsWith' }
+  ];
+
+  public readonly listboxPositionOptions: Array<any> = [
+    { label: 'Top', value: 'top' },
+    { label: 'Bottom', value: 'bottom' }
   ];
 
   public readonly iconsOptions: Array<PoRadioGroupOption> = [

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -28,6 +28,7 @@ import { PoMultiselectFilterService } from './po-multiselect-filter.service';
 const PO_MULTISELECT_DEBOUNCE_TIME_DEFAULT = 400;
 const PO_MULTISELECT_FIELD_LABEL_DEFAULT = 'label';
 const PO_MULTISELECT_FIELD_VALUE_DEFAULT = 'value';
+const poMultiselectContainerPositionDefault = 'bottom';
 
 export const poMultiselectLiteralsDefault = {
   en: <PoMultiselectLiterals>{
@@ -267,6 +268,34 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * Determinar se o valor do compo deve retorna objeto do tipo {value: any, label: any}
    */
   @Input({ alias: 'p-control-value-with-label', transform: convertToBoolean }) controlValueWithLabel?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define se o `listbox` será aberto acima (`top`) ou abaixo (`bottom`) do campo.
+   * Essa propriedade é útil para controlar manualmente o posicionamento do dropdown em situações com espaço de tela limitado,
+   * como em modais ou containers com rolagem, permitindo exibi-lo acima quando não houver espaço suficiente abaixo, por exemplo.
+   *
+   * Quando não definida, o componente calcula automaticamente a melhor posição com base no espaço disponível na tela.
+   */
+  @Input('p-listbox-control-position') listboxControlPosition: 'top' | 'bottom' = poMultiselectContainerPositionDefault;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a altura em pixels, do dropdown (`listbox`) exibido pelo componente.
+   * Essa propriedade permite limitar visualmente a altura da lista de opções, especialmente útil quando há muitos itens.
+   *
+   * Quando utilizada, o conteúdo excedente será rolável, preservando o espaço da interface e evitando que o dropdown ocupe
+   * toda a tela ou ultrapasse os limites visuais do container.
+   *
+   * > Se não for definida, a altura será ajustada automaticamente conforme a quantidade de itens disponíveis.
+   */
+  @Input('p-listbox-height') listboxHeight?: number;
 
   selectedOptions: Array<PoMultiselectOption | any> = [];
   visibleOptionsDropdown: Array<PoMultiselectOption | any> = [];

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
@@ -23,6 +23,7 @@
         (p-change-search)="callChangeSearch($event)"
         (p-close)="closeDropdown.emit()"
         [p-container-width]="containerWidth"
+        [p-height]="listboxHeight"
       >
       </po-listbox>
     </ng-container>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
@@ -64,6 +64,8 @@ export class PoMultiselectDropdownComponent {
   /** Tamanho do componente. */
   @Input('p-size') size: string;
 
+  @Input('p-listbox-height') listboxHeight?: number;
+
   /** Evento disparado a cada tecla digitada na pesquisa. */
   @Output('p-change-search') changeSearch = new EventEmitter();
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -99,11 +99,12 @@
       [p-field-label]="fieldLabel"
       [p-multiselect-template]="multiselectOptionTemplate"
       [p-size]="size"
+      [p-container-width]="containerWidth"
+      [p-listbox-height]="listboxHeight"
       (p-change)="changeItems($event)"
       (p-change-search)="changeSearch($event)"
       (p-close-dropdown)="controlDropdownVisibility(false)"
       (keydown)="onKeyDownDropdown($event, 0)"
-      [p-container-width]="containerWidth"
     >
     </po-multiselect-dropdown>
   </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -31,7 +31,6 @@ import { PoMultiselectFilterService } from './po-multiselect-filter.service';
 import { PoMultiselectOptionTemplateDirective } from './po-multiselect-option-template/po-multiselect-option-template.directive';
 
 const poMultiselectContainerOffset = 8;
-const poMultiselectContainerPositionDefault = 'bottom';
 const poMultiselectInputPaddingRight = 52;
 const poMultiselectSpaceBetweenTags = 8;
 
@@ -555,7 +554,7 @@ export class PoMultiselectComponent
   }
 
   private adjustContainerPosition(): void {
-    this.controlPosition.adjustPosition(poMultiselectContainerPositionDefault);
+    this.controlPosition.adjustPosition(this.listboxControlPosition);
   }
 
   private close(): void {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
@@ -24,6 +24,8 @@
     [p-show-required]="properties.includes('showRequired')"
     [p-size]="size"
     [p-sort]="properties.includes('sort')"
+    [p-listbox-height]="listboxHeight"
+    [p-listbox-control-position]="listboxPosition"
     (p-change)="changeEvent('p-change')"
     (p-keydown)="changeEvent('p-keydown')"
     [p-error-limit]="properties?.includes('errorLimit')"
@@ -115,6 +117,18 @@
   <po-input class="po-md-6" name="fieldValue" [(ngModel)]="fieldValue" p-clean p-label="Field Value"> </po-input>
 
   <po-input class="po-md-6" name="fieldLabel" [(ngModel)]="fieldLabel" p-clean p-label="Field Label"> </po-input>
+
+  <po-widget p-label="Propriedade do Listbox">
+    <po-radio-group
+      class="po-md-6"
+      name="listboxPosition"
+      [(ngModel)]="listboxPosition"
+      p-label="Listbox Position"
+      [p-options]="listboxPositionOptions"
+    ></po-radio-group>
+    <po-number class="po-md-6" name="listboxHeight" [(ngModel)]="listboxHeight" p-clean p-label="Listbox Height">
+    </po-number>
+  </po-widget>
 
   <po-checkbox-group
     class="po-md-12"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
@@ -31,11 +31,18 @@ export class SamplePoMultiselectLabsComponent implements OnInit {
   fieldLabel: string;
   fieldValue: string;
   size: string;
+  listboxPosition: string;
+  listboxHeight: number;
 
   public readonly filterModeOptions: Array<PoRadioGroupOption> = [
     { label: 'Starts With', value: 'startsWith' },
     { label: 'Contains', value: 'contains' },
     { label: 'Ends With', value: 'endsWith' }
+  ];
+
+  public readonly listboxPositionOptions: Array<any> = [
+    { label: 'Top', value: 'top' },
+    { label: 'Bottom', value: 'bottom' }
   ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [

--- a/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.ts
@@ -166,6 +166,8 @@ export class PoListBoxBaseComponent {
 
   @Input('p-container-width') containerWidth: number;
 
+  @Input('p-height') height?: number;
+
   // Evento disparado quando uma tab é ativada
   @Output('p-activated-tabs') activatedTab = new EventEmitter();
 

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
@@ -3,6 +3,8 @@
   class="po-listbox"
   [class.po-listbox-check]="type === 'check' || type === 'option'"
   [attr.data-type]="type"
+  [style.min-height]="getMinHeight()"
+  [style.height]="getHeight()"
   [hidden]="visible"
 >
   <ng-content select="[p-popup-header-template]"></ng-content>

--- a/projects/ui/src/lib/components/po-search/po-search.component.spec.ts
+++ b/projects/ui/src/lib/components/po-search/po-search.component.spec.ts
@@ -342,9 +342,16 @@ describe('PoSearchComponent', () => {
     });
 
     it('should focus the listbox if the input have a arrowdown keypress', () => {
+      // Mock completo do listboxItemList com querySelector
       component.poListbox.listboxItemList = {
-        nativeElement: { offsetHeight: 100, scrollTop: 100, scrollHeight: 200 }
+        nativeElement: {
+          offsetHeight: 100,
+          scrollTop: 100,
+          scrollHeight: 200,
+          querySelector: jasmine.createSpy('querySelector').and.returnValue({ offsetHeight: 40 }) // <-- Adicione esta linha
+        }
       };
+
       component.type = 'trigger';
       component.listboxOpen = true;
 

--- a/projects/ui/src/lib/services/po-control-position/po-control-position.service.ts
+++ b/projects/ui/src/lib/services/po-control-position/po-control-position.service.ts
@@ -189,7 +189,7 @@ export class PoControlPositionService {
         innerWidth: window.innerWidth,
         innerHeight: window.innerHeight
       },
-      element: this.element.getBoundingClientRect(),
+      element: this.element?.getBoundingClientRect(),
       target: this.targetElement ? this.targetElement.getBoundingClientRect() : { top: 0, bottom: 0, right: 0, left: 0 }
     };
   }


### PR DESCRIPTION
Garante que o listbox do po-multiselect reposicione para cima quando não houver espaço suficiente na parte inferior da tela, evitando que o conteúdo fique cortado e inviabilize a seleção de opções pelo usuário.

Fixes DTHFUI-10389
