### PR TITLE
fix(overlay): evita múltiplas instâncias do PoActiveOverlayService

### DIFF
--- a/projects/ui/src/lib/components/po-modal/po-modal.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.ts
@@ -52,7 +52,12 @@ export class PoModalComponent extends PoModalBaseComponent {
   }
 
   close(xClosed = false) {
-    this.poActiveOverlayService.activeOverlay.pop();
+    if (
+      this.poActiveOverlayService.activeOverlay.length > 0 &&
+      this.poActiveOverlayService.activeOverlay[this.poActiveOverlayService.activeOverlay.length - 1] === this.id
+    ) {
+      this.poActiveOverlayService.activeOverlay.pop();
+    }
 
     super.close(xClosed);
 

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.spec.ts
@@ -104,6 +104,19 @@ describe('PoPageSlideComponent', () => {
 
       expect(component['poActiveOverlayService'].activeOverlay).toEqual([]);
     });
+
+    it('close: should remove id value from `poActiveOverlayService.activeOverlay` list when last element', () => {
+      component['id'] = '2';
+      component['poActiveOverlayService'].activeOverlay = ['1', '2'];
+
+      component.open();
+      fixture.detectChanges();
+
+      component.close();
+      fixture.detectChanges();
+
+      expect(component['poActiveOverlayService'].activeOverlay).toEqual(['1']);
+    });
   });
 
   it('should open() and close() methods includes and removes component on DOM', () => {

--- a/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-slide/po-page-slide.component.ts
@@ -110,7 +110,13 @@ export class PoPageSlideComponent extends PoPageSlideBaseComponent {
   }
 
   public close(): void {
-    this.poActiveOverlayService.activeOverlay.pop();
+    if (
+      this.poActiveOverlayService.activeOverlay.length > 0 &&
+      this.poActiveOverlayService.activeOverlay[this.poActiveOverlayService.activeOverlay.length - 1] === this.id
+    ) {
+      this.poActiveOverlayService.activeOverlay.pop();
+    }
+
     super.close();
 
     this.removeEventListeners();

--- a/projects/ui/src/lib/services/services.module.ts
+++ b/projects/ui/src/lib/services/services.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 
-import { PoActiveOverlayModule } from './po-active-overlay/po-active-overlay.module';
 import { PoColorPaletteModule } from './po-color-palette/po-color-palette.module';
 import { PoComponentInjectorModule } from './po-component-injector/po-component-injector.module';
 import { PoControlPositionModule } from './po-control-position/po-control-position.module';
@@ -15,7 +14,6 @@ import { PoThemeModule } from './po-theme/po-theme.module';
 @NgModule({
   declarations: [PoI18nPipe],
   imports: [
-    PoActiveOverlayModule,
     PoColorPaletteModule,
     PoComponentInjectorModule,
     PoControlPositionModule,
@@ -27,7 +25,6 @@ import { PoThemeModule } from './po-theme/po-theme.module';
     PoThemeModule
   ],
   exports: [
-    PoActiveOverlayModule,
     PoColorPaletteModule,
     PoComponentInjectorModule,
     PoControlPositionModule,


### PR DESCRIPTION
Corrige o erro "Maximum call stack size exceeded", mantendo apenas o providedIn root do PoActiveOverlayService, e garante a remoção correta dos IDs de overlays fechadas.

Fixes DTHFUI-11114

**po-active-overlay**

**DTHFUI-11114**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Atualmente, é possível criar múltiplas instâncias do PoActiveOverlayService, mesmo que ele seja um serviço com `providedIn: 'root'`. Esse comportamento pode ocasionar o erro "Maximum call stack size exceeded" em cenários de renderização de um modal dentro de um page-slide com componente dinamicamente criados.

**Qual o novo comportamento?**
Remove a importação e exportação do PoActiveOverlayModule que estava presente no PoServicesModule, para garantir que apenas uma instância do PoActiveOverlayService seja compartilhada em toda a aplicação.

**Simulação**
