### PR TITLE
fix(po-multiselect): evita corte do listbox ao abrir próximo da borda

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -178,6 +178,27 @@ export interface PoDynamicFormField extends PoDynamicField {
   formatModel?: boolean;
 
   /**
+   * Define a posição de abertura do `listbox`, permitindo forçar sua exibição acima (`top`) ou abaixo (`bottom`) do campo.
+   * Essa propriedade pode ser utilizada para garantir o posicionamento correto do dropdown em cenários com containers que possuem `scroll`,
+   * `overflow: hidden` ou `position: relative`, evitando que o conteúdo seja cortado.
+   *
+   * > Quando não definida, o componente calcula automaticamente a melhor posição com base no espaço disponível na tela.
+   *
+   * **Componentes compatíveis:** `po-multiselect`, `po-lookup`.
+   */
+  listboxControlPosition?: 'top' | 'bottom';
+
+  /**
+   * Define a altura máxima, em pixels, do dropdown (`po-listbox`).
+   * Essa propriedade permite limitar a altura da lista de opções, evitando que ocupe toda a tela.
+   *
+   * > Caso não seja informada, será considerado o comportamento padrão de altura baseado na quantidade de itens.
+   *
+   * **Componentes compatíveis:** `po-multiselect`, `po-combo`.
+   */
+  listboxMaxHeight?: number;
+
+  /**
    * Valor máximo a ser informado no componente, podendo ser utilizado quando o tipo de dado por *number*, *date* ou *dateTime*.
    *
    * **Componentes compatíveis:** `po-datepicker`, `po-datepicker-range`, `po-number`, `po-decimal`

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -255,6 +255,8 @@
       [p-disabled-tab-filter]="field.disabledTabFilter"
       [p-debounce-time]="field.debounceTime"
       [p-change-on-enter]="field.changeOnEnter"
+      [p-listbox-control-position]="field.listboxControlPosition"
+      [p-listbox-max-height]="field.listboxMaxHeight"
     >
     </po-combo>
 
@@ -339,6 +341,8 @@
       [p-placeholder-search]="field.placeholderSearch"
       [p-hide-search]="field.hideSearch"
       [p-hide-select-all]="field.hideSelectAll"
+      [p-listbox-control-position]="field.listboxControlPosition"
+      [p-listbox-max-height]="field.listboxMaxHeight"
     >
     </po-multiselect>
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -18,6 +18,7 @@ import { PoComboFilterService } from './po-combo-filter.service';
 const PO_COMBO_DEBOUNCE_TIME_DEFAULT = 400;
 const PO_COMBO_FIELD_LABEL_DEFAULT = 'label';
 const PO_COMBO_FIELD_VALUE_DEFAULT = 'value';
+const poMultiselectContainerPositionDefault = 'bottom';
 
 /**
  * @description
@@ -275,6 +276,38 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    */
   @Output('p-input-change') inputChange: EventEmitter<string> = new EventEmitter<string>();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define se o `listbox` será aberto acima (`top`) ou abaixo (`bottom`) do campo.
+   * Essa propriedade é útil para controlar manualmente o posicionamento do dropdown em situações com espaço de tela limitado,
+   * como em modais ou containers com rolagem, permitindo exibi-lo acima quando não houver espaço suficiente abaixo, por exemplo.
+   *
+   * Quando não definida, o componente calcula automaticamente a melhor posição com base no espaço disponível na tela.
+   *
+   * **Componentes compatíveis:** `po-combo`, `po-multiselect`.
+   */
+  @Input('p-listbox-control-position') listboxControlPosition: 'top' | 'bottom' = poMultiselectContainerPositionDefault;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a altura máxima, em pixels, do dropdown (`listbox`) exibido pelo componente.
+   * Essa propriedade permite limitar visualmente a altura da lista de opções, especialmente útil quando há muitos itens.
+   *
+   * Quando utilizada, o conteúdo excedente será rolável, preservando o espaço da interface e evitando que o dropdown ocupe
+   * toda a tela ou ultrapasse os limites visuais do container.
+   *
+   * > Se não for definida, a altura será ajustada automaticamente conforme a quantidade de itens disponíveis.
+   *
+   * **Componentes compatíveis:** `po-multiselect`, `po-combo`.
+   */
+  @Input('p-listbox-max-height') listboxMaxHeight?: number;
 
   cacheOptions: Array<any> = [];
   defaultService: PoComboFilterService;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -106,6 +106,7 @@
         (p-update-infinite-scroll)="showMoreInfiniteScroll()"
         (p-close)="onCloseCombo()"
         [p-container-width]="containerWidth"
+        [p-max-height]="listboxMaxHeight"
       ></po-listbox>
     </div>
   </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -31,7 +31,6 @@ import { uuid } from '../../../utils/util';
 import { PoListBoxComponent } from './../../po-listbox/po-listbox.component';
 
 const poComboContainerOffset = 8;
-const poComboContainerPositionDefault = 'bottom';
 
 /**
  * @docsExtends PoComboBaseComponent
@@ -573,7 +572,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   private adjustContainerPosition() {
-    this.controlPosition.adjustPosition(poComboContainerPositionDefault);
+    this.controlPosition.adjustPosition(this.listboxControlPosition);
   }
 
   private close(reset: boolean) {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -24,6 +24,7 @@ import { PoMultiselectOption } from './po-multiselect-option.interface';
 const PO_MULTISELECT_DEBOUNCE_TIME_DEFAULT = 400;
 const PO_MULTISELECT_FIELD_LABEL_DEFAULT = 'label';
 const PO_MULTISELECT_FIELD_VALUE_DEFAULT = 'value';
+const poMultiselectContainerPositionDefault = 'bottom';
 
 export const poMultiselectLiteralsDefault = {
   en: <PoMultiselectLiterals>{
@@ -196,6 +197,38 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * @default `false`
    */
   @Input({ alias: 'p-append-in-body', transform: convertToBoolean }) appendBox?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define se o `listbox` será aberto acima (`top`) ou abaixo (`bottom`) do campo.
+   * Essa propriedade é útil para controlar manualmente o posicionamento do dropdown em situações com espaço de tela limitado,
+   * como em modais ou containers com rolagem, permitindo exibi-lo acima quando não houver espaço suficiente abaixo, por exemplo.
+   *
+   * Quando não definida, o componente calcula automaticamente a melhor posição com base no espaço disponível na tela.
+   *
+   * **Componentes compatíveis:** `po-combo`, `po-multiselect`.
+   */
+  @Input('p-listbox-control-position') listboxControlPosition: 'top' | 'bottom' = poMultiselectContainerPositionDefault;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a altura máxima, em pixels, do dropdown (`listbox`) exibido pelo componente.
+   * Essa propriedade permite limitar visualmente a altura da lista de opções, especialmente útil quando há muitos itens.
+   *
+   * Quando utilizada, o conteúdo excedente será rolável, preservando o espaço da interface e evitando que o dropdown ocupe
+   * toda a tela ou ultrapasse os limites visuais do container.
+   *
+   * > Se não for definida, a altura será ajustada automaticamente conforme a quantidade de itens disponíveis.
+   *
+   * **Componentes compatíveis:** `po-multiselect`, `po-combo`.
+   */
+  @Input('p-listbox-max-height') listboxMaxHeight?: number;
 
   selectedOptions: Array<PoMultiselectOption | any> = [];
   visibleOptionsDropdown: Array<PoMultiselectOption | any> = [];

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
@@ -22,6 +22,7 @@
         (p-change-search)="callChangeSearch($event)"
         (p-close)="closeDropdown.emit()"
         [p-container-width]="containerWidth"
+        [p-max-height]="listboxMaxHeight"
       >
       </po-listbox>
     </ng-container>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
@@ -59,6 +59,8 @@ export class PoMultiselectDropdownComponent {
 
   @Input('p-container-width') containerWidth: number;
 
+  @Input() listboxMaxHeight?: number;
+
   /** Evento disparado a cada tecla digitada na pesquisa. */
   @Output('p-change-search') changeSearch = new EventEmitter();
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -86,6 +86,8 @@
       (p-close-dropdown)="controlDropdownVisibility(false)"
       (keydown)="onKeyDownDropdown($event, 0)"
       [p-container-width]="containerWidth"
+      [p-container-width]="containerWidth"
+      [listboxMaxHeight]="listboxMaxHeight"
     >
     </po-multiselect-dropdown>
   </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -1,6 +1,6 @@
 import { OverlayModule } from '@angular/cdk/overlay';
-import { HttpClient, HttpHandler } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpClient, HttpHandler, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { Observable, of, throwError } from 'rxjs';
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -30,7 +30,6 @@ import { PoMultiselectOptionTemplateDirective } from './po-multiselect-option-te
 import { PoMultiselectOption } from './po-multiselect-option.interface';
 
 const poMultiselectContainerOffset = 8;
-const poMultiselectContainerPositionDefault = 'bottom';
 const poMultiselectInputPaddingRight = 52;
 const poMultiselectSpaceBetweenTags = 8;
 
@@ -492,7 +491,7 @@ export class PoMultiselectComponent
   }
 
   private adjustContainerPosition(): void {
-    this.controlPosition.adjustPosition(poMultiselectContainerPositionDefault);
+    this.controlPosition.adjustPosition(this.listboxControlPosition);
   }
 
   private close(): void {

--- a/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox-base.component.ts
@@ -155,6 +155,8 @@ export class PoListBoxBaseComponent {
 
   @Input('p-container-width') containerWidth: number;
 
+  @Input('p-max-height') maxHeight?: number;
+
   // Evento disparado quando uma tab é ativada
   @Output('p-activated-tabs') activatedTab = new EventEmitter();
 

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
@@ -511,6 +511,24 @@ describe('PoListBoxComponent', () => {
 
         expect(component['renderer'].setStyle).not.toHaveBeenCalled();
       });
+
+      it('should call `renderer.setStyle` with `this.maxHeight` when maxHeight is defined', () => {
+        component.maxHeight = 123;
+        component.items = [
+          { label: 'Item 1', value: 1 },
+          { label: 'Item 2', value: 2 },
+          { label: 'Item 3', value: 3 }
+        ];
+        component['listbox'] = {
+          nativeElement: document.createElement('div')
+        };
+
+        const rendererSpy = spyOn(component['renderer'], 'setStyle');
+
+        component['setListBoxMaxHeight']();
+
+        expect(rendererSpy).toHaveBeenCalledWith(component['listbox'].nativeElement, 'maxHeight', '123px');
+      });
     });
 
     describe('checkboxClicked:', () => {

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
@@ -230,12 +230,13 @@ export class PoListBoxComponent extends PoListBoxBaseComponent implements AfterV
   }
 
   private setListBoxMaxHeight(): void {
-    const itemsLength = this.items.length;
-    if (itemsLength > 6) {
-      if (this.type === 'check' && !this.hideSearch) {
-        this.renderer.setStyle(this.listbox.nativeElement, 'maxHeight', `${44 * 6 - 44 / 3 + 60}px`);
-      } else {
-        this.renderer.setStyle(this.listbox.nativeElement, 'maxHeight', `${44 * 6 - 44 / 3}px`);
+    if (this.maxHeight) {
+      this.renderer.setStyle(this.listbox.nativeElement, 'maxHeight', `${this.maxHeight}px`);
+    } else {
+      const itemsLength = this.items.length;
+      if (itemsLength > 6) {
+        const extra = this.type === 'check' && !this.hideSearch ? 60 : 0;
+        this.renderer.setStyle(this.listbox.nativeElement, 'maxHeight', `${44 * 6 - 44 / 3 + extra}px`);
       }
     }
   }


### PR DESCRIPTION
Garante que o listbox do po-multiselect reposicione para cima quando não houver espaço suficiente na parte inferior da tela, evitando que o conteúdo fique cortado e inviabilize a seleção de opções pelo usuário.

Fixes DTHFUI-10389