### PR TITLE
fix(fields): atualiza renderização de mensagens ao manipular forms

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -363,15 +363,17 @@ describe('PoDatepickerBaseComponent:', () => {
       it(`should invalidate form and set errorPattern with errorPattern value
         when has an errorPattern value and date is invalid`, () => {
         component.errorPattern = 'errorPattern';
-
+        component['cd'] = { markForCheck: () => {} } as any;
+        spyOn(component['cd'], 'markForCheck');
         expect(component.validate(new UntypedFormControl([]))).toEqual(invalidDateError);
         expect(component.errorPattern).toBe('errorPattern');
       });
 
       it(`should invalidate form and set errorPattern 'Data inválida' when
         doesn't have an errorPattern value and date is invalid`, () => {
+        component['cd'] = { markForCheck: () => {} } as any;
         component.errorPattern = '';
-
+        spyOn(component['cd'], 'markForCheck');
         expect(component.validate(new UntypedFormControl([]))).toEqual(invalidDateError);
         expect(component.errorPattern).toBe('Data inválida');
       });
@@ -379,7 +381,8 @@ describe('PoDatepickerBaseComponent:', () => {
       it(`should invalidate form and set errorPattern 'Data inválida' when
         errorPattern is equal to 'Data fora do período' and date is invalid`, () => {
         component.errorPattern = 'Data fora do período';
-
+        component['cd'] = { markForCheck: () => {} } as any;
+        spyOn(component['cd'], 'markForCheck');
         expect(component.validate(new UntypedFormControl([]))).toEqual(invalidDateError);
         expect(component.errorPattern).toBe('Data inválida');
       });
@@ -391,7 +394,8 @@ describe('PoDatepickerBaseComponent:', () => {
           }
         };
         spyOn(ValidatorsFunctions, 'requiredFailed').and.returnValue(true);
-
+        component['cd'] = { markForCheck: () => {} } as any;
+        spyOn(component['cd'], 'markForCheck');
         expect(component.validate(new UntypedFormControl(undefined))).toEqual(invalidRequiredError);
         expect(component.errorPattern).toBe('');
       });
@@ -400,15 +404,17 @@ describe('PoDatepickerBaseComponent:', () => {
         spyOn(UtilsFunctions, 'validateDateRange').and.returnValue(false);
 
         component['date'] = new Date(2018, 5, 5);
-
+        component['cd'] = { markForCheck: () => {} } as any;
+        spyOn(component['cd'], 'markForCheck');
         expect(component.validate(new UntypedFormControl('Tue Jun 05 2018 00:00:00'))).toEqual(invalidDateError);
         expect(component.errorPattern).toBe('Data fora do período');
       });
 
       it(`should invalidate form and set errorPattern 'Data fora do período' when
         has a date out of range and errorPattern is 'Data inválida'`, () => {
+        component['cd'] = { markForCheck: () => {} } as any;
         spyOn(UtilsFunctions, 'validateDateRange').and.returnValue(false);
-
+        spyOn(component['cd'], 'markForCheck');
         component.errorPattern = 'Data inválida';
         component['date'] = new Date(2018, 5, 5);
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -613,6 +613,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
     if (dateFailed(c.value)) {
       this.errorPattern = this.errorPattern || 'Data inválida';
 
+      this.cd?.markForCheck();
       return {
         date: {
           valid: false
@@ -621,6 +622,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
     }
 
     if (requiredFailed(this.required, this.disabled, c.value)) {
+      this.cd?.markForCheck();
       return {
         required: {
           valid: false
@@ -631,6 +633,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
     if (this.date && !validateDateRange(this.date, this._minDate, this._maxDate)) {
       this.errorPattern = this.errorPattern || 'Data fora do período';
 
+      this.cd?.markForCheck();
       return {
         date: {
           valid: false
@@ -644,7 +647,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
         .pipe(
           switchMap(status => {
             if (status === 'INVALID') {
-              this.cd.markForCheck();
+              this.cd?.markForCheck();
             }
             return [];
           })

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -644,6 +644,7 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
 
     if (requiredFailed(this.required, this.disabled, this.getScreenValue())) {
       this.isInvalid = true;
+      this.cd?.markForCheck();
       return {
         required: {
           valid: false
@@ -655,6 +656,7 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
       maxlengpoailed(this.maxlength, this.getScreenValue(), this.maskFormatModel ? false : this.maskNoLengthValidation)
     ) {
       this.isInvalid = true;
+      this.cd?.markForCheck();
       return {
         maxlength: {
           valid: false
@@ -666,6 +668,7 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
       minlengpoailed(this.minlength, this.getScreenValue(), this.maskFormatModel ? false : this.maskNoLengthValidation)
     ) {
       this.isInvalid = true;
+      this.cd?.markForCheck();
       return {
         minlength: {
           valid: false
@@ -675,6 +678,7 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
 
     if (patternFailed(this.pattern, c.value)) {
       this.isInvalid = true;
+      this.cd?.markForCheck();
       this.validatePatternOnWriteValue(c.value);
       return {
         pattern: {
@@ -689,7 +693,7 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
           switchMap(status => {
             if (status === 'INVALID') {
               this.isInvalid = true;
-              this.cd.markForCheck();
+              this.cd?.markForCheck();
             }
             return [];
           })

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectorRef, Directive, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 
 import { Observable, Subject, Subscription } from 'rxjs';
@@ -684,7 +684,8 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
 
   constructor(
     languageService: PoLanguageService,
-    protected poThemeService: PoThemeService
+    protected poThemeService: PoThemeService,
+    protected cd?: ChangeDetectorRef
   ) {
     this.language = languageService.getShortLanguage();
   }
@@ -808,6 +809,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
 
   validate(c: AbstractControl): { [key: string]: any } {
     if (requiredFailed(this.required, this.disabled, c.value)) {
+      this.cd?.markForCheck();
       return {
         required: {
           valid: false

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.ts
@@ -130,11 +130,11 @@ export class PoMultiselectDropdownComponent {
   }
 
   everyVisibleOptionsSelected(selectedValues) {
-    return this.visibleOptions.every(visibleOption => selectedValues.includes(visibleOption[this.fieldValue]));
+    return this.visibleOptions?.every(visibleOption => selectedValues.includes(visibleOption[this.fieldValue]));
   }
 
   someVisibleOptionsSelected(selectedValues) {
-    return this.visibleOptions.some(visibleOption => selectedValues.includes(visibleOption[this.fieldValue]));
+    return this.visibleOptions?.some(visibleOption => selectedValues.includes(visibleOption[this.fieldValue]));
   }
 
   getStateSelectAll() {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -154,7 +154,7 @@ export class PoMultiselectComponent
     languageService: PoLanguageService,
     protected poThemeService: PoThemeService
   ) {
-    super(languageService, poThemeService);
+    super(languageService, poThemeService, changeDetector);
     const language = languageService.getShortLanguage();
     this.literalsTag = {
       ...literalsTagRemoveOthers[poLocaleDefault],


### PR DESCRIPTION
Adiciona chamadas ao markForCheck no método validate dos componentes po-datepicker, po-input e po-multiselect para garantir que as mensagens de erro sejam exibidas imediatamente ao sujar o campo (dirty/touched).

Resolve o problema onde a view só atualizava após foco ou blur, não refletindo o erro de forma imediata.

fixes DTHFUI-11419

**< po-datepicker, po-input e po-multiselect >**

**< DTHFUI-11419 >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
