### PR TITLE
fix(toolbar): corrige exibição do profile ao renderizar scroll - v17

### DIFF
--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.html
@@ -5,7 +5,9 @@
   [attr.data-type]="type"
   [hidden]="visible"
 >
-  <ng-content select="[p-popup-header-template]"></ng-content>
+  <div #popupHeaderContainer>
+    <ng-content select="[p-popup-header-template]"></ng-content>
+  </div>
 
   <po-search-list
     #searchElement

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.spec.ts
@@ -511,6 +511,61 @@ describe('PoListBoxComponent', () => {
 
         expect(component['renderer'].setStyle).not.toHaveBeenCalled();
       });
+
+      it('should call `renderer.setStyle` and `renderer.removeStyle` when has more than 6 items and popupHeaderContainer contains children', () => {
+        spyOn<any>(component['renderer'], 'setStyle');
+        spyOn<any>(component['renderer'], 'removeStyle');
+        component.items = [
+          { label: 'Item 1', value: 1 },
+          { label: 'Item 2', value: 2 },
+          { label: 'Item 3', value: 3 },
+          { label: 'Item 4', value: 4 },
+          { label: 'Item 5', value: 5 },
+          { label: 'Item 6', value: 6 },
+          { label: 'Item 7', value: 7 }
+        ];
+
+        component.type = 'action';
+        component.popupHeaderContainer = new ElementRef(document.createElement('div'));
+        component.popupHeaderContainer.nativeElement.appendChild(document.createElement('div'));
+
+        component['setListBoxMaxHeight']();
+
+        expect(component['renderer'].setStyle).toHaveBeenCalledWith(
+          component.listbox.nativeElement.querySelector('ul[role=listbox]'),
+          'maxHeight',
+          `${44 * 6 - 44 / 3}px`
+        );
+        expect(component['renderer'].removeStyle).toHaveBeenCalledWith(component.listbox.nativeElement, 'maxHeight');
+      });
+
+      it(`should'n call 'renderer.removeStyle' when has more than 6 items and popupHeaderContainer is undefined`, () => {
+        spyOn<any>(component['renderer'], 'setStyle');
+        spyOn<any>(component['renderer'], 'removeStyle');
+        component.items = [
+          { label: 'Item 1', value: 1 },
+          { label: 'Item 2', value: 2 },
+          { label: 'Item 3', value: 3 },
+          { label: 'Item 4', value: 4 },
+          { label: 'Item 5', value: 5 },
+          { label: 'Item 6', value: 6 },
+          { label: 'Item 7', value: 7 }
+        ];
+
+        component.type = 'action';
+
+        component['setListBoxMaxHeight']();
+
+        expect(component['renderer'].setStyle).toHaveBeenCalledWith(
+          component.listbox.nativeElement,
+          'maxHeight',
+          `${44 * 6 - 44 / 3}px`
+        );
+        expect(component['renderer'].removeStyle).not.toHaveBeenCalledWith(
+          component.listbox.nativeElement,
+          'maxHeight'
+        );
+      });
     });
 
     describe('checkboxClicked:', () => {

--- a/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
+++ b/projects/ui/src/lib/components/po-listbox/po-listbox.component.ts
@@ -28,13 +28,14 @@ export class PoListBoxComponent extends PoListBoxBaseComponent implements AfterV
   @ViewChild('listbox', { static: true }) listbox: ElementRef;
   @ViewChild('listboxItemList', { static: false }) listboxItemList: ElementRef;
   @ViewChild('searchElement') searchElement: PoSearchListComponent;
+  @ViewChild('popupHeaderContainer') popupHeaderContainer: ElementRef;
 
   private scrollEvent$: Observable<any>;
   private subscriptionScrollEvent: Subscription;
 
   constructor(
     public element: ElementRef,
-    private renderer: Renderer2,
+    private readonly renderer: Renderer2,
     languageService: PoLanguageService,
     private router: Router,
     private changeDetector: ChangeDetectorRef
@@ -59,7 +60,7 @@ export class PoListBoxComponent extends PoListBoxBaseComponent implements AfterV
   }
 
   ngOnDestroy() {
-    if (this.subscriptionScrollEvent && this.subscriptionScrollEvent.unsubscribe) {
+    if (this.subscriptionScrollEvent?.unsubscribe) {
       this.subscriptionScrollEvent.unsubscribe();
     }
   }
@@ -231,9 +232,18 @@ export class PoListBoxComponent extends PoListBoxBaseComponent implements AfterV
 
   private setListBoxMaxHeight(): void {
     const itemsLength = this.items.length;
+    const hasPopupHeaderContainer = this.popupHeaderContainer?.nativeElement?.children?.length > 0;
+
     if (itemsLength > 6) {
       if (this.type === 'check' && !this.hideSearch) {
         this.renderer.setStyle(this.listbox.nativeElement, 'maxHeight', `${44 * 6 - 44 / 3 + 60}px`);
+      } else if (hasPopupHeaderContainer) {
+        this.renderer.setStyle(
+          this.listbox.nativeElement.querySelector('ul[role=listbox]'),
+          'maxHeight',
+          `${44 * 6 - 44 / 3}px`
+        );
+        this.renderer.removeStyle(this.listbox.nativeElement, 'maxHeight');
       } else {
         this.renderer.setStyle(this.listbox.nativeElement, 'maxHeight', `${44 * 6 - 44 / 3}px`);
       }

--- a/projects/ui/src/lib/components/po-popup/po-popup.component.html
+++ b/projects/ui/src/lib/components/po-popup/po-popup.component.html
@@ -3,9 +3,7 @@
 
   <div class="po-popup-container">
     <po-listbox #listbox #poListBoxRef p-type="action" [p-items]="actions" [p-param]="param" (p-close)="close()">
-      <div p-popup-header-template>
-        <ng-content select="[p-popup-header-template]"></ng-content>
-      </div>
+      <ng-content p-popup-header-template select="[p-popup-header-template]"></ng-content>
     </po-listbox>
   </div>
 </div>


### PR DESCRIPTION
Ao incluir mais do que 6 actions no componente po-toolbar o mesmo deixa de apresentar a linha de profile.
Agora, quando são incluídos mais de 6 ações no componente po-toolbar, a linha do profile é exibida no topo do po-toolbar.

Fixes DTHFUI-10678

**po-toolbar**

**DTHFUI-10678**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao incluir mais do que 6 actions no componente po-toolbar o mesmo deixa de apresentar a linha de profile.
![image](https://github.com/user-attachments/assets/8dc6b9ac-cbc7-41f1-a42d-b9c96e631da4)

**Qual o novo comportamento?**
Quando são incluídos mais de 6 ações no componente po-toolbar, a linha do profile é exibida no topo do po-toolbar:
![image](https://github.com/user-attachments/assets/f8038a3e-9be5-406b-8d19-c4f74feff77c)

**Simulação**
![po-toolbar-simulacao](https://github.com/user-attachments/assets/83e66344-51be-4cf9-9d11-1793de41b936)