### PR TITLE
fix(table): corrige tabela piscando ao realizar scroll

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -256,7 +256,7 @@
               }"
               [ngStyle]="{
                 'width':
-                  height > 0 && !virtualScroll ? (!hasItems ? '100%' : applyFixedColumns() ? column.width : 'auto') : ''
+                  height > 0 && !virtualScroll ? (!hasItems ? '100%' : applyFixedColumns() ? column.width : null) : null
               }"
               [class.po-table-header-subtitle]="column.type === 'subtitle'"
               [class.po-table-column-drag-box]="this.isDraggable"
@@ -296,7 +296,7 @@
               }"
               [ngStyle]="{
                 'width':
-                  height > 0 && !virtualScroll ? (!hasItems ? '100%' : applyFixedColumns() ? column.width : 'auto') : ''
+                  height > 0 && !virtualScroll ? (!hasItems ? '100%' : applyFixedColumns() ? column.width : null) : null
               }"
               [class.po-table-header-subtitle]="column.type === 'subtitle'"
               (click)="sortColumn(column)"
@@ -531,365 +531,377 @@
   </table>
 </ng-template>
 
-<!-- Table with virtual scroll -->
 <ng-template #tableVirtualScrollTemplate>
-  <cdk-virtual-scroll-viewport
-    #tableVirtualScroll
-    [itemSize]="itemSize"
-    [style.height.px]="heightTableContainer"
-    [minBufferPx]="heightTableContainer < 100 ? 100 : heightTableContainer"
-    [maxBufferPx]="heightTableContainer < 200 ? 200 : heightTableContainer"
-  >
-    <table
-      class="po-table"
-      [ngClass]="{
-        'po-table-interactive': selectable || sort,
-        'po-table-selectable': selectable,
-        'po-table-striped': striped,
-        'po-table-data-fixed-columns': applyFixedColumns(),
-        'po-table-text-wrap-enabled': textWrap
-      }"
-      [attr.p-spacing]="spacing"
-    >
-      <thead
-        class="po-table-header-sticky"
-        [style.top]="inverseOfTranslation"
-        [attr.p-spacing]="spacing ?? (componentsSize === 'small' ? 'extraSmall' : 'medium')"
+  <div class="po-table-virtual-scroll-wrapper" #virtualScrollWrapper [style.height.px]="heightTableContainer">
+    <div class="po-table-header-virtual-scroll" #headerScrollContainer>
+      <table
+        #headerTable
+        class="po-table"
+        [ngClass]="{
+          'po-table-interactive': selectable || sort,
+          'po-table-selectable': selectable,
+          'po-table-striped': striped,
+          'po-table-data-fixed-columns': applyFixedColumns(),
+          'po-table-text-wrap-enabled': textWrap
+        }"
+        [attr.p-spacing]="spacing"
       >
-        <tr
-          [class.po-table-header]="!height"
-          cdkDropList
-          cdkDropListOrientation="horizontal"
-          (cdkDropListDropped)="drop($event)"
-        >
-          @if (hasSelectableColumn) {
-            <th [style.pointer-events]="hideSelectAll ? 'none' : 'auto'" class="po-table-column-selectable">
-              <div [class.po-table-header-fixed-inner]="height">
-                @if (!hideSelectAll) {
-                  <po-checkbox
-                    name="selectAll"
-                    (p-change)="selectAllRows()"
-                    [p-checkboxValue]="selectAll === null ? 'mixed' : selectAll"
-                    [p-size]="componentsSize"
-                  ></po-checkbox>
-                }
-              </div>
-            </th>
-          }
-
-          @if ((hasMasterDetailColumn || hasRowTemplate) && hasMainColumns && !hasRowTemplateWithArrowDirectionRight) {
-            <th class="po-table-header-column po-table-header-master-detail"></th>
-          }
-
-          <!-- Coluna criada para caso as ações fiquem no lado esquerdo -->
-          @if (!actionRight && hasItems && hasMainColumns && (visibleActions.length > 1 || isSingleAction)) {
-            <th
-              #columnActionLeft
-              [class.po-table-header-master-detail]="!isSingleAction"
-              [class.po-table-header-single-action]="isSingleAction"
-            ></th>
-          }
-
-          @if (!hasMainColumns) {
-            <th #noColumnsHeader class="po-table-header-column po-text-center" [attr.colspan]="columnCount">
-              @if (height) {
-                <div class="po-table-header-fixed-inner" [style.width.px]="hasValidColumns ? headerWidth : null">
-                  {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
-                </div>
-              } @else {
-                {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
-              }
-            </th>
-          }
-
-          @if (this.isDraggable || hasSomeFixed()) {
-            @for (column of mainColumns; track trackBy(i); let i = $index) {
-              <th
-                class="po-table-header-ellipsis p-element po-frozen-column"
-                [style.width]="column.width"
-                [style.max-width]="column.width"
-                [style.min-width]="column.width"
-                [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
-                [class.po-clickable]="(sort && column.sortable !== false) || hasService"
-                [ngClass]="{
-                  'po-table-header-sorted':
-                    sort &&
-                    JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
-                    (sortedColumn.ascending || !sortedColumn.ascending)
-                }"
-                [ngStyle]="{ 'width': !hasItems ? '100%' : applyFixedColumns() ? column.width : 'auto' }"
-                [class.po-table-header-subtitle]="column.type === 'subtitle'"
-                [class.po-table-column-drag-box]="this.isDraggable"
-                (click)="sortColumn(column)"
-                cdkDrag
-                cdkDragLockAxis="x"
-                [cdkDragDisabled]="column.fixed ? 'true' : 'false'"
-                [pFrozenColumn]="column.fixed"
-              >
-                <div
-                  class="po-table-header-flex"
-                  [class.po-table-header-fixed-inner]="height"
-                  [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
-                  [class.po-table-header-flex-center]="column.type === 'subtitle'"
-                >
-                  @if (this.isDraggable && !column.fixed) {
-                    <po-icon cdkDragHandle p-icon="ICON_DRAG"></po-icon>
-                  }
-                  <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }">
-                  </ng-container>
-                </div>
-              </th>
-            }
-          } @else {
-            @for (column of mainColumns; track trackBy(i); let i = $index) {
-              <th
-                class="po-table-header-ellipsis p-element po-frozen-column example-box"
-                [style.width]="column.width"
-                [style.max-width]="column.width"
-                [style.min-width]="column.width"
-                [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
-                [class.po-clickable]="(sort && column.sortable !== false) || hasService"
-                [ngClass]="{
-                  'po-table-header-sorted':
-                    sort &&
-                    JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
-                    (sortedColumn.ascending || !sortedColumn.ascending)
-                }"
-                [ngStyle]="{ 'width': !hasItems ? '100%' : applyFixedColumns() ? column.width : 'auto' }"
-                [class.po-table-header-subtitle]="column.type === 'subtitle'"
-                (click)="sortColumn(column)"
-                [pFrozenColumn]="column.fixed"
-              >
-                <div
-                  class="po-table-header-flex"
-                  [class.po-table-header-fixed-inner]="height"
-                  [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
-                  [class.po-table-header-flex-center]="column.type === 'subtitle'"
-                >
-                  <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }">
-                  </ng-container>
-                </div>
-              </th>
-            }
-          }
-
-          @if (hasRowTemplateWithArrowDirectionRight && hasMainColumns && (hasVisibleActions || hideColumnsManager)) {
-            <th class="po-table-header-column po-table-header-master-detail"></th>
-          }
-
-          @if (
-            hasVisibleActions &&
-            actionRight &&
-            hasItems &&
-            hasMainColumns &&
-            (visibleActions.length > 1 || isSingleAction)
-          ) {
-            <th
-              [class.po-table-header-single-action]="isSingleAction"
-              [class.po-table-header-actions]="!isSingleAction"
-            ></th>
-          }
-        </tr>
-      </thead>
-
-      @if (!hasItems || !hasMainColumns) {
-        <tbody class="po-table-group-row">
-          <tr class="po-table-row po-table-row-no-data">
-            <td [colSpan]="columnCount" class="po-table-no-data po-text-center">
-              <span> {{ literals.noData }} </span>
-            </td>
-          </tr>
-        </tbody>
-      }
-
-      @if (hasMainColumns) {
-        <tbody
-          class="po-table-group-row"
-          *cdkVirtualFor="let row of filteredItems; let rowIndex = index; trackBy: trackBy"
+        <thead
+          class="po-table-header-relative"
+          [attr.p-spacing]="spacing ?? (componentsSize === 'small' ? 'extraSmall' : 'medium')"
         >
           <tr
-            class="po-table-row"
-            [class.po-table-row-active]="row.$selected || (row.$selected === null && selectable)"
+            [class.po-table-header]="!height"
+            cdkDropList
+            cdkDropListOrientation="horizontal"
+            (cdkDropListDropped)="drop($event)"
           >
-            @if (selectable) {
-              <td class="po-table-column-selectable">
-                <ng-container
-                  *ngTemplateOutlet="singleSelect ? inputRadio : inputCheckbox; context: { $implicit: row }"
-                >
-                </ng-container>
-              </td>
-            }
-            <!-- Valida se a origem do detail é pelo input do po-table pela diretiva -->
-            @if (
-              (columnMasterDetail && !hideDetail && !hasRowTemplate) ||
-              (hasRowTemplate && !hasRowTemplateWithArrowDirectionRight)
-            ) {
-              <td class="po-table-column-detail-toggle" (click)="toggleDetail(row)">
-                <ng-template
-                  [ngTemplateOutlet]="poTableColumnDetail"
-                  [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-                >
-                </ng-template>
-              </td>
-            }
-            <!-- Coluna com as ações na esquerda (padrão)-->
-            @if (!actionRight && (visibleActions.length > 1 || isSingleAction)) {
-              <ng-template
-                [ngTemplateOutlet]="ActionsColumnTemplate"
-                [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-              >
-              </ng-template>
-            }
-            @for (column of mainColumns; track trackBy(columnIndex); let columnIndex = $index) {
-              <td
-                [style.width]="column.width"
-                [style.max-width]="column.width"
-                [style.min-width]="column.width"
-                [class.po-table-column]="column.type !== 'icon'"
-                [class.po-table-column-right]="column.type === 'currency' || column.type === 'number'"
-                [class.po-table-column-center]="column.type === 'subtitle'"
-                [class.po-table-column-icons]="column.type === 'icon'"
-                [ngClass]="getClassColor(row, column)"
-                [pFrozenColumn]="column.fixed"
-                class="p-element po-frozen-column"
-                (click)="hasSelectableRow() ? selectRow(row) : 'javascript:;'"
-              >
-                <div
-                  class="po-table-column-cell po-table-body-ellipsis notranslate"
-                  [p-tooltip]="tooltipText"
-                  [p-append-in-body]="true"
-                  (mouseenter)="tooltipMouseEnter($event, column, row)"
-                  (mouseleave)="tooltipMouseLeave()"
-                >
-                  @switch (column.type) {
-                    @case ('columnTemplate') {
-                      <span>
-                        <ng-container
-                          *ngTemplateOutlet="getTemplate(column); context: { $implicit: getCellData(row, column) }"
-                        >
-                        </ng-container>
-                      </span>
-                    }
-                    @case ('cellTemplate') {
-                      <span>
-                        <ng-container
-                          *ngTemplateOutlet="tableCellTemplate?.templateRef; context: { row: row, column: column }"
-                        >
-                        </ng-container>
-                      </span>
-                    }
-                    @case ('boolean') {
-                      <span>
-                        {{ getBooleanLabel(getCellData(row, column), column) }}
-                      </span>
-                    }
-                    @case ('currency') {
-                      <span>
-                        {{ getCellData(row, column) | currency: column.format : 'symbol' : '1.2-2' }}
-                      </span>
-                    }
-                    @case ('date') {
-                      <span>
-                        {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy' }}
-                      </span>
-                    }
-                    @case ('time') {
-                      <span>
-                        {{ getCellData(row, column) | po_time: column.format || 'HH:mm:ss.ffffff' }}
-                      </span>
-                    }
-                    @case ('dateTime') {
-                      <span>
-                        {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy HH:mm:ss' }}
-                      </span>
-                    }
-                    @case ('number') {
-                      <span>
-                        {{ formatNumber(getCellData(row, column), column.format) }}
-                      </span>
-                    }
-                    @case ('link') {
-                      <po-table-column-link
-                        [p-action]="column.action"
-                        [p-disabled]="checkDisabled(row, column)"
-                        [p-link]="row[column.link]"
-                        [p-row]="row"
-                        [p-value]="getCellData(row, column)"
-                        (click)="onClickLink($event, row, column)"
-                      >
-                      </po-table-column-link>
-                    }
-                    @case ('icon') {
-                      <po-table-column-icon [p-column]="column" [p-icons]="getColumnIcons(row, column)" [p-row]="row">
-                      </po-table-column-icon>
-                    }
-                    @case ('subtitle') {
-                      <span>
-                        <po-table-subtitle-circle
-                          [p-subtitle]="getSubtitleColumn(row, column)"
-                        ></po-table-subtitle-circle>
-                      </span>
-                    }
-                    @case ('label') {
-                      <span>
-                        <po-table-column-label [p-value]="getColumnLabel(row, column)"> </po-table-column-label>
-                      </span>
-                    }
-                    @default {
-                      <span>{{ getCellData(row, column) }}</span>
-                    }
+            @if (hasSelectableColumn) {
+              <th [style.pointer-events]="hideSelectAll ? 'none' : 'auto'" class="po-table-column-selectable">
+                <div [class.po-table-header-fixed-inner]="height">
+                  @if (!hideSelectAll) {
+                    <po-checkbox
+                      name="selectAll"
+                      (p-change)="selectAllRows()"
+                      [p-checkboxValue]="selectAll === null ? 'mixed' : selectAll"
+                      [p-size]="componentsSize"
+                    ></po-checkbox>
                   }
                 </div>
-              </td>
+              </th>
             }
-            @if (hasRowTemplateWithArrowDirectionRight) {
-              <td class="po-table-column-detail-toggle" (click)="toggleDetail(row)">
+
+            @if (
+              (hasMasterDetailColumn || hasRowTemplate) && hasMainColumns && !hasRowTemplateWithArrowDirectionRight
+            ) {
+              <th class="po-table-header-column po-table-header-master-detail"></th>
+            }
+
+            @if (!actionRight && hasItems && hasMainColumns && (visibleActions.length > 1 || isSingleAction)) {
+              <th
+                #columnActionLeft
+                [class.po-table-header-master-detail]="!isSingleAction"
+                [class.po-table-header-single-action]="isSingleAction"
+              ></th>
+            }
+
+            @if (!hasMainColumns) {
+              <th #noColumnsHeader class="po-table-header-column po-text-center" [attr.colspan]="columnCount">
+                @if (height) {
+                  <div class="po-table-header-fixed-inner" [style.width.px]="hasValidColumns ? headerWidth : null">
+                    {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
+                  </div>
+                } @else {
+                  {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
+                }
+              </th>
+            }
+
+            @if (this.isDraggable || hasSomeFixed()) {
+              @for (column of mainColumns; track trackBy(i); let i = $index) {
+                <th
+                  class="po-table-header-ellipsis p-element po-frozen-column"
+                  [style.width]="applyFixedColumns() ? column.width : computedColumnWidths[i]"
+                  [style.max-width]="applyFixedColumns() ? column.width : computedColumnWidths[i]"
+                  [style.min-width]="applyFixedColumns() ? column.width : computedColumnWidths[i]"
+                  [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
+                  [class.po-clickable]="(sort && column.sortable !== false) || hasService"
+                  [ngClass]="{
+                    'po-table-header-sorted':
+                      sort &&
+                      JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
+                      (sortedColumn.ascending || !sortedColumn.ascending)
+                  }"
+                  [class.po-table-header-subtitle]="column.type === 'subtitle'"
+                  [class.po-table-column-drag-box]="this.isDraggable"
+                  (click)="sortColumn(column)"
+                  cdkDrag
+                  cdkDragLockAxis="x"
+                  [cdkDragDisabled]="column.fixed ? 'true' : 'false'"
+                  [pFrozenColumn]="column.fixed"
+                >
+                  <div
+                    class="po-table-header-flex"
+                    [class.po-table-header-fixed-inner]="height"
+                    [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
+                    [class.po-table-header-flex-center]="column.type === 'subtitle'"
+                  >
+                    @if (this.isDraggable && !column.fixed) {
+                      <po-icon cdkDragHandle p-icon="ICON_DRAG"></po-icon>
+                    }
+                    <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }">
+                    </ng-container>
+                  </div>
+                </th>
+              }
+            } @else {
+              @for (column of mainColumns; track trackBy(i); let i = $index) {
+                <th
+                  class="po-table-header-ellipsis p-element po-frozen-column"
+                  [style.width]="applyFixedColumns() ? column.width : computedColumnWidths[i]"
+                  [style.max-width]="applyFixedColumns() ? column.width : computedColumnWidths[i]"
+                  [style.min-width]="applyFixedColumns() ? column.width : computedColumnWidths[i]"
+                  [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
+                  [class.po-clickable]="(sort && column.sortable !== false) || hasService"
+                  [ngClass]="{
+                    'po-table-header-sorted':
+                      sort &&
+                      JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
+                      (sortedColumn.ascending || !sortedColumn.ascending)
+                  }"
+                  [class.po-table-header-subtitle]="column.type === 'subtitle'"
+                  (click)="sortColumn(column)"
+                  [pFrozenColumn]="column.fixed"
+                >
+                  <div
+                    class="po-table-header-flex"
+                    [class.po-table-header-fixed-inner]="height"
+                    [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
+                    [class.po-table-header-flex-center]="column.type === 'subtitle'"
+                  >
+                    <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }">
+                    </ng-container>
+                  </div>
+                </th>
+              }
+            }
+
+            @if (hasRowTemplateWithArrowDirectionRight && hasMainColumns && (hasVisibleActions || hideColumnsManager)) {
+              <th class="po-table-header-column po-table-header-master-detail"></th>
+            }
+
+            @if (
+              hasVisibleActions &&
+              actionRight &&
+              hasItems &&
+              hasMainColumns &&
+              (visibleActions.length > 1 || isSingleAction)
+            ) {
+              <th
+                [class.po-table-header-single-action]="isSingleAction"
+                [class.po-table-header-actions]="!isSingleAction"
+              ></th>
+            }
+          </tr>
+        </thead>
+      </table>
+    </div>
+
+    <cdk-virtual-scroll-viewport
+      #tableVirtualScroll
+      [itemSize]="itemSize"
+      [style.height.px]="heightTableVirtual"
+      [minBufferPx]="heightTableVirtual < 100 ? 100 : heightTableVirtual"
+      [maxBufferPx]="heightTableVirtual < 200 ? 200 : heightTableVirtual"
+    >
+      <table
+        #bodyTable
+        class="po-table po-table-virtual-scroll"
+        [ngClass]="{
+          'po-table-interactive': selectable || sort,
+          'po-table-selectable': selectable,
+          'po-table-striped': striped,
+          'po-table-data-fixed-columns': applyFixedColumns(),
+          'po-table-text-wrap-enabled': textWrap
+        }"
+        [attr.p-spacing]="spacing"
+      >
+        @if (!hasItems || !hasMainColumns) {
+          <tbody class="po-table-group-row">
+            <tr class="po-table-row po-table-row-no-data">
+              <td [colSpan]="columnCount" class="po-table-no-data po-text-center">
+                <span> {{ literals.noData }} </span>
+              </td>
+            </tr>
+          </tbody>
+        }
+
+        @if (hasMainColumns) {
+          <tbody
+            class="po-table-group-row"
+            *cdkVirtualFor="let row of filteredItems; let rowIndex = index; trackBy: trackBy"
+          >
+            <tr
+              class="po-table-row"
+              [class.po-table-row-active]="row.$selected || (row.$selected === null && selectable)"
+            >
+              @if (selectable) {
+                <td class="po-table-column-selectable">
+                  <ng-container
+                    *ngTemplateOutlet="singleSelect ? inputRadio : inputCheckbox; context: { $implicit: row }"
+                  >
+                  </ng-container>
+                </td>
+              }
+              @if (
+                (columnMasterDetail && !hideDetail && !hasRowTemplate) ||
+                (hasRowTemplate && !hasRowTemplateWithArrowDirectionRight)
+              ) {
+                <td class="po-table-column-detail-toggle" (click)="toggleDetail(row)">
+                  <ng-template
+                    [ngTemplateOutlet]="poTableColumnDetail"
+                    [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+                  >
+                  </ng-template>
+                </td>
+              }
+              @if (!actionRight && (visibleActions.length > 1 || isSingleAction)) {
                 <ng-template
-                  [ngTemplateOutlet]="poTableColumnDetail"
+                  [ngTemplateOutlet]="ActionsColumnTemplate"
                   [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
                 >
                 </ng-template>
-              </td>
-            }
-            <!-- Coluna de açoes na direita -->
-            @if (actionRight) {
-              <ng-template
-                [ngTemplateOutlet]="ActionsColumnTemplate"
-                [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-              >
-              </ng-template>
-            }
-          </tr>
-          @if (hasMainColumns && hasRowTemplate && row.$showDetail && isShowRowTemplate(row, rowIndex)) {
-            <tr>
-              <td class="po-table-row-template-container" [colSpan]="columnCountForMasterDetail">
+              }
+              @for (column of mainColumns; track trackBy(columnIndex); let columnIndex = $index) {
+                <td
+                  [style.width]="applyFixedColumns() ? column.width : computedColumnWidths[columnIndex]"
+                  [style.max-width]="applyFixedColumns() ? column.width : computedColumnWidths[columnIndex]"
+                  [style.min-width]="applyFixedColumns() ? column.width : computedColumnWidths[columnIndex]"
+                  [class.po-table-column]="column.type !== 'icon'"
+                  [class.po-table-column-right]="column.type === 'currency' || column.type === 'number'"
+                  [class.po-table-column-center]="column.type === 'subtitle'"
+                  [class.po-table-column-icons]="column.type === 'icon'"
+                  [ngClass]="getClassColor(row, column)"
+                  [pFrozenColumn]="column.fixed"
+                  class="p-element po-frozen-column"
+                  (click)="hasSelectableRow() ? selectRow(row) : 'javascript:;'"
+                >
+                  <div
+                    class="po-table-column-cell po-table-body-ellipsis notranslate"
+                    [p-tooltip]="tooltipText"
+                    [p-append-in-body]="true"
+                    (mouseenter)="tooltipMouseEnter($event, column, row)"
+                    (mouseleave)="tooltipMouseLeave()"
+                  >
+                    @switch (column.type) {
+                      @case ('columnTemplate') {
+                        <span>
+                          <ng-container
+                            *ngTemplateOutlet="getTemplate(column); context: { $implicit: getCellData(row, column) }"
+                          >
+                          </ng-container>
+                        </span>
+                      }
+                      @case ('cellTemplate') {
+                        <span>
+                          <ng-container
+                            *ngTemplateOutlet="tableCellTemplate?.templateRef; context: { row: row, column: column }"
+                          >
+                          </ng-container>
+                        </span>
+                      }
+                      @case ('boolean') {
+                        <span>
+                          {{ getBooleanLabel(getCellData(row, column), column) }}
+                        </span>
+                      }
+                      @case ('currency') {
+                        <span>
+                          {{ getCellData(row, column) | currency: column.format : 'symbol' : '1.2-2' }}
+                        </span>
+                      }
+                      @case ('date') {
+                        <span>
+                          {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy' }}
+                        </span>
+                      }
+                      @case ('time') {
+                        <span>
+                          {{ getCellData(row, column) | po_time: column.format || 'HH:mm:ss.ffffff' }}
+                        </span>
+                      }
+                      @case ('dateTime') {
+                        <span>
+                          {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy HH:mm:ss' }}
+                        </span>
+                      }
+                      @case ('number') {
+                        <span>
+                          {{ formatNumber(getCellData(row, column), column.format) }}
+                        </span>
+                      }
+                      @case ('link') {
+                        <po-table-column-link
+                          [p-action]="column.action"
+                          [p-disabled]="checkDisabled(row, column)"
+                          [p-link]="row[column.link]"
+                          [p-row]="row"
+                          [p-value]="getCellData(row, column)"
+                          (click)="onClickLink($event, row, column)"
+                        >
+                        </po-table-column-link>
+                      }
+                      @case ('icon') {
+                        <po-table-column-icon [p-column]="column" [p-icons]="getColumnIcons(row, column)" [p-row]="row">
+                        </po-table-column-icon>
+                      }
+                      @case ('subtitle') {
+                        <span>
+                          <po-table-subtitle-circle
+                            [p-subtitle]="getSubtitleColumn(row, column)"
+                          ></po-table-subtitle-circle>
+                        </span>
+                      }
+                      @case ('label') {
+                        <span>
+                          <po-table-column-label [p-value]="getColumnLabel(row, column)"> </po-table-column-label>
+                        </span>
+                      }
+                      @default {
+                        <span>{{ getCellData(row, column) }}</span>
+                      }
+                    }
+                  </div>
+                </td>
+              }
+              @if (hasRowTemplateWithArrowDirectionRight) {
+                <td class="po-table-column-detail-toggle" (click)="toggleDetail(row)">
+                  <ng-template
+                    [ngTemplateOutlet]="poTableColumnDetail"
+                    [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+                  >
+                  </ng-template>
+                </td>
+              }
+              @if (actionRight) {
                 <ng-template
-                  [ngTemplateOutlet]="tableRowTemplate.templateRef"
-                  [ngTemplateOutletContext]="{ $implicit: row, rowIndex: rowIndex }"
+                  [ngTemplateOutlet]="ActionsColumnTemplate"
+                  [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
                 >
                 </ng-template>
-              </td>
+              }
             </tr>
-          }
-          @if (hasMainColumns && isShowMasterDetail(row)) {
-            <tr>
-              <td class="po-table-column-detail" [colSpan]="columnCountForMasterDetail">
-                <po-table-detail
-                  [p-selectable]="selectable && !detailHideSelect"
-                  [p-detail]="columnMasterDetail.detail"
-                  [p-items]="row[nameColumnDetail]"
-                  [p-parent-row]="row"
-                  [p-components-size]="componentsSize"
-                  (p-select-row)="selectDetailRow($event)"
-                >
-                </po-table-detail>
-              </td>
-            </tr>
-          }
-        </tbody>
-      }
-    </table>
-  </cdk-virtual-scroll-viewport>
+            @if (hasMainColumns && hasRowTemplate && row.$showDetail && isShowRowTemplate(row, rowIndex)) {
+              <tr>
+                <td class="po-table-row-template-container" [colSpan]="columnCountForMasterDetail">
+                  <ng-template
+                    [ngTemplateOutlet]="tableRowTemplate.templateRef"
+                    [ngTemplateOutletContext]="{ $implicit: row, rowIndex: rowIndex }"
+                  >
+                  </ng-template>
+                </td>
+              </tr>
+            }
+            @if (hasMainColumns && isShowMasterDetail(row)) {
+              <tr>
+                <td class="po-table-column-detail" [colSpan]="columnCountForMasterDetail">
+                  <po-table-detail
+                    [p-selectable]="selectable && !detailHideSelect"
+                    [p-detail]="columnMasterDetail.detail"
+                    [p-items]="row[nameColumnDetail]"
+                    [p-parent-row]="row"
+                    [p-components-size]="componentsSize"
+                    (p-select-row)="selectDetailRow($event)"
+                  >
+                  </po-table-detail>
+                </td>
+              </tr>
+            }
+          </tbody>
+        }
+      </table>
+    </cdk-virtual-scroll-viewport>
+  </div>
 </ng-template>
 
 <po-popup #popup [p-actions]="actions" [p-size]="componentsSize" [p-target]="popupTarget"> </po-popup>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -219,7 +219,13 @@ describe('PoTableComponent:', () => {
       checkChangesItems: () => {},
       debounceResize: () => true,
       checkInfiniteScroll: () => {},
-      applyFixedColumns: () => {}
+      applyFixedColumns: () => {},
+      clearColumnWidths: () => {},
+      syncHeaderTableWidth: () => {},
+      mainColumns: [],
+      lastColumnsKey: '',
+      virtualScroll: false,
+      hasItems: false
     };
   }
 
@@ -627,7 +633,6 @@ describe('PoTableComponent:', () => {
       heightTableContainer: 0,
       setTableOpacity: () => {},
       changeDetector: {
-        detectChanges: () => {},
         markForCheck: () => {}
       }
     };
@@ -881,10 +886,24 @@ describe('PoTableComponent:', () => {
 
       component.drop(event as any);
 
-      expect(component.newOrderColumns[previousIndex]).toEqual(mockColumns[currentIndex]);
-      expect(component.newOrderColumns[currentIndex]).toEqual(mockColumns[previousIndex]);
-      expect(component.newOrderColumns[2]).toEqual(mockColumns[2]);
-      expect(component.onVisibleColumnsChange).toHaveBeenCalledWith(component.newOrderColumns);
+      expect(component.mainColumns[previousIndex]).toEqual(mockColumns[currentIndex]);
+      expect(component.mainColumns[currentIndex]).toEqual(mockColumns[previousIndex]);
+      expect(component.mainColumns[2]).toEqual(mockColumns[2]);
+      expect(component.onVisibleColumnsChange).toHaveBeenCalledWith(component.mainColumns);
+    });
+
+    it('drop: should call clearColumnWidths before reordering columns', () => {
+      const event = {
+        previousIndex: 0,
+        currentIndex: 1
+      };
+
+      component.mainColumns = [{ property: 'column1' }, { property: 'column2' }];
+      const clearSpy = spyOn<any>(component, 'clearColumnWidths');
+
+      component.drop(event as any);
+
+      expect(clearSpy).toHaveBeenCalled();
     });
 
     it('drop: should update mainColumns when `hideColumnsManager` is true', () => {
@@ -1315,12 +1334,11 @@ describe('PoTableComponent:', () => {
       expect(component['setTableOpacity']).toHaveBeenCalledWith(1);
     });
 
-    it(`calculateHeightTableContainer: should call 'detectChanges'`, () => {
+    it(`calculateHeightTableContainer: should call 'markForCheck'`, () => {
       const fakeThis = {
         heightTableContainer: 400,
         setTableOpacity: () => {},
         changeDetector: {
-          detectChanges: () => {},
           markForCheck: () => {}
         },
         getHeightTableFooter: () => {},
@@ -1511,16 +1529,18 @@ describe('PoTableComponent:', () => {
       expect(component['getDefaultColumns']).not.toHaveBeenCalled();
     });
 
-    it('onVisibleColumnsChange: should set `columns` and call `detectChanges`', () => {
+    it('onVisibleColumnsChange: should call `clearColumnWidths` and `markForCheck`', () => {
       const newColumns: Array<PoTableColumn> = [{ property: 'age', visible: false }];
 
       component.columns = [];
 
-      const spyDetectChanges = spyOn(component['changeDetector'], 'detectChanges');
+      const spyClearColumnWidths = spyOn(component as any, 'clearColumnWidths');
+      const spyMarkForCheck = spyOn(component['changeDetector'], 'markForCheck');
 
       component.onVisibleColumnsChange(newColumns);
 
-      expect(spyDetectChanges).toHaveBeenCalled();
+      expect(spyClearColumnWidths).toHaveBeenCalled();
+      expect(spyMarkForCheck).toHaveBeenCalled();
     });
 
     it('trackBy: should return index param', () => {
@@ -2076,25 +2096,699 @@ describe('PoTableComponent:', () => {
         expect(result).toBe(expectedValue);
       });
 
-      it('inverseOfTranslation: should return the correct value of inverseOfTranslation', () => {
-        const mockRenderedContentOffset = 10;
+      it('configureVirtualScrollOverflow: should fix content wrapper and add scroll sync listener', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        const mockContentWrapper = document.createElement('div');
+        mockContentWrapper.classList.add('cdk-virtual-scroll-content-wrapper');
+        mockViewportEl.appendChild(mockContentWrapper);
 
-        component.viewPort = { _renderedContentOffset: mockRenderedContentOffset } as any;
+        const mockHeaderContainer = document.createElement('div');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.headerScrollContainer = { nativeElement: mockHeaderContainer } as any;
 
-        const resultado = component.inverseOfTranslation;
-        expect(resultado).toEqual('-10px');
+        component['configureVirtualScrollOverflow']();
+
+        expect(mockContentWrapper.style.contain).toBe('layout style');
+        expect(mockContentWrapper.style.minWidth).toBe('100%');
+        expect(mockHeaderContainer.style.overflow).toBe('hidden');
+        expect(component['scrollSyncListener']).toBeTruthy();
+        expect(component['virtualScrollOverflowConfigured']).toBe(true);
       });
 
-      it('inverseOfTranslation: should return "-0px" if viewPort or _renderedContentOffset are not set', () => {
-        component.viewPort = null;
+      it('configureVirtualScrollOverflow: should not apply styles when tableVirtualScroll is not available', () => {
+        component.tableVirtualScroll = null;
+        component['virtualScrollOverflowConfigured'] = false;
 
-        const resultado1 = component.inverseOfTranslation;
-        expect(resultado1).toEqual('-0px');
+        component['configureVirtualScrollOverflow']();
 
-        component.viewPort = { _renderedContentOffset: null } as any;
+        expect(component['virtualScrollOverflowConfigured']).toBe(false);
+      });
 
-        const resultado2 = component.inverseOfTranslation;
-        expect(resultado2).toEqual('-0px');
+      it('syncColumnWidths: should skip when applyFixedColumns returns true', () => {
+        spyOn(component, 'applyFixedColumns').and.returnValue(true);
+        const setStyleSpy = spyOn(component['renderer'], 'setStyle');
+
+        component['syncColumnWidths']();
+
+        expect(setStyleSpy).not.toHaveBeenCalled();
+      });
+
+      it('syncColumnWidths: should apply max-content temporarily, sync widths and store computedColumnWidths', () => {
+        const mockHeaderTable = document.createElement('table');
+        const mockThead = document.createElement('thead');
+        const mockTh = document.createElement('th');
+        mockTh.classList.add('po-table-header-ellipsis');
+        mockThead.appendChild(mockTh);
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+        const mockTbody = document.createElement('tbody');
+        const mockTr = document.createElement('tr');
+        const mockTd = document.createElement('td');
+        mockTd.classList.add('p-element');
+        mockTr.appendChild(mockTd);
+        mockTbody.appendChild(mockTr);
+        mockBodyTable.appendChild(mockTbody);
+
+        document.body.appendChild(mockHeaderTable);
+        document.body.appendChild(mockBodyTable);
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+        spyOn(component, 'applyFixedColumns').and.returnValue(false);
+
+        const setStyleSpy = spyOn(component['renderer'], 'setStyle').and.callThrough();
+
+        component['syncColumnWidths']();
+
+        const maxContentCalls = setStyleSpy.calls
+          .allArgs()
+          .filter(args => args[1] === 'width' && args[2] === 'max-content');
+        expect(maxContentCalls.length).toBe(2);
+
+        expect(mockTh.style.width).toBeTruthy();
+        expect(mockTh.style.minWidth).toBeTruthy();
+        expect(mockTd.style.width).toBeTruthy();
+        expect(mockTd.style.minWidth).toBeTruthy();
+
+        expect(component.computedColumnWidths.length).toBe(1);
+        expect(component.computedColumnWidths[0]).toMatch(/^\d+(\.\d+)?px$/);
+
+        document.body.removeChild(mockHeaderTable);
+        document.body.removeChild(mockBodyTable);
+      });
+
+      it('syncColumnWidths: should not apply styles when header or body table is not available', () => {
+        component.headerTableElement = null;
+        component.bodyTableElement = null;
+
+        expect(() => component['syncColumnWidths']()).not.toThrow();
+      });
+
+      it('syncColumnWidths: should not apply styles when body has no rows', () => {
+        const mockHeaderTable = document.createElement('table');
+        const mockThead = document.createElement('thead');
+        const mockTh = document.createElement('th');
+        mockThead.appendChild(mockTh);
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+        const mockTbody = document.createElement('tbody');
+        mockBodyTable.appendChild(mockTbody);
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+
+        expect(() => component['syncColumnWidths']()).not.toThrow();
+      });
+
+      it('syncColumnWidths: should not apply styles when cells are empty', () => {
+        const mockHeaderTable = document.createElement('table');
+        const mockThead = document.createElement('thead');
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+        const mockTbody = document.createElement('tbody');
+        const mockTr = document.createElement('tr');
+        mockTbody.appendChild(mockTr);
+        mockBodyTable.appendChild(mockTbody);
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+
+        expect(() => component['syncColumnWidths']()).not.toThrow();
+      });
+
+      it('syncColumnWidths: should clear inline widths and use max-content before recalculating', () => {
+        const mockHeaderTable = document.createElement('table');
+        const mockThead = document.createElement('thead');
+        const mockTh = document.createElement('th');
+        mockTh.classList.add('po-table-header-ellipsis');
+        mockTh.style.width = '500px';
+        mockTh.style.minWidth = '500px';
+        mockThead.appendChild(mockTh);
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+        const mockTbody = document.createElement('tbody');
+        const mockTr = document.createElement('tr');
+        const mockTd = document.createElement('td');
+        mockTd.classList.add('p-element');
+        mockTd.style.width = '500px';
+        mockTd.style.minWidth = '500px';
+        mockTr.appendChild(mockTd);
+        mockTbody.appendChild(mockTr);
+        mockBodyTable.appendChild(mockTbody);
+
+        document.body.appendChild(mockHeaderTable);
+        document.body.appendChild(mockBodyTable);
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+        spyOn(component, 'applyFixedColumns').and.returnValue(false);
+
+        const removeStyleSpy = spyOn(component['renderer'], 'removeStyle').and.callThrough();
+
+        component['syncColumnWidths']();
+
+        expect(removeStyleSpy).toHaveBeenCalled();
+        const removeTableLayoutCalls = removeStyleSpy.calls.allArgs().filter(args => args[1] === 'table-layout');
+        expect(removeTableLayoutCalls.length).toBe(2);
+
+        document.body.removeChild(mockHeaderTable);
+        document.body.removeChild(mockBodyTable);
+      });
+
+      it('clearColumnWidths: should remove inline width, minWidth and table-layout from header and body and reset computedColumnWidths', () => {
+        const mockHeaderTable = document.createElement('table');
+        mockHeaderTable.style.tableLayout = 'auto';
+        mockHeaderTable.style.width = 'max-content';
+        const mockThead = document.createElement('thead');
+        const mockTh = document.createElement('th');
+        mockTh.style.width = '200px';
+        mockTh.style.minWidth = '200px';
+        mockThead.appendChild(mockTh);
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+        mockBodyTable.style.tableLayout = 'auto';
+        mockBodyTable.style.width = 'max-content';
+        const mockTbody = document.createElement('tbody');
+        const mockTr = document.createElement('tr');
+        const mockTd = document.createElement('td');
+        mockTd.style.width = '200px';
+        mockTd.style.minWidth = '200px';
+        mockTr.appendChild(mockTd);
+        mockTbody.appendChild(mockTr);
+        mockBodyTable.appendChild(mockTbody);
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+        component.computedColumnWidths = ['200px'];
+
+        component['clearColumnWidths']();
+
+        expect(mockTh.style.width).toBe('');
+        expect(mockTh.style.minWidth).toBe('');
+        expect(mockTd.style.width).toBe('');
+        expect(mockTd.style.minWidth).toBe('');
+        expect(mockHeaderTable.style.tableLayout).toBe('');
+        expect(mockHeaderTable.style.width).toBe('');
+        expect(mockBodyTable.style.tableLayout).toBe('');
+        expect(mockBodyTable.style.width).toBe('');
+        expect(component.computedColumnWidths).toEqual([]);
+      });
+
+      it('clearColumnWidths: should not fail when tables are not available', () => {
+        component.headerTableElement = null;
+        component.bodyTableElement = null;
+
+        expect(() => component['clearColumnWidths']()).not.toThrow();
+      });
+
+      it('clearColumnWidths: should not fail when body has no rows', () => {
+        const mockHeaderTable = document.createElement('table');
+        const mockThead = document.createElement('thead');
+        const mockTh = document.createElement('th');
+        mockThead.appendChild(mockTh);
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+
+        expect(() => component['clearColumnWidths']()).not.toThrow();
+      });
+      it('drop: should schedule syncColumnWidths after clearing and reordering', done => {
+        const event = {
+          previousIndex: 0,
+          currentIndex: 1
+        };
+
+        component.mainColumns = [{ property: 'column1' }, { property: 'column2' }];
+        spyOn<any>(component, 'clearColumnWidths');
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+
+        component.drop(event as any);
+
+        expect(component['clearColumnWidths']).toHaveBeenCalled();
+        expect(syncSpy).not.toHaveBeenCalled();
+
+        setTimeout(() => {
+          expect(syncSpy).toHaveBeenCalled();
+          done();
+        });
+      });
+
+      it('drop: should schedule syncColumnWidths via else branch when hideColumnsManager is true and virtualScroll is active', fakeAsync(() => {
+        const event = { previousIndex: 0, currentIndex: 1 };
+
+        component.mainColumns = [{ property: 'column1' }, { property: 'column2' }];
+        component['_virtualScroll'] = true;
+        component.hideColumnsManager = true;
+        component.computedColumnWidths = ['100px', '200px'];
+        component['resizeObserver']?.disconnect();
+        component['resizeObserver'] = jasmine.createSpyObj('ResizeObserver', ['observe', 'disconnect', 'unobserve']);
+        spyOn<any>(component, 'clearColumnWidths');
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+        const visibleSpy = spyOn(component, 'onVisibleColumnsChange');
+
+        component.drop(event as any);
+
+        expect(visibleSpy).not.toHaveBeenCalled();
+        expect(syncSpy).not.toHaveBeenCalled();
+
+        tick(0);
+
+        expect(syncSpy).toHaveBeenCalledTimes(1);
+      }));
+
+      it('drop: should not schedule syncColumnWidths twice when hideColumnsManager is false and virtualScroll is active', fakeAsync(() => {
+        const event = { previousIndex: 0, currentIndex: 1 };
+
+        component.mainColumns = [{ property: 'column1' }, { property: 'column2' }];
+        component['_virtualScroll'] = true;
+        component.hideColumnsManager = false;
+        component.computedColumnWidths = ['100px', '200px'];
+        component['resizeObserver']?.disconnect();
+        component['resizeObserver'] = jasmine.createSpyObj('ResizeObserver', ['observe', 'disconnect', 'unobserve']);
+        spyOn<any>(component, 'clearColumnWidths');
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+
+        component.drop(event as any);
+
+        tick(0);
+
+        expect(syncSpy).toHaveBeenCalledTimes(1);
+      }));
+
+      it('ngDoCheck: should clear computedColumnWidths when columns change', () => {
+        component.computedColumnWidths = ['100px', '200px'];
+        component['lastColumnsKey'] = 'col1::col2::';
+        component.mainColumns = [{ property: 'col1' }, { property: 'col2' }, { property: 'col3' }];
+
+        component.ngDoCheck();
+
+        expect(component.computedColumnWidths).toEqual([]);
+      });
+
+      it('ngAfterViewChecked: should schedule syncColumnWidths when computedColumnWidths is empty and viewport has rendered rows', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [{ id: 1 }];
+        component.computedColumnWidths = [];
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 1 }) } as any;
+        component.tableVirtualScroll = null;
+        component['virtualScrollOverflowConfigured'] = true;
+        component['resizeObserver'] = { observe: () => {}, disconnect: () => {}, unobserve: () => {} };
+        component['syncScheduled'] = false;
+        spyOn(component, 'applyFixedColumns').and.returnValue(false);
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+        spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+          cb(0);
+          return 0;
+        });
+
+        component.ngAfterViewChecked();
+
+        expect(syncSpy).toHaveBeenCalled();
+        expect(component['syncScheduled']).toBe(false);
+      });
+
+      it('ngAfterViewChecked: should not schedule syncColumnWidths when sync is already scheduled', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [{ id: 1 }];
+        component.computedColumnWidths = [];
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 1 }) } as any;
+        component.tableVirtualScroll = null;
+        component['virtualScrollOverflowConfigured'] = true;
+        component['resizeObserver'] = { observe: () => {}, disconnect: () => {}, unobserve: () => {} };
+        component['syncScheduled'] = true;
+        spyOn(component, 'applyFixedColumns').and.returnValue(false);
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+        const rafSpy = spyOn(window, 'requestAnimationFrame');
+
+        component.ngAfterViewChecked();
+
+        expect(rafSpy).not.toHaveBeenCalled();
+        expect(syncSpy).not.toHaveBeenCalled();
+      });
+
+      it('ngAfterViewChecked: should update heightTableVirtual when header height changes in virtual scroll', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.heightTableContainer = 500;
+        component['lastHeaderHeight'] = 0;
+        component.heightTableVirtual = 0;
+        component.headerScrollContainer = { nativeElement: { offsetHeight: 40 } } as any;
+        component['virtualScrollOverflowConfigured'] = true;
+        component['resizeObserver'] = { observe: () => {}, disconnect: () => {}, unobserve: () => {} };
+        spyOn(component['changeDetector'], 'markForCheck');
+        spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+          cb(0);
+          return 0;
+        });
+
+        component.ngAfterViewChecked();
+
+        expect(component['lastHeaderHeight']).toBe(40);
+        expect(component.heightTableVirtual).toBe(460);
+        expect(component['changeDetector'].markForCheck).toHaveBeenCalled();
+      });
+
+      it('ngAfterViewChecked: should not update heightTableVirtual when header height is unchanged', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.heightTableContainer = 500;
+        component['lastHeaderHeight'] = 40;
+        component.headerScrollContainer = { nativeElement: { offsetHeight: 40 } } as any;
+        component['virtualScrollOverflowConfigured'] = true;
+        component['resizeObserver'] = { observe: () => {}, disconnect: () => {}, unobserve: () => {} };
+        const rafSpy = spyOn(window, 'requestAnimationFrame');
+
+        component.ngAfterViewChecked();
+
+        expect(rafSpy).not.toHaveBeenCalled();
+      });
+
+      it('ngAfterViewChecked: should call configureVirtualScrollOverflow when virtualScroll is active and not yet configured', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.height = 400;
+        component.virtualScroll = true;
+        component['virtualScrollOverflowConfigured'] = false;
+
+        spyOn<any>(component, 'configureVirtualScrollOverflow');
+
+        component.ngAfterViewChecked();
+
+        expect(component['configureVirtualScrollOverflow']).toHaveBeenCalled();
+      });
+
+      it('ngAfterViewChecked: should not call configureVirtualScrollOverflow when already configured', () => {
+        component.virtualScroll = true;
+        component['virtualScrollOverflowConfigured'] = true;
+
+        spyOn<any>(component, 'configureVirtualScrollOverflow');
+
+        component.ngAfterViewChecked();
+
+        expect(component['configureVirtualScrollOverflow']).not.toHaveBeenCalled();
+      });
+
+      it('setupColumnWidthSync: should create ResizeObserver and observe viewport when virtualScroll is true', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.height = 400;
+        component.virtualScroll = true;
+
+        component['setupColumnWidthSync']();
+
+        expect(component['resizeObserver']).toBeTruthy();
+      });
+
+      it('setupColumnWidthSync: should not create ResizeObserver when virtualScroll is false', () => {
+        component['resizeObserver'] = undefined;
+        component.height = 0;
+        component.virtualScroll = false;
+
+        component['setupColumnWidthSync']();
+
+        expect(component['resizeObserver']).toBeUndefined();
+      });
+
+      it('setupColumnWidthSync: should not create ResizeObserver when tableVirtualScroll is not available', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.tableVirtualScroll = null;
+        component['resizeObserver'] = undefined;
+
+        component['setupColumnWidthSync']();
+
+        expect(component['resizeObserver']).toBeUndefined();
+      });
+
+      it('setupColumnWidthSync: should not create a second ResizeObserver when already configured', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.height = 400;
+        component.virtualScroll = true;
+
+        const existingObserver = { observe: () => {}, disconnect: () => {}, unobserve: () => {} } as any;
+        component['resizeObserver'] = existingObserver;
+
+        component['setupColumnWidthSync']();
+
+        expect(component['resizeObserver']).toBe(existingObserver);
+      });
+
+      it('ngAfterViewChecked: should call setupColumnWidthSync when virtualScroll is active and resizeObserver is not yet configured', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.height = 400;
+        component.virtualScroll = true;
+        component['resizeObserver'] = undefined;
+        component['virtualScrollOverflowConfigured'] = true;
+
+        spyOn<any>(component, 'setupColumnWidthSync');
+
+        component.ngAfterViewChecked();
+
+        expect(component['setupColumnWidthSync']).toHaveBeenCalled();
+      });
+
+      it('ngAfterViewChecked: should not call setupColumnWidthSync when resizeObserver is already configured', () => {
+        component.virtualScroll = true;
+        component['resizeObserver'] = { observe: () => {}, disconnect: () => {}, unobserve: () => {} };
+        component['virtualScrollOverflowConfigured'] = true;
+
+        spyOn<any>(component as any, 'setupColumnWidthSync');
+
+        component.ngAfterViewChecked();
+
+        expect((component as any)['setupColumnWidthSync']).not.toHaveBeenCalled();
+      });
+
+      it('ngOnDestroy: should call scrollSyncListener and set to null', () => {
+        const scrollSyncSpy = jasmine.createSpy('scrollSyncListener');
+        component['scrollSyncListener'] = scrollSyncSpy;
+
+        component.ngOnDestroy();
+
+        expect(scrollSyncSpy).toHaveBeenCalled();
+        expect(component['scrollSyncListener']).toBeNull();
+      });
+
+      it('ngOnDestroy: should call containerScrollSyncListener and set to null', () => {
+        const containerSyncSpy = jasmine.createSpy('containerScrollSyncListener');
+        component['containerScrollSyncListener'] = containerSyncSpy;
+
+        component.ngOnDestroy();
+
+        expect(containerSyncSpy).toHaveBeenCalled();
+        expect(component['containerScrollSyncListener']).toBeNull();
+      });
+
+      it('ngOnDestroy: should call resizeObserver.disconnect when disconnect is a function', () => {
+        const disconnectSpy = jasmine.createSpy('disconnect');
+        component['resizeObserver'] = { observe: () => {}, disconnect: disconnectSpy, unobserve: () => {} };
+
+        component.ngOnDestroy();
+
+        expect(disconnectSpy).toHaveBeenCalled();
+      });
+
+      it('ngOnDestroy: should not fail when scrollSyncListener and containerScrollSyncListener are null', () => {
+        component['scrollSyncListener'] = null;
+        component['containerScrollSyncListener'] = null;
+        component['resizeObserver'] = undefined;
+
+        expect(() => component.ngOnDestroy()).not.toThrow();
+      });
+
+      it('ngDoCheck: should call syncHeaderTableWidth when virtualScroll is active and hasItems', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [{ id: 1 }];
+
+        const syncSpy = spyOn<any>(component, 'syncHeaderTableWidth');
+
+        component.ngDoCheck();
+
+        expect(syncSpy).toHaveBeenCalled();
+      });
+
+      it('ngDoCheck: should not call syncHeaderTableWidth when virtualScroll is false', () => {
+        component.virtualScroll = false;
+        component.items = [{ id: 1 }];
+
+        const syncSpy = spyOn<any>(component, 'syncHeaderTableWidth');
+
+        component.ngDoCheck();
+
+        expect(syncSpy).not.toHaveBeenCalled();
+      });
+
+      it('onVisibleColumnsChange: should schedule syncColumnWidths when virtualScroll is active', done => {
+        component.height = 400;
+        component.virtualScroll = true;
+
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+        spyOn<any>(component, 'clearColumnWidths');
+
+        component.onVisibleColumnsChange([{ property: 'id' }]);
+
+        setTimeout(() => {
+          expect(syncSpy).toHaveBeenCalled();
+          done();
+        });
+      });
+
+      it('onVisibleColumnsChange: should not schedule syncColumnWidths when virtualScroll is false', () => {
+        component.virtualScroll = false;
+
+        spyOn<any>(component, 'clearColumnWidths');
+        const markSpy = spyOn(component['changeDetector'], 'markForCheck');
+
+        component.onVisibleColumnsChange([{ property: 'id' }]);
+
+        expect(markSpy).toHaveBeenCalled();
+        expect(component.columns).toEqual([{ property: 'id' }]);
+      });
+
+      it('syncHeaderTableWidth: should update headerTableScrollWidth when width changes', () => {
+        const mockHeaderTable = document.createElement('table');
+        mockHeaderTable.innerHTML = '<thead><tr><th style="width:200px">Col</th></tr></thead>';
+        document.body.appendChild(mockHeaderTable);
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.headerTableScrollWidth = 999;
+
+        const markSpy = spyOn(component['changeDetector'], 'markForCheck');
+
+        component['syncHeaderTableWidth']();
+
+        expect(component.headerTableScrollWidth).not.toBe(999);
+        expect(markSpy).toHaveBeenCalled();
+
+        document.body.removeChild(mockHeaderTable);
+      });
+
+      it('syncHeaderTableWidth: should not call markForCheck when width has not changed', () => {
+        const mockHeaderTable = document.createElement('table');
+        document.body.appendChild(mockHeaderTable);
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.headerTableScrollWidth = mockHeaderTable.scrollWidth;
+
+        const markSpy = spyOn(component['changeDetector'], 'markForCheck');
+
+        component['syncHeaderTableWidth']();
+
+        expect(markSpy).not.toHaveBeenCalled();
+
+        document.body.removeChild(mockHeaderTable);
+      });
+
+      it('syncHeaderTableWidth: should not fail when headerTableElement is null', () => {
+        component.headerTableElement = null;
+
+        expect(() => component['syncHeaderTableWidth']()).not.toThrow();
+      });
+
+      it('clearColumnWidths: should reset headerScrollContainer scrollLeft', () => {
+        const mockHeaderTable = document.createElement('table');
+        const mockHeaderContainer = document.createElement('div');
+        Object.defineProperty(mockHeaderContainer, 'scrollLeft', { value: 100, writable: true });
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = null;
+        component.headerScrollContainer = { nativeElement: mockHeaderContainer } as any;
+
+        component['clearColumnWidths']();
+
+        expect(mockHeaderContainer.scrollLeft).toBe(0);
+      });
+
+      it('configureVirtualScrollOverflow: should not set overflow when headerScrollContainer is null', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.headerScrollContainer = null;
+
+        component['configureVirtualScrollOverflow']();
+
+        expect(component['virtualScrollOverflowConfigured']).toBe(true);
+      });
+
+      it('configureVirtualScrollOverflow: should not create duplicate scroll sync listeners', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        const mockHeaderContainer = document.createElement('div');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.headerScrollContainer = { nativeElement: mockHeaderContainer } as any;
+        component['scrollSyncListener'] = () => {};
+
+        const listenSpy = spyOn(component['renderer'], 'listen');
+
+        component['configureVirtualScrollOverflow']();
+
+        const viewportListenCalls = listenSpy.calls
+          .allArgs()
+          .filter(args => args[1] === 'scroll' && args[0] === mockViewportEl);
+        expect(viewportListenCalls.length).toBe(0);
+      });
+
+      it('configureVirtualScrollOverflow: scroll sync listener should sync headerScrollContainer scrollLeft from viewport', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        const mockHeaderEl = document.createElement('div');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.headerScrollContainer = { nativeElement: mockHeaderEl } as any;
+        component['scrollSyncListener'] = null;
+
+        let scrollCallback: Function;
+        const originalListen = component['renderer'].listen.bind(component['renderer']);
+        spyOn(component['renderer'], 'listen').and.callFake((target: any, event: string, callback: Function) => {
+          if (target === mockViewportEl && event === 'scroll') {
+            scrollCallback = callback;
+          }
+          return originalListen(target, event, callback);
+        });
+
+        component['configureVirtualScrollOverflow']();
+
+        scrollCallback();
+
+        expect(scrollCallback).toBeDefined();
+      });
+
+      it('configureVirtualScrollOverflow: container scroll sync listener should sync headerScrollContainer scrollLeft from container', () => {
+        const fixedInnerContainer = document.createElement('div');
+        fixedInnerContainer.classList.add('po-table-container-fixed-inner');
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        fixedInnerContainer.appendChild(mockViewportEl);
+        document.body.appendChild(fixedInnerContainer);
+
+        const mockHeaderEl = document.createElement('div');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.headerScrollContainer = { nativeElement: mockHeaderEl } as any;
+        component['scrollSyncListener'] = null;
+        component['containerScrollSyncListener'] = null;
+
+        let containerScrollCallback: Function;
+        const originalListen = component['renderer'].listen.bind(component['renderer']);
+        spyOn(component['renderer'], 'listen').and.callFake((target: any, event: string, callback: Function) => {
+          if (target === fixedInnerContainer && event === 'scroll') {
+            containerScrollCallback = callback;
+          }
+          return originalListen(target, event, callback);
+        });
+
+        component['configureVirtualScrollOverflow']();
+
+        containerScrollCallback();
+
+        expect(containerScrollCallback).toBeDefined();
+
+        document.body.removeChild(fixedInnerContainer);
       });
 
       it('should update filteredItems on onFilteredItemsChange call', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -3,6 +3,7 @@ import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 
 import { DecimalPipe } from '@angular/common';
 import {
+  AfterViewChecked,
   AfterViewInit,
   ChangeDetectorRef,
   Component,
@@ -100,11 +101,19 @@ import { PoFieldSize } from '../../enums/po-field-size.enum';
   providers: [PoDateService, PoTableService],
   standalone: false
 })
-export class PoTableComponent extends PoTableBaseComponent implements AfterViewInit, DoCheck, OnDestroy, OnInit {
+export class PoTableComponent
+  extends PoTableBaseComponent
+  implements AfterViewChecked, AfterViewInit, DoCheck, OnDestroy, OnInit
+{
   @ContentChild(PoTableRowTemplateDirective, { static: true }) tableRowTemplate: PoTableRowTemplateDirective;
   @ContentChild(PoTableCellTemplateDirective) tableCellTemplate: PoTableCellTemplateDirective;
 
   @ContentChildren(PoTableColumnTemplateDirective) tableColumnTemplates: QueryList<PoTableColumnTemplateDirective>;
+
+  @ViewChild('virtualScrollWrapper', { read: ElementRef, static: false }) virtualScrollWrapper: ElementRef;
+  @ViewChild('headerScrollContainer', { read: ElementRef, static: false }) headerScrollContainer: ElementRef;
+  @ViewChild('headerTable', { read: ElementRef, static: false }) headerTableElement: ElementRef;
+  @ViewChild('bodyTable', { read: ElementRef, static: false }) bodyTableElement: ElementRef;
 
   @ViewChild('noColumnsHeader', { read: ElementRef }) noColumnsHeader;
   @ViewChild('popup') poPopupComponent: PoPopupComponent;
@@ -139,9 +148,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   idRadio: string;
   inputFieldValue = '';
   JSON: JSON;
-  newOrderColumns: Array<PoTableColumn>;
   sizeLoading: string = 'sm';
   headerWidth: number;
+  headerTableScrollWidth: number;
+  computedColumnWidths: Array<string> = [];
 
   close: PoModalAction = {
     action: () => {
@@ -167,6 +177,21 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   private scrollEvent$: Observable<any>;
   private subscriptionScrollEvent: Subscription;
   private readonly subscriptionService: Subscription = new Subscription();
+  private resizeObserver: ResizeObserver;
+  private scrollSyncListener: (() => void) | null = null;
+  private containerScrollSyncListener: (() => void) | null = null;
+  private virtualScrollOverflowConfigured = false;
+  private syncScheduled = false;
+  private lastColumnsKey = '';
+  private lastHeaderHeight = 0;
+
+  private readonly SELECTOR_BODY_ROW = 'tbody tr';
+  private readonly SELECTOR_HEADER_CELLS = 'thead th';
+  private readonly SELECTOR_HEADER_MAIN_CELLS = 'thead th.po-table-header-ellipsis';
+  private readonly SELECTOR_BODY_CELLS = 'td';
+  private readonly SELECTOR_BODY_MAIN_CELLS = 'td.p-element';
+  private readonly SELECTOR_CDK_CONTENT_WRAPPER = '.cdk-virtual-scroll-content-wrapper';
+  private readonly SELECTOR_FIXED_INNER_CONTAINER = '.po-table-container-fixed-inner';
 
   private readonly clickListener: () => void;
   private readonly resizeListener: () => void;
@@ -194,7 +219,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   constructor(
     poDate: PoDateService,
     differs: IterableDiffers,
-    renderer: Renderer2,
+    private readonly renderer: Renderer2,
     poLanguageService: PoLanguageService,
     private readonly changeDetector: ChangeDetectorRef,
     private readonly decimalPipe: DecimalPipe,
@@ -281,16 +306,6 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return this.draggable;
   }
 
-  public get inverseOfTranslation(): string {
-    if (!this.viewPort || !this.viewPort['_renderedContentOffset']) {
-      return '-0px';
-    }
-
-    const offset = this.viewPort['_renderedContentOffset'];
-
-    return `-${offset}px`;
-  }
-
   ngOnInit() {
     this.idRadio = `po-radio-${uuid()}`;
   }
@@ -307,6 +322,49 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.changeHeaderWidth();
     this.changeSizeLoading();
     this.applyFixedColumns();
+    this.syncHeaderTableWidth();
+    this.setupColumnWidthSync();
+    this.configureVirtualScrollOverflow();
+  }
+
+  ngAfterViewChecked(): void {
+    if (this.virtualScroll && !this.virtualScrollOverflowConfigured && this.tableVirtualScroll?.nativeElement) {
+      this.configureVirtualScrollOverflow();
+    }
+
+    if (this.virtualScroll && !this.resizeObserver && this.tableVirtualScroll?.nativeElement) {
+      this.setupColumnWidthSync();
+    }
+
+    if (this.virtualScroll && this.heightTableContainer) {
+      const currentHeaderHeight = this.headerScrollContainer?.nativeElement?.offsetHeight;
+      if (currentHeaderHeight && currentHeaderHeight !== this.lastHeaderHeight) {
+        this.lastHeaderHeight = currentHeaderHeight;
+        requestAnimationFrame(() => {
+          this.heightTableVirtual = this.heightTableContainer - currentHeaderHeight;
+          this.changeDetector.markForCheck();
+        });
+      }
+    }
+
+    if (this.shouldScheduleVirtualScrollColumnSyncWithoutWidths()) {
+      this.syncScheduled = true;
+      requestAnimationFrame(() => {
+        this.syncColumnWidths();
+        this.syncScheduled = false;
+      });
+    }
+  }
+
+  private shouldScheduleVirtualScrollColumnSyncWithoutWidths(): boolean {
+    return (
+      this.virtualScroll &&
+      this.hasItems &&
+      !this.applyFixedColumns() &&
+      this.computedColumnWidths.length === 0 &&
+      !this.syncScheduled &&
+      (this.viewPort?.getRenderedRange().end ?? 0) > 0
+    );
   }
 
   showMoreInfiniteScroll({ target }): void {
@@ -321,18 +379,37 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.checkChangesItems();
     this.verifyCalculateHeightTableContainer();
 
-    // Permite que os cabeçalhos sejam calculados na primeira vez que o componente torna-se visível,
-    // evitando com isso, problemas com Tabs ou Divs que iniciem escondidas.
+    const columnsKey = this.mainColumns?.map(c => `${c.property}:${c.fixed || ''}:${c.width || ''}`).join('|') || '';
+    if (columnsKey !== this.lastColumnsKey) {
+      this.lastColumnsKey = columnsKey;
+      this.clearColumnWidths();
+    }
+
     if (this.tableWrapperElement?.nativeElement.offsetWidth && !this.visibleElement && this.initialized) {
       this.debounceResize();
       this.checkInfiniteScroll();
       this.visibleElement = true;
+    }
+
+    if (this.virtualScroll && this.hasItems) {
+      this.syncHeaderTableWidth();
     }
   }
 
   ngOnDestroy() {
     this.removeListeners();
     this.subscriptionService?.unsubscribe();
+    if (this.resizeObserver && typeof this.resizeObserver.disconnect === 'function') {
+      this.resizeObserver.disconnect();
+    }
+    if (this.scrollSyncListener) {
+      this.scrollSyncListener();
+      this.scrollSyncListener = null;
+    }
+    if (this.containerScrollSyncListener) {
+      this.containerScrollSyncListener();
+      this.containerScrollSyncListener = null;
+    }
   }
 
   /**
@@ -584,8 +661,13 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   onVisibleColumnsChange(columns: Array<PoTableColumn>) {
+    this.clearColumnWidths();
     this.columns = columns;
-    this.changeDetector.detectChanges();
+    this.changeDetector.markForCheck();
+
+    if (this.virtualScroll) {
+      setTimeout(() => this.syncColumnWidths());
+    }
   }
 
   tooltipMouseEnter(event: any, column?: PoTableColumn, row?: any) {
@@ -668,24 +750,28 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   drop(event: CdkDragDrop<Array<string>>) {
     if (!this.mainColumns[event.currentIndex].fixed) {
+      this.clearColumnWidths();
       moveItemInArray(this.mainColumns, event.previousIndex, event.currentIndex);
 
       if (this.hideColumnsManager === false) {
-        this.newOrderColumns = this.mainColumns;
+        const newOrderColumns = this.mainColumns;
         const detail = this.columns.filter(item => item.property === 'detail')[0];
 
         if (detail !== undefined) {
-          this.newOrderColumns.push(detail);
+          newOrderColumns.push(detail);
         }
 
-        this.columns.map((item, index) => {
+        this.columns.forEach((item, index) => {
           if (!item.visible) {
-            this.newOrderColumns.splice(index, 0, item);
+            newOrderColumns.splice(index, 0, item);
           }
         });
-        this.columns = this.newOrderColumns;
+        this.columns = newOrderColumns;
 
-        this.onVisibleColumnsChange(this.newOrderColumns);
+        this.onVisibleColumnsChange(newOrderColumns);
+      } else if (this.virtualScroll) {
+        // Re-sincroniza larguras após Angular renderizar a nova ordem
+        setTimeout(() => this.syncColumnWidths());
       }
     }
   }
@@ -722,7 +808,8 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.itemSize =
       PO_TABLE_ROW_HEIGHT_BY_SPACING[this.spacing] ?? PO_TABLE_ROW_HEIGHT_BY_SPACING[PoTableColumnSpacing.Medium];
     this.heightTableContainer = height ? height - this.getHeightTableFooter() : undefined;
-    this.heightTableVirtual = this.heightTableContainer ? this.heightTableContainer - this.itemSize : undefined;
+    const headerHeight = this.headerScrollContainer?.nativeElement?.offsetHeight || this.itemSize;
+    this.heightTableVirtual = this.heightTableContainer ? this.heightTableContainer - headerHeight : undefined;
     this.setTableOpacity(1);
     this.changeDetector.markForCheck();
   }
@@ -981,6 +1068,159 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
           item.$selected = selectValue;
         }
       });
+    }
+  }
+
+  private configureVirtualScrollOverflow(): void {
+    if (!this.tableVirtualScroll?.nativeElement) return;
+
+    const viewportEl = this.tableVirtualScroll.nativeElement;
+
+    this.applyVirtualScrollStyles(viewportEl);
+    this.registerScrollSyncListeners(viewportEl);
+
+    this.virtualScrollOverflowConfigured = true;
+  }
+
+  private applyVirtualScrollStyles(viewportEl: HTMLElement): void {
+    const contentWrapper = viewportEl.querySelector(this.SELECTOR_CDK_CONTENT_WRAPPER);
+    if (contentWrapper) {
+      this.renderer.setStyle(contentWrapper, 'contain', 'layout style');
+      this.renderer.setStyle(contentWrapper, 'min-width', '100%');
+    }
+
+    if (this.headerScrollContainer?.nativeElement) {
+      this.renderer.setStyle(this.headerScrollContainer.nativeElement, 'overflow', 'hidden');
+    }
+  }
+
+  private registerScrollSyncListeners(viewportEl: HTMLElement): void {
+    if (!this.scrollSyncListener) {
+      this.scrollSyncListener = this.renderer.listen(viewportEl, 'scroll', () => {
+        this.syncHeaderScrollLeft(viewportEl.scrollLeft);
+      });
+    }
+
+    const fixedInnerContainer = viewportEl.closest(this.SELECTOR_FIXED_INNER_CONTAINER);
+    if (fixedInnerContainer && !this.containerScrollSyncListener) {
+      this.containerScrollSyncListener = this.renderer.listen(fixedInnerContainer, 'scroll', () => {
+        this.syncHeaderScrollLeft(fixedInnerContainer.scrollLeft);
+      });
+    }
+  }
+
+  private syncHeaderScrollLeft(scrollLeft: number): void {
+    if (this.headerScrollContainer?.nativeElement) {
+      this.headerScrollContainer.nativeElement.scrollLeft = scrollLeft;
+    }
+  }
+
+  private setupColumnWidthSync(): void {
+    if (!this.virtualScroll || this.resizeObserver) return;
+
+    const viewportEl = this.tableVirtualScroll?.nativeElement;
+    if (!viewportEl) return;
+
+    this.resizeObserver = new ResizeObserver(this.syncColumnWidths.bind(this));
+    this.resizeObserver.observe(viewportEl);
+  }
+
+  private clearColumnWidths(): void {
+    const headerTable = this.headerTableElement?.nativeElement;
+    const bodyTable = this.bodyTableElement?.nativeElement;
+
+    if (headerTable) {
+      const headerCells = headerTable.querySelectorAll(this.SELECTOR_HEADER_CELLS);
+      this.removeCellWidthStyles(headerCells);
+      this.renderer.removeStyle(headerTable, 'table-layout');
+      this.renderer.removeStyle(headerTable, 'width');
+    }
+
+    if (bodyTable) {
+      const bodyRow = bodyTable.querySelector(this.SELECTOR_BODY_ROW);
+      if (bodyRow) {
+        const bodyCells = bodyRow.querySelectorAll(this.SELECTOR_BODY_CELLS);
+        this.removeCellWidthStyles(bodyCells);
+      }
+      this.renderer.removeStyle(bodyTable, 'table-layout');
+      this.renderer.removeStyle(bodyTable, 'width');
+    }
+
+    if (this.headerScrollContainer?.nativeElement) {
+      this.headerScrollContainer.nativeElement.scrollLeft = 0;
+    }
+
+    this.computedColumnWidths = [];
+  }
+
+  private removeCellWidthStyles(cells: NodeListOf<Element>): void {
+    cells.forEach(cell => {
+      this.renderer.removeStyle(cell, 'width');
+      this.renderer.removeStyle(cell, 'minWidth');
+    });
+  }
+
+  private syncColumnWidths(): void {
+    if (this.applyFixedColumns()) return;
+    if (!this.headerTableElement?.nativeElement || !this.bodyTableElement?.nativeElement) return;
+
+    const headerTable = this.headerTableElement.nativeElement;
+    const bodyTable = this.bodyTableElement.nativeElement;
+
+    const headerCells = headerTable.querySelectorAll(this.SELECTOR_HEADER_MAIN_CELLS);
+    const bodyRow = bodyTable.querySelector(this.SELECTOR_BODY_ROW);
+    if (!bodyRow) return;
+
+    const bodyCells = bodyRow.querySelectorAll(this.SELECTOR_BODY_MAIN_CELLS);
+    if (!headerCells.length || !bodyCells.length) return;
+
+    const count = Math.min(headerCells.length, bodyCells.length);
+    const maxColumnWidths: Array<number> = new Array(count).fill(0);
+
+    this.measureCellWidths(bodyTable, bodyCells, count, maxColumnWidths);
+    this.measureCellWidths(headerTable, headerCells, count, maxColumnWidths);
+
+    this.computedColumnWidths = maxColumnWidths.map(w => `${w}px`);
+
+    for (let i = 0; i < count; i++) {
+      const widthPx = this.computedColumnWidths[i];
+      this.renderer.setStyle(headerCells[i] as HTMLElement, 'width', widthPx);
+      this.renderer.setStyle(headerCells[i] as HTMLElement, 'minWidth', widthPx);
+      this.renderer.setStyle(bodyCells[i] as HTMLElement, 'width', widthPx);
+      this.renderer.setStyle(bodyCells[i] as HTMLElement, 'minWidth', widthPx);
+    }
+
+    this.syncHeaderTableWidth();
+    this.changeDetector.markForCheck();
+  }
+
+  private measureCellWidths(
+    table: HTMLElement,
+    cells: NodeListOf<Element>,
+    count: number,
+    maxColumnWidths: Array<number>
+  ): void {
+    for (let i = 0; i < count; i++) {
+      this.renderer.removeStyle(cells[i], 'width');
+      this.renderer.removeStyle(cells[i], 'minWidth');
+    }
+    this.renderer.setStyle(table, 'width', 'max-content');
+    this.renderer.removeStyle(table, 'table-layout');
+
+    for (let i = 0; i < count; i++) {
+      maxColumnWidths[i] = Math.max(maxColumnWidths[i], cells[i].getBoundingClientRect().width);
+    }
+
+    this.renderer.removeStyle(table, 'width');
+  }
+
+  private syncHeaderTableWidth(): void {
+    if (this.headerTableElement?.nativeElement) {
+      const newWidth = this.headerTableElement.nativeElement.scrollWidth;
+      if (newWidth !== this.headerTableScrollWidth) {
+        this.headerTableScrollWidth = newWidth;
+        this.changeDetector.markForCheck();
+      }
     }
   }
 }


### PR DESCRIPTION
Tabela com muitos itens ao realizar o scroll acontece flickering (piscar) em toda tabela. Extrai o <thead> de dentro do 'cdk-virtual-scroll-viewport' mantendo a visualização da tag ao realizar o scroll.

Feat: DTHFUI-11105

**PO-TABLE**

**DTHFUI-11105**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Tabela com muitos itens ao realizar o scroll acontece flickering (piscar) em toda tabela

**Qual o novo comportamento?**
Extrai o <thead> de dentro do 'cdk-virtual-scroll-viewport' mantendo a visualização da tag ao realizar o scroll.

**Simulação**
[app.zip](https://github.com/user-attachments/files/26037633/app.zip)

<!-- devin-review-badge-begin -->

---

<a href="https://totvs.devinenterprise.com/review/po-ui/po-angular/pull/2773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
