### PR TITLE
build(ci): sanitiza variáveis para evitar injeção no payload JSON

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -9,6 +9,10 @@ on:
     types:
       - created
 
+permissions:
+  issues: read
+  discussions: read
+
 # Os jobs são conjuntos de actions que são executados na mesma máquina virtual.
 # É possível ter mais de um job e assim executar ações paralelamente.
 jobs:
@@ -19,7 +23,9 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL_ISSUES: ${{ secrets.DISCORD_WEBHOOK_URL_ISSUES }}
         run: |
-          if [ "${{ github.event_name }}" == "issues" ]; then
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "issues" ]; then
             AUTHOR="${{ github.event.issue.user.login }}"
             TITLE="${{ github.event.issue.title }}"
             URL="${{ github.event.issue.html_url }}"
@@ -32,7 +38,21 @@ jobs:
             TYPE="Discussão"
             ICON="💬"
           fi
-          
+
+          TITLE=$(echo "$TITLE" | tr -d '\n\r')
+          AUTHOR=$(echo "$AUTHOR" | tr -d '\n\r')
+          URL=$(echo "$URL" | tr -d '\n\r')
+
+          PAYLOAD=$(jq -n \
+            --arg icon "$ICON" \
+            --arg type "$TYPE" \
+            --arg author "$AUTHOR" \
+            --arg title "$TITLE" \
+            --arg url "$URL" \
+            '{content: "\($icon) **Nova \($type) Criada \($icon)**\n- Autor: \($author)\n- Título: \($title)\n- Link: \($url)"}'
+          )
+
           curl -X POST -H "Content-Type: application/json" \
-          -d "{\"content\": \"$ICON **Nova $TYPE Criada $ICON**\\n- Autor: $AUTHOR\\n- Título: $TITLE\\n- Link: $URL\"}" \
-          $DISCORD_WEBHOOK_URL_ISSUES
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL_ISSUES"
+        shell: bash


### PR DESCRIPTION
Sanitiza as variáveis TITLE, AUTHOR e URL removendo quebras de linha antes de montar o payload enviado ao Discord, prevenindo possíveis tentativas de injeção de conteúdo malicioso no JSON.

Fixes #2603

**ci**

**2603**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
