### PR TITLE
fix(dynamic-form): corrige visible dinâmico dos campos

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -29,7 +29,10 @@ describe('PoDynamicFormFieldsComponent: ', () => {
 
     fixture = TestBed.createComponent(PoDynamicFormFieldsComponent);
     component = fixture.componentInstance;
-    component['form'] = <any>{ dirty: true };
+
+    Object.defineProperty(component, 'form', {
+      get: () => ({ dirty: true })
+    });
 
     fixture.detectChanges();
 
@@ -97,9 +100,11 @@ describe('PoDynamicFormFieldsComponent: ', () => {
       expect(component['previousValue']).toEqual(value);
     });
 
-    it('trackBy: should return index', () => {
+    it('trackBy: should return field.property', () => {
       const index = 1;
-      expect(component.trackBy(index)).toBe(index);
+      const field = { property: 'field' };
+
+      expect(component.trackBy(index, field)).toBe('field');
     });
 
     it('focus: should call `fieldComponent.focus` if find field by property param.', () => {
@@ -132,7 +137,10 @@ describe('PoDynamicFormFieldsComponent: ', () => {
         component['value']['test1'] = 'new value';
 
         const field = { changedField: fakeVisibleField, changedFieldIndex };
-        component['form'] = <any>{ touched: false };
+
+        Object.defineProperty(component, 'form', {
+          get: () => ({ touched: false })
+        });
 
         spyOn(component, <any>'getField').and.returnValue(field);
         component.onChangeField(fakeVisibleField);
@@ -147,7 +155,10 @@ describe('PoDynamicFormFieldsComponent: ', () => {
         component['value']['test1'] = 'new value';
 
         const field = { changedField: fakeVisibleField, changedFieldIndex };
-        component['form'] = <any>{ touched: false };
+
+        Object.defineProperty(component, 'form', {
+          get: () => ({ touched: false })
+        });
 
         spyOn(component, <any>'getField').and.returnValue(field);
         component.onChangeField(fakeVisibleField);
@@ -339,7 +350,10 @@ describe('PoDynamicFormFieldsComponent: ', () => {
 
         component['previousValue']['test1'] = undefined;
         component['value']['test1'] = 'value';
-        component['form'] = <any>{ touched: false };
+
+        Object.defineProperty(component, 'form', {
+          get: () => ({ touched: false })
+        });
 
         spyOn(component, <any>'triggerValidationOnForm');
 
@@ -847,6 +861,16 @@ describe('PoDynamicFormFieldsComponent: ', () => {
       component.visibleFields = [{ property: 'test 1' }, { property: 'test 2' }];
 
       expect(component['hasContainer']()).toBeFalsy();
+    });
+
+    it('hasContainer: should return false if visibleFields is undefined', () => {
+      component.visibleFields = undefined;
+      expect(component['hasContainer']()).toBeFalse();
+    });
+
+    it('hasContainer: should return false if visibleFields is null', () => {
+      component.visibleFields = null;
+      expect(component['hasContainer']()).toBeFalse();
     });
   });
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -34,9 +34,9 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
   constructor(
     titleCasePipe: TitleCasePipe,
     protected poThemeService: PoThemeService,
-    private validationService: PoDynamicFormValidationService,
-    private changes: ChangeDetectorRef,
-    private form: NgForm
+    private readonly validationService: PoDynamicFormValidationService,
+    private readonly changes: ChangeDetectorRef,
+    private readonly form: NgForm
   ) {
     super(poThemeService, titleCasePipe);
   }
@@ -113,8 +113,8 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
     this.previousValue = JSON.parse(JSON.stringify(this.value));
   }
 
-  trackBy(index) {
-    return index;
+  trackBy(index: number, field: PoDynamicFormField) {
+    return field.property;
   }
 
   private applyFieldValidation(index: number, validatedField: PoDynamicFormFieldValidation) {
@@ -299,7 +299,7 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
   }
 
   private hasContainer() {
-    return this.visibleFields && this.visibleFields.some(field => field.container);
+    return this.visibleFields?.some(field => field.container) ?? false;
   }
 
   private handleChangesContainer(prevContainers, currContainers, key) {


### PR DESCRIPTION
fixes DTHFUI-10571

**PO-DYNAMIC-FORM**

**DTHFUI-10571**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao aplicar a propriedade visible dinamicamente em campos semelhantes (mesmo componente), sem o uso de um container, o primeiro campo afeta os valores dos campos seguintes.

**Qual o novo comportamento?**
Corrige o comportamento quando o visible é aplicado de forma dinâmica, garantindo que campos com ou sem divider sejam exibidos corretamente.

**Simulação**
