### PR TITLE
fix(components): ajusta detecção do estado disable via FormControl

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.spec.ts
@@ -14,7 +14,8 @@ describe('PoCheckboxBaseComponent:', () => {
   let component: PoCheckboxBaseComponent;
 
   beforeEach(() => {
-    component = new PoCheckboxComponent();
+    const changeDetector: any = { markForCheck: () => {} };
+    component = new PoCheckboxComponent(changeDetector);
     component.propagateChange = (value: any) => {};
   });
 
@@ -115,8 +116,12 @@ describe('PoCheckboxBaseComponent:', () => {
 
     it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
       const expectedValue = true;
+      const markForCheck = spyOn(component['cd'], 'markForCheck');
+
       component.setDisabledState(expectedValue);
+
       expect(component.disabled).toBe(expectedValue);
+      expect(markForCheck).toHaveBeenCalled();
     });
 
     it('changeValue: should call only `change.emit` with `checkboxValue` if propagateChange is `null`', () => {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectorRef, Directive, EventEmitter, Input, Output } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 
 import { convertToBoolean, getDefaultSizeFn, uuid, validateSizeFn } from './../../../utils/util';
@@ -196,6 +196,8 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
     return this._size ?? getDefaultSizeFn(PoCheckboxSize);
   }
 
+  constructor(private readonly cd: ChangeDetectorRef) {}
+
   changeValue() {
     if (this.propagateChange) {
       this.propagateChange(this.checkboxValue);
@@ -215,6 +217,7 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
   // Usada para interceptar os estados de habilitado via forms api
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
+    this.cd.markForCheck();
   }
 
   registerOnChange(fn: any): void {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.ts
@@ -49,7 +49,7 @@ import { PoCheckboxBaseComponent } from './po-checkbox-base.component';
   standalone: false
 })
 export class PoCheckboxComponent extends PoCheckboxBaseComponent implements AfterViewInit {
-  private changeDetector = inject(ChangeDetectorRef);
+  private readonly changeDetector: ChangeDetectorRef;
 
   private _iconToken: { [key: string]: string };
 
@@ -60,7 +60,9 @@ export class PoCheckboxComponent extends PoCheckboxBaseComponent implements Afte
       [key: string]: string;
     }>(ICONS_DICTIONARY, { optional: true });
 
-    super();
+    const changeDetector = inject(ChangeDetectorRef);
+    super(changeDetector);
+    this.changeDetector = changeDetector;
 
     this._iconToken = value ?? AnimaliaIconDictionary;
   }

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -1023,6 +1023,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   // Usada para interceptar os estados de habilitado via forms api
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
+    this.changeDetector.markForCheck();
   }
 
   registerOnChange(fn: any): void {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -411,9 +411,14 @@ describe('PoDatepickerRangeBaseComponent:', () => {
       });
 
       it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
+        component['changeDetector'] = { markForCheck: () => {} } as any;
         const expectedValue = true;
+        const markForCheck = spyOn(component['changeDetector'], 'markForCheck');
+
         component.setDisabledState(expectedValue);
+
         expect(component.disabled).toBe(expectedValue);
+        expect(markForCheck).toHaveBeenCalled();
       });
 
       it(`should call 'dateRangeFormatFailed', set 'errorMessage' as 'literals.invalidFormat'

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -528,6 +528,7 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   // Usada para interceptar os estados de habilitado via forms api
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
+    this.changeDetector.markForCheck();
   }
 
   // Função implementada do ControlValueAccessor

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -28,7 +28,7 @@ describe('PoDatepickerBaseComponent:', () => {
   const languageService: PoLanguageService = new PoLanguageService();
 
   beforeEach(() => {
-    const changeDetector: any = { detectChanges: () => {} };
+    const changeDetector: any = { detectChanges: () => {}, markForCheck: () => {} };
 
     component = new PoDatepickerComponent(languageService, changeDetector);
     component['shortLanguage'] = 'pt';
@@ -193,8 +193,12 @@ describe('PoDatepickerBaseComponent:', () => {
 
   it('setDisabledState: should set `component.disabled` with boolean parameter', () => {
     const expectedValue = true;
+    const markForCheck = spyOn(component['cd'], 'markForCheck');
+
     component.setDisabledState(expectedValue);
+
     expect(component.disabled).toBe(expectedValue);
+    expect(markForCheck).toHaveBeenCalled();
   });
 
   it('should be call callOnChange with minDate', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -581,6 +581,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   // Usada para interceptar os estados de habilitado via forms api
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
+    this.cd.markForCheck();
   }
 
   // Função implementada do ControlValueAccessor

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -754,6 +754,17 @@ describe('PoDatepickerComponent:', () => {
 
         expect(component.togglePicker).toHaveBeenCalled();
       });
+
+      it('should emit event when field is focused', () => {
+        const fakeEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+
+        spyOn(component.keydown, 'emit');
+        spyOnProperty(document, 'activeElement', 'get').and.returnValue(component.inputEl.nativeElement);
+
+        component.onKeyDown(fakeEvent);
+
+        expect(component.keydown.emit).toHaveBeenCalled();
+      });
     });
 
     it('togglePicker: should keep the component invisible when `disabled` and `readonly` is true', () => {

--- a/projects/ui/src/lib/components/po-field/po-field-validate.model.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-validate.model.ts
@@ -75,7 +75,7 @@ export abstract class PoFieldValidateModel<T> extends PoFieldModel<T> implements
   private onValidatorChange;
 
   constructor(public changeDetector: ChangeDetectorRef) {
-    super();
+    super(changeDetector);
   }
 
   validate(abstractControl: AbstractControl): ValidationErrors {

--- a/projects/ui/src/lib/components/po-field/po-field.model.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.model.spec.ts
@@ -8,7 +8,8 @@ describe('PoFieldModel', () => {
   let component: Field;
 
   beforeEach(() => {
-    component = new Field();
+    const changeDetector: any = { markForCheck: () => {} };
+    component = new Field(changeDetector);
   });
 
   it('should be created', () => {
@@ -54,10 +55,12 @@ describe('PoFieldModel', () => {
 
   it('setDisabledState: should set disabled property', () => {
     const isDisabled = true;
+    const markForCheck = spyOn(component['cd'], 'markForCheck');
 
     component.setDisabledState(isDisabled);
 
     expect(component.disabled).toBe(true);
+    expect(markForCheck).toHaveBeenCalled();
   });
 
   it('writeValue: should call onWriteValue with value', () => {

--- a/projects/ui/src/lib/components/po-field/po-field.model.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.model.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectorRef, Directive, EventEmitter, Input, Output } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 
 import { convertToBoolean } from '../../utils/util';
@@ -88,12 +88,13 @@ export abstract class PoFieldModel<T> implements ControlValueAccessor {
 
   private propagateChange: any;
 
-  constructor() {}
+  constructor(private readonly cd: ChangeDetectorRef) {}
 
   // Função implementada do ControlValueAccessor
   // Usada para interceptar os estados de habilitado via forms api
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
+    this.cd?.markForCheck();
   }
 
   registerOnChange(fn: any): void {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpHandler } from '@angular/common/http';
-import { Component, inject } from '@angular/core';
+import { ChangeDetectorRef, Component, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, UntypedFormControl } from '@angular/forms';
 
@@ -24,8 +24,9 @@ import { PoUploadService } from './po-upload.service';
 class PoUploadComponent extends PoUploadBaseComponent {
   constructor() {
     const uploadService = inject(PoUploadService);
+    const cd = inject(ChangeDetectorRef);
 
-    super(uploadService, new PoLanguageService());
+    super(uploadService, new PoLanguageService(), cd);
   }
 
   sendFeedback() {}

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, HostBinding, Input, Output } from '@angular/core';
+import { ChangeDetectorRef, Directive, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms';
 
 import { convertToBoolean, getDefaultSizeFn, isEquals, isIE, isMobile, validateSizeFn } from '../../../utils/util';
@@ -720,7 +720,8 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
 
   constructor(
     protected uploadService: PoUploadService,
-    languageService: PoLanguageService
+    languageService: PoLanguageService,
+    protected cd: ChangeDetectorRef
   ) {
     this.language = languageService.getShortLanguage();
   }
@@ -729,6 +730,7 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
   // Usada para interceptar os estados de habilitado via forms api
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
+    this.cd.markForCheck();
   }
 
   registerOnChange(fn: any): void {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
@@ -78,7 +78,6 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
   renderer = inject(Renderer2);
   private i18nPipe = inject(PoI18nPipe);
   private notification = inject(PoNotificationService);
-  private cd = inject(ChangeDetectorRef);
 
   @ViewChild('inputFile', { read: ElementRef, static: true }) private inputFile: ElementRef;
   @ViewChild(PoUploadDragDropComponent) private poUploadDragDropComponent: PoUploadDragDropComponent;
@@ -109,8 +108,9 @@ export class PoUploadComponent extends PoUploadBaseComponent implements AfterVie
   constructor() {
     const uploadService = inject(PoUploadService);
     const languageService = inject(PoLanguageService);
+    const cd = inject(ChangeDetectorRef);
 
-    super(uploadService, languageService);
+    super(uploadService, languageService, cd);
   }
 
   get displayDragDrop(): boolean {


### PR DESCRIPTION
** `po-checkbox`, `po-combo`, `po-datepicker`, `po-select` e
`po-upload`**

**DTHFUI-11949**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Os componentes (mencionados) não regiam quando desabilitado via FormControl

**Qual o novo comportamento?**
Os componentes (mencionados) devem reger quando desabilitado via FormControl

**Simulação**
[Uploading app_po-ui.zip…]()
