### PR TITLE
fix(page-dynamic-table): ajusta o GET request com atributo `range`

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -219,11 +219,12 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(component.poAdvancedFilter.open).toHaveBeenCalled();
     });
 
-    it(`onAdvancedSearch: should call 'setDisclaimers', 'setFilters' and 'advancedSearch.emit'`, () => {
+    it(`onAdvancedSearch: should call 'setDisclaimers', 'setFilters', 'addComplexFilter' and 'advancedSearch.emit'`, () => {
       const filter = { property: 'value1' };
       const optionsService = undefined;
 
       spyOn(component, <any>'setDisclaimers');
+      spyOn(component, <any>'addComplexFilter').and.returnValue(filter);
       spyOn(component.advancedSearch, 'emit');
       spyOn(component, <any>'setFilters');
 
@@ -231,6 +232,7 @@ describe('PoPageDynamicSearchComponent:', () => {
 
       expect(component['setDisclaimers']).toHaveBeenCalledWith(filter, optionsService);
       expect(component['setFilters']).toHaveBeenCalledBefore(component.advancedSearch.emit);
+      expect(component['addComplexFilter']).toHaveBeenCalledWith(filter);
       expect(component.advancedSearch.emit).toHaveBeenCalledWith(filter);
     });
 
@@ -256,7 +258,8 @@ describe('PoPageDynamicSearchComponent:', () => {
         },
         poPageList: {
           clearInputSearch: () => {}
-        }
+        },
+        addComplexFilter: () => ({})
       };
       const filteredItems = { filter: 'fakeFilter', optionsService: 'fakeOptionsService' };
       const isAdvancedSearch = true;
@@ -465,6 +468,85 @@ describe('PoPageDynamicSearchComponent:', () => {
       ];
 
       expect(component['setDisclaimers'](filters)).toEqual(result);
+    });
+
+    it(`addComplexFilter: should return {}`, () => {
+      component.filters = [{ property: 'name' }, { property: 'genre' }, { property: 'birthdate' }];
+
+      const filters = {};
+
+      const result = {};
+
+      expect(component['addComplexFilter'](filters)).toEqual(result);
+    });
+
+    it(`addComplexFilter: should return filter without attribute 'range'`, () => {
+      component.filters = [{ property: 'name' }, { property: 'genre' }, { property: 'birthdate' }];
+
+      const filters = { name: 'Name1', genre: 'male', birthdate: '2020-01-15' };
+
+      const result = { name: 'Name1', genre: 'male', birthdate: '2020-01-15' };
+
+      expect(component['addComplexFilter'](filters)).toEqual(result);
+    });
+
+    it(`addComplexFilter: should return filter with attribute 'range'`, () => {
+      component.filters = [{ property: 'name' }, { property: 'genre' }, { property: 'birthdate', range: true }];
+
+      const filters = { name: 'Name1', genre: 'male', birthdate: { start: '2020-01-01', end: '2020-01-31' } };
+
+      const result = {
+        name: 'Name1',
+        genre: 'male',
+        $filter: 'birthdate ge "2020-01-01" and birthdate le "2020-01-31"'
+      };
+
+      expect(component['addComplexFilter'](filters)).toEqual(result);
+    });
+
+    it(`addComplexFilter: should return filter with attribute 'range' and final date 'undefined'`, () => {
+      component.filters = [{ property: 'name' }, { property: 'genre' }, { property: 'birthdate', range: true }];
+
+      const filters = { name: 'Name1', genre: 'male', birthdate: { start: '2020-01-01', end: undefined } };
+
+      const result = { name: 'Name1', genre: 'male', birthdate: { start: '2020-01-01', end: undefined } };
+
+      expect(component['addComplexFilter'](filters)).toEqual(result);
+    });
+
+    it(`addComplexFilter: should return filter with attribute 'range' and initial date 'undefined'`, () => {
+      component.filters = [{ property: 'name' }, { property: 'genre' }, { property: 'birthdate', range: true }];
+
+      const filters = { name: 'Name1', genre: 'male', birthdate: { start: undefined, end: '2020-01-31' } };
+
+      const result = { name: 'Name1', genre: 'male', birthdate: { start: undefined, end: '2020-01-31' } };
+
+      expect(component['addComplexFilter'](filters)).toEqual(result);
+    });
+
+    it(`addComplexFilter: should return filter with two attribute 'range'`, () => {
+      component.filters = [
+        { property: 'name' },
+        { property: 'genre' },
+        { property: 'birthdate', range: true },
+        { property: 'deathdate', range: true }
+      ];
+
+      const filters = {
+        name: 'Name1',
+        genre: 'male',
+        birthdate: { start: '2020-01-01', end: '2020-01-31' },
+        deathdate: { start: '2021-01-01', end: '2021-01-31' }
+      };
+
+      const result = {
+        name: 'Name1',
+        genre: 'male',
+        $filter:
+          'birthdate ge "2020-01-01" and birthdate le "2020-01-31" and deathdate ge "2021-01-01" and deathdate le "2021-01-31"'
+      };
+
+      expect(component['addComplexFilter'](filters)).toEqual(result);
     });
 
     it('getFilterValueToDisclaimer: should return formated date if field type is PoDynamicFieldType.Date', () => {


### PR DESCRIPTION
Foi incluído o `$filter` para filtros complexos no GET Request quando o atributo `range` está com `true`

Fixes #1211

**Page Dynamic Table**

**1211**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Quando é usado o atributo range a URL da requisição está sendo gerada com um objeto e não funciona conforme esperado.

**Qual o novo comportamento?**
Quando é usado o atributo range a URL da requisição está sendo gerado o atributo $filter para filtro complexo conforme o [Guia de APIs da Totvs - Filtros complexos](https://tdn.totvs.com/pages/viewpage.action?pageId=484701395#Guiadeimplementa%C3%A7%C3%A3odeAPIV2.0-Filtroscomplexos(opcional))

**Simulação**
