### PR TITLE
fix(sync): adiciona fallback para body undefined ou null

### DIFF
--- a/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.spec.ts
+++ b/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.spec.ts
@@ -815,6 +815,26 @@ describe('PoEventSourcingService:', () => {
       expect(result).toEqual(expectedValue);
     });
 
+    it('createPoHttpRequestData: should return body as empty object when record is undefined', async () => {
+      const url = 'http://url.com/customers';
+      const method = PoHttpRequestType.POST;
+      const headers = [{ name: 'test', value: 'teste1' }];
+
+      const poHttpRequestData: PoHttpRequestData = {
+        url,
+        method,
+        body: {},
+        headers
+      };
+
+      spyOn(eventSourcingService, <any>'createFormData');
+
+      const result = await eventSourcingService['createPoHttpRequestData'](url, method, undefined, headers);
+
+      expect(result).toEqual(poHttpRequestData);
+      expect(eventSourcingService['createFormData']).not.toHaveBeenCalled();
+    });
+
     it('createFormData: should return a FormData', async () => {
       const file = new File([''], 'filename', { type: 'text/html' });
       const body = 'Data: ';

--- a/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.ts
+++ b/projects/sync/src/lib/services/po-event-sourcing/po-event-sourcing.service.ts
@@ -461,9 +461,9 @@ export class PoEventSourcingService {
     record?: PoEventSourcingItem['record'],
     headers?: Array<PoHttpHeaderOption>
   ): Promise<PoHttpRequestData> {
-    let body = record.body ?? record;
+    let body = record?.body ?? record ?? {};
 
-    if (record.bodyType === 'File') {
+    if (record?.bodyType === 'File') {
       body = await this.createFormData(body, record.fileName, record.mimeType, record.formField);
     }
 


### PR DESCRIPTION
Ajusta método createPoHttpRequestData para definir body como objeto vazio caso record seja null/undefined.

Fixes: DTHFUI-11347

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
