### PR TITLE
feat(table): adiciona tamanho extraSmall ao p-spacing

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -211,12 +211,6 @@ describe('PoPageDynamicTableComponent:', () => {
 
         expectPropertiesValues(component, 'spacing', validValues, validValues);
       });
-
-      it('should set spacing to PoTableColumnSpacing.Medium if the given value is invalid', () => {
-        const invalidValue = 'double-extra-large' as unknown as PoTableColumnSpacing;
-
-        expectPropertiesValues(component, 'spacing', [invalidValue], PoTableColumnSpacing.Medium);
-      });
     });
 
     it('p-virtual-scroll: should default virtualScroll to true when height is defined.', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -299,7 +299,6 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   private _defaultTableActions: Array<PoTableAction> = [];
   private _hideCloseDisclaimers: Array<string> = [];
   private _draggable = false;
-  private _spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
   private _virtualScroll?: boolean = true;
 
   private set defaultPageActions(value: Array<PoPageAction>) {
@@ -551,23 +550,18 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
    *
    * @description
    *
-   * Responsável por aplicar espaçamento nas colunas.
+   * Define o espaçamento interno das células, impactando diretamente na altura das linhas do table. Os valores
+   * permitidos são definidos pelo enum **PoTableColumnSpacing**.
    *
-   * Deve receber um dos valores do enum `PoTableColumnSpacing`.
+   * > Em nível de acessibilidade **AA**, caso o valor de `p-spacing` não seja definido, o valor padrão será
+   * > `extraSmall` nos seguintes cenários:
+   * > - Quando o valor de `p-components-size` for `small`;
+   * > - Quando o valor padrão dos componentes for configurado como `small` no
+   * > [serviço de tema](https://po-ui.io/documentation/po-theme).
    *
    * @default `medium`
    */
-  @Input('p-spacing') set spacing(value: PoTableColumnSpacing) {
-    if (value === 'small' || value === 'medium' || value === 'large') {
-      this._spacing = value;
-    } else {
-      this._spacing = PoTableColumnSpacing.Medium;
-    }
-  }
-
-  get spacing() {
-    return this._spacing;
-  }
+  @Input('p-spacing') spacing: string;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -32,6 +32,8 @@ class PoLookupComponent extends PoLookupBaseComponent {
   setDisclaimers() {}
 
   updateVisibleItems() {}
+
+  getDefaultSpacing() {}
 }
 
 describe('PoLookupBaseComponent:', () => {
@@ -970,10 +972,6 @@ describe('PoLookupBaseComponent:', () => {
     it('p-placeholder: should update property p-placeholder with empty value if set with invalid values.', () => {
       const invalidValues = [false, 0, null, undefined, NaN];
       expectPropertiesValues(component, 'placeholder', invalidValues, '');
-    });
-
-    it('p-spacing: should update property with valid values', () => {
-      expectPropertiesValues(component, 'spacing', 'small', 'small');
     });
 
     describe('p-size', () => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -72,6 +72,7 @@ export abstract class PoLookupBaseComponent
   private _literals?: PoLookupLiterals;
   private readonly language: string;
   private _size?: string = undefined;
+  private _spacing: PoTableColumnSpacing;
 
   // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
   @Input() additionalHelpEventTrigger: string | undefined;
@@ -408,13 +409,28 @@ export abstract class PoLookupBaseComponent
    *
    * @description
    *
-   * Responsável por aplicar espaçamento nas colunas da tabela contida no lookup.
+   * Define o espaçamento interno das células, impactando diretamente na altura das linhas do table dentro do modal. Os
+   * valores permitidos são definidos pelo enum **PoTableColumnSpacing**.
    *
-   * Deve receber um dos valores do enum `PoTableColumnSpacing`.
+   * > Em nível de acessibilidade **AA**, caso o valor de `p-spacing` não seja definido, o valor padrão será `extraSmall`
+   * > nos seguintes cenários:
+   * > - Quando o valor de `p-size` for `small`;
+   * > - Quando o valor padrão dos componentes for configurado como `small` no
+   * > [serviço de tema](https://po-ui.io/documentation/po-theme).
    *
    * @default `medium`
    */
-  @Input('p-spacing') spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
+  @Input('p-spacing') set spacing(value: string) {
+    if (Object.values(PoTableColumnSpacing).includes(value as PoTableColumnSpacing)) {
+      this._spacing = value as PoTableColumnSpacing;
+    } else {
+      this._spacing = this.getDefaultSpacing();
+    }
+  }
+
+  get spacing() {
+    return this._spacing ?? this.getDefaultSpacing();
+  }
 
   /**
    * @optional
@@ -910,4 +926,6 @@ export abstract class PoLookupBaseComponent
   abstract setDisclaimers(a);
 
   abstract updateVisibleItems();
+
+  protected abstract getDefaultSpacing();
 }

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.ts
@@ -153,10 +153,10 @@ export abstract class PoLookupModalBaseComponent implements OnDestroy, OnInit {
   @Input('p-field-value') fieldValue: string;
 
   /**
-   * Responsável por aplicar espaçamento nas colunas da tabela contida no lookup.
-   * Deve receber um dos valores do enum `PoTableColumnSpacing`.
+   * Define o espaçamento interno das células, impactando diretamente na altura das linhas do table dentro do modal. Os
+   * valores permitidos são definidos pelo enum **PoTableColumnSpacing**.
    */
-  @Input('p-spacing') spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
+  @Input('p-spacing') spacing: PoTableColumnSpacing;
 
   /** Define o tamanho do componente. */
   @Input('p-size') size: string;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -15,10 +15,12 @@ import {
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR, NgControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
-import { uuid } from '../../../utils/util';
+import { getDefaultSize, uuid } from '../../../utils/util';
 
+import { PoFieldSize } from '../../../enums/po-field-size.enum';
 import { PoThemeService } from '../../../services';
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { PoTableColumnSpacing } from '../../po-table';
 import { PoLookupBaseComponent } from './po-lookup-base.component';
 import { PoLookupFilterService } from './services/po-lookup-filter.service';
 import { PoLookupModalService } from './services/po-lookup-modal.service';
@@ -481,6 +483,13 @@ export class PoLookupComponent extends PoLookupBaseComponent implements AfterVie
 
   showAdditionalHelpIcon() {
     return !!this.additionalHelpTooltip || this.isAdditionalHelpEventTriggered();
+  }
+
+  protected getDefaultSpacing(): PoTableColumnSpacing {
+    return this.size === PoFieldSize.Small ||
+      getDefaultSize(this.poThemeService, PoTableColumnSpacing) === PoTableColumnSpacing.Small
+      ? PoTableColumnSpacing.ExtraSmall
+      : PoTableColumnSpacing.Medium;
   }
 
   private isAdditionalHelpEventTriggered(): boolean {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -148,6 +148,7 @@
     name="spacing"
     [(ngModel)]="spacing"
     p-columns="4"
+    p-help="Para aplicar o tamanho extraSmall, configure o nível de acessibilidade para AA, ajustável no navbar ou serviço de tema (https://po-ui.io/documentation/po-theme)."
     p-label="Spacing"
     [p-options]="typeSpacing"
   >

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
@@ -81,6 +81,7 @@ export class SamplePoLookupLabsComponent implements OnInit {
   };
 
   public readonly typeSpacing: Array<PoRadioGroupOption> = [
+    { label: 'ExtraSmall', value: 'extraSmall' },
     { label: 'Small', value: 'small' },
     { label: 'Medium', value: 'medium' },
     { label: 'Large', value: 'large' }

--- a/projects/ui/src/lib/components/po-table/enums/po-table-spacing.enum.ts
+++ b/projects/ui/src/lib/components/po-table/enums/po-table-spacing.enum.ts
@@ -1,16 +1,19 @@
 /**
- * @usedBy PoTableComponent
+ * @usedBy PoTableComponent, PoLookupComponent, PoPageDynamicTableComponent
  *
  * @description
- * Tipos de espaçamento das colunas da tabela.
+ * Tipos de espaçamento interno (padding) das células (**p-spacing**) do po-table.
  */
 export enum PoTableColumnSpacing {
-  /** Espaçamento pequeno */
+  /** Espaçamento extra pequeno: 0.25rem (vertical) x 1rem (horizontal). */
+  ExtraSmall = 'extraSmall',
+
+  /** Espaçamento pequeno: 0.5rem (vertical) x 1rem (horizontal). */
   Small = 'small',
 
-  /** Espaçamento médio */
+  /** Espaçamento médio: 0.75rem (vertical) x 1rem (horizontal). */
   Medium = 'medium',
 
-  /** Espaçamento grande */
+  /** Espaçamento grande: 1rem (vertical) x 1rem (horizontal). */
   Large = 'large'
 }

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -23,6 +23,7 @@ class PoTableComponent extends PoTableBaseComponent {
   calculateHeightTableContainer(height) {}
   changeSizeLoading() {}
   changeHeaderWidth() {}
+  getDefaultSpacing() {}
 }
 
 describe('PoTableBaseComponent:', () => {
@@ -1778,15 +1779,6 @@ describe('PoTableBaseComponent:', () => {
 
     it('p-service-delete: should update property with valid values', () => {
       expectPropertiesValues(component, 'serviceDeleteApi', 'https://po-ui.io', 'https://po-ui.io');
-    });
-
-    it('p-spacing: should update property with valid values', () => {
-      expectPropertiesValues(component, 'spacing', 'small', 'small');
-    });
-
-    it('p-spacing: should update property with `Medium` if values are invalid', () => {
-      const invalidValues = [undefined, null, true, false, 'qdqdsa', [], {}];
-      expectPropertiesValues(component, 'spacing', invalidValues, 'medium');
     });
 
     it('visibleActions: should be `false` if doesn`t have action.', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -492,7 +492,7 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   fixedLayout: boolean = false;
   private initialVisibleColumns: boolean = false;
   private _componentsSize?: string = undefined;
-  private _spacing: PoTableColumnSpacing = PoTableColumnSpacing.Medium;
+  private _spacing: PoTableColumnSpacing;
   private _filteredColumns: Array<string>;
   private _actions?: Array<PoTableAction> = [];
   private _columns: Array<PoTableColumn> = [];
@@ -912,22 +912,27 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    *
    * @description
    *
-   * Responsável por aplicar espaçamento nas colunas.
+   * Define o espaçamento interno das células, impactando diretamente na altura das linhas do table. Os valores
+   * permitidos são definidos pelo enum **PoTableColumnSpacing**.
    *
-   * Deve receber um dos valores do enum `PoTableColumnSpacing`.
+   * > Em nível de acessibilidade **AA**, caso o valor de `p-spacing` não seja definido, o valor padrão será `extraSmall`
+   * > nos seguintes cenários:
+   * > - Quando o valor de `p-components-size` for `small`;
+   * > - Quando o valor padrão dos componentes for configurado como `small` no
+   * > [serviço de tema](https://po-ui.io/documentation/po-theme).
    *
    * @default `medium`
    */
-  @Input('p-spacing') set spacing(value: PoTableColumnSpacing) {
-    if (value === 'small' || value === 'medium' || value === 'large') {
-      this._spacing = value;
+  @Input('p-spacing') set spacing(value: string) {
+    if (Object.values(PoTableColumnSpacing).includes(value as PoTableColumnSpacing)) {
+      this._spacing = value as PoTableColumnSpacing;
     } else {
-      this._spacing = PoTableColumnSpacing.Medium;
+      this._spacing = this.getDefaultSpacing();
     }
   }
 
   get spacing() {
-    return this._spacing;
+    return this._spacing ?? this.getDefaultSpacing();
   }
 
   /**
@@ -1391,4 +1396,6 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
   protected abstract changeSizeLoading();
 
   protected abstract changeHeaderWidth();
+
+  protected abstract getDefaultSpacing();
 }

--- a/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.html
@@ -1,5 +1,5 @@
 <po-icon
-  class="po-table-icon-content {{ disabled ? '' : color }}"
+  class="po-field-icon po-table-icon-content {{ disabled ? '' : color }}"
   [ngClass]="{ 'po-clickable': clickable, 'po-table-icon-disabled': disabled }"
   [p-icon]="icon"
   [p-tooltip]="tooltip"

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -122,9 +122,12 @@
       'po-table-data-fixed-columns': applyFixedColumns(),
       'po-table-text-wrap-enabled': textWrap
     }"
-    [attr.p-spacing]="componentsSize === 'small' ? 'small' : spacing"
+    [attr.p-spacing]="spacing"
   >
-    <thead [class.po-table-header-sticky]="height > 0 && !virtualScroll">
+    <thead
+      [class.po-table-header-sticky]="height > 0 && !virtualScroll"
+      [attr.p-spacing]="spacing ?? (componentsSize === 'small' ? 'extraSmall' : 'medium')"
+    >
       <tr
         [ngClass]="!height ? { 'no-hover': hideSelectAll, 'po-table-column-drag': this.isDraggable } : ''"
         [class.po-table-header]="!height"
@@ -464,9 +467,13 @@
         'po-table-data-fixed-columns': applyFixedColumns(),
         'po-table-text-wrap-enabled': textWrap
       }"
-      [attr.p-spacing]="componentsSize === 'small' ? 'small' : spacing"
+      [attr.p-spacing]="spacing"
     >
-      <thead class="po-table-header-sticky" [style.top]="inverseOfTranslation">
+      <thead
+        class="po-table-header-sticky"
+        [style.top]="inverseOfTranslation"
+        [attr.p-spacing]="spacing ?? (componentsSize === 'small' ? 'extraSmall' : 'medium')"
+      >
         <tr
           [class.po-table-header]="!height"
           cdkDropList
@@ -933,14 +940,18 @@
       [class.po-table-action-disabled]="firstAction.disabled ? validateTableAction(row, firstAction) : false"
       (click)="executeTableAction(row, firstAction)"
     >
-      <po-icon *ngIf="firstAction.icon" class="po-table-single-action-content" [p-icon]="firstAction.icon"></po-icon>
+      <po-icon
+        *ngIf="firstAction.icon"
+        class="po-table-single-action-content po-field-icon"
+        [p-icon]="firstAction.icon"
+      ></po-icon>
       {{ firstAction.label }}
     </div>
   </td>
 
   <td *ngIf="visibleActions.length > 1" class="po-table-column-actions">
     <div #popupTarget class="po-clickable" (click)="togglePopup(row, popupTarget)">
-      <po-icon p-icon="ICON_MORE"></po-icon>
+      <po-icon class="po-field-icon" p-icon="ICON_MORE"></po-icon>
     </div>
   </td>
 </ng-template>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -13,7 +13,10 @@ import * as utilsFunctions from '../../utils/util';
 import { PoColorPaletteService } from './../../services/po-color-palette/po-color-palette.service';
 
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { PoFieldSize } from '../../enums/po-field-size.enum';
+import { PoThemeService } from '../../services/po-theme/po-theme.service';
 import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-arrow-direction.enum';
 import { PoTableColumnSpacing } from './enums/po-table-spacing.enum';
 import { PoTableAction } from './interfaces/po-table-action.interface';
@@ -23,7 +26,6 @@ import { PoTableColumnTemplateDirective } from './po-table-column-template/po-ta
 import { PoTableComponent } from './po-table.component';
 import { PoTableModule } from './po-table.module';
 import { PoTableService } from './services/po-table.service';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 @Component({
   template: 'Search',
@@ -68,7 +70,7 @@ describe('PoTableComponent:', () => {
   let tableElement;
   let tableFooterElement;
   const poTableService: jasmine.SpyObj<PoTableService> = jasmine.createSpyObj('PoTableService', ['scrollListener']);
-
+  let poThemeServiceMock: jasmine.SpyObj<PoThemeService>;
   // mocks
   let actions: Array<PoTableAction>;
   let columns: Array<PoTableColumn>;
@@ -228,6 +230,9 @@ describe('PoTableComponent:', () => {
     });
 
     changeDetector = jasmine.createSpyObj('ChangeDetectorRef', ['detectChanges']);
+
+    poThemeServiceMock = jasmine.createSpyObj('PoThemeService', ['getA11yLevel', 'getA11yDefaultSize']);
+
     await TestBed.configureTestingModule({
       declarations: [TestMenuComponent, SearchComponent],
       imports: [RouterTestingModule.withRoutes(routes), PoTableModule, NoopAnimationsModule],
@@ -239,6 +244,7 @@ describe('PoTableComponent:', () => {
         { provide: PoTableService, useValue: poTableService },
         { provide: CdkVirtualScrollViewport, useValue: mockViewPort },
         { provide: changeDetector, useValue: changeDetector },
+        { provide: PoThemeService, useValue: poThemeServiceMock },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting()
       ]
@@ -3308,6 +3314,29 @@ describe('PoTableComponent:', () => {
     component['changeSizeLoading'].call(fakeTable);
 
     expect(fakeTable.sizeLoading).toBe('lg');
+  });
+
+  describe('getDefaultSpacing:', () => {
+    it('should return ExtraSmall when componentSize is Small', () => {
+      poThemeServiceMock.getA11yDefaultSize.and.returnValue('small');
+
+      component.componentsSize = PoFieldSize.Small;
+      component.spacing = undefined;
+      expect(component['getDefaultSpacing']()).toBe(PoTableColumnSpacing.ExtraSmall);
+    });
+
+    it('should return ExtraSmall when accessibility size is Small', () => {
+      poThemeServiceMock.getA11yDefaultSize.and.returnValue('small');
+      component.componentsSize = PoFieldSize.Medium;
+      component.spacing = undefined;
+      expect(component['getDefaultSpacing']()).toBe(PoTableColumnSpacing.ExtraSmall);
+    });
+
+    it('should return Medium when accessibility size is Medium', () => {
+      poThemeServiceMock.getA11yDefaultSize.and.returnValue('medium');
+      component.spacing = PoTableColumnSpacing.ExtraSmall;
+      expect(component['getDefaultSpacing']()).toBe(PoTableColumnSpacing.Medium);
+    });
   });
 
   it('changeHeaderWidth: should set width if noColumnsHeader ', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -27,7 +27,7 @@ import { Observable, Subscription } from 'rxjs';
 import { PoDateService } from '../../services/po-date/po-date.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { PoNotificationService } from '../../services/po-notification/po-notification.service';
-import { convertToBoolean } from '../../utils/util';
+import { convertToBoolean, getDefaultSize } from '../../utils/util';
 import { PoModalAction, PoModalComponent } from '../po-modal';
 import { PoPopupComponent } from '../po-popup/po-popup.component';
 import { PoTableColumnLabel } from './po-table-column-label/po-table-column-label.interface';
@@ -44,6 +44,8 @@ import { PoTableColumnTemplateDirective } from './po-table-column-template/po-ta
 import { PoTableRowTemplateDirective } from './po-table-row-template/po-table-row-template.directive';
 import { PoTableSubtitleColumn } from './po-table-subtitle-footer/po-table-subtitle-column.interface';
 import { PoTableService } from './services/po-table.service';
+import { PoTableColumnSpacing } from './enums/po-table-spacing.enum';
+import { PoFieldSize } from '../../enums/po-field-size.enum';
 
 /**
  * @docsExtends PoTableBaseComponent
@@ -780,6 +782,13 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     }
 
     this.changeDetector.detectChanges();
+  }
+
+  protected getDefaultSpacing(): PoTableColumnSpacing {
+    return this.componentsSize === PoFieldSize.Small ||
+      getDefaultSize(this.poThemeService, PoTableColumnSpacing) === PoTableColumnSpacing.Small
+      ? PoTableColumnSpacing.ExtraSmall
+      : PoTableColumnSpacing.Medium;
   }
 
   private checkChangesItems() {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -118,6 +118,7 @@
       name="spacing"
       [(ngModel)]="spacing"
       p-columns="4"
+      p-help="Para aplicar o tamanho extraSmall, configure o nível de acessibilidade para AA, ajustável no navbar ou serviço de tema (https://po-ui.io/documentation/po-theme)."
       p-label="Spacing"
       [p-options]="typeSpacing"
     >

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -114,6 +114,7 @@ export class SamplePoTableLabsComponent implements OnInit {
   ];
 
   public readonly typeSpacing: Array<PoRadioGroupOption> = [
+    { label: 'ExtraSmall', value: 'extraSmall' },
     { label: 'Small', value: 'small' },
     { label: 'Medium', value: 'medium' },
     { label: 'Large', value: 'large' }


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-10661**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
A propriedade p-spacing do po-table disponibiliza atualmente três opções de espaçamento: large, medium e small.

**Qual o novo comportamento?**
Adiciona a opção de espaçamento extraSmall, que é disponibilizada automaticamente quando o nível de acessibilidade AA estiver configurado por meio do serviço de tema. Essa nova opção também passa a ser aplicada nos componentes que consomem o po-table, como po-lookup e po-dynamic-table.

**Simulação**
