### PR TITLE
refactor(gauge): marca componente po-gauge como depreciado

### DIFF
--- a/projects/ui/src/lib/components/po-gauge/po-gauge.component.ts
+++ b/projects/ui/src/lib/components/po-gauge/po-gauge.component.ts
@@ -20,6 +20,9 @@ import { PoChartOptions, PoChartSerie } from '../po-chart';
  *  <file name="sample-po-gauge-summary/sample-po-gauge-summary.component.html"> </file>
  *  <file name="sample-po-gauge-summary/sample-po-gauge-summary.component.ts"> </file>
  * </example>
+ *
+ * @deprecated v22.x.x
+ * Utilize o `po-chart` com `type="gauge"` como alternativa recomendada.
  */
 @Component({
   selector: 'po-gauge',


### PR DESCRIPTION
Marca o componente `po-gauge` como @deprecated,
indicando que ele será removido em versões futuras. A recomendação é utilizar o `po-chart` com `type="gauge"`.

Fixes: DTHFUI-11334

BREAKING CHANGE: marca componente `po-gauge` como @deprecated

O componente `po-gauge` não será mais mantido e
será removido em versões futuras.
A alternativa recomendada é utilizar o `po-chart` com `type="gauge"`.

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
