### PR TITLE
fix(theme): ajusta ordem de inserção de estilos no DOM

### DIFF
--- a/projects/ui/src/lib/services/po-theme/po-theme.service.spec.ts
+++ b/projects/ui/src/lib/services/po-theme/po-theme.service.spec.ts
@@ -780,6 +780,72 @@ describe('PoThemeService:', () => {
         `;
         validateStyleContent(expectedCss);
       });
+
+      it('should apply type and accessibility and a single prefix', () => {
+        service.setPerComponentAndOnRoot(active, perComponent, onRoot, 'myTheme');
+
+        const expectedCss = `
+          :root[class*="-light-AAA"][class*="myTheme"] {
+            po-listbox {display: flex;};
+            --font-family: Roboto;
+          }
+        `;
+        validateStyleContent(expectedCss);
+      });
+
+      it('should apply type and accessibility and a multiple prefix', () => {
+        service.setPerComponentAndOnRoot(active, perComponent, onRoot, ['myTheme', 'portal-v2']);
+
+        const expectedCss = `
+          :root[class*="-light-AAA"][class*="myTheme"], :root[class*="-light-AAA"][class*="portal-v2"] {
+            po-listbox {display: flex;};
+            --font-family: Roboto;
+          }
+        `;
+        validateStyleContent(expectedCss);
+      });
+    });
+
+    it('applyThemeStyles: should use document.head.firstChild as reference when baseStyle does not exist', () => {
+      const testCss = '.test { color: red; }';
+
+      // Remove o baseStyle se já existir
+      const existingBaseStyle = document.getElementById('baseStyle');
+      if (existingBaseStyle) {
+        document.head.removeChild(existingBaseStyle);
+      }
+
+      // Cria e adiciona nosso nó de referência
+      const mockFirstChild = document.createElement('meta');
+      document.head.insertBefore(mockFirstChild, document.head.firstChild);
+
+      // Configura spies para os seletores
+      spyOn(document, 'querySelector')
+        .withArgs('#theme')
+        .and.returnValue(null)
+        .withArgs('#baseStyle')
+        .and.returnValue(null);
+
+      // Chama o método
+      service['applyThemeStyles'](testCss);
+
+      // Verifica se o novo style foi inserido antes do mockFirstChild
+      const insertedStyle = document.getElementById('theme');
+      expect(insertedStyle).toBeTruthy();
+      expect(insertedStyle.innerHTML).toBe(testCss);
+
+      // Verifica a ordem dos nós
+      const nodes = Array.from(document.head.childNodes);
+      expect(nodes.indexOf(insertedStyle)).toBeLessThan(nodes.indexOf(mockFirstChild));
+
+      // Limpeza
+      document.head.removeChild(insertedStyle);
+      document.head.removeChild(mockFirstChild);
+
+      // Restaura o baseStyle se necessário
+      if (existingBaseStyle) {
+        document.head.appendChild(existingBaseStyle);
+      }
     });
 
     it('applyThemeStyles: should use document.head.firstChild as reference when baseStyle does not exist', () => {


### PR DESCRIPTION
- Garantir que baseStyle e theme sejam inseridos no início do <head>
- Estilos do usuário (styles.scss) são carregados após as definições do framework
- Documentação atualizada para orientar customizações corretamente

fixes DTHFUI-11244

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
