### PR TITLE
fix(table): ajusta alinhamento de coluna fixa com ação única à esquerda

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-column-frozen/po-table-column-frozen.directive.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-frozen/po-table-column-frozen.directive.ts
@@ -63,6 +63,8 @@ export class PoTableColumnFrozenDirective implements AfterViewInit, OnChanges {
           prev &&
           !prev.classList.contains('po-table-column-selectable') &&
           !prev.classList.contains('po-table-column-actions') &&
+          !prev.classList.contains('po-table-header-single-action') &&
+          !prev.classList.contains('po-table-column-single-action') &&
           !prev.classList.contains('po-table-column-detail-toggle') &&
           !prev.classList.contains('po-table-header-master-detail')
         ) {


### PR DESCRIPTION
Corrige alinhamento incorreto de colunas fixas quando há uma única ação posicionada à esquerda ao aplicar scroll horizontal.

fixes DTHFUI-10907

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
