### PR TITLE
fix(context-tabs): ajusta adição dinâmica de tabs

### DIFF
--- a/projects/ui/src/lib/components/po-context-tabs/po-context-tabs.component.ts
+++ b/projects/ui/src/lib/components/po-context-tabs/po-context-tabs.component.ts
@@ -207,13 +207,13 @@ export class PoContextTabsComponent extends PoTabsComponent {
 
       if (!currentTab) {
         this.initialTabsWidth.push({ id: tab.nativeElement.id, width: tab.nativeElement.offsetWidth });
-        if (index > quantityTabs - 1) {
+        if (index > quantityTabs) {
           tab.nativeElement.style.display = 'none';
           tab.nativeElement.hidden = true;
         }
         this.tabsChildren['_results'] = this.tabsChildren['_results'].filter(item => !item.removed);
       }
-      if (tab.nativeElement.hidden && index <= quantityTabs - 1) return;
+      if (tab.nativeElement.hidden && index <= quantityTabs) return;
       index++;
     });
     this.calculateTabs(true);


### PR DESCRIPTION
Ajusta adição de tabs dinamicamente para ser exibida fora do dropdown enquanto houver espaço em tela.

Fixes: DTHFUI-11863

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
