### PR TITLE
feat(listbox): adiciona propriedade para controle de posição

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/interfaces/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/interfaces/po-dynamic-form-field.interface.ts
@@ -221,6 +221,18 @@ export interface PoDynamicFormField extends PoDynamicField {
   formatModel?: boolean;
 
   /**
+   * Define a direção preferida para exibição do `listbox` em relação ao campo (`top` ou `bottom`).
+   * Útil em casos onde o posicionamento automático não se comporta como esperado, como quando o componente está próximo
+   * ao final do formulário ou do container visível. Na maioria dos casos, essa direção será respeitada; no entanto,
+   * pode ser ajustada automaticamente conforme o espaço disponível na tela.
+   *
+   * **Componentes compatíveis:** `po-multiselect`, `po-combo`.
+   *
+   * @default `bottom`
+   */
+  listboxControlPosition?: 'top' | 'bottom';
+
+  /**
    * Valor máximo a ser informado no componente, podendo ser utilizado quando o tipo de dado por *number*, *date* ou *dateTime*.
    *
    * **Componentes compatíveis:** `po-datepicker`, `po-datepicker-range`, `po-number`, `po-decimal`

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -324,6 +324,7 @@
       [p-size]="field.size || componentsSize"
       (p-keydown)="field.keydown?.($event)"
       (p-additional-help)="field.additionalHelp?.($event)"
+      [p-listbox-control-position]="field.listboxControlPosition"
     >
     </po-combo>
 
@@ -429,6 +430,7 @@
       [p-size]="field.size || componentsSize"
       (p-additional-help)="field.additionalHelp?.($event)"
       (p-keydown)="field.keydown?.($event)"
+      [p-listbox-control-position]="field.listboxControlPosition"
     >
     </po-multiselect>
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-container/sample-po-dynamic-form-container.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-container/sample-po-dynamic-form-container.component.ts
@@ -1,13 +1,13 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 
 import {
+  ForceBooleanComponentEnum,
+  PoDynamicFormComponent,
   PoDynamicFormField,
   PoDynamicFormFieldChanged,
   PoDynamicFormValidation,
   PoNotificationService,
-  ForceBooleanComponentEnum,
-  PoUploadFile,
-  PoDynamicFormComponent
+  PoUploadFile
 } from '@po-ui/ng-components';
 import { PoDynamicFormContainerService } from './sample-po-dynamic-form-container.service';
 
@@ -148,7 +148,8 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
       gridSmColumns: 12,
       optional: true,
       options: ['Soccer', 'Basketball', 'Bike', 'Yoga', 'Travel', 'Run'],
-      optionsMulti: true
+      optionsMulti: true,
+      listboxControlPosition: 'top'
     },
     {
       property: 'favoriteHero',
@@ -172,7 +173,8 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
       optionsService: 'https://po-sample-api.onrender.com/v1/people',
       fieldLabel: 'name',
       fieldValue: 'id',
-      optional: true
+      optional: true,
+      listboxControlPosition: 'top'
     },
     {
       property: 'videogame',
@@ -190,7 +192,8 @@ export class SamplePoDynamicFormContainerComponent implements OnInit {
         { console: 'Playstation 5', code: 'PS5' },
         { console: 'Xbox Series S|X', code: 'XSSX' }
       ],
-      optionsMulti: true
+      optionsMulti: true,
+      listboxControlPosition: 'top'
     },
     {
       property: 'agree',

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -20,6 +20,7 @@ import { PoComboFilterService } from './po-combo-filter.service';
 const PO_COMBO_DEBOUNCE_TIME_DEFAULT = 400;
 const PO_COMBO_FIELD_LABEL_DEFAULT = 'label';
 const PO_COMBO_FIELD_VALUE_DEFAULT = 'value';
+const poMultiselectContainerPositionDefault = 'bottom';
 
 /**
  * @description
@@ -342,6 +343,20 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * Determinar se o valor do compo deve retorna objeto do tipo {value: any, label: any}
    */
   @Input({ alias: 'p-control-value-with-label', transform: convertToBoolean }) controlValueWithLabel?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a direção preferida para exibição do `listbox` em relação ao campo (`top` ou `bottom`).
+   * Útil em casos onde o posicionamento automático não se comporta como esperado, como quando o componente está próximo
+   * ao final do formulário ou do container visível. Na maioria dos casos, essa direção será respeitada; no entanto,
+   * pode ser ajustada automaticamente conforme o espaço disponível na tela.
+   *
+   * @default `bottom`
+   */
+  @Input('p-listbox-control-position') listboxControlPosition: 'top' | 'bottom' = poMultiselectContainerPositionDefault;
 
   cacheOptions: Array<any> = [];
   defaultService: PoComboFilterService;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -33,7 +33,6 @@ import { PoComboFilterService } from './po-combo-filter.service';
 import { PoComboOptionTemplateDirective } from './po-combo-option-template/po-combo-option-template.directive';
 
 const poComboContainerOffset = 8;
-const poComboContainerPositionDefault = 'bottom';
 
 /**
  * @docsExtends PoComboBaseComponent
@@ -647,7 +646,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   }
 
   private adjustContainerPosition() {
-    this.controlPosition.adjustPosition(poComboContainerPositionDefault);
+    this.controlPosition.adjustPosition(this.listboxControlPosition);
   }
 
   private close(reset: boolean) {

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-hotels/sample-po-combo-hotels.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-hotels/sample-po-combo-hotels.component.html
@@ -64,6 +64,7 @@
       p-label="Search a hotel"
       p-sort
       p-filter-service="https://po-sample-api.onrender.com/v1/hotels"
+      p-listbox-control-position="top"
       [p-filter-params]="filterParams"
     >
     </po-combo>

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -26,9 +26,10 @@
   [p-show-required]="properties.includes('showRequired')"
   [p-sort]="properties.includes('sort')"
   [p-size]="size"
+  [p-error-limit]="properties?.includes('errorLimit')"
+  [p-listbox-control-position]="listboxPosition"
   (p-change)="changeEvent('p-change')"
   (p-keydown)="changeEvent('p-keydown')"
-  [p-error-limit]="properties?.includes('errorLimit')"
 >
 </po-combo>
 
@@ -151,7 +152,7 @@
     </po-radio-group>
 
     <po-radio-group
-      class="po-md-12"
+      class="po-lg-6"
       name="size"
       [(ngModel)]="size"
       p-columns="4"
@@ -160,6 +161,14 @@
       [p-options]="sizeOptions"
     >
     </po-radio-group>
+
+    <po-radio-group
+      class="po-lg-6"
+      name="listboxPosition"
+      [(ngModel)]="listboxPosition"
+      p-label="Listbox Position"
+      [p-options]="listboxPositionOptions"
+    ></po-radio-group>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
@@ -43,10 +43,17 @@ export class SamplePoComboLabsComponent implements OnInit {
   selectedOptionsGroup: string;
   size: string;
 
+  listboxPosition: string = 'bottom';
+
   public readonly filterModeOptions: Array<PoRadioGroupOption> = [
     { label: 'Starts With', value: 'startsWith' },
     { label: 'Contains', value: 'contains' },
     { label: 'Ends With', value: 'endsWith' }
+  ];
+
+  public readonly listboxPositionOptions: Array<any> = [
+    { label: 'top', value: 'top' },
+    { label: 'bottom', value: 'bottom' }
   ];
 
   public readonly iconsOptions: Array<PoRadioGroupOption> = [

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -28,6 +28,7 @@ import { PoMultiselectFilterService } from './po-multiselect-filter.service';
 const PO_MULTISELECT_DEBOUNCE_TIME_DEFAULT = 400;
 const PO_MULTISELECT_FIELD_LABEL_DEFAULT = 'label';
 const PO_MULTISELECT_FIELD_VALUE_DEFAULT = 'value';
+const poMultiselectContainerPositionDefault = 'bottom';
 
 export const poMultiselectLiteralsDefault = {
   en: <PoMultiselectLiterals>{
@@ -267,6 +268,20 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * Determinar se o valor do compo deve retorna objeto do tipo {value: any, label: any}
    */
   @Input({ alias: 'p-control-value-with-label', transform: convertToBoolean }) controlValueWithLabel?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a direção preferida para exibição do `listbox` em relação ao campo (`top` ou `bottom`).
+   * Útil em casos onde o posicionamento automático não se comporta como esperado, como quando o componente está próximo
+   * ao final do formulário ou do container visível. Na maioria dos casos, essa direção será respeitada; no entanto,
+   * pode ser ajustada automaticamente conforme o espaço disponível na tela.
+   *
+   * @default `bottom`
+   */
+  @Input('p-listbox-control-position') listboxControlPosition: 'top' | 'bottom' = poMultiselectContainerPositionDefault;
 
   selectedOptions: Array<PoMultiselectOption | any> = [];
   visibleOptionsDropdown: Array<PoMultiselectOption | any> = [];

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
@@ -10,7 +10,6 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { PoFieldSize } from '../../../../enums/po-field-size.enum';
 import { PoMultiselectLiterals } from '../../index';
 import { PoMultiselectOption } from '../interfaces/po-multiselect-option.interface';
 import { PoListBoxComponent } from './../../../po-listbox/po-listbox.component';

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -99,11 +99,11 @@
       [p-field-label]="fieldLabel"
       [p-multiselect-template]="multiselectOptionTemplate"
       [p-size]="size"
+      [p-container-width]="containerWidth"
       (p-change)="changeItems($event)"
       (p-change-search)="changeSearch($event)"
       (p-close-dropdown)="controlDropdownVisibility(false)"
       (keydown)="onKeyDownDropdown($event, 0)"
-      [p-container-width]="containerWidth"
     >
     </po-multiselect-dropdown>
   </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -31,7 +31,6 @@ import { PoMultiselectFilterService } from './po-multiselect-filter.service';
 import { PoMultiselectOptionTemplateDirective } from './po-multiselect-option-template/po-multiselect-option-template.directive';
 
 const poMultiselectContainerOffset = 8;
-const poMultiselectContainerPositionDefault = 'bottom';
 const poMultiselectInputPaddingRight = 52;
 const poMultiselectSpaceBetweenTags = 8;
 
@@ -555,7 +554,7 @@ export class PoMultiselectComponent
   }
 
   private adjustContainerPosition(): void {
-    this.controlPosition.adjustPosition(poMultiselectContainerPositionDefault);
+    this.controlPosition.adjustPosition(this.listboxControlPosition);
   }
 
   private close(): void {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-any-array/sample-po-multiselect-any-array.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-any-array/sample-po-multiselect-any-array.component.html
@@ -23,6 +23,7 @@
         class="po-md-12"
         name="multiselect"
         p-label="Select your Company"
+        p-listbox-control-position="top"
         [p-options]="options"
         [p-field-value]="fieldValue"
         [p-field-label]="fieldLabel"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
@@ -24,6 +24,7 @@
     [p-show-required]="properties.includes('showRequired')"
     [p-size]="size"
     [p-sort]="properties.includes('sort')"
+    [p-listbox-control-position]="listboxPosition"
     (p-change)="changeEvent('p-change')"
     (p-keydown)="changeEvent('p-keydown')"
     [p-error-limit]="properties?.includes('errorLimit')"
@@ -138,7 +139,7 @@
   </po-radio-group>
 
   <po-radio-group
-    class="po-md-12"
+    class="po-lg-6"
     name="size"
     [(ngModel)]="size"
     p-columns="4"
@@ -147,6 +148,14 @@
     [p-options]="sizeOptions"
   >
   </po-radio-group>
+
+  <po-radio-group
+    class="po-lg-6"
+    name="listboxPosition"
+    [(ngModel)]="listboxPosition"
+    p-label="Listbox Position"
+    [p-options]="listboxPositionOptions"
+  ></po-radio-group>
 
   <div class="po-row">
     <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
@@ -31,11 +31,17 @@ export class SamplePoMultiselectLabsComponent implements OnInit {
   fieldLabel: string;
   fieldValue: string;
   size: string;
+  listboxPosition: string = 'bottom';
 
   public readonly filterModeOptions: Array<PoRadioGroupOption> = [
     { label: 'Starts With', value: 'startsWith' },
     { label: 'Contains', value: 'contains' },
     { label: 'Ends With', value: 'endsWith' }
+  ];
+
+  public readonly listboxPositionOptions: Array<any> = [
+    { label: 'top', value: 'top' },
+    { label: 'bottom', value: 'bottom' }
   ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
@@ -1,5 +1,5 @@
 import { ElementRef, NO_ERRORS_SCHEMA, SimpleChange } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PoListBoxComponent } from './po-listbox.component';
 import * as UtilFunctions from './../../utils/util';

--- a/projects/ui/src/lib/services/po-control-position/po-control-position.service.ts
+++ b/projects/ui/src/lib/services/po-control-position/po-control-position.service.ts
@@ -189,7 +189,7 @@ export class PoControlPositionService {
         innerWidth: window.innerWidth,
         innerHeight: window.innerHeight
       },
-      element: this.element.getBoundingClientRect(),
+      element: this.element?.getBoundingClientRect(),
       target: this.targetElement ? this.targetElement.getBoundingClientRect() : { top: 0, bottom: 0, right: 0, left: 0 }
     };
   }


### PR DESCRIPTION
Adiciona a propriedade `p-listbox-control-position` aos componentes po-multiselect e po-combo, permitindo definir a posição preferencial do listbox (acima ou abaixo do campo). A funcionalidade também foi repassada para o po-dynamic-form.

fixes DTHFUI-10389

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
