### PR TITLE
feat(combo): implementar acessibilidade com append-in-body

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -45,6 +45,7 @@
           [id]="id"
           [placeholder]="disabled ? '' : placeholder"
           [required]="required"
+          [attr.data-append-in-body]="appendBox"
           (click)="toggleComboVisibility()"
           (keyup)="onKeyUp($event)"
           (blur)="onBlur($event)"
@@ -59,12 +60,13 @@
             [attr.aria-label]="literals.clean"
             class="po-combo-clean po-icon-input"
             [class.po-combo-clean-aa]="size === 'small'"
-            *ngIf="clean && !disabled && inp.value"
+            *ngIf="isCleanVisible()"
             [p-element-ref]="inputEl"
             [p-size]="size"
             (p-change-event)="clear($event)"
             (click)="clear(null); $event.preventDefault()"
             (keydown.enter)="clearAndFocus(); $event.preventDefault()"
+            (keydown.tab)="handleCleanKeyboardTab($event)"
           >
           </po-clean>
 
@@ -94,7 +96,12 @@
     </ng-template>
 
     <ng-template #dropdownCDK>
-      <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="true">
+      <ng-template
+        cdkConnectedOverlay
+        [cdkConnectedOverlayOrigin]="trigger"
+        [cdkConnectedOverlayOpen]="true"
+        [cdkConnectedOverlayDisableClose]="true"
+      >
         <ng-container *ngTemplateOutlet="dropdownListbox"></ng-container>
       </ng-template>
     </ng-template>
@@ -127,7 +134,6 @@
         [p-infinite-scroll]="infiniteScroll"
         [p-filtering]="isFiltering"
         [p-cache]="cache"
-        (p-selectcombo-item)="onOptionClick($event, $event.event)"
         [p-filter-mode]="filterMode"
         [p-visible]="comboOpen"
         [p-is-searching]="isServerSearching"
@@ -136,9 +142,11 @@
         [p-combo-service]="service"
         [p-infinite-scroll-distance]="infiniteScrollDistance"
         [p-size]="size"
+        [p-container-width]="containerWidth"
+        (p-selectcombo-item)="onOptionClick($event, $event.event)"
         (p-update-infinite-scroll)="showMoreInfiniteScroll()"
         (p-close)="onCloseCombo()"
-        [p-container-width]="containerWidth"
+        (keydown)="onListboxKeyDown($event)"
       ></po-listbox>
     </div>
   </ng-template>


### PR DESCRIPTION
**PO-COMBO**

**DTHFUI-10960**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não possue suporte de navegação por teclado entre o input e o listbox quando usado o append-in-body

**Qual o novo comportamento?**
Adiciona navegação por teclado e suporte a leitores de tela no modo append-in-body, implementando fluxo de Tab e Arrow-down para abrir o listbox

**Simulação**
<po-combo 
            name="combo2" 
            p-label="PO Combo" 
            [p-options]="[{ value: 'Option 1' }, { value: 'Option 2' }]"
            [p-clean]="true"
            p-append-in-body="true"
> </po-combo>