### PR TITLE
fix(markdown): adiciona overrides para mermaid e @mermaid-js/parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,13 @@
     "validate.js": "file:libs/validate.js-v0.13.2.tgz"
   },
   "overrides": {
-    "axios": "1.12.2"
+    "axios": "1.12.2",
+    "ngx-markdown": {
+      "mermaid": "11.12.3"
+    },
+    "mermaid": {
+      "@mermaid-js/parser": "1.0.0"
+    }
   },
   "standard-version": {
     "skip": {


### PR DESCRIPTION
## Summary

Adiciona overrides no `package.json` para travar `mermaid` em `11.12.3` e `@mermaid-js/parser` em `1.0.0`, corrigindo o erro `ELSPROBLEMS` no `npm ls --json --long --all` que impede a geração do SBOM (`THF generate sbom POUI`).

**Causa raiz:** `ngx-markdown` declara `mermaid` como dependência opcional com range `>= 10.6.0 < 12.0.0`. Quando o pipeline resolve dependências sem respeitar o lockfile, a cadeia completa deriva para versões incompatíveis:

- `mermaid@11.13+` → `@mermaid-js/parser@1.0.1+` → `langium@4.2.2` → `chevrotain@~12.0.0` ❌
- `mermaid@11.12.3` → `@mermaid-js/parser@1.0.0` → `langium@4.2.1` → `chevrotain@~11.1.1` ✅

O `langium` introduziu breaking change numa minor (`4.2.1` → `4.2.2`: chevrotain `~11.1.1` → `~12.0.0`), gerando pacotes extraneous, missing e invalid na árvore.

> **Nota:** Complementa o PR #2798 (development) que pinava apenas `mermaid` — insuficiente porque `@mermaid-js/parser` também derivava para versão mais nova.

## Review & Testing Checklist for Human

- [ ] **Executar `THF generate sbom POUI` no Azure Agent** após o merge — este é o único ambiente onde o bug se manifesta. A correção foi verificada localmente (`npm ls --all` sem erros), mas não foi testada no pipeline real.
- [ ] **Verificar se o pipeline de SBOM usa `npm install` ou `npm ci`** — o problema só ocorre porque o lockfile não é respeitado. Trocar para `npm ci` resolveria a causa raiz e tornaria estes overrides apenas uma camada de defesa extra.
- [ ] Validar que nenhuma funcionalidade de renderização markdown/mermaid (se utilizada) foi afetada pelo pin de versão.

### Notes

- O `package-lock.json` não foi alterado — ele já travava as versões corretas; os overrides protegem ambientes que não respeitam o lockfile
- Estas versões pinadas precisarão ser revisadas quando `langium` ou `mermaid` corrigirem o conflito upstream com chevrotain 12.x
- Se aparecerem novos erros de SBOM futuramente, a causa mais provável será outra dependência transitiva derivando — a solução definitiva é garantir `npm ci` no pipeline

Link to Devin session: https://totvs.devinenterprise.com/sessions/3884ade5d2554dda9efbdd088df1d7c8
Requested by: @pedrodominguesp