### PR TITLE
fix(input-generic): reseta modelLastUpdate

### DIFF
--- a/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.ts
@@ -46,9 +46,9 @@ import { PoModalPasswordRecoveryService } from './po-modal-password-recovery.ser
   standalone: false
 })
 export class PoModalPasswordRecoveryComponent extends PoModalPasswordRecoveryBaseComponent implements OnDestroy {
-  private router = inject(Router);
-  private poI18nPipe = inject(PoI18nPipe);
-  private poModalPasswordRecoveryService = inject(PoModalPasswordRecoveryService);
+  private readonly router = inject(Router);
+  private readonly poI18nPipe = inject(PoI18nPipe);
+  private readonly poModalPasswordRecoveryService = inject(PoModalPasswordRecoveryService);
 
   @ViewChild('emailForm') emailForm: NgForm;
 

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
@@ -416,10 +416,14 @@ describe('PoInputGeneric:', () => {
         _formatModel: false
       },
       change: component.change,
-      passedWriteValue: false
+      passedWriteValue: false,
+      modelLastUpdate: 'oldValue'
     };
+
     component.writeValueModel.call(fakeThis, '');
+
     expect(component.inputEl.nativeElement.value).toBe('');
+    expect(fakeThis.modelLastUpdate).toBe('');
     expect(fakeThis.passedWriteValue).toBeTruthy();
   });
 

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -258,6 +258,7 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
       } else {
         // Se o valor for indefinido, deve limpar o campo.
         this.inputEl.nativeElement.value = '';
+        this.modelLastUpdate = '';
       }
     }
 


### PR DESCRIPTION
Altera p-change-model pra ngModelChange, para disparar o método em todas as mudanças que ocorrerem no ngModel.

Fixes DTHFUI-11447

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
