### PR TITLE
docs(checkbox): adiciona descrição do evento p-blur

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -112,7 +112,13 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
    */
   @Output('p-additional-help') additionalHelp = new EventEmitter<any>();
 
-  // Evento disparado ao sair do campo.
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao sair do campo.
+   */
   @Output('p-blur') blur: EventEmitter<any> = new EventEmitter();
 
   /**


### PR DESCRIPTION
**checkbox**

**DTHFUI-11408**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Não é exibido o evento "p-blur" do checkbox na documentação.

**Qual o novo comportamento?**
Adiciona o evento "p-blur" do checkbox na documentação.

**Simulação**
<img width="1919" height="929" alt="image" src="https://github.com/user-attachments/assets/da9c4719-7203-4624-9c67-adc49cfedc31" />