### PR TITLE
feat(components): adiciona emissão de evento blur

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -97,6 +97,15 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @description
    *
+   * Evento disparado ao sair do campo.
+   */
+  @Output('p-blur') blur: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Aplica foco no elemento ao ser iniciado.
    *
    * > Caso mais de um elemento seja configurado com essa propriedade, apenas o último elemento declarado com ela terá o foco.

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -47,7 +47,7 @@
           [required]="required"
           (click)="toggleComboVisibility()"
           (keyup)="onKeyUp($event)"
-          (blur)="onBlur()"
+          (blur)="onBlur($event)"
           (keyup)="searchOnEnterOrArrow($event, $event.target.value)"
           (keydown)="onKeyDown($event)"
         />

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -464,7 +464,7 @@ describe('PoComboComponent:', () => {
 
     describe('onBlur:', () => {
       let setupTest;
-
+      const fakeEvent = { target: { value: '' } };
       beforeEach(() => {
         setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
           component.additionalHelpTooltip = tooltip;
@@ -478,7 +478,7 @@ describe('PoComboComponent:', () => {
         component['onModelTouched'] = () => {};
         spyOn(component, <any>'onModelTouched');
 
-        component.onBlur();
+        component.onBlur(fakeEvent);
 
         expect(component['onModelTouched']).toHaveBeenCalled();
       });
@@ -486,7 +486,7 @@ describe('PoComboComponent:', () => {
       it('shouldn´t throw error if onModelTouched is falsy', () => {
         component['onModelTouched'] = null;
 
-        const fnError = () => component.onBlur();
+        const fnError = () => component.onBlur(fakeEvent);
 
         expect(fnError).not.toThrow();
       });
@@ -494,22 +494,38 @@ describe('PoComboComponent:', () => {
       it('should call showAdditionalHelp when the tooltip is displayed', () => {
         setupTest('Mensagem de apoio adicional.', true, { observed: false });
 
-        component.onBlur();
+        component.onBlur(fakeEvent);
         expect(component.showAdditionalHelp).toHaveBeenCalled();
       });
 
       it('should not call showAdditionalHelp when tooltip is not displayed', () => {
         setupTest('Mensagem de apoio adicional.', false, { observed: false });
 
-        component.onBlur();
+        component.onBlur(fakeEvent);
         expect(component.showAdditionalHelp).not.toHaveBeenCalled();
       });
 
       it('should not call showAdditionalHelp when additionalHelp event is true', () => {
         setupTest('Mensagem de apoio adicional.', true, { observed: true });
 
-        component.onBlur();
+        component.onBlur(fakeEvent);
         expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+
+      it('should emit blur event when event.type is "blur"', () => {
+        spyOn(component.blur, 'emit');
+
+        component.onBlur({ type: 'blur' });
+
+        expect(component.blur.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit blur event when event.type is different from "blur"', () => {
+        spyOn(component.blur, 'emit');
+
+        component.onBlur({ type: 'focus' });
+
+        expect(component.blur.emit).not.toHaveBeenCalled();
       });
     });
 

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -231,10 +231,14 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     return this.isAdditionalHelpEventTriggered() ? null : this.additionalHelpTooltip;
   }
 
-  onBlur() {
+  onBlur(event: any) {
     this.onModelTouched?.();
     if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
       this.showAdditionalHelp();
+    }
+
+    if (event.type === 'blur') {
+      this.blur.emit();
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -144,6 +144,15 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    */
   @Input({ alias: 'p-auto-focus', transform: convertToBoolean }) autoFocus: boolean = false;
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao sair do campo.
+   */
+  @Output('p-blur') blur: EventEmitter<any> = new EventEmitter();
+
   /** Label no componente. */
   @Input('p-label') label?: string;
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.html
@@ -25,7 +25,7 @@
         [class.po-multiselect-input-aa]="size === 'small'"
         (keydown)="onKeyDown($event)"
         (click)="toggleDropdownVisibility()"
-        (blur)="onBlur()"
+        (blur)="onBlur($event)"
       >
         <span
           *ngIf="!disabled && !visibleTags?.length"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -841,7 +841,7 @@ describe('PoMultiselectComponent:', () => {
 
     describe('onBlur', () => {
       let setupTest;
-
+      const fakeEvent = { target: { value: '' } };
       beforeEach(() => {
         setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
           component.additionalHelpTooltip = tooltip;
@@ -853,19 +853,19 @@ describe('PoMultiselectComponent:', () => {
 
       it('should call showAdditionalHelp when the tooltip is displayed', () => {
         setupTest('Mensagem de apoio adicional.', true, { observed: false });
-        component.onBlur();
+        component.onBlur(fakeEvent);
         expect(component.showAdditionalHelp).toHaveBeenCalled();
       });
 
       it('should not call showAdditionalHelp when tooltip is not displayed', () => {
         setupTest('Mensagem de apoio adicional.', false, { observed: false });
-        component.onBlur();
+        component.onBlur(fakeEvent);
         expect(component.showAdditionalHelp).not.toHaveBeenCalled();
       });
 
       it('should not call showAdditionalHelp when additionalHelp event is true', () => {
         setupTest('Mensagem de apoio adicional.', true, { observed: true });
-        component.onBlur();
+        component.onBlur(fakeEvent);
         expect(component.showAdditionalHelp).not.toHaveBeenCalled();
       });
 
@@ -875,7 +875,7 @@ describe('PoMultiselectComponent:', () => {
         component.label = 'New Label';
         spyOn(component, <any>'onModelTouched');
 
-        component.onBlur();
+        component.onBlur(fakeEvent);
 
         expect(inputEl.getAttribute('aria-label')).toBe('New Label');
         expect(component['onModelTouched']).toHaveBeenCalled();
@@ -887,7 +887,7 @@ describe('PoMultiselectComponent:', () => {
         component.label = '';
         spyOn(component, <any>'onModelTouched');
 
-        component.onBlur();
+        component.onBlur(fakeEvent);
 
         expect(inputEl.getAttribute('aria-label')).toBe('');
         expect(component['onModelTouched']).toHaveBeenCalled();
@@ -899,9 +899,25 @@ describe('PoMultiselectComponent:', () => {
         component.label = 'New Label';
         spyOn(component, <any>'onModelTouched');
 
-        component.onBlur();
+        component.onBlur(fakeEvent);
 
         expect(component['onModelTouched']).toHaveBeenCalled();
+      });
+
+      it('should emit blur event when event.type is "blur"', () => {
+        spyOn(component.blur, 'emit');
+
+        component.onBlur({ type: 'blur' });
+
+        expect(component.blur.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit blur event when event.type is different from "blur"', () => {
+        spyOn(component.blur, 'emit');
+
+        component.onBlur({ type: 'focus' });
+
+        expect(component.blur.emit).not.toHaveBeenCalled();
       });
     });
 

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -330,7 +330,7 @@ export class PoMultiselectComponent
     this.changeDetector.markForCheck();
   }
 
-  onBlur() {
+  onBlur(event: any) {
     if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
       this.showAdditionalHelp();
     }
@@ -342,6 +342,10 @@ export class PoMultiselectComponent
       this.inputElement.nativeElement.setAttribute('aria-label', this.label ? this.label : '');
     }
     this.onModelTouched?.();
+
+    if (event.type === 'blur') {
+      this.blur.emit();
+    }
   }
 
   onKeyDown(event?: any) {

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.html
@@ -17,7 +17,7 @@
       [disabled]="disabled"
       [id]="id"
       [required]="required"
-      (blur)="onBlur()"
+      (blur)="onBlur($event)"
       (change)="onSelectChange($event.target.value)"
       (keydown)="onKeyDown($event)"
     >

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -142,7 +142,7 @@ describe('PoSelectComponent:', () => {
 
     describe('onBlur', () => {
       let setupTest;
-
+      const fakeEvent = { target: { value: '' } };
       beforeEach(() => {
         setupTest = (tooltip: string, displayHelp: boolean, additionalHelpEvent: any) => {
           component.additionalHelpTooltip = tooltip;
@@ -156,7 +156,7 @@ describe('PoSelectComponent:', () => {
         component['onModelTouched'] = () => {};
         spyOn(component, <any>'onModelTouched');
 
-        component.onBlur();
+        component.onBlur(fakeEvent);
 
         expect(component['onModelTouched']).toHaveBeenCalled();
       });
@@ -164,27 +164,43 @@ describe('PoSelectComponent:', () => {
       it('shouldn´t throw error if onModelTouched is falsy', () => {
         component['onModelTouched'] = null;
 
-        const fnError = () => component.onBlur();
+        const fnError = () => component.onBlur(fakeEvent);
 
         expect(fnError).not.toThrow();
       });
 
       it('should call showAdditionalHelp when the tooltip is displayed', () => {
         setupTest('Mensagem de apoio adicional.', true, { observed: false });
-        component.onBlur();
+        component.onBlur(fakeEvent);
         expect(component.showAdditionalHelp).toHaveBeenCalled();
       });
 
       it('should not call showAdditionalHelp when tooltip is not displayed', () => {
         setupTest('Mensagem de apoio adicional.', false, { observed: false });
-        component.onBlur();
+        component.onBlur(fakeEvent);
         expect(component.showAdditionalHelp).not.toHaveBeenCalled();
       });
 
       it('should not call showAdditionalHelp when additionalHelp event is true', () => {
         setupTest('Mensagem de apoio adicional.', true, { observed: true });
-        component.onBlur();
+        component.onBlur(fakeEvent);
         expect(component.showAdditionalHelp).not.toHaveBeenCalled();
+      });
+
+      it('should emit blur event when event.type is "blur"', () => {
+        spyOn(component.blur, 'emit');
+
+        component.onBlur({ type: 'blur' });
+
+        expect(component.blur.emit).toHaveBeenCalled();
+      });
+
+      it('should not emit blur event when event.type is different from "blur"', () => {
+        spyOn(component.blur, 'emit');
+
+        component.onBlur({ type: 'focus' });
+
+        expect(component.blur.emit).not.toHaveBeenCalled();
       });
     });
 

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -133,6 +133,15 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
    *
    * @description
    *
+   * Evento disparado ao sair do campo.
+   */
+  @Output('p-blur') blur: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
    *
    * Na versão 12.2.0 do Angular a verificação `strictTemplates` vem true como default. Portanto, para utilizar
@@ -366,11 +375,15 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
     );
   }
 
-  onBlur() {
+  onBlur(event: any) {
     this.onModelTouched?.();
 
     if (this.getAdditionalHelpTooltip() && this.displayAdditionalHelp) {
       this.showAdditionalHelp();
+    }
+
+    if (event.type === 'blur') {
+      this.blur.emit();
     }
   }
 


### PR DESCRIPTION
agora os seguintes componentes emitem o evento 'blur':
- po-combo
- po-multiselect
- po-select

fixes DTHFUI-11330
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)


