### PR TITLE
fix(markdown): adiciona override para pinar mermaid em 11.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,10 @@
     "validate.js": "file:libs/validate.js-v0.13.2.tgz"
   },
   "overrides": {
-    "axios": "1.12.2"
+    "axios": "1.12.2",
+    "ngx-markdown": {
+      "mermaid": "11.12.3"
+    }
   },
   "standard-version": {
     "skip": {


### PR DESCRIPTION
## Summary

Adiciona um override no `package.json` para travar `mermaid` em `11.12.3` quando resolvido via `ngx-markdown`, corrigindo o erro `ELSPROBLEMS` no comando `npm ls --json --long --all` que impede a geração do SBOM.

**Causa raiz:** `ngx-markdown` declara `mermaid` como dependência opcional com range `>= 10.6.0 < 12.0.0`. A partir do `mermaid@11.13.0`, a cadeia de dependências muda para `@mermaid-js/parser@1.1.0` → `langium@4.2.2` → `chevrotain@~12.0.0`, introduzindo uma breaking change (langium 4.2.1 usava `chevrotain@~11.1.1`). Isso gera pacotes extraneous, missing e invalid na árvore de dependências.

O `package-lock.json` não foi alterado pois já travava mermaid em 11.12.3 — o override protege ambientes que resolvem dependências sem respeitar o lockfile (e.g., `npm install` sem lockfile ou sem `npm ci`).

## Review & Testing Checklist for Human

- [ ] Executar `THF generate sbom POUI` no ambiente Azure Agent para confirmar que o erro `ELSPROBLEMS` foi resolvido
- [ ] Verificar se o pipeline de SBOM conclui com sucesso após a mudança
- [ ] Considerar se o pipeline deveria usar `npm ci` em vez de `npm install` como proteção adicional contra drift de versão

### Notes

- O override está escopado apenas a `ngx-markdown > mermaid`, não afeta outras dependências
- Esta versão pinada precisará ser revisada quando `langium` ou `mermaid` corrigirem o conflito upstream com chevrotain 12.x

Link to Devin session: https://totvs.devinenterprise.com/sessions/3884ade5d2554dda9efbdd088df1d7c8
Requested by: @pedrodominguesp