### PR TITLE
fix(lookup): corrige o preenchimento do valor do componente e corrige preenchimento múltiplo ao pesquisar "."

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
@@ -560,5 +560,46 @@ describe('PoDynamicFormComponent:', () => {
       expect(nativeElement.querySelector('form')).toBeFalsy();
       expect(nativeElement.querySelector('po-dynamic-form-fields')).toBeTruthy();
     });
+
+    it('should render lookup fields with correct values when `getObjectByValue` returns an object or an array', fakeAsync(() => {
+      const mockServiceObject = {
+        getObjectByValue: () =>
+          new Observable(observer => {
+            observer.next({ id: 1, name: 'Tony Stark' });
+            observer.complete();
+          }),
+        getFilteredItems: null
+      };
+      const mockServiceArray = {
+        getObjectByValue: () =>
+          new Observable(observer => {
+            observer.next([{ id: 1, name: 'Tony Stark' }]);
+            observer.complete();
+          }),
+        getFilteredItems: null
+      };
+      component.fields = [
+        { property: 'heroeObject', searchService: mockServiceObject, fieldValue: 'id', fieldLabel: 'name' },
+        { property: 'heroeArray', searchService: mockServiceArray, fieldValue: 'id', fieldLabel: 'name' }
+      ];
+      component.value = {
+        heroeObject: 1,
+        heroeArray: [1]
+      };
+
+      tick();
+      fixture.detectChanges();
+
+      (nativeElement.querySelectorAll('.po-lookup-input')[0] as HTMLElement).blur();
+      (nativeElement.querySelectorAll('.po-lookup-input')[1] as HTMLElement).blur();
+
+      tick();
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('form')).toBeTruthy();
+      expect(nativeElement.querySelector('po-dynamic-form-fields')).toBeTruthy();
+      expect(nativeElement.querySelectorAll('.po-lookup-input')[0].value).toBe('Tony Stark');
+      expect(nativeElement.querySelectorAll('.po-lookup-input')[1].value).toBe('Tony Stark');
+    }));
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -766,7 +766,7 @@ export abstract class PoLookupBaseComponent
       checkedValue = checkedValue.trim();
     }
 
-    if (checkedValue !== '') {
+    if (checkedValue !== '' && checkedValue !== '.') {
       const oldDisable = this.disabled;
       this.disabled = true;
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -70,7 +70,7 @@ export abstract class PoLookupBaseComponent
   implements ControlValueAccessor, OnDestroy, OnInit, Validator, AfterViewInit, OnChanges
 {
   private _literals?: PoLookupLiterals;
-  private language: string;
+  private readonly language: string;
   private _size?: string = undefined;
 
   // Propriedade interna que define se o ícone de ajuda adicional terá cursor clicável (evento) ou padrão (tooltip).
@@ -532,15 +532,15 @@ export abstract class PoLookupBaseComponent
   private _noAutocomplete: boolean;
   private _placeholder: string = '';
   private _required?: boolean = false;
-  private _autoHeight: boolean = false;
+  private readonly _autoHeight: boolean = false;
 
-  private autoHeightInitialValue: boolean;
+  private readonly autoHeightInitialValue: boolean;
   private onChangePropagate: any = null;
   private validatorChange: any;
 
   private control!: AbstractControl;
 
-  private injectOptions: InjectOptions = {
+  private readonly injectOptions: InjectOptions = {
     self: true
   };
 
@@ -671,8 +671,8 @@ export abstract class PoLookupBaseComponent
   }
 
   constructor(
-    private defaultService: PoLookupFilterService,
-    @Inject(Injector) private injector: Injector,
+    private readonly defaultService: PoLookupFilterService,
+    @Inject(Injector) private readonly injector: Injector,
     public poLookupModalService: PoLookupModalService,
     languageService: PoLanguageService,
     protected poThemeService: PoThemeService
@@ -735,11 +735,13 @@ export abstract class PoLookupBaseComponent
   // Seleciona o valor do model.
   selectValue(valueSelected: any) {
     this.valueToModel = valueSelected;
-    this.multiple
-      ? this.callOnChange(this.valueToModel)
-      : this.valueToModel
-        ? this.callOnChange(this.valueToModel[this.fieldValue])
-        : this.callOnChange(undefined);
+    if (this.multiple) {
+      this.callOnChange(this.valueToModel);
+    } else if (this.valueToModel) {
+      this.callOnChange(this.valueToModel[this.fieldValue]);
+    } else {
+      this.callOnChange(undefined);
+    }
     this.selected.emit(valueSelected);
   }
 
@@ -794,7 +796,7 @@ export abstract class PoLookupBaseComponent
                 this.updateVisibleItems();
               }
 
-              this.selectModel(this.multiple ? element : [element]);
+              this.selectModel(Array.isArray(element) ? element : [element]);
             } else {
               this.cleanModel();
             }

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -114,6 +114,72 @@ describe('PoLookupComponent:', () => {
     }
   ));
 
+  it('should define the initial value with a object response from the service', fakeAsync(() => {
+    fixture.detectChanges();
+    const serviceResponse = { 'id': 'SIM', 'name': 'Sim' };
+    component.fieldValue = 'id';
+    component.fieldLabel = 'name';
+
+    spyOn(component.service, 'getObjectByValue').and.returnValue(of(serviceResponse));
+    spyOn(component, 'selectModel' as any).and.callThrough();
+
+    component.searchById(serviceResponse.id);
+
+    tick();
+    fixture.detectChanges();
+
+    expect(component['selectModel']).toHaveBeenCalled();
+    expect(component.inputEl.nativeElement.value).toBe('Sim');
+    expect(component['selectedOptions']).toEqual([serviceResponse]);
+    flush();
+  }));
+
+  it('should define the initial value with a array response with a single item from the service', fakeAsync(() => {
+    fixture.detectChanges();
+    const serviceResponse = [{ 'id': 'SIM', 'name': 'Sim' }];
+    component.fieldValue = 'id';
+    component.fieldLabel = 'name';
+
+    spyOn(component.service, 'getObjectByValue').and.returnValue(of(serviceResponse));
+    spyOn(component, 'selectModel' as any).and.callThrough();
+
+    component.searchById(serviceResponse.map(item => item.id));
+
+    tick();
+    fixture.detectChanges();
+
+    expect(component['selectModel']).toHaveBeenCalled();
+    expect(component.inputEl.nativeElement.value).toBe('Sim');
+    expect(component['selectedOptions']).toEqual(serviceResponse);
+    flush();
+  }));
+
+  it('should define the initial value with a array response with multiple items from the service', fakeAsync(() => {
+    fixture.detectChanges();
+    const serviceResponse = [
+      { 'id': 'SIM', 'name': 'Sim' },
+      { 'id': 'NAO', 'name': 'Não' }
+    ];
+    component.fieldValue = 'id';
+    component.fieldLabel = 'name';
+
+    spyOn(component.service, 'getObjectByValue').and.returnValue(of(serviceResponse));
+    spyOn(component, 'selectModel' as any).and.callThrough();
+
+    component.searchById(serviceResponse.map(item => item.id));
+
+    tick();
+    fixture.detectChanges();
+
+    expect(component['selectModel']).toHaveBeenCalled();
+    expect(component['selectedOptions']).toEqual(serviceResponse);
+    expect(component.disclaimers).toEqual([
+      { 'id': 'SIM', 'name': 'Sim', 'label': 'Sim', 'value': 'SIM' },
+      { 'id': 'NAO', 'name': 'Não', 'label': 'Não', 'value': 'NAO' }
+    ]);
+    flush();
+  }));
+
   describe('Properties:', () => {
     it('autocomplete: should return `off` if `noAutocomplete` is true', () => {
       component.noAutocomplete = true;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -180,6 +180,23 @@ describe('PoLookupComponent:', () => {
     flush();
   }));
 
+  it('should not set value after searching "."', fakeAsync(() => {
+    fixture.detectChanges();
+    const serviceResponse = { id: 1234, name: 'Peter Parker', email: 'peterP@mail.com' };
+    component.fieldValue = 'id';
+    component.fieldLabel = 'name';
+    spyOn(component.service, 'getObjectByValue').and.returnValue(of(serviceResponse));
+
+    component.searchById('.');
+
+    tick();
+    fixture.detectChanges();
+
+    expect(component.inputEl.nativeElement.value).not.toBe('Peter Parker');
+    expect(component['selectedOptions']).toEqual([]);
+    flush();
+  }));
+
   describe('Properties:', () => {
     it('autocomplete: should return `off` if `noAutocomplete` is true', () => {
       component.noAutocomplete = true;


### PR DESCRIPTION
**po-lookup**

**DTHFUI-10860 e #2430**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
DTHFUI-10860: Ao utilizar o po-lookup single, de forma individual ou no dynamic-form, o valor não é preenchido corretamente quando o searchService retorna uma resposta no padrão de coleção utilizado pelo PO-UI, não exibindo o valor definido programaticamente.

#2430: Ao utilizar o po-lookup, caso seja inserido "." no campo de busca do componente e pressionado o botão "tab" do teclado (removido o foco), são adicionados todos os itens retornados pelo searchService.

**Qual o novo comportamento?**
DTHFUI-10860: Corrige o preenchimento do valor do componente, passando a aceitar as respostas no padrão de coleção e objeto definidas na documentação do PO-UI.

#2430: Corrige o preenchimento verificando se o valor inserido pelo usuário é diferente do caractere "." antes de realizar a requisição para o searchService.

**Simulação**
DTHFUI-10860:
- Antes: ![image](https://github.com/user-attachments/assets/7f524951-3ac2-4638-9902-0049e7023216)
- Depois: ![image](https://github.com/user-attachments/assets/f788d642-9b8f-4ee4-89e0-4c7f7969b7da)

#2430:
- Antes: ![po lookup corrige preenchimento múltiplo](https://github.com/user-attachments/assets/57228593-d45c-4ea8-b71a-827b3871225e)
- Depois: ![po lookup corrige preenchimento múltiplo depois](https://github.com/user-attachments/assets/59e76f70-f7a3-4167-94b5-c639b30b4e0f)
