### PR TITLE
feat(datepicker): implementa acessibilidade com append-in-body

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-wrapper/po-calendar-wrapper.component.html
@@ -99,6 +99,8 @@
           type="button"
           class="po-calendar-footer-today-button"
           (click)="onSelectDate(today)"
+          (keydown.enter)="onSelectDate(today)"
+          (keydown.space)="onSelectDate(today)"
           [disabled]="isTodayUnavailable()"
         >
           {{ displayToday }}

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/interfaces/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/interfaces/po-dynamic-form-field.interface.ts
@@ -54,8 +54,7 @@ export interface PoDynamicFormField extends PoDynamicField {
    * página e não dentro do componente. Essa opção é necessária para cenários com containers que possuem scroll ou
    * overflow escondido, garantindo o posicionamento correto de ambos próximo ao elemento.
    *
-   * > O uso dessa propriedade pode acarretar na perda sequencial da tabulação da página.
-   * Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
+   * > Quando utilizado com `p-additional-help-tooltip`, leitores de tela como o NVDA podem não ler o conteúdo do tooltip.
    */
   appendBox?: boolean;
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
@@ -27,9 +27,11 @@
           [placeholder]="disabled ? '' : placeholder"
           [readonly]="readonly"
           [required]="required"
+          [attr.data-append-in-body]="appendBox"
           (blur)="eventOnBlur($event)"
           (click)="eventOnClick($event)"
           (keydown)="onKeyDown($event)"
+          (keydown.tab)="handleCleanKeyboardTab($event)"
         />
         <div class="po-field-icon-container-right">
           <po-clean
@@ -51,6 +53,7 @@
         [p-disabled]="disabled || readonly"
         [p-size]="size"
         (keydown)="onKeyPress($event)"
+        (keydown.tab)="handleCleanKeyboardTab($event)"
         (p-click)="togglePicker()"
       >
       </po-button>
@@ -59,16 +62,17 @@
     <ng-container *ngIf="appendBox; then dropdownCDK; else dropdownDefault"> </ng-container>
 
     <ng-template #sharedCalendarContent>
-      <div #dialogPicker [class.po-datepicker-popup-calendar]="!verifyMobile()">
+      <div #dialogPicker [class.po-datepicker-popup-calendar]="!verifyMobile()" tabindex="-1">
         <div *ngIf="verifyMobile()" class="po-datepicker-calendar-overlay"></div>
         <po-calendar
-          [class.po-datepicker-calendar-mobile]="verifyMobile()"
           #calendar
+          [class.po-datepicker-calendar-mobile]="verifyMobile()"
           [(ngModel)]="date"
           [p-max-date]="maxDate"
           [p-min-date]="minDate"
           [p-locale]="locale"
           (p-change)="dateSelected()"
+          (keydown)="onCalendarKeyDown($event)"
         ></po-calendar>
       </div>
     </ng-template>
@@ -78,7 +82,12 @@
     </ng-template>
 
     <ng-template #dropdownCDK>
-      <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="true">
+      <ng-template
+        cdkConnectedOverlay
+        [cdkConnectedOverlayOrigin]="trigger"
+        [cdkConnectedOverlayOpen]="true"
+        [cdkConnectedOverlayDisableClose]="true"
+      >
         <ng-container *ngTemplateOutlet="sharedCalendarContent"></ng-container>
       </ng-template>
     </ng-template>

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.ts
@@ -103,7 +103,6 @@ export class PoModalComponent extends PoModalBaseComponent {
   private initFocus() {
     this.focusFunction = (event: any) => {
       const isCdkOverlayListbox = event.target.closest('.cdk-overlay-container') !== null;
-
       const modalElement = this.modalContent.nativeElement;
 
       if (

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
@@ -149,7 +149,6 @@ export class PoPageSlideComponent extends PoPageSlideBaseComponent {
     // O foco não pode sair da página.
     this.focusEvent = (event: Event) => {
       const isCdkOverlayListbox = event.target['closest']('.cdk-overlay-container') !== null;
-
       if (
         !this.pageContent.nativeElement.contains(event.target) &&
         !isCdkOverlayListbox &&


### PR DESCRIPTION
**Datepicker**

**DTHFUI-11416**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando no modo 'append-in-body' a tabulação não funciona corretamente

**Qual o novo comportamento?**
Adiciona navegação por teclado e suporte a leitores de tela no modo append-in-body, implementando fluxo de Tab para abrir o listbox

**Simulação**
Testar tabulação quando o calendar estiver visivel.
Tab: Seguir fluxo INPUT → botão (ABRIR CALENDARIO) → CALENDARIO (botão hoje) → botão (ABRIR CALENDARIO)
`<po-datepicker name="datepicker" p-label="PO Datepicker" p-append-in-body="true" />`

