### PR TITLE
fix(components): ajusta validação com p-control-value-with-label

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -896,8 +896,31 @@ describe('PoComboBaseComponent:', () => {
       expect(ValidatorsFunctions.requiredFailed).toHaveBeenCalled();
     });
 
+    it('validate: should return required obj when `requiredFailed` and `controlValeuWithLabel` is true.', () => {
+      const validObj = {
+        required: {
+          valid: false
+        }
+      };
+
+      spyOn(ValidatorsFunctions, 'requiredFailed').and.returnValue(true);
+      component.controlValueWithLabel = true;
+
+      expect(component.validate(new FormControl({ value: 1, label: 'Label1' }))).toEqual(validObj);
+      expect(ValidatorsFunctions.requiredFailed).toHaveBeenCalled();
+    });
+
     it('validate: should return undefined when `requiredFailed` is false', () => {
       spyOn(ValidatorsFunctions, 'requiredFailed').and.returnValue(false);
+
+      expect(component.validate(new UntypedFormControl(null))).toBeUndefined();
+      expect(ValidatorsFunctions.requiredFailed).toHaveBeenCalled();
+    });
+
+    it('validate: should return undefined when `requiredFailed` is false and `controlValueWithLabel` is true', () => {
+      spyOn(ValidatorsFunctions, 'requiredFailed').and.returnValue(false);
+
+      component.controlValueWithLabel = true;
 
       expect(component.validate(new UntypedFormControl(null))).toBeUndefined();
       expect(ValidatorsFunctions.requiredFailed).toHaveBeenCalled();

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -1041,11 +1041,16 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   }
 
   validate(abstractControl: AbstractControl): { [key: string]: any } {
+    let { value } = abstractControl;
+    if (this.controlValueWithLabel && value?.value) {
+      value = value.value;
+    }
+
     if (!this.hasValidatorRequired && this.fieldErrorMessage && abstractControl.hasValidator(Validators.required)) {
       this.hasValidatorRequired = true;
     }
 
-    if (requiredFailed(this.required || this.hasValidatorRequired, this.disabled, abstractControl.value)) {
+    if (requiredFailed(this.required || this.hasValidatorRequired, this.disabled, value)) {
       this.changeDetector.markForCheck();
       return {
         required: {

--- a/projects/ui/src/lib/components/po-field/po-field-validate.model.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-validate.model.spec.ts
@@ -77,8 +77,31 @@ describe('PoFieldValidateModel', () => {
     expect(ValidatorsFunctions.requiredFailed).toHaveBeenCalled();
   });
 
+  it('validate: should return required obj when `requiredFailed` and `controlValueWithLabel` is true.', () => {
+    const validObj = {
+      required: {
+        valid: false
+      }
+    };
+
+    spyOn(ValidatorsFunctions, 'requiredFailed').and.returnValue(true);
+    component.controlValueWithLabel = true;
+
+    expect(component.validate(new FormControl({ value: 1, label: 'Label1' }))).toEqual(validObj);
+    expect(ValidatorsFunctions.requiredFailed).toHaveBeenCalled();
+  });
+
   it('validate: should return undefined when `requiredFailed` is false', () => {
     spyOn(ValidatorsFunctions, 'requiredFailed').and.returnValue(false);
+
+    expect(component.validate(new UntypedFormControl(null))).toBeNull();
+    expect(ValidatorsFunctions.requiredFailed).toHaveBeenCalled();
+  });
+
+  it('validate: should return undefined when `requiredFailed` is false and `controlValueWithLabel` is true', () => {
+    spyOn(ValidatorsFunctions, 'requiredFailed').and.returnValue(false);
+
+    component.controlValueWithLabel = true;
 
     expect(component.validate(new UntypedFormControl(null))).toBeNull();
     expect(ValidatorsFunctions.requiredFailed).toHaveBeenCalled();

--- a/projects/ui/src/lib/components/po-field/po-field-validate.model.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-validate.model.ts
@@ -12,6 +12,13 @@ import { requiredFailed } from './validators';
 @Directive()
 export abstract class PoFieldValidateModel<T> extends PoFieldModel<T> implements Validator {
   /**
+   * @docsPrivate
+   *
+   * Determinar se o valor do compo deve retorna objeto do tipo {value: any, label: any}
+   */
+  @Input({ alias: 'p-control-value-with-label', transform: convertToBoolean }) controlValueWithLabel?: boolean = false;
+
+  /**
    * @optional
    *
    * @description
@@ -79,11 +86,16 @@ export abstract class PoFieldValidateModel<T> extends PoFieldModel<T> implements
   }
 
   validate(abstractControl: AbstractControl): ValidationErrors {
+    let { value } = abstractControl;
+    if (this.controlValueWithLabel && value?.value) {
+      value = value.value;
+    }
+
     if (!this.hasValidatorRequired && this.fieldErrorMessage && abstractControl.hasValidator(Validators.required)) {
       this.hasValidatorRequired = true;
     }
 
-    if (requiredFailed(this.required || this.hasValidatorRequired, this.disabled, abstractControl.value)) {
+    if (requiredFailed(this.required || this.hasValidatorRequired, this.disabled, value)) {
       this.changeDetector.markForCheck();
       return {
         required: {

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -286,13 +286,6 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
     }
   }
 
-  /**
-   * @docsPrivate
-   *
-   * Determinar se o valor do compo deve retorna objeto do tipo {value: any, label: any}
-   */
-  @Input({ alias: 'p-control-value-with-label', transform: convertToBoolean }) controlValueWithLabel?: boolean = false;
-
   get fieldValue() {
     return this._fieldValue;
   }


### PR DESCRIPTION
**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao utilizar as propriedade p-required e p-control-value-with-label ao selecionar qualquer item na lista de opções o campo é sinalizado como inválido

**Qual o novo comportamento?**
Ao utilizar as propriedade p-required e p-control-value-with-label ao selecionar qualquer item na lista de opções o campo não deve ser sinalizado como inválido

**Simulação**
[app.zip](https://github.com/user-attachments/files/21165697/app.zip)
