### PR TITLE
feat(chart): implementa nova funcionalidade stacked

### DIFF
--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-options.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-options.interface.ts
@@ -219,6 +219,21 @@ export interface PoChartOptions {
    *
    * @description
    *
+   * Agrupa todas as séries numa única coluna ou barra por categoria. Essa propriedade sobrescreve a propriedade `stackGroupName` da interface `PoChartSerie`
+   *
+   * > Válido para gráfico do tipo `Column` e `Bar`.
+   *
+   * > Essa propriedade habilita a propriedade `p-data-label` por padrão, podendo ser desabilitada passando `[p-data-label]={ fixed: false }`.
+   *
+   * @default `false`
+   */
+  stacked?: boolean;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Define um subtítulo para o Gauge. Indicamos um subtítulo pequeno, com uma quantidade máxima de 32 caracteres na altura padrão.
    *
    * > Válido para gráfico do tipo `Gauge`.

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie-data-label.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie-data-label.interface.ts
@@ -19,7 +19,7 @@ export interface PoChartDataLabel {
    *   - O *tooltip* não será exibido.
    *   - As outras séries ficarão com opacidade reduzida ao passar o mouse sobre a série ativa.
    *
-   * > Disponível apenas para o tipo de gráfico `PoChartType.Line`.
+   * > Disponível para os tipo de gráfico `PoChartType.Line`, `PoChartType.Area`, `PoChartType.Column` e `PoChartType.Bar`.
    */
   fixed?: boolean;
 }

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie.interface.ts
@@ -94,4 +94,23 @@ export interface PoChartSerie {
    * > Propriedade válida para gráfico do tipo `Gauge`.
    */
   to?: number;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Agrupa as séries em barras ou colunas que receberem o mesmo `stackGroupName`. Exemplo:
+   * - Serie A: `{ data: 500, stackGroupName: 'group1' ... }`;
+   * - Série B: `{ data: 200, stackGroupName: 'group1' ... }`.
+   * - Série C: `{ data: 100, stackGroupName: 'group2' ... }`.
+   * - Série D: `{ data: 400, stackGroupName: 'group2' ... }`.
+   *
+   * Nesse caso será criado duas barras ou colunas com duas series agrupadas em cada uma por categoria.
+   * > Válido para gráfico do tipo `Column` e `Bar`. Essa propriedade é ignorada caso a propriedade `stacked` da interface `PoChartOptions` esteja como `true`.
+   *
+   * > Essa propriedade habilita a propriedade `p-data-label` por padrão, podendo ser desabilitada passando `[p-data-label]={ fixed: false }`.
+   *
+   */
+  stackGroupName?: string;
 }

--- a/projects/ui/src/lib/components/po-chart/po-chart-grid-utils.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-grid-utils.spec.ts
@@ -63,13 +63,27 @@ describe('PoChartGridUtils', () => {
 
   describe('setSerieTypeBarColumn', () => {
     it('should set itemStyle and emphasis when type is bar', () => {
-      const serie: any = { type: 'bar' };
+      const serie: any = { type: 'bar', data: [200] };
+      const color = '#f00';
+      utils['component'].options.stacked = true;
+
+      utils.setSerieTypeBarColumn(serie, color);
+
+      expect(serie.itemStyle.color).toBe(color);
+      expect(serie.emphasis.focus).toBe('series');
+      expect(serie.stack).toBe('total');
+      expect(mockCtx.boundaryGap).toBe(true);
+    });
+
+    it('should set itemStyle and emphasis when type is bar', () => {
+      const serie: any = { type: 'bar', stackGroupName: 'group1', data: [200] };
       const color = '#f00';
 
       utils.setSerieTypeBarColumn(serie, color);
 
       expect(serie.itemStyle.color).toBe(color);
       expect(serie.emphasis.focus).toBe('series');
+      expect(serie.stack).toBe('group1');
       expect(mockCtx.boundaryGap).toBe(true);
     });
   });
@@ -89,13 +103,7 @@ describe('PoChartGridUtils', () => {
 
   describe('setListPie', () => {
     const labelProperties = {
-      show: false,
-      position: 'center',
-      formatter: undefined,
-      fontFamily: '',
-      fontSize: undefined,
-      color: '',
-      fontWeight: 0
+      show: false
     };
 
     it('should set pie config with radius 95% and center 50% 50% when legend is false', () => {
@@ -158,13 +166,17 @@ describe('PoChartGridUtils', () => {
 
   describe('setListDonut', () => {
     const labelProperties = {
-      show: true,
-      position: 'center',
-      formatter: 'test',
-      fontFamily: '',
-      fontSize: undefined,
-      color: '',
-      fontWeight: 0
+      type: 'text',
+      left: 'center',
+      top: '44%',
+      style: {
+        text: 'test',
+        fontSize: undefined,
+        fontWeight: 0,
+        fontFamily: '',
+        fill: ''
+      },
+      silent: true
     };
 
     it('should set donut config if innerRadius is 100 and roseType is true', () => {
@@ -190,40 +202,43 @@ describe('PoChartGridUtils', () => {
           emphasis: { focus: 'self' },
           data: [],
           label: {
-            show: true,
-            position: 'center',
-            formatter: 'test',
-            fontFamily: '',
-            fontSize: undefined,
-            color: '',
-            fontWeight: 0
+            show: false
           },
           blur: { itemStyle: { opacity: 0.4 } }
         }
       ]);
+      expect(utils.textCenterDonut).toEqual(labelProperties);
     });
 
     it('should set donut config if innerRadius is 80', () => {
-      utils['component'].options = { innerRadius: 80, textCenterGraph: 'test' } as PoChartOptions;
+      utils['component'].options = {
+        innerRadius: 80,
+        textCenterGraph: 'test',
+        legendVerticalPosition: 'top'
+      } as PoChartOptions;
       utils['component'].series = [
         { label: 'Serie 1', data: 10 },
         { label: 'Serie 2', data: 30 }
       ];
+      const labelText = { ...labelProperties, top: '52%' };
 
       utils.setListTypeDonutPie(PoChartType.Donut);
 
       expect(utils['component'].listTypePieDonut).toEqual([
         {
           type: 'pie',
-          center: ['50%', '46%'],
+          center: ['50%', '54%'],
           radius: ['44%', '80%'],
           roseType: undefined,
           emphasis: { focus: 'self' },
           data: [],
-          label: labelProperties,
+          label: {
+            show: false
+          },
           blur: { itemStyle: { opacity: 0.4 } }
         }
       ]);
+      expect(utils.textCenterDonut).toEqual(labelText);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart-grid-utils.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-grid-utils.ts
@@ -17,7 +17,8 @@ const gridPaddingValues = {
 } as const;
 
 export class PoChartGridUtils {
-  private isTypeDonut = false;
+  isTypeDonut = false;
+  textCenterDonut = {};
   constructor(private readonly component: PoChartComponent) {}
 
   setGridOption(options) {
@@ -162,6 +163,14 @@ export class PoChartGridUtils {
         itemStyle: { opacity: 0.4 }
       };
       this.component.boundaryGap = true;
+
+      if (this.component.options?.stacked || serie.stackGroupName) {
+        serie.stack = this.component.options?.stacked ? 'total' : serie.stackGroupName;
+        if (this.component.dataLabel?.fixed !== false) {
+          this.component.dataLabel = { fixed: true };
+          serie.label = { show: true };
+        }
+      }
     }
   }
 
@@ -177,8 +186,7 @@ export class PoChartGridUtils {
           borderColor: borderColor,
           color: color,
           borderRadius: this.component.options?.borderRadius
-        },
-        label: { show: this.isTypeDonut && this.component.options?.textCenterGraph }
+        }
       };
       this.component.listTypePieDonut[0].data.push(seriePie);
     }
@@ -210,20 +218,32 @@ export class PoChartGridUtils {
         center: ['50%', positionHorizontal],
         radius: radius,
         roseType: this.component.options?.roseType ? 'area' : undefined,
-        label: {
-          show: !!(this.isTypeDonut && this.component.options?.textCenterGraph),
-          position: 'center',
-          formatter: this.component.options?.textCenterGraph,
-          fontSize: this.resolvePx('--font-size-md'),
-          fontWeight: Number(this.component.getCSSVariable('--font-weight-hightlight-value', '.po-chart')),
-          fontFamily: this.component.getCSSVariable('--font-family-hightlight-value', '.po-chart'),
-          color: this.component.getCSSVariable('--color-hightlight-value', '.po-chart')
-        },
+        label: { show: false },
         emphasis: { focus: 'self' },
         data: [],
         blur: { itemStyle: { opacity: 0.4 } }
       }
     ];
+
+    this.setTextCenterDonut();
+  }
+
+  private setTextCenterDonut() {
+    if (this.isTypeDonut && this.component.options?.textCenterGraph) {
+      this.textCenterDonut = {
+        type: 'text',
+        left: 'center',
+        top: this.component.options?.legendVerticalPosition === 'top' ? '52%' : '44%',
+        style: {
+          text: this.component.options?.textCenterGraph,
+          fontSize: this.resolvePx('--font-size-md'),
+          fontWeight: Number(this.component.getCSSVariable('--font-weight-hightlight-value', '.po-chart')),
+          fontFamily: this.component.getCSSVariable('--font-family-hightlight-value', '.po-chart'),
+          fill: this.component.getCSSVariable('--color-hightlight-value', '.po-chart')
+        },
+        silent: true
+      };
+    }
   }
 
   private getAdjustedRadius(radius: string, innerRadius: number): string {

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
@@ -1051,6 +1051,40 @@ describe('PoChartComponent', () => {
       expect(result.grid.top).toBe(56);
     });
 
+    it('should apply text center in donut type when enabled', () => {
+      component.listTypePieDonut = [
+        {
+          type: 'pie',
+          center: ['50%', '46%'],
+          radius: ['50%'],
+          roseType: undefined,
+          label: { show: false },
+          emphasis: { focus: 'self' },
+          data: [],
+          blur: { itemStyle: { opacity: 0.4 } }
+        }
+      ];
+      component['isTypeGauge'] = false;
+      component['chartGridUtils'].textCenterDonut = {
+        type: 'text',
+        left: 'center',
+        top: '44%',
+        style: {
+          text: 'test',
+          fontSize: undefined,
+          fontWeight: 0,
+          fontFamily: '',
+          fill: ''
+        },
+        silent: true
+      };
+      component['chartGridUtils'].isTypeDonut = true;
+      component.options.textCenterGraph = 'test';
+
+      const result = component['setOptions']();
+      expect(result.graphic).toEqual(component['chartGridUtils'].textCenterDonut);
+    });
+
     it('should apply correct axis configurations', () => {
       component.options.axis = {
         minRange: 10,

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.ts
@@ -82,6 +82,11 @@ use([
  *  <file name="sample-po-chart-coffee-ranking/sample-po-chart-coffee-ranking.component.ts"> </file>
  * </example>
  *
+ * <example name="po-chart-stacked" title="PO Chart - Stacked">
+ *  <file name="sample-po-chart-stacked/sample-po-chart-stacked.component.html"> </file>
+ *  <file name="sample-po-chart-stacked/sample-po-chart-stacked.component.ts"> </file>
+ * </example>
+ *
  * <example name="po-chart-summary" title="PO Chart - Summary">
  *  <file name="sample-po-chart-summary/sample-po-chart-summary.component.html"> </file>
  *  <file name="sample-po-chart-summary/sample-po-chart-summary.component.ts"> </file>
@@ -484,6 +489,8 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
       if (this.options?.dataZoom) {
         this.chartGridUtils.setOptionDataZoom(options);
       }
+    } else if (this.chartGridUtils.isTypeDonut && this.options?.textCenterGraph) {
+      options.graphic = this.chartGridUtils.textCenterDonut;
     }
 
     if (this.options?.legend !== false) {

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.html
@@ -38,7 +38,7 @@
   <po-input class="po-md-3" name="title" p-label="Title" [(ngModel)]="title"> </po-input>
 
   <po-checkbox-group
-    *ngIf="isLineType()"
+    *ngIf="isTypeGrid()"
     class="po-md-3"
     name="dataLabel"
     p-label="DataLabel"
@@ -105,6 +105,15 @@
     ></po-input>
 
     <po-input class="po-md-4" name="color" p-label="Color" p-help="Custom Color" [(ngModel)]="color"></po-input>
+
+    <po-input
+      *ngIf="type === 'bar' || serieType === 'bar' || type === 'column' || serieType === 'column'"
+      class="po-md-4"
+      name="stackGroupName"
+      p-label="Stack Group Name"
+      p-help="Custom Group Name"
+      [(ngModel)]="stackGroupName"
+    ></po-input>
 
     <po-number *ngIf="isTypeGauge" class="po-md-4" p-label="From" name="from" [(ngModel)]="fromGauge"></po-number>
 
@@ -339,6 +348,16 @@
       [p-options]="[{ label: 'pointer', value: 'pointer' }]"
       [(ngModel)]="selectedPointer"
       (p-change)="changePointer()"
+    >
+    </po-checkbox-group>
+
+    <po-checkbox-group
+      class="po-md-4"
+      name="stacked"
+      p-label="Stacked"
+      [p-options]="[{ label: 'stacked', value: 'stacked' }]"
+      [(ngModel)]="selectedStacked"
+      (p-change)="changeStacked()"
     >
     </po-checkbox-group>
 

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-labs/sample-po-chart-labs.component.ts
@@ -16,6 +16,7 @@ import {
 })
 export class SamplePoChartLabsComponent implements OnInit {
   color: string;
+  stackGroupName: string;
   data;
   label: string;
   tooltip: string;
@@ -68,6 +69,7 @@ export class SamplePoChartLabsComponent implements OnInit {
     bottomDataZoom: undefined,
     rendererOption: undefined,
     pointer: undefined,
+    stacked: undefined,
     roseType: undefined,
     showFromToLegend: undefined
   };
@@ -80,6 +82,7 @@ export class SamplePoChartLabsComponent implements OnInit {
   selectedRoseType: Array<string> = [];
   selectedFromToLegend: Array<string> = [];
   selectedPointer: Array<string> = [];
+  selectedStacked: Array<string> = [];
   selectedValuesLegend: Array<string> = ['legend'];
   selectedLegendVerticalPosition: PoChartOptions['legendVerticalPosition'] = 'bottom';
   selectedLegendPosition: PoChartOptions['legendPosition'] = 'center';
@@ -213,6 +216,13 @@ export class SamplePoChartLabsComponent implements OnInit {
     };
   }
 
+  changeStacked() {
+    this.options = {
+      ...this.options,
+      stacked: this.selectedStacked.includes('stacked')
+    };
+  }
+
   changeLegendVerticalPosition() {
     this.options = {
       ...this.options,
@@ -277,6 +287,7 @@ export class SamplePoChartLabsComponent implements OnInit {
     let data = isNaN(this.data) ? this.convertToArray(this.data) : Math.floor(this.data);
     const type = this.serieType ?? this.type;
     const color = this.color;
+    const stackGroupName = this.stackGroupName;
     if (this.isTypeGauge && !this.series?.length && !this.toGauge) {
       data = this.valueGauge;
     }
@@ -289,6 +300,7 @@ export class SamplePoChartLabsComponent implements OnInit {
         tooltip: this.tooltip,
         ...(color ? { color } : {}),
         type,
+        stackGroupName,
         from: this.fromGauge,
         to: this.toGauge
       }
@@ -300,13 +312,19 @@ export class SamplePoChartLabsComponent implements OnInit {
     this.tooltip = undefined;
     this.fromGauge = undefined;
     this.toGauge = undefined;
+    this.stackGroupName = undefined;
     if (!this.isTypeGauge) {
       this.type = undefined;
     }
   }
 
-  isLineType(): boolean {
-    return this.type === PoChartType.Line;
+  isTypeGrid(): boolean {
+    return (
+      this.type === PoChartType.Line ||
+      this.type === PoChartType.Area ||
+      this.type === PoChartType.Column ||
+      this.type === PoChartType.Bar
+    );
   }
 
   changeEvent(eventName: string, serieEvent: PoChartSerie): void {
@@ -369,6 +387,7 @@ export class SamplePoChartLabsComponent implements OnInit {
       bottomDataZoom: undefined,
       rendererOption: undefined,
       pointer: undefined,
+      stacked: undefined,
       roseType: undefined,
       showFromToLegend: undefined
     };

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-stacked/sample-po-chart-stacked.component.html
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-stacked/sample-po-chart-stacked.component.html
@@ -1,0 +1,25 @@
+<po-container>
+  <div class="po-font-title po-mb-3">Energy and Climate Analysis</div>
+  <div class="po-row">
+    <po-chart
+      class="po-lg-6"
+      p-title="Average Temperature by Region"
+      [p-height]="500"
+      [p-options]="optionsColumn"
+      [p-categories]="categoriesColumn"
+      [p-series]="seriesColumn"
+    >
+    </po-chart>
+
+    <po-chart
+      class="po-lg-6"
+      p-title="Energy Consumption by Region"
+      [p-type]="typeBar"
+      [p-height]="500"
+      [p-options]="optionsBar"
+      [p-categories]="categoriesBar"
+      [p-series]="seriesBar"
+    >
+    </po-chart>
+  </div>
+</po-container>

--- a/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-stacked/sample-po-chart-stacked.component.ts
+++ b/projects/ui/src/lib/components/po-chart/samples/sample-po-chart-stacked/sample-po-chart-stacked.component.ts
@@ -1,0 +1,50 @@
+import { Component } from '@angular/core';
+
+import { PoChartOptions, PoChartSerie, PoChartType } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-chart-stacked',
+  templateUrl: './sample-po-chart-stacked.component.html',
+  standalone: false
+})
+export class SamplePoChartStackedComponent {
+  typeBar = PoChartType.Bar;
+
+  optionsColumn: PoChartOptions = {
+    axis: {
+      minRange: -20,
+      gridLines: 7
+    }
+  };
+
+  categoriesColumn: Array<string> = ['North Region', 'Central Region', 'South Region'];
+
+  seriesColumn: Array<PoChartSerie> = [
+    { label: 'Year 2014', data: [51, 40, 42], stackGroupName: 'group1' },
+    { label: 'Year 2017', data: [53, 52, 18] },
+    { label: 'Year 2020', data: [55, 21, -17], stackGroupName: 'group1' },
+    { label: 'Year 2023', data: [35, 27, 23], stackGroupName: 'group2' },
+    { label: 'Year 2026', data: [45, 34, 17], stackGroupName: 'group2' },
+    { label: 'Year 2029', data: [23, 63, 56], stackGroupName: 'group1' }
+  ];
+
+  optionsBar: PoChartOptions = {
+    stacked: true
+  };
+
+  categoriesBar: Array<string> = [
+    'North Region',
+    'Central Region',
+    'South Region',
+    'Southeast Region',
+    'Northeast Region'
+  ];
+
+  seriesBar: Array<PoChartSerie> = [
+    { label: 'Year 2014', data: [199, 340, 247, 236, 222] },
+    { label: 'Year 2017', data: [221, 252, 225, 241, 225] },
+    { label: 'Year 2020', data: [229, 213, 196, 212, 237] },
+    { label: 'Year 2023', data: [240, 237, 230, 223, 231] },
+    { label: 'Year 2026', data: [235, 270, 239, 255, 242] }
+  ];
+}


### PR DESCRIPTION
PO-CHART

DTHFUI-11561
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
O chart do tipo donut ao possuir um texto centralizado e passar o mouse sobre ele, acaba exibindo a tooltip e aplicando foco à primeira serie.

**Qual o novo comportamento?**
Permite agrupar todas ou algumas series nos gráficos do tipo Bar e Column. Para o efeito de aplicar foco à primeira serie ao passar o mouse sobre o texto centralizado do donut.

**Simulação**
[app.zip](https://github.com/user-attachments/files/20927129/app.zip)
