### PR TITLE
feat(page): adiciona tipos de header e layout de ações

### DIFF
--- a/projects/portal/src/styles.css
+++ b/projects/portal/src/styles.css
@@ -19,11 +19,6 @@ html.potheme-light-AAA #logo-totvs {
   content: url('./assets/graphics/logo-totvs-preto.png');
 }
 
-html.potheme-dark-AA .po-header-nav,
-html.potheme-dark-AAA .po-header-nav {
-  --stroke-color: var(--color-brand-01-dark);
-}
-
 .dot {
   border-radius: 50%;
   display: inline-block;

--- a/projects/portal/src/styles.css
+++ b/projects/portal/src/styles.css
@@ -19,6 +19,11 @@ html.potheme-light-AAA #logo-totvs {
   content: url('./assets/graphics/logo-totvs-preto.png');
 }
 
+html.potheme-dark-AA .po-header-nav,
+html.potheme-dark-AAA .po-header-nav {
+  --stroke-color: var(--color-brand-01-dark);
+}
+
 .dot {
   border-radius: 50%;
   display: inline-block;
@@ -615,7 +620,7 @@ blockquote {
 }
 
 .app-portal-home .po-page .po-page-content {
-  padding: 0 0 4.5rem;
+  padding: 0 0 var(--spacing-xs);
 }
 
 .guides-grid-system-box {

--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown-action.interface.ts
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown-action.interface.ts
@@ -2,7 +2,8 @@ import { PoPopupAction } from '../po-popup/po-popup-action.interface';
 
 /**
  * @description
- * Interface do componente po-dropdown
+ *
+ * Interface para as ações do componente `po-dropdown`.
  *
  * @docsExtends PoPopupAction
  *
@@ -10,13 +11,13 @@ import { PoPopupAction } from '../po-popup/po-popup-action.interface';
  */
 export interface PoDropdownAction extends PoPopupAction {
   /**
-   * Array de ações (`PoDropdownAction`) usado para criar agrupadores de subitens.
+   * @optional
    *
-   * - Permite a criação de menus aninhados (submenus).
+   * @description
    *
-   * > Boas práticas de desenvolvimento:
-   * Recomenda-se limitar a navegação a, no máximo, três níveis hierárquicos.
-   * Isso evita sobrecarga cognitiva, facilita a memorização da estrutura e garante uma melhor experiência de uso.
+   * Array de ações (`PoDropdownAction`) usado para criar agrupadores de subitens (submenus).
+   *
+   * > Recomenda-se limitar a navegação a, no máximo, três níveis hierárquicos.
    */
   subItems?: Array<PoDropdownAction>;
 }

--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown-base.component.ts
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown-base.component.ts
@@ -1,9 +1,12 @@
 import { Directive, HostBinding, HostListener, Input } from '@angular/core';
 
 import { convertToBoolean, getDefaultSizeFn, validateSizeFn } from './../../utils/util';
+import { PO_CONTROL_POSITIONS } from './../../services/po-control-position/po-control-position.constants';
 
 import { PoFieldSize } from '../../enums/po-field-size.enum';
 import { PoDropdownAction } from './po-dropdown-action.interface';
+
+const poDropdownDefaultPosition = 'bottom-left';
 
 /**
  * @description
@@ -77,6 +80,7 @@ export class PoDropdownBaseComponent {
   private _disabled: boolean = false;
   private _size?: string = undefined;
   private _initialSize?: string = undefined;
+  private _position: string = poDropdownDefaultPosition;
 
   /** Lista de ações que serão exibidas no componente. */
   @Input('p-actions') set actions(value: Array<PoDropdownAction>) {
@@ -127,6 +131,52 @@ export class PoDropdownBaseComponent {
   @HostBinding('attr.p-size')
   get size(): string {
     return this._size ?? getDefaultSizeFn(PoFieldSize);
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a posição preferencial de abertura do popup do dropdown em relação ao botão.
+   *
+   * Posições válidas:
+   * - `right`: No lado direito.
+   * - `right-bottom`: No lado direito inferior.
+   * - `right-top`: No lado direito superior.
+   * - `bottom`: Abaixo.
+   * - `bottom-left`: Abaixo e à esquerda (padrão).
+   * - `bottom-right`: Abaixo e à direita.
+   * - `left`: No lado esquerdo.
+   * - `left-top`: No lado esquerdo superior.
+   * - `left-bottom`: No lado esquerdo inferior.
+   * - `top`: Acima.
+   * - `top-right`: Acima e à direita.
+   * - `top-left`: Acima e à esquerda.
+   *
+   * > O popup será rotacionado automaticamente caso não caiba na posição definida.
+   *
+   * @default `bottom-left`
+   */
+  @Input('p-position') set position(value: string) {
+    this._position = PO_CONTROL_POSITIONS.includes(value) ? value : poDropdownDefaultPosition;
+  }
+
+  get position(): string {
+    return this._position;
+  }
+
+  get popupCustomPositions(): Array<string> {
+    if (this._position === 'bottom-right') {
+      return ['bottom-right', 'top-right'];
+    }
+    if (this._position === 'top-left') {
+      return ['top-left', 'bottom-left'];
+    }
+    if (this._position === 'top-right') {
+      return ['top-right', 'bottom-right'];
+    }
+    return ['bottom-left', 'top-left'];
   }
 
   @HostListener('window:PoUiThemeChange')

--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown-base.componente.spec.ts
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown-base.componente.spec.ts
@@ -98,5 +98,44 @@ describe('PoDropdownBaseComponent:', () => {
         expect((component as any).applySizeBasedOnA11y).toHaveBeenCalled();
       });
     });
+
+    describe('p-position:', () => {
+      it('should set position to valid value', () => {
+        component.position = 'bottom-right';
+        expect(component.position).toBe('bottom-right');
+      });
+
+      it('should default to bottom-left with invalid value', () => {
+        component.position = 'invalid';
+        expect(component.position).toBe('bottom-left');
+      });
+
+      it('should default to bottom-left with empty string', () => {
+        component.position = '';
+        expect(component.position).toBe('bottom-left');
+      });
+    });
+
+    describe('popupCustomPositions:', () => {
+      it('should return bottom-right and top-right when position is bottom-right', () => {
+        component.position = 'bottom-right';
+        expect(component.popupCustomPositions).toEqual(['bottom-right', 'top-right']);
+      });
+
+      it('should return top-left and bottom-left when position is top-left', () => {
+        component.position = 'top-left';
+        expect(component.popupCustomPositions).toEqual(['top-left', 'bottom-left']);
+      });
+
+      it('should return top-right and bottom-right when position is top-right', () => {
+        component.position = 'top-right';
+        expect(component.popupCustomPositions).toEqual(['top-right', 'bottom-right']);
+      });
+
+      it('should return bottom-left and top-left as default', () => {
+        component.position = 'bottom-left';
+        expect(component.popupCustomPositions).toEqual(['bottom-left', 'top-left']);
+      });
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.html
@@ -19,9 +19,9 @@
   #popupRef
   p-hide-arrow
   p-is-corner-align
-  p-position="bottom-left"
+  [p-position]="position"
   [p-actions]="actions"
-  [p-custom-positions]="['bottom-left', 'top-left']"
+  [p-custom-positions]="popupCustomPositions"
   [p-size]="size"
   [p-target]="dropdownRef"
   [p-listbox-subitems]="true"

--- a/projects/ui/src/lib/components/po-icon/po-icon-dictionary.ts
+++ b/projects/ui/src/lib/components/po-icon/po-icon-dictionary.ts
@@ -6,6 +6,7 @@ export const AnimaliaIconDictionary: { [key: string]: string } = {
   ICON_ALIGN_LEFT: 'an an-text-align-left',
   ICON_ALIGN_RIGHT: 'an an-text-align-right',
   ICON_ARROW_ARC_LEFT: 'an an-arrow-arc-left',
+  ICON_ARROW_BACK: 'an an-arrow-left',
   ICON_ARROW_DOWN: 'an an-caret-down',
   ICON_OTHER_ARROW_DOWN: 'an an-arrow-down',
   ICON_ARROW_LEFT: 'an an-caret-left',

--- a/projects/ui/src/lib/components/po-page/index.ts
+++ b/projects/ui/src/lib/components/po-page/index.ts
@@ -1,3 +1,5 @@
+export * from './po-page-default/enums/po-page-actions-layout.enum';
+export * from './po-page-default/enums/po-page-header-type.enum';
 export * from './po-page-default/po-page-default.component';
 export * from './po-page-default/po-page-default.interface';
 export * from './po-page-default/po-page-default-literals.interface';

--- a/projects/ui/src/lib/components/po-page/interfaces/po-page-action.interface.ts
+++ b/projects/ui/src/lib/components/po-page/interfaces/po-page-action.interface.ts
@@ -2,16 +2,38 @@ import { PoDropdownAction } from '../../po-dropdown';
 
 /**
  * @description
- * Interface para as ações dos componentes po-page-default e po-page-list.
  *
- * > Quando o array de actions possui quatro ou mais registros, os dois últimos e os seguintes são automaticamente agrupados no po-dropdown.
- * A partir desse ponto, as propriedades `selected`, `separator`, `type` e `subItems` passam a ter efeito apenas nas ações exibidas dentro do dropdown, ou seja, a partir da terceira ação.
- * Dessa forma, o uso de subItems (agrupadores dentro do dropdown) só terá efeito quando houver pelo menos quatro ações definidas.
+ * Interface para as ações dos componentes `po-page-default` e `po-page-list`.
  *
- * @docsExtends PoDropdownAction
+ * As ações são exibidas como botões no cabeçalho e, caso excedam o limite de exibição ou o layout
+ * seja configurado para tal, são agrupadas automaticamente em um *dropdown*.
+ *
+ * > As propriedades `separator`, `selected` e `subItems` possuem efeito apenas quando
+ * a ação é exibida dentro do *dropdown*.
  *
  * @ignoreExtendedDescription
  *
  * @usedBy PoPageDefaultComponent, PoPageListComponent
  */
-export interface PoPageAction extends PoDropdownAction {}
+export interface PoPageAction extends PoDropdownAction {
+  /**
+   * @description
+   *
+   * Define o estilo visual da ação quando ela é exibida como botão fora do *dropdown*.
+   *
+   * Valores permitidos:
+   * - `primary`: Botão com maior destaque visual.
+   * - `secondary`: Estilo padrão para a maioria das ações.
+   *
+   * > Valores inválidos são ignorados, mantendo o valor padrão da posição da ação.
+   *
+   * > Aplicável apenas a ações exibidas como botões (fora do *dropdown*). Ações dentro do *dropdown* não utilizam esta propriedade.
+   *
+   * > Funciona independentemente da posição da ação e com qualquer `PoPageHeaderType` ou `PoPageActionsLayout`.
+   *
+   * **Valores padrão por posição (quando `kind` não é definido):**
+   * - Layout `default`: primeira ação = `primary`, demais = `secondary`.
+   * - Layout `mixed`: primeira ação = `primary` (header primary) ou `secondary` (header secondary/tertiary).
+   */
+  kind?: string;
+}

--- a/projects/ui/src/lib/components/po-page/interfaces/po-page-action.interface.ts
+++ b/projects/ui/src/lib/components/po-page/interfaces/po-page-action.interface.ts
@@ -5,11 +5,13 @@ import { PoDropdownAction } from '../../po-dropdown';
  *
  * Interface para as ações dos componentes `po-page-default` e `po-page-list`.
  *
- * As ações são exibidas como botões no cabeçalho e, caso excedam o limite de exibição ou o layout
- * seja configurado para tal, são agrupadas automaticamente em um *dropdown*.
+ * As ações podem ser exibidas como botões no cabeçalho ou agrupadas em um *dropdown*,
+ * conforme o `PoPageActionsLayout` e o tamanho da tela.
  *
  * > As propriedades `separator`, `selected` e `subItems` possuem efeito apenas quando
  * a ação é exibida dentro do *dropdown*.
+ *
+ * @docsExtends PoDropdownAction
  *
  * @ignoreExtendedDescription
  *
@@ -17,23 +19,22 @@ import { PoDropdownAction } from '../../po-dropdown';
  */
 export interface PoPageAction extends PoDropdownAction {
   /**
+   * @optional
+   *
    * @description
    *
-   * Define o estilo visual da ação quando ela é exibida como botão fora do *dropdown*.
+   * Define o estilo visual da ação quando exibida como botão fora do *dropdown*.
    *
    * Valores permitidos:
-   * - `primary`: Botão com maior destaque visual.
-   * - `secondary`: Estilo padrão para a maioria das ações.
+   * - `primary`: botão com maior destaque visual.
+   * - `secondary`: estilo padrão.
    *
-   * > Valores inválidos são ignorados, mantendo o valor padrão da posição da ação.
+   * > Valores inválidos são ignorados e o componente aplica o estilo padrão da posição.
    *
-   * > Aplicável apenas a ações exibidas como botões (fora do *dropdown*). Ações dentro do *dropdown* não utilizam esta propriedade.
+   * > Somente uma ação pode ter `kind` igual a `primary`. Caso mais de uma defina `primary`,
+   * apenas a primeira será mantida e as demais receberão `secondary`.
    *
-   * > Funciona independentemente da posição da ação e com qualquer `PoPageHeaderType` ou `PoPageActionsLayout`.
-   *
-   * **Valores padrão por posição (quando `kind` não é definido):**
-   * - Layout `default`: primeira ação = `primary`, demais = `secondary`.
-   * - Layout `mixed`: primeira ação = `primary` (header primary) ou `secondary` (header secondary/tertiary).
+   * > Quando não definido, o estilo é determinado pelo `PoPageActionsLayout`.
    */
   kind?: string;
 }

--- a/projects/ui/src/lib/components/po-page/po-page-content/po-page-content.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-content/po-page-content.component.html
@@ -1,3 +1,3 @@
-<div class="po-page-content" [style.height]="height" [style.opacity]="contentOpacity" [style.overflow-y]="overflowY">
+<div class="po-page-content" [style.height]="height" [style.opacity]="contentOpacity">
   <ng-content></ng-content>
 </div>

--- a/projects/ui/src/lib/components/po-page/po-page-content/po-page-content.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-content/po-page-content.component.spec.ts
@@ -1,51 +1,23 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Component } from '@angular/core';
 
 import { changeBrowserInnerWidth, configureTestSuite } from '../../../util-test/util-expect.spec';
 
 import { PoPageContentComponent } from './po-page-content.component';
 
-@Component({
-  selector: 'po-page-content-div',
-  template: `
-    <div class="po-toolbar"></div>
-    <div class="po-page-header"></div>
-  `,
-  styles: [
-    `
-      .po-page-header {
-        height: 100px;
-        width: 100%;
-      }
-      .po-toolbar {
-        height: 33px;
-        width: 100%;
-      }
-    `
-  ],
-  standalone: false
-})
-class ContentDivComponent {}
-
 describe('PoPageContentComponent:', () => {
   let component: PoPageContentComponent;
   let fixture: ComponentFixture<PoPageContentComponent>;
-
-  let fixtureDiv: ComponentFixture<ContentDivComponent>;
 
   const eventResize = document.createEvent('Event');
   eventResize.initEvent('resize', false, true);
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      declarations: [ContentDivComponent, PoPageContentComponent]
+      declarations: [PoPageContentComponent]
     });
   });
 
   beforeEach(() => {
-    fixtureDiv = TestBed.createComponent(ContentDivComponent);
-    fixtureDiv.detectChanges();
-
     fixture = TestBed.createComponent(PoPageContentComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -55,7 +27,7 @@ describe('PoPageContentComponent:', () => {
     expect(component instanceof PoPageContentComponent).toBeTruthy();
   });
 
-  it('constructor: should call recalculateHeaderSize', () => {
+  it('constructor: should call recalculateHeaderSize on resize', () => {
     component['initializeListeners']();
     spyOn(component, 'recalculateHeaderSize');
 
@@ -66,12 +38,12 @@ describe('PoPageContentComponent:', () => {
   });
 
   describe('Methods:', () => {
-    it('recalculateHeaderSize: should call setHeightContent and set `contentOpacity` to equal 1.', fakeAsync(() => {
-      spyOn(component, 'setHeightContent');
+    it('recalculateHeaderSize: should set height and contentOpacity to 1', fakeAsync(() => {
       component.recalculateHeaderSize();
       tick(100);
-      expect(component.setHeightContent).toHaveBeenCalled();
+
       expect(component.contentOpacity).toBe(1);
+      expect(component.height).toBeTruthy();
     }));
 
     it('ngAfterViewInit: should call recalculateHeaderSize', () => {
@@ -82,24 +54,44 @@ describe('PoPageContentComponent:', () => {
       expect(component.recalculateHeaderSize).toHaveBeenCalled();
     });
 
-    it('setHeightContent: should calculate height without pageHeader', () => {
-      component.setHeightContent(undefined);
+    it('should calculate height based on viewport when no .po-page ancestor', fakeAsync(() => {
+      component.recalculateHeaderSize();
+      tick(100);
 
-      const bodyHeight = document.body.clientHeight;
-      const valueExpected = bodyHeight;
+      expect(component.height).toMatch(/^\d+px$|^auto$|^90%$/);
+    }));
 
-      expect(component.height).toBe(`${valueExpected}px`);
-    });
+    it('should set height to auto when inside nested po-page-content', fakeAsync(() => {
+      const wrapper = document.createElement('div');
+      wrapper.classList.add('po-page-content');
+      const poPage = document.createElement('div');
+      poPage.classList.add('po-page');
+      wrapper.appendChild(poPage);
+      poPage.appendChild(fixture.nativeElement);
+      document.body.appendChild(wrapper);
 
-    it('setHeightContent: should calculate height with bottom actions', () => {
-      const pageHeaderElement = fixtureDiv.debugElement.nativeElement.querySelector('.po-page-header') as HTMLElement;
-      const pageHeaderHeight = pageHeaderElement.offsetTop + pageHeaderElement.offsetHeight;
-      const bodyHeight = document.body.clientHeight;
-      const valueExpected = bodyHeight - pageHeaderHeight;
+      component.recalculateHeaderSize();
+      tick(100);
 
-      component.setHeightContent(pageHeaderElement);
+      expect(component.height).toBe('auto');
 
-      expect(component.height).toBe(`${valueExpected}px`);
-    });
+      document.body.removeChild(wrapper);
+    }));
+
+    it('should fallback to 90% when calculated height is zero or negative without .po-page', fakeAsync(() => {
+      spyOn(fixture.nativeElement, 'getBoundingClientRect').and.returnValue({
+        top: window.innerHeight + 100,
+        bottom: window.innerHeight + 200,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 0
+      });
+
+      component.recalculateHeaderSize();
+      tick(100);
+
+      expect(component.height).toBe('90%');
+    }));
   });
 });

--- a/projects/ui/src/lib/components/po-page/po-page-content/po-page-content.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-content/po-page-content.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, OnDestroy, Renderer2, inject } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, NgZone, OnDestroy, Renderer2, inject } from '@angular/core';
 
 import { PoPageContentBaseComponent } from './po-page-content-base.component';
 
@@ -13,49 +13,82 @@ import { PoPageContentBaseComponent } from './po-page-content-base.component';
   standalone: false
 })
 export class PoPageContentComponent extends PoPageContentBaseComponent implements AfterViewInit, OnDestroy {
-  renderer = inject(Renderer2);
+  private readonly renderer = inject(Renderer2);
+  private readonly elementRef = inject(ElementRef);
+  private readonly ngZone = inject(NgZone);
 
   contentOpacity: number = 0;
+
   height: string = '90%';
-  overflowY: string = 'none';
 
   constructor() {
     super();
     this.initializeListeners();
   }
 
-  ngAfterViewInit() {
+  ngAfterViewInit(): void {
     this.recalculateHeaderSize();
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.removeListeners();
   }
 
-  recalculateHeaderSize() {
+  /**
+   * Recalcula a altura do po-page-content.
+   * Chamado internamente pelo po-page-default quando inputs que afetam
+   * o tamanho do header mudam (title, subtitle, breadcrumb, headerType, theme).
+   */
+  recalculateHeaderSize(): void {
     setTimeout(() => {
-      const pageHeaderElement: HTMLElement = document.querySelector('div.po-page-header');
-
-      this.setHeightContent(pageHeaderElement);
+      this.setHeightContent();
       this.contentOpacity = 1;
     });
   }
 
-  setHeightContent(poPageHeader: HTMLElement) {
-    const bodyHeight = document.body.clientHeight;
-    const pageHeaderHeight = poPageHeader ? poPageHeader.offsetTop + poPageHeader.offsetHeight : 0;
-    const newHeight = bodyHeight - pageHeaderHeight;
+  private setHeightContent(): void {
+    const poPageDiv: HTMLElement = this.elementRef.nativeElement.closest('.po-page');
+    const contentHost: HTMLElement = this.elementRef.nativeElement;
 
-    this.height = `${newHeight}px`;
+    if (!poPageDiv) {
+      const contentTop = contentHost.getBoundingClientRect().top;
+      const newHeight = window.innerHeight - contentTop;
+      this.height = newHeight > 0 ? `${newHeight}px` : '90%';
+      return;
+    }
+
+    // Page nested (dentro de outro po-page-content): height controlado externamente.
+    if (poPageDiv.closest('.po-page-content')) {
+      this.height = 'auto';
+      return;
+    }
+
+    const pageHeader: HTMLElement = poPageDiv.querySelector(':scope > po-page-header');
+    const gap = parseFloat(getComputedStyle(poPageDiv).gap) || 0;
+
+    let contentTop: number;
+
+    if (pageHeader) {
+      contentTop = pageHeader.getBoundingClientRect().bottom + gap;
+    } else {
+      contentTop = poPageDiv.getBoundingClientRect().top;
+    }
+
+    const newHeight = window.innerHeight - contentTop;
+    this.height = newHeight > 0 ? `${newHeight}px` : '90%';
   }
 
-  private initializeListeners() {
-    this.resizeListener = this.renderer.listen('window', 'resize', () => {
-      this.recalculateHeaderSize();
+  private initializeListeners(): void {
+    this.ngZone.runOutsideAngular(() => {
+      this.resizeListener = this.renderer.listen('window', 'resize', () => {
+        this.ngZone.run(() => this.recalculateHeaderSize());
+      });
     });
   }
 
-  private removeListeners() {
-    this.resizeListener();
+  private removeListeners(): void {
+    if (this.resizeListener) {
+      this.resizeListener();
+    }
   }
 }

--- a/projects/ui/src/lib/components/po-page/po-page-default/enums/po-page-actions-layout.enum.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/enums/po-page-actions-layout.enum.ts
@@ -3,24 +3,26 @@
  *
  * @description
  *
- * Enum que define os layouts de ações disponíveis no `po-page-default`.
+ * Define os layouts de exibição das ações no cabeçalho do `po-page-default`.
  *
- * > Compatível com todos os valores de `PoPageHeaderType` (`primary`, `secondary` e `tertiary`).
- *
- * Define os layouts de exibição das ações no cabeçalho.
+ * > Compatível com todos os valores de `PoPageHeaderType`.
  */
 export enum PoPageActionsLayout {
   /**
-   * Comportamento padrão: as ações são exibidas como botões (até 3 em desktop e 2 em mobile)
-   * e as demais são agrupadas no *dropdown*.
+   * Exibe as ações como botões (até 3 em desktop e 2 em mobile), agrupando as demais no *dropdown*.
+   *
+   * Quando `PoPageAction.kind` não é definido, a primeira ação recebe o estilo `primary`
+   * e as demais recebem `secondary`.
    */
   default = 'default',
 
-  /** Todas as ações são agrupadas exclusivamente dentro do menu *dropdown*. */
+  /**
+   * Agrupa todas as ações exclusivamente dentro do menu *dropdown*.
+   */
   dropdown = 'dropdown',
 
   /**
-   * A primeira ação é exibida como um botão de destaque e todas as demais são movidas para o *dropdown*.
+   * Exibe a primeira ação como botão e agrupa as demais no *dropdown*.
    */
   mixed = 'mixed'
 }

--- a/projects/ui/src/lib/components/po-page/po-page-default/enums/po-page-actions-layout.enum.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/enums/po-page-actions-layout.enum.ts
@@ -1,0 +1,26 @@
+/**
+ * @usedBy PoPageDefaultComponent
+ *
+ * @description
+ *
+ * Enum que define os layouts de ações disponíveis no `po-page-default`.
+ *
+ * > Compatível com todos os valores de `PoPageHeaderType` (`primary`, `secondary` e `tertiary`).
+ *
+ * Define os layouts de exibição das ações no cabeçalho.
+ */
+export enum PoPageActionsLayout {
+  /**
+   * Comportamento padrão: as ações são exibidas como botões (até 3 em desktop e 2 em mobile)
+   * e as demais são agrupadas no *dropdown*.
+   */
+  default = 'default',
+
+  /** Todas as ações são agrupadas exclusivamente dentro do menu *dropdown*. */
+  dropdown = 'dropdown',
+
+  /**
+   * A primeira ação é exibida como um botão de destaque e todas as demais são movidas para o *dropdown*.
+   */
+  mixed = 'mixed'
+}

--- a/projects/ui/src/lib/components/po-page/po-page-default/enums/po-page-header-type.enum.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/enums/po-page-header-type.enum.ts
@@ -1,0 +1,26 @@
+/**
+ * @usedBy PoPageDefaultComponent
+ *
+ * @description
+ *
+ * Define os tipos de cabeçalho disponíveis, alterando a hierarquia visual e os elementos de navegação.
+ */
+export enum PoPageHeaderType {
+  /**
+   * Layout padrão que permite o uso de `p-breadcrumb`. As ações seguem o estilo definido
+   * em suas propriedades individuais (padrão: `primary` para a primeira ação).
+   */
+  primary = 'primary',
+
+  /**
+   * Exibe um botão de retorno (voltar) ao lado do título e oculta o `p-breadcrumb`.
+   * Por padrão, as ações assumem o estilo `secondary`.
+   */
+  secondary = 'secondary',
+
+  /**
+   * Layout simplificado sem botões de navegação e sem `p-breadcrumb`.
+   * Assim como no tipo `secondary`, as ações assumem o estilo `secondary` por padrão.
+   */
+  tertiary = 'tertiary'
+}

--- a/projects/ui/src/lib/components/po-page/po-page-default/enums/po-page-header-type.enum.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/enums/po-page-header-type.enum.ts
@@ -3,24 +3,25 @@
  *
  * @description
  *
- * Define os tipos de cabeçalho disponíveis, alterando a hierarquia visual e os elementos de navegação.
+ * Define os tipos de cabeçalho disponíveis no `po-page-default`.
  */
 export enum PoPageHeaderType {
   /**
-   * Layout padrão que permite o uso de `p-breadcrumb`. As ações seguem o estilo definido
-   * em suas propriedades individuais (padrão: `primary` para a primeira ação).
+   * Layout padrão com suporte a `p-breadcrumb`.
    */
   primary = 'primary',
 
   /**
-   * Exibe um botão de retorno (voltar) ao lado do título e oculta o `p-breadcrumb`.
-   * Por padrão, as ações assumem o estilo `secondary`.
+   * Exibe um botão de retorno ao lado do título.
+   *
+   * > Incompatível com `p-breadcrumb`.
    */
   secondary = 'secondary',
 
   /**
-   * Layout simplificado sem botões de navegação e sem `p-breadcrumb`.
-   * Assim como no tipo `secondary`, as ações assumem o estilo `secondary` por padrão.
+   * Layout simplificado sem botão de retorno.
+   *
+   * > Incompatível com `p-breadcrumb`.
    */
   tertiary = 'tertiary'
 }

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.spec.ts
@@ -1,5 +1,5 @@
 import { Directive } from '@angular/core';
-import { fakeAsync, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
@@ -105,6 +105,36 @@ describe('PoPageDefaultBaseComponent:', () => {
       tick();
 
       expect(component.title).toBe('teste');
+      expect(component.poPageContent.recalculateHeaderSize).toHaveBeenCalled();
+    }));
+
+    it('p-subtitle: should call recalculateHeaderSize when set subtitle', fakeAsync(() => {
+      component.poPageContent = <any>{
+        recalculateHeaderSize: () => {}
+      };
+
+      spyOn(component.poPageContent, 'recalculateHeaderSize');
+
+      component.subtitle = 'sub teste';
+
+      tick();
+
+      expect(component.subtitle).toBe('sub teste');
+      expect(component.poPageContent.recalculateHeaderSize).toHaveBeenCalled();
+    }));
+
+    it('p-breadcrumb: should call recalculateHeaderSize when set breadcrumb', fakeAsync(() => {
+      component.poPageContent = <any>{
+        recalculateHeaderSize: () => {}
+      };
+
+      spyOn(component.poPageContent, 'recalculateHeaderSize');
+
+      component.breadcrumb = { items: [{ label: 'Home' }] };
+
+      tick();
+
+      expect(component.breadcrumb.items.length).toBe(1);
       expect(component.poPageContent.recalculateHeaderSize).toHaveBeenCalled();
     }));
 

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.spec.ts
@@ -19,10 +19,12 @@ describe('PoPageDefaultBaseComponent:', () => {
   let languageService: PoLanguageService;
   let component: PoPageDefaultComponent;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({}).compileComponents();
+
     languageService = new PoLanguageService();
 
-    component = new PoPageDefaultComponent(languageService);
+    component = TestBed.runInInjectionContext(() => new PoPageDefaultComponent(languageService));
   });
 
   it('should be created', () => {
@@ -116,6 +118,58 @@ describe('PoPageDefaultBaseComponent:', () => {
       const validValues = [[{ label: 'Share', icon: 'po-icon-share' }]];
 
       expectPropertiesValues(component, 'actions', validValues, validValues);
+    });
+
+    describe('p-page-header-type:', () => {
+      it('should set `pageHeaderType` to `primary` when receiving `primary`.', () => {
+        component.pageHeaderType = 'primary';
+        expect(component.pageHeaderType).toBe('primary');
+      });
+
+      it('should set `pageHeaderType` to `secondary` when receiving `secondary`.', () => {
+        component.pageHeaderType = 'secondary';
+        expect(component.pageHeaderType).toBe('secondary');
+      });
+
+      it('should set `pageHeaderType` to `tertiary` when receiving `tertiary`.', () => {
+        component.pageHeaderType = 'tertiary';
+        expect(component.pageHeaderType).toBe('tertiary');
+      });
+
+      it('should default `pageHeaderType` to `primary` with invalid values.', () => {
+        const invalidValues = ['invalid', '', null, undefined, 'other'];
+
+        invalidValues.forEach(value => {
+          component.pageHeaderType = value;
+          expect(component.pageHeaderType).toBe('primary');
+        });
+      });
+    });
+
+    describe('p-page-actions-layout:', () => {
+      it('should set `pageActionsLayout` to `default` when receiving `default`.', () => {
+        component.pageActionsLayout = 'default';
+        expect(component.pageActionsLayout).toBe('default');
+      });
+
+      it('should set `pageActionsLayout` to `dropdown` when receiving `dropdown`.', () => {
+        component.pageActionsLayout = 'dropdown';
+        expect(component.pageActionsLayout).toBe('dropdown');
+      });
+
+      it('should set `pageActionsLayout` to `mixed` when receiving `mixed`.', () => {
+        component.pageActionsLayout = 'mixed';
+        expect(component.pageActionsLayout).toBe('mixed');
+      });
+
+      it('should default `pageActionsLayout` to `default` with invalid values.', () => {
+        const invalidValues = ['invalid', '', null, undefined, 'other'];
+
+        invalidValues.forEach(value => {
+          component.pageActionsLayout = value;
+          expect(component.pageActionsLayout).toBe('default');
+        });
+      });
     });
 
     describe('p-components-size', () => {

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.ts
@@ -37,18 +37,10 @@ export const backNavigationAriaLabels = {
 /**
  * @description
  *
- * O `po-page-default` é utilizado como o container principal para as telas sem um template definido.
+ * O `po-page-default` é utilizado como container principal para telas sem um template definido.
  *
- * Ele oferece uma estrutura robusta com suporte a:
- * - Cabeçalhos dinâmicos (`primary`, `secondary` ou `tertiary`).
- * - Sistema de navegação via *breadcrumb*.
- * - Gerenciamento inteligente de ações com suporte a *dropdown* responsivo.
- * - Controle total sobre o layout das ações, permitindo modos fixos ou mistos.
- *
- * **Responsividade:**
- *
- * O componente adapta automaticamente a exibição das ações e elementos do cabeçalho conforme a
- * largura de tela, garantindo a melhor experiência tanto em *desktop* quanto em dispositivos móveis.
+ * Oferece suporte a cabeçalhos dinâmicos via `p-page-header-type`, navegação por *breadcrumb*
+ * e gerenciamento de ações com agrupamento responsivo via `p-page-actions-layout`.
  *
  * #### Tokens customizáveis
  *
@@ -76,11 +68,13 @@ export abstract class PoPageDefaultBaseComponent {
   protected language: string;
 
   private _actions?: Array<PoPageAction> = [];
+  private _breadcrumb?: PoBreadcrumb;
   private _componentsSize?: string = undefined;
   private _initialComponentsSize?: string = undefined;
   private _literals: PoPageDefaultLiterals;
   private _pageActionsLayout: string = PoPageActionsLayout.default;
   private _pageHeaderType: string = PoPageHeaderType.primary;
+  private _subtitle: string;
   private _title: string;
 
   /**
@@ -91,11 +85,6 @@ export abstract class PoPageDefaultBaseComponent {
    * Define a lista de ações que serão exibidas no cabeçalho da página.
    *
    * Recebe um array de objetos que implementam a interface `PoPageAction`.
-   *
-   * **Comportamento responsivo padrão:**
-   * - **Desktop:** Exibe até **3 ações** principais; as demais são agrupadas no *dropdown*.
-   * - **Mobile:** Exibe até **2 ações** principais; as demais são agrupadas no *dropdown*.
-   * - Em telas menores que **480px**, as ações fora do *dropdown* exibem apenas o ícone caso a propriedade `PoPageAction.icon` esteja definida.
    *
    * > O comportamento de exibição pode ser customizado através da propriedade `p-page-actions-layout`.
    *
@@ -123,7 +112,14 @@ export abstract class PoPageDefaultBaseComponent {
    *
    * > Compatível com o cabeçalho (`p-page-header-type`) do tipo `primary`.
    */
-  @Input('p-breadcrumb') breadcrumb?: PoBreadcrumb;
+  @Input('p-breadcrumb') set breadcrumb(value: PoBreadcrumb) {
+    this._breadcrumb = value;
+    setTimeout(() => this.poPageContent?.recalculateHeaderSize());
+  }
+
+  get breadcrumb(): PoBreadcrumb {
+    return this._breadcrumb;
+  }
 
   /**
    * @optional
@@ -228,6 +224,7 @@ export abstract class PoPageDefaultBaseComponent {
   @Input('p-page-header-type') set pageHeaderType(value: string | PoPageHeaderType) {
     const strValue = typeof value === 'string' ? value : '';
     this._pageHeaderType = PoPageHeaderType[strValue] ? PoPageHeaderType[strValue] : PoPageHeaderType.primary;
+    setTimeout(() => this.poPageContent?.recalculateHeaderSize());
   }
 
   get pageHeaderType(): string {
@@ -243,7 +240,7 @@ export abstract class PoPageDefaultBaseComponent {
    */
   @Input('p-title') set title(title: string) {
     this._title = title;
-    setTimeout(() => this.poPageContent.recalculateHeaderSize());
+    setTimeout(() => this.poPageContent?.recalculateHeaderSize());
   }
 
   get title() {
@@ -259,7 +256,14 @@ export abstract class PoPageDefaultBaseComponent {
    *
    * > Requer que`p-title` esteja definido.
    */
-  @Input('p-subtitle') subtitle: string;
+  @Input('p-subtitle') set subtitle(value: string) {
+    this._subtitle = value;
+    setTimeout(() => this.poPageContent?.recalculateHeaderSize());
+  }
+
+  get subtitle(): string {
+    return this._subtitle;
+  }
 
   /**
    * @optional
@@ -279,6 +283,9 @@ export abstract class PoPageDefaultBaseComponent {
   @HostListener('window:PoUiThemeChange')
   protected onThemeChange(): void {
     this.applySizeBasedOnA11y();
+
+    // Recalcula o height do content após os componentes reagirem à mudança de tema/a11y
+    setTimeout(() => this.poPageContent?.recalculateHeaderSize());
   }
 
   private applySizeBasedOnA11y(): void {

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.ts
@@ -1,4 +1,4 @@
-import { Directive, HostBinding, HostListener, Input, ViewChild } from '@angular/core';
+import { Directive, HostBinding, HostListener, Input, ViewChild, output } from '@angular/core';
 
 import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
 import { PoLanguageService } from './../../../services/po-language/po-language.service';
@@ -8,6 +8,8 @@ import { getDefaultSizeFn, validateSizeFn } from '../../../utils/util';
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
 import { PoPageAction } from '../interfaces/po-page-action.interface';
 import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
+import { PoPageActionsLayout } from './enums/po-page-actions-layout.enum';
+import { PoPageHeaderType } from './enums/po-page-header-type.enum';
 import { PoPageDefaultLiterals } from './po-page-default-literals.interface';
 
 export const poPageDefaultLiteralsDefault = {
@@ -25,31 +27,49 @@ export const poPageDefaultLiteralsDefault = {
   }
 };
 
+export const backNavigationAriaLabels = {
+  en: 'Back',
+  es: 'Volver',
+  pt: 'Voltar',
+  ru: 'Назад'
+};
+
 /**
  * @description
  *
- * O componente `po-page-default` é utilizado como o container principal para as telas sem um template definido.
+ * O `po-page-default` é utilizado como o container principal para as telas sem um template definido.
+ *
+ * Ele oferece uma estrutura robusta com suporte a:
+ * - Cabeçalhos dinâmicos (`primary`, `secondary` ou `tertiary`).
+ * - Sistema de navegação via *breadcrumb*.
+ * - Gerenciamento inteligente de ações com suporte a *dropdown* responsivo.
+ * - Controle total sobre o layout das ações, permitindo modos fixos ou mistos.
+ *
+ * **Responsividade:**
+ *
+ * O componente adapta automaticamente a exibição das ações e elementos do cabeçalho conforme a
+ * largura de tela, garantindo a melhor experiência tanto em *desktop* quanto em dispositivos móveis.
  *
  * #### Tokens customizáveis
  *
  * > Para maiores informações, acesse o guia [Personalizando o Tema Padrão com Tokens CSS](https://po-ui.io/guides/theme-customization).
  *
- * | Propriedade         | Descrição                                   | Valor Padrão                          |
- * |---------------------|---------------------------------------------|---------------------------------------|
- * | **Header**          |                                             |                                       |
- * | `--padding`         | Espaçamento do header                       | `var(--spacing-xs) var(--spacing-md)` |
- * | `--gap`             | Espaçamento entre os breadcrumbs e o título | `var(--spacing-md)`                   |
- * | `--gap-actions`     | Espaçamento entre as ações                  | `var(--spacing-xs)`                   |
- * | `--font-family`     | Família tipográfica do título               | `var(--font-family-theme)`            |
- * | **Content**         |                                             |                                       |
- * | `--padding-content` | Espaçamento do conteúdo                     | `var(--spacing-xs) var(--spacing-sm)` |
+ * | Propriedade                                        | Descrição                                   | Valor Padrão                          |
+ * |----------------------------------------------------|---------------------------------------------|---------------------------------------|
+ * | **Página (po-page-default)**                       |                                             |                                       |
+ * | `--background`                                     | Background da página (header e body)        | `var(--color-page-background-color-page)` |
+ * | **Header (po-page-header)**                        |                                             |                                       |
+ * | `--padding`                                        | Espaçamento do header                       | `var(--spacing-xs) var(--spacing-md)` |
+ * | `--gap`                                            | Espaçamento entre os breadcrumbs e o título | `var(--spacing-md)`                   |
+ * | `--gap-actions`                                    | Espaçamento entre as ações                  | `var(--spacing-xs)`                   |
+ * | **Header (po-page-header .po-page-header-title)**  |                                             |                                       |
+ * | `--font-family`                                    | Família tipográfica do título               | `var(--font-family-theme)`            |
+ * | **Content (po-page-content)**                      |                                             |                                       |
+ * | `--padding-content`                                | Espaçamento do conteúdo                     | `var(--spacing-xs) var(--spacing-sm)` |
  */
 @Directive()
 export abstract class PoPageDefaultBaseComponent {
   @ViewChild(PoPageContentComponent, { static: true }) poPageContent: PoPageContentComponent;
-
-  /** Objeto com propriedades do breadcrumb. */
-  @Input('p-breadcrumb') breadcrumb?: PoBreadcrumb;
 
   visibleActions: Array<PoPageAction> = [];
 
@@ -59,6 +79,8 @@ export abstract class PoPageDefaultBaseComponent {
   private _componentsSize?: string = undefined;
   private _initialComponentsSize?: string = undefined;
   private _literals: PoPageDefaultLiterals;
+  private _pageActionsLayout: string = PoPageActionsLayout.default;
+  private _pageHeaderType: string = PoPageHeaderType.primary;
   private _title: string;
 
   /**
@@ -66,7 +88,18 @@ export abstract class PoPageDefaultBaseComponent {
    *
    * @description
    *
-   * Nesta propriedade deve ser definido um array de objetos que implementam a interface `PoPageAction`.
+   * Define a lista de ações que serão exibidas no cabeçalho da página.
+   *
+   * Recebe um array de objetos que implementam a interface `PoPageAction`.
+   *
+   * **Comportamento responsivo padrão:**
+   * - **Desktop:** Exibe até **3 ações** principais; as demais são agrupadas no *dropdown*.
+   * - **Mobile:** Exibe até **2 ações** principais; as demais são agrupadas no *dropdown*.
+   * - Em telas menores que **480px**, as ações fora do *dropdown* exibem apenas o ícone caso a propriedade `PoPageAction.icon` esteja definida.
+   *
+   * > O comportamento de exibição pode ser customizado através da propriedade `p-page-actions-layout`.
+   *
+   * @default `[]`
    */
   @Input('p-actions') set actions(actions: Array<PoPageAction>) {
     this._actions = Array.isArray(actions) ? actions : [];
@@ -78,6 +111,19 @@ export abstract class PoPageDefaultBaseComponent {
   get actions(): Array<PoPageAction> {
     return this._actions;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o sistema de navegação que indica o caminho da página atual na hierarquia da aplicação.
+   *
+   * Recebe um objeto que implementa a interface `PoBreadcrumb`.
+   *
+   * > Compatível com o cabeçalho (`p-page-header-type`) do tipo `primary`.
+   */
+  @Input('p-breadcrumb') breadcrumb?: PoBreadcrumb;
 
   /**
    * @optional
@@ -109,33 +155,23 @@ export abstract class PoPageDefaultBaseComponent {
    *
    * @description
    *
-   * Objeto com as literais usadas no `po-page-default`.
+   * Permite a customização das literais utilizadas no componente.
    *
-   * Existem duas maneiras de customizar o componente, passando um objeto com todas as literais disponíveis:
+   * Para customizar, basta passar um objeto parcial ou completo que implemente a interface `PoPageDefaultLiterals`.
    *
-   * ```
-   *  const customLiterals: PoPageDefaultLiterals = {
-   *    otherActions: 'Mais ações'
-   *  };
-   * ```
+   * Exemplo de uso:
    *
-   * Ou passando apenas as literais que deseja customizar:
-   *
-   * ```
-   *  const customLiterals: PoPageDefaultLiterals = {
-   *    otherActions: 'Ações da página'
-   *  };
+   * ```html
+   * <po-page-default [p-literals]="customLiterals"></po-page-default>
    * ```
    *
-   * E para carregar as literais customizadas, basta apenas passar o objeto para o componente.
-   *
-   * ```
-   * <po-page-default
-   *   [p-literals]="customLiterals">
-   * </po-page-default>
+   * ```typescript
+   * const customLiterals: PoPageDefaultLiterals = {
+   *   otherActions: 'Mais opções'
+   * };
    * ```
    *
-   * > O valor padrão será traduzido de acordo com o idioma configurado no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
+   * > O valor padrão será traduzido de acordo com o idioma configurado no [`PoI18nService`](/documentation/po-i18n) ou navegador.
    */
   @Input('p-literals') set literals(value: PoPageDefaultLiterals) {
     if (value instanceof Object && !(value instanceof Array)) {
@@ -153,7 +189,58 @@ export abstract class PoPageDefaultBaseComponent {
     return this._literals || poPageDefaultLiteralsDefault[this.language];
   }
 
-  /** Título da página. */
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o layout de exibição das ações no cabeçalho.
+   *
+   * Aceita valores do enum `PoPageActionsLayout`.
+   *
+   * > Em telas reduzidas (< 480px) as ações fora do *dropdown* que possuam a propriedade `PoPageAction.icon` definida
+   * exibirão apenas o ícone.
+   *
+   * @default `default`
+   */
+  @Input('p-page-actions-layout') set pageActionsLayout(value: string | PoPageActionsLayout) {
+    const strValue = typeof value === 'string' ? value : '';
+    this._pageActionsLayout = PoPageActionsLayout[strValue]
+      ? PoPageActionsLayout[strValue]
+      : PoPageActionsLayout.default;
+  }
+
+  get pageActionsLayout(): string {
+    return this._pageActionsLayout;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o tipo de cabeçalho da página.
+   *
+   * Aceita valores do enum `PoPageHeaderType`.
+   *
+   * @default `primary`
+   */
+  @Input('p-page-header-type') set pageHeaderType(value: string | PoPageHeaderType) {
+    const strValue = typeof value === 'string' ? value : '';
+    this._pageHeaderType = PoPageHeaderType[strValue] ? PoPageHeaderType[strValue] : PoPageHeaderType.primary;
+  }
+
+  get pageHeaderType(): string {
+    return this._pageHeaderType;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o título principal da página.
+   */
   @Input('p-title') set title(title: string) {
     this._title = title;
     setTimeout(() => this.poPageContent.recalculateHeaderSize());
@@ -168,9 +255,22 @@ export abstract class PoPageDefaultBaseComponent {
    *
    * @description
    *
-   * Subtitulo do Header da página
+   * Define um texto de apoio ou informações adicionais logo abaixo do título principal.
+   *
+   * > Requer que`p-title` esteja definido.
    */
   @Input('p-subtitle') subtitle: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado ao clicar no botão voltar exibido no cabeçalho.
+   *
+   * > Botão exibido apenas quando a propriedade `p-page-header-type` está configurada como `secondary`.
+   */
+  back = output<void>({ alias: 'p-back' });
 
   constructor(languageService: PoLanguageService) {
     this.language = languageService.getShortLanguage();

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.html
@@ -1,47 +1,147 @@
 <po-page>
+  <!-- Shared action templates -->
+  <ng-template #actionsDropdown>
+    @if (visibleActions.length) {
+      <po-dropdown
+        p-position="bottom-right"
+        [p-label]="literals.otherActions"
+        [p-actions]="visibleActions"
+        [p-size]="componentsSize"
+      ></po-dropdown>
+    }
+  </ng-template>
+
+  <ng-template #actionsMixed let-kindFallback="kindFallback">
+    @if (visibleActions.length > 1) {
+      <po-dropdown
+        [p-label]="literals.otherActions"
+        [p-actions]="dropdownActions"
+        [p-size]="componentsSize"
+      ></po-dropdown>
+    }
+    @if (visibleActions[0]) {
+      <po-button
+        [p-kind]="getActionKind(visibleActions[0], kindFallback)"
+        [p-danger]="visibleActions[0].type === 'danger'"
+        [p-disabled]="actionIsDisabled(visibleActions[0])"
+        [p-icon]="visibleActions[0].icon"
+        [p-label]="isMobile && visibleActions[0].icon ? '' : visibleActions[0].label"
+        [p-aria-label]="visibleActions[0].label"
+        [p-size]="componentsSize"
+        (p-click)="callAction(visibleActions[0])"
+      ></po-button>
+    }
+  </ng-template>
+
+  <ng-template #actionsDefault>
+    @if (visibleActions.length > limitPrimaryActions) {
+      <po-dropdown
+        [p-label]="literals.otherActions"
+        [p-actions]="dropdownActions"
+        [p-size]="componentsSize"
+      ></po-dropdown>
+    }
+    @if (visibleActions.length === 3 && visibleActions[2] && !isMobile) {
+      <po-button
+        [p-kind]="getActionKind(visibleActions[2], 'secondary')"
+        [p-danger]="visibleActions[2].type === 'danger'"
+        [p-disabled]="actionIsDisabled(visibleActions[2])"
+        [p-icon]="visibleActions[2].icon"
+        [p-label]="visibleActions[2].label"
+        [p-size]="componentsSize"
+        (p-click)="callAction(visibleActions[2])"
+      ></po-button>
+    }
+    @if (visibleActions[1] && (visibleActions.length === 2 || !isMobile)) {
+      <po-button
+        [p-kind]="getActionKind(visibleActions[1], 'secondary')"
+        [p-disabled]="actionIsDisabled(visibleActions[1])"
+        [p-icon]="visibleActions[1].icon"
+        [p-label]="visibleActions[1].label"
+        [p-danger]="visibleActions[1].type === 'danger'"
+        [p-size]="componentsSize"
+        (p-click)="callAction(visibleActions[1])"
+      ></po-button>
+    }
+    @if (visibleActions[0]) {
+      <po-button
+        [p-kind]="getActionKind(visibleActions[0], 'primary')"
+        [p-danger]="visibleActions[0].type === 'danger'"
+        [p-disabled]="actionIsDisabled(visibleActions[0])"
+        [p-icon]="visibleActions[0].icon"
+        [p-label]="isMobile && visibleActions[0].icon ? '' : visibleActions[0].label"
+        [p-aria-label]="visibleActions[0].label"
+        [p-size]="componentsSize"
+        (p-click)="callAction(visibleActions[0])"
+      ></po-button>
+    }
+  </ng-template>
+
   <!-- HEADER -->
   @if (hasPageHeader()) {
-    <po-page-header [p-breadcrumb]="breadcrumb" [p-size]="componentsSize" [p-subtitle]="subtitle" [p-title]="title">
-      <!-- OPERATIONS -->
-      <div class="po-page-header-actions">
-        @if (visibleActions.length > limitPrimaryActions) {
-          <po-dropdown [p-label]="literals.otherActions" [p-actions]="dropdownActions" [p-size]="componentsSize">
-          </po-dropdown>
-        }
-        @if (visibleActions.length === 3 && visibleActions[2] && !isMobile) {
+    @switch (pageHeaderType) {
+      @case ('secondary') {
+        <po-page-header [p-type]="'secondary'" [p-size]="componentsSize" [p-subtitle]="subtitle" [p-title]="title">
+          <!-- Back navigation button (icon-only, aria-label for screen readers) -->
           <po-button
-            [p-danger]="visibleActions[2].type === 'danger'"
-            [p-disabled]="actionIsDisabled(visibleActions[2])"
-            [p-label]="visibleActions[2].label"
+            po-page-header-navigation
+            p-kind="tertiary"
+            [p-icon]="backIcon"
             [p-size]="componentsSize"
-            (p-click)="callAction(visibleActions[2])"
-          >
-          </po-button>
-        }
-        @if (visibleActions[1] && (visibleActions.length === 2 || !isMobile)) {
-          <po-button
-            [p-disabled]="actionIsDisabled(visibleActions[1])"
-            [p-label]="visibleActions[1].label"
-            [p-danger]="visibleActions[1].type === 'danger'"
-            [p-size]="componentsSize"
-            (p-click)="callAction(visibleActions[1])"
-          >
-          </po-button>
-        }
-        @if (visibleActions[0]) {
-          <po-button
-            p-kind="primary"
-            [p-danger]="visibleActions[0].type === 'danger'"
-            [p-disabled]="actionIsDisabled(visibleActions[0])"
-            [p-icon]="visibleActions[0].icon"
-            [p-label]="visibleActions[0].label"
-            [p-size]="componentsSize"
-            (p-click)="callAction(visibleActions[0])"
-          >
-          </po-button>
-        }
-      </div>
-    </po-page-header>
+            [p-aria-label]="backNavigationLabel"
+            (p-click)="back.emit()"
+          ></po-button>
+
+          <div class="po-page-header-actions">
+            @switch (pageActionsLayout) {
+              @case ('dropdown') {
+                <ng-container *ngTemplateOutlet="actionsDropdown"></ng-container>
+              }
+              @case ('mixed') {
+                <ng-container *ngTemplateOutlet="actionsMixed; context: { kindFallback: 'secondary' }"></ng-container>
+              }
+              @default {
+                <ng-container *ngTemplateOutlet="actionsDefault"></ng-container>
+              }
+            }
+          </div>
+        </po-page-header>
+      }
+      @case ('tertiary') {
+        <po-page-header [p-type]="'tertiary'" [p-size]="componentsSize" [p-subtitle]="subtitle" [p-title]="title">
+          <div class="po-page-header-actions">
+            @switch (pageActionsLayout) {
+              @case ('dropdown') {
+                <ng-container *ngTemplateOutlet="actionsDropdown"></ng-container>
+              }
+              @case ('mixed') {
+                <ng-container *ngTemplateOutlet="actionsMixed; context: { kindFallback: 'secondary' }"></ng-container>
+              }
+              @default {
+                <ng-container *ngTemplateOutlet="actionsDefault"></ng-container>
+              }
+            }
+          </div>
+        </po-page-header>
+      }
+      @default {
+        <po-page-header [p-breadcrumb]="breadcrumb" [p-size]="componentsSize" [p-subtitle]="subtitle" [p-title]="title">
+          <div class="po-page-header-actions">
+            @switch (pageActionsLayout) {
+              @case ('dropdown') {
+                <ng-container *ngTemplateOutlet="actionsDropdown"></ng-container>
+              }
+              @case ('mixed') {
+                <ng-container *ngTemplateOutlet="actionsMixed; context: { kindFallback: 'primary' }"></ng-container>
+              }
+              @default {
+                <ng-container *ngTemplateOutlet="actionsDefault"></ng-container>
+              }
+            }
+          </div>
+        </po-page-header>
+      }
+    }
   }
 
   <!-- CONTENT -->

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.spec.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -11,10 +12,12 @@ import { PoBreadcrumbModule } from '../../po-breadcrumb/po-breadcrumb.module';
 import { PoButtonModule } from '../../po-button';
 import { PoDropdownModule } from '../../po-dropdown/po-dropdown.module';
 
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
 import { PoPageDefaultComponent } from './po-page-default.component';
 import { PoPageComponent } from '../po-page.component';
 import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
 import { PoPageHeaderComponent } from '../po-page-header/po-page-header.component';
+import { backNavigationAriaLabels } from './po-page-default-base.component';
 
 const eventClick = document.createEvent('Event');
 eventClick.initEvent('click', false, true);
@@ -57,7 +60,7 @@ describe('PoPageDefaultComponent mobile', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes([]), PoBreadcrumbModule, PoButtonModule, PoDropdownModule],
+      imports: [CommonModule, RouterTestingModule.withRoutes([]), PoBreadcrumbModule, PoButtonModule, PoDropdownModule],
       declarations: [
         MobileComponent,
         PoPageDefaultComponent,
@@ -155,7 +158,7 @@ describe('PoPageDefaultComponent desktop', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes([]), PoBreadcrumbModule, PoButtonModule, PoDropdownModule],
+      imports: [CommonModule, RouterTestingModule.withRoutes([]), PoBreadcrumbModule, PoButtonModule, PoDropdownModule],
       declarations: [
         DesktopComponent,
         PoPageDefaultComponent,
@@ -298,7 +301,7 @@ describe('PoPageDefaultComponent desktop', () => {
       expect(fixture.debugElement.nativeElement.querySelector('po-page-header')).toBeFalsy();
     });
 
-    it('should show only one icon in button actions.', () => {
+    it('should show icons in all visible button actions.', () => {
       component.actions[0] = { label: 'action 1', icon: 'an-newspaper' };
       component.actions[1] = { label: 'action 2', icon: 'an-newspaper' };
       component.actions[2] = { label: 'action 3', icon: 'an-newspaper' };
@@ -307,7 +310,7 @@ describe('PoPageDefaultComponent desktop', () => {
 
       const icons = fixture.debugElement.nativeElement.querySelectorAll('.an-newspaper');
 
-      expect(icons.length).toBe(1);
+      expect(icons.length).toBe(3);
     });
 
     it('should not display buttons that have visible equal to false', () => {
@@ -383,12 +386,42 @@ describe('PoPageDefaultComponent desktop', () => {
       expect(component.hasPageHeader()).toBe(true);
     });
 
+    it('hasPageHeader: should return true through visibleActions length in primary header', () => {
+      component.pageHeaderType = 'primary';
+      component.breadcrumb = undefined;
+      component.title = undefined;
+
+      spyOn(component, 'getVisibleActions').and.returnValue([{ label: 'action' }]);
+
+      expect(component.hasPageHeader()).toBe(true);
+    });
+
     it('hasPageHeader: should return true if has title', () => {
       component.actions = [];
       component.breadcrumb = undefined;
       component.title = 'Title';
 
       expect(component.hasPageHeader()).toBe(true);
+    });
+
+    it('hasPageHeader: should return true for tertiary header when title is empty and has visible actions', () => {
+      component.pageHeaderType = 'tertiary';
+      component.title = undefined;
+      component.breadcrumb = undefined;
+
+      spyOn(component, 'getVisibleActions').and.returnValue([{ label: 'action' }]);
+
+      expect(component.hasPageHeader()).toBe(true);
+    });
+
+    it('hasPageHeader: should return false for tertiary header when title is empty and has no visible actions', () => {
+      component.pageHeaderType = 'tertiary';
+      component.title = undefined;
+      component.breadcrumb = { items: [{ label: 'Breadcrumb' }] };
+
+      spyOn(component, 'getVisibleActions').and.returnValue([]);
+
+      expect(component.hasPageHeader()).toBe(false);
     });
 
     it('hasPageHeader: should return false if doesn`t have actions, breadcrumb and title', () => {
@@ -398,5 +431,210 @@ describe('PoPageDefaultComponent desktop', () => {
 
       expect(component.hasPageHeader()).toBe(false);
     });
+
+    it('hasPageHeader: should return true for secondary header even without title, actions and breadcrumb', () => {
+      component.actions = [];
+      component.breadcrumb = undefined;
+      component.title = undefined;
+      component.pageHeaderType = 'secondary';
+
+      expect(component.hasPageHeader()).toBe(true);
+    });
+
+    it('setDropdownActions: should put all actions in dropdown when pageActionsLayout is `dropdown`', () => {
+      component.actions = [{ label: 'action1' }, { label: 'action2' }, { label: 'action3' }];
+      component.pageActionsLayout = 'dropdown';
+      component.setDropdownActions();
+
+      expect(component.dropdownActions).toEqual(component.visibleActions);
+    });
+
+    it('setDropdownActions: should put all actions except first in dropdown when pageActionsLayout is `mixed`', () => {
+      component.actions = [{ label: 'action1' }, { label: 'action2' }, { label: 'action3' }];
+      component.pageActionsLayout = 'mixed';
+      component.setDropdownActions();
+
+      expect(component.dropdownActions).toEqual(component.visibleActions.slice(1));
+    });
+
+    it('setDropdownActions: should use default behavior when pageActionsLayout is `default`', () => {
+      component.actions = [{ label: 'action1' }, { label: 'action2' }, { label: 'action3' }, { label: 'action4' }];
+      component.pageActionsLayout = 'default';
+      component.setDropdownActions();
+
+      expect(component.dropdownActions).toEqual(component.visibleActions.slice(component.limitPrimaryActions - 1));
+    });
+  });
+
+  describe('Template - Secondary Header', () => {
+    it('should render back button with icon-only (no label) by default when pageHeaderType is secondary', () => {
+      component.pageHeaderType = 'secondary';
+      component.title = 'Secondary Page';
+      component.actions = [];
+
+      fixture.detectChanges();
+
+      const backButton = fixture.debugElement.nativeElement.querySelector('po-button[po-page-header-navigation]');
+      expect(backButton).toBeTruthy();
+
+      const buttonEl = backButton.querySelector('button');
+      expect(buttonEl).toBeTruthy();
+    });
+
+    it('should emit `back` event when back button is clicked on secondary header', () => {
+      component.pageHeaderType = 'secondary';
+      component.title = 'Secondary Page';
+      component.actions = [];
+
+      fixture.detectChanges();
+
+      spyOn(component.back, 'emit');
+
+      const backButton = fixture.debugElement.nativeElement.querySelector(
+        'po-button[po-page-header-navigation] button'
+      );
+      if (backButton) {
+        backButton.click();
+        expect(component.back.emit).toHaveBeenCalled();
+      }
+    });
+
+    it('should not render breadcrumb when pageHeaderType is secondary', () => {
+      component.pageHeaderType = 'secondary';
+      component.title = 'Secondary Page';
+      component.breadcrumb = { items: [{ label: 'Home' }] };
+      component.actions = [];
+
+      fixture.detectChanges();
+
+      const breadcrumb = fixture.debugElement.nativeElement.querySelector('.po-page-header-breadcrumb');
+      expect(breadcrumb).toBeFalsy();
+    });
+
+    it('should default action buttons to secondary kind when pageHeaderType is secondary', () => {
+      component.pageHeaderType = 'secondary';
+      component.title = 'Secondary Page';
+      component.actions = [{ label: 'Action 1' }, { label: 'Action 2' }];
+
+      fixture.detectChanges();
+
+      const buttons = fixture.debugElement.nativeElement.querySelectorAll('.po-page-header-actions po-button');
+      buttons.forEach(button => {
+        const buttonEl = button.querySelector('button');
+        if (buttonEl) {
+          expect(buttonEl.classList.contains('po-button-primary')).toBeFalsy();
+        }
+      });
+    });
+
+    it('should respect individual kind from PoPageAction when pageHeaderType is secondary', () => {
+      component.pageHeaderType = 'secondary';
+      component.title = 'Secondary Page';
+      component.actions = [{ label: 'Action 1', kind: 'primary' }, { label: 'Action 2' }];
+
+      fixture.detectChanges();
+
+      const buttons = fixture.debugElement.nativeElement.querySelectorAll('.po-page-header-actions po-button');
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it('should not render breadcrumb when pageHeaderType is tertiary', () => {
+      component.pageHeaderType = 'tertiary';
+      component.title = 'Tertiary Page';
+      component.breadcrumb = { items: [{ label: 'Home' }] };
+      component.actions = [];
+
+      fixture.detectChanges();
+
+      const breadcrumb = fixture.debugElement.nativeElement.querySelector('.po-page-header-breadcrumb');
+      expect(breadcrumb).toBeFalsy();
+    });
+
+    it('should not render back button when pageHeaderType is tertiary', () => {
+      component.pageHeaderType = 'tertiary';
+      component.title = 'Tertiary Page';
+      component.actions = [{ label: 'Action 1' }];
+
+      fixture.detectChanges();
+
+      const backButton = fixture.debugElement.nativeElement.querySelector('po-button[po-page-header-navigation]');
+      expect(backButton).toBeFalsy();
+    });
+
+    it('should respect individual `kind` from PoPageAction when pageHeaderType is tertiary', () => {
+      component.pageHeaderType = 'tertiary';
+      component.title = 'Tertiary Page';
+      component.actions = [{ label: 'Action 1', kind: 'primary' }];
+
+      fixture.detectChanges();
+
+      const buttons = fixture.debugElement.nativeElement.querySelectorAll('.po-page-header-actions po-button');
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('backNavigationLabel', () => {
+    it('should fallback to english label when language is not mapped in backNavigationAriaLabels', () => {
+      const languageService = TestBed.inject(PoLanguageService);
+      spyOn(languageService, 'getShortLanguage').and.returnValue('de');
+
+      const newFixture = TestBed.createComponent(PoPageDefaultComponent);
+      const newComponent = newFixture.componentInstance;
+
+      expect(newComponent.backNavigationLabel).toBe('Back');
+    });
+  });
+
+  describe('getActionKind', () => {
+    it('should return "primary" when action.kind is "primary"', () => {
+      expect(component.getActionKind({ label: 'A', kind: 'primary' }, 'secondary')).toBe('primary');
+    });
+
+    it('should return "secondary" when action.kind is "secondary"', () => {
+      expect(component.getActionKind({ label: 'A', kind: 'secondary' }, 'primary')).toBe('secondary');
+    });
+
+    it('should return fallback when action.kind is "tertiary" (invalid)', () => {
+      expect(component.getActionKind({ label: 'A', kind: 'tertiary' }, 'primary')).toBe('primary');
+    });
+
+    it('should return fallback when action.kind is undefined', () => {
+      expect(component.getActionKind({ label: 'A' }, 'secondary')).toBe('secondary');
+    });
+
+    it('should return fallback when action.kind is an invalid string', () => {
+      expect(component.getActionKind({ label: 'A', kind: 'invalid' }, 'primary')).toBe('primary');
+    });
+
+    it('should return fallback when action.kind is empty string', () => {
+      expect(component.getActionKind({ label: 'A', kind: '' }, 'secondary')).toBe('secondary');
+    });
+
+    it('should allow only one primary kind - second primary falls back to secondary', () => {
+      component.hasPageHeader();
+      expect(component.getActionKind({ label: 'A', kind: 'primary' }, 'secondary')).toBe('primary');
+      expect(component.getActionKind({ label: 'B', kind: 'primary' }, 'secondary')).toBe('secondary');
+    });
+  });
+});
+
+describe('PoPageDefaultComponent i18n fallback', () => {
+  let fixture: ComponentFixture<PoPageDefaultComponent>;
+  let component: PoPageDefaultComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, RouterTestingModule.withRoutes([]), PoBreadcrumbModule, PoButtonModule, PoDropdownModule],
+      declarations: [PoPageDefaultComponent, PoPageComponent, PoPageContentComponent, PoPageHeaderComponent],
+      providers: [{ provide: PoLanguageService, useValue: { getShortLanguage: () => 'fr' } }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PoPageDefaultComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('constructor: should fallback back navigation aria label to english when language key is not found', () => {
+    expect(component['backNavigationLabel']).toBe(backNavigationAriaLabels['en']);
   });
 });

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.ts
@@ -1,20 +1,13 @@
-import {
-  AfterContentInit,
-  Component,
-  OnChanges,
-  Renderer2,
-  SimpleChange,
-  ViewContainerRef,
-  inject
-} from '@angular/core';
+import { AfterContentInit, Component, inject, OnChanges, Renderer2, SimpleChange } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { PoLanguageService } from './../../../services/po-language/po-language.service';
 
 import { isExternalLink, isTypeof, PoUtils } from '../../../utils/util';
+import { AnimaliaIconDictionary } from '../../po-icon/po-icon-dictionary';
 import { PoPageAction } from '../interfaces/po-page-action.interface';
 
-import { PoPageDefaultBaseComponent } from './po-page-default-base.component';
+import { backNavigationAriaLabels, PoPageDefaultBaseComponent } from './po-page-default-base.component';
 
 /**
  * @docsExtends PoPageDefaultBaseComponent
@@ -47,6 +40,9 @@ export class PoPageDefaultComponent extends PoPageDefaultBaseComponent implement
   private readonly renderer = inject(Renderer2);
   private readonly router = inject(Router);
 
+  readonly backIcon: string = AnimaliaIconDictionary.ICON_ARROW_BACK;
+  readonly backNavigationLabel: string;
+
   limitPrimaryActions: number = 3;
   dropdownActions: Array<PoPageAction>;
   isMobile: boolean;
@@ -57,6 +53,8 @@ export class PoPageDefaultComponent extends PoPageDefaultBaseComponent implement
     const languageService = inject(PoLanguageService);
 
     super(languageService);
+
+    this.backNavigationLabel = backNavigationAriaLabels[this.language] || backNavigationAriaLabels['en'];
   }
 
   public ngAfterContentInit(): void {
@@ -90,23 +88,40 @@ export class PoPageDefaultComponent extends PoPageDefaultBaseComponent implement
 
   hasPageHeader() {
     this.visibleActions = this.getVisibleActions();
-    this.setDropdownActions();
 
-    return !!(
-      this.title ||
-      (this.visibleActions && this.visibleActions.length) ||
-      (this.breadcrumb && this.breadcrumb.items.length)
-    );
+    if (this.pageHeaderType === 'secondary') {
+      return true;
+    }
+
+    if (this.pageHeaderType === 'tertiary') {
+      return !!(this.title || this.visibleActions?.length);
+    }
+
+    return !!(this.title || this.visibleActions?.length || this.breadcrumb?.items.length);
   }
 
   setDropdownActions(): void {
-    if (this.visibleActions.length > this.limitPrimaryActions) {
-      this.dropdownActions = this.visibleActions.slice(this.limitPrimaryActions - 1);
+    if (this.pageActionsLayout === 'dropdown') {
+      this.dropdownActions = this.visibleActions;
+    } else if (this.pageActionsLayout === 'mixed') {
+      this.dropdownActions = this.visibleActions.slice(1);
+    } else {
+      if (this.visibleActions.length > this.limitPrimaryActions) {
+        this.dropdownActions = this.visibleActions.slice(this.limitPrimaryActions - 1);
+      } else {
+        this.dropdownActions = [];
+      }
     }
   }
 
   getVisibleActions() {
     return this.actions.filter(action => this.actionIsVisible(action) !== false);
+  }
+
+  // Retorna o kind validado da ação. Apenas 'primary' e 'secondary' são permitidos.
+  // Valores inválidos são ignorados, retornando o fallback informado.
+  getActionKind(action: PoPageAction, fallback: string): string {
+    return action.kind === 'primary' || action.kind === 'secondary' ? action.kind : fallback;
   }
 
   private onResize(event: Event): void {

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Component, inject, OnChanges, Renderer2, SimpleChange } from '@angular/core';
+import { AfterContentInit, Component, inject, OnChanges, OnDestroy, Renderer2, SimpleChange } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { PoLanguageService } from './../../../services/po-language/po-language.service';
@@ -36,7 +36,10 @@ import { backNavigationAriaLabels, PoPageDefaultBaseComponent } from './po-page-
   templateUrl: './po-page-default.component.html',
   standalone: false
 })
-export class PoPageDefaultComponent extends PoPageDefaultBaseComponent implements AfterContentInit, OnChanges {
+export class PoPageDefaultComponent
+  extends PoPageDefaultBaseComponent
+  implements AfterContentInit, OnChanges, OnDestroy
+{
   private readonly renderer = inject(Renderer2);
   private readonly router = inject(Router);
 
@@ -48,6 +51,8 @@ export class PoPageDefaultComponent extends PoPageDefaultBaseComponent implement
   isMobile: boolean;
 
   private readonly maxWidthMobile: number = 480;
+  private _primaryKindUsed = false;
+  private resizeUnlisten: () => void;
 
   constructor() {
     const languageService = inject(PoLanguageService);
@@ -61,13 +66,19 @@ export class PoPageDefaultComponent extends PoPageDefaultBaseComponent implement
     this.setIsMobile();
     this.setDropdownActions();
 
-    this.renderer.listen('window', 'resize', (event: Event) => {
+    this.resizeUnlisten = this.renderer.listen('window', 'resize', (event: Event) => {
       this.onResize(event);
     });
   }
 
   ngOnChanges(changes: { [propName: string]: SimpleChange }) {
     this.setDropdownActions();
+  }
+
+  ngOnDestroy(): void {
+    if (this.resizeUnlisten) {
+      this.resizeUnlisten();
+    }
   }
 
   actionIsDisabled(action: any) {
@@ -88,6 +99,7 @@ export class PoPageDefaultComponent extends PoPageDefaultBaseComponent implement
 
   hasPageHeader() {
     this.visibleActions = this.getVisibleActions();
+    this._primaryKindUsed = false;
 
     if (this.pageHeaderType === 'secondary') {
       return true;
@@ -120,8 +132,18 @@ export class PoPageDefaultComponent extends PoPageDefaultBaseComponent implement
 
   // Retorna o kind validado da ação. Apenas 'primary' e 'secondary' são permitidos.
   // Valores inválidos são ignorados, retornando o fallback informado.
+  // Somente uma ação pode ter kind 'primary' — a primeira encontrada mantém,
+  // as demais caem para 'secondary'.
   getActionKind(action: PoPageAction, fallback: string): string {
-    return action.kind === 'primary' || action.kind === 'secondary' ? action.kind : fallback;
+    if (action.kind === 'primary') {
+      if (!this._primaryKindUsed) {
+        this._primaryKindUsed = true;
+        return 'primary';
+      }
+      return 'secondary';
+    }
+
+    return action.kind === 'secondary' ? action.kind : fallback;
   }
 
   private onResize(event: Event): void {

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
@@ -3,18 +3,70 @@
   [p-breadcrumb]="breadcrumb"
   [p-components-size]="componentsSize"
   [p-literals]="customLiterals"
+  [p-page-actions-layout]="pageActionsLayout"
+  [p-page-header-type]="pageHeaderType"
   [p-title]="title"
   [p-subtitle]="subtitle"
+  (p-back)="onBack()"
 >
 </po-page-default>
 
-<po-divider />
+<po-divider></po-divider>
+
+<form #formPage="ngForm">
+  <div class="po-row">
+    <po-input class="po-md-6" name="title" [(ngModel)]="title" p-label="Title" p-required> </po-input>
+
+    <po-input class="po-md-6" name="subtitle" [(ngModel)]="subtitle" p-label="Subtitle"> </po-input>
+
+    <po-select
+      class="po-lg-3 po-md-6"
+      name="pageHeaderType"
+      [(ngModel)]="pageHeaderType"
+      p-label="Page Header Type"
+      [p-options]="pageHeaderTypeOptions"
+    >
+    </po-select>
+
+    <po-select
+      class="po-lg-3 po-md-6"
+      name="pageActionsLayout"
+      [(ngModel)]="pageActionsLayout"
+      p-label="Page Actions Layout"
+      [p-options]="pageActionsLayoutOptions"
+    >
+    </po-select>
+
+    <po-input
+      class="po-md-6"
+      name="literals"
+      [(ngModel)]="literals"
+      p-help='Ex.: {"otherActions": "Mais ações"}'
+      p-label="Literals"
+      (p-change)="changeLiterals()"
+    >
+    </po-input>
+
+    <po-radio-group
+      class="po-md-12"
+      name="size"
+      [(ngModel)]="componentsSize"
+      p-columns="4"
+      p-label="Components size"
+      p-help="Para aplicar o tamanho small, configure o nível de acessibilidade para AA, ajustável no navbar ou serviço de tema (https://po-ui.io/documentation/po-theme)."
+      [p-options]="componentsSizeOptions"
+    >
+    </po-radio-group>
+  </div>
+</form>
+
+<po-divider></po-divider>
 
 <form #formAction="ngForm">
   <div class="po-row">
-    <po-input class="po-md-6" name="actionAction" [(ngModel)]="action.action" p-clean p-label="Action"> </po-input>
-
     <po-input class="po-md-6" name="actionLabel" [(ngModel)]="action.label" p-label="Label" p-required> </po-input>
+
+    <po-input class="po-md-6" name="actionAction" [(ngModel)]="action.action" p-clean p-label="Action"> </po-input>
 
     <po-input class="po-md-6" name="actionURL" [(ngModel)]="action.url" p-label="URL"> </po-input>
 
@@ -22,6 +74,15 @@
     </po-select>
 
     <po-select class="po-lg-3 po-md-6" name="icon" [(ngModel)]="action.icon" p-label="Icon" [p-options]="iconOptions">
+    </po-select>
+
+    <po-select
+      class="po-lg-3 po-md-6"
+      name="kind"
+      [(ngModel)]="action.kind"
+      p-label="Kind"
+      [p-options]="actionKindOptions"
+    >
     </po-select>
 
     <po-checkbox-group
@@ -47,7 +108,7 @@
   </div>
 </form>
 
-<po-divider />
+<po-divider></po-divider>
 
 <form #formBreadcrumbFavorite="ngForm">
   <div class="po-row">
@@ -97,7 +158,7 @@
   </div>
 </form>
 
-<po-divider />
+<po-divider></po-divider>
 
 <form #formBreadcrumbParams="ngForm">
   <div class="po-row">
@@ -133,36 +194,8 @@
   </div>
 </form>
 
-<po-divider />
+<po-divider></po-divider>
 
-<form #formPage="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="title" [(ngModel)]="title" p-label="Title" p-required> </po-input>
-    <po-input class="po-md-6" name="subtitle" [(ngModel)]="subtitle" p-label="Subtitle"> </po-input>
-
-    <po-input
-      class="po-md-6"
-      name="literals"
-      [(ngModel)]="literals"
-      p-help='Ex.: {"otherActions": "Mais ações"}'
-      p-label="Literals"
-      (p-change)="changeLiterals()"
-    >
-    </po-input>
-
-    <po-radio-group
-      class="po-md-12"
-      name="size"
-      [(ngModel)]="componentsSize"
-      p-columns="4"
-      p-label="Components size"
-      p-help="Para aplicar o tamanho small, configure o nível de acessibilidade para AA, ajustável no navbar ou serviço de tema (https://po-ui.io/documentation/po-theme)."
-      [p-options]="componentsSizeOptions"
-    >
-    </po-radio-group>
-  </div>
-
-  <div class="po-row">
-    <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
-  </div>
-</form>
+<div class="po-row">
+  <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="restore()"> </po-button>
+</div>

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.ts
@@ -4,11 +4,12 @@ import {
   PoBreadcrumb,
   PoBreadcrumbItem,
   PoCheckboxGroupOption,
+  PoNotificationService,
+  PoPageAction,
+  PoPageDefaultLiterals,
   PoRadioGroupOption,
   PoSelectOption
 } from '@po-ui/ng-components';
-
-import { PoNotificationService, PoPageAction, PoPageDefaultLiterals } from '@po-ui/ng-components';
 
 @Component({
   selector: 'sample-po-page-default-labs',
@@ -18,16 +19,23 @@ import { PoNotificationService, PoPageAction, PoPageDefaultLiterals } from '@po-
 export class SamplePoPageDefaultLabsComponent implements OnInit {
   private poNotification = inject(PoNotificationService);
 
-  action: PoPageAction;
-  actions: Array<PoPageAction>;
-  breadcrumb: PoBreadcrumb;
-  breadcrumbItem: PoBreadcrumbItem;
-  breadcrumbParams: any;
-  componentsSize: string;
-  customLiterals: PoPageDefaultLiterals;
-  literals: string;
-  title: string;
-  subtitle: string;
+  action: PoPageAction = { label: '' };
+  actions: Array<PoPageAction> = [];
+  breadcrumb: PoBreadcrumb = { items: [] };
+  breadcrumbItem: PoBreadcrumbItem = { label: undefined, link: undefined };
+  breadcrumbParams: { property?: string; value?: string } = {};
+  componentsSize: string = 'medium';
+  customLiterals: PoPageDefaultLiterals | undefined;
+  literals: string = '';
+  pageActionsLayout: string = 'default';
+  pageHeaderType: string = 'primary';
+  subtitle: string = '';
+  title: string = 'PO Page Default';
+
+  public readonly actionKindOptions: Array<PoSelectOption> = [
+    { label: 'primary', value: 'primary' },
+    { label: 'secondary', value: 'secondary' }
+  ];
 
   public readonly actionOptions: Array<PoCheckboxGroupOption> = [
     { label: 'Disabled', value: 'disabled' },
@@ -48,6 +56,18 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
     { value: 'fa fa-podcast', label: 'fa fa-podcast' }
   ];
 
+  public readonly pageActionsLayoutOptions: Array<PoSelectOption> = [
+    { label: 'default', value: 'default' },
+    { label: 'dropdown', value: 'dropdown' },
+    { label: 'mixed', value: 'mixed' }
+  ];
+
+  public readonly pageHeaderTypeOptions: Array<PoSelectOption> = [
+    { label: 'primary', value: 'primary' },
+    { label: 'secondary', value: 'secondary' },
+    { label: 'tertiary', value: 'tertiary' }
+  ];
+
   public readonly typeOptions: Array<PoSelectOption> = [
     { label: 'Danger', value: 'danger' },
     { label: 'Default', value: 'default' }
@@ -58,7 +78,7 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
   }
 
   addAction(action: PoPageAction) {
-    const newAction = Object.assign({}, action);
+    const newAction: PoPageAction = { ...action };
     newAction.action = newAction.action ? this.showAction.bind(this, newAction.action) : undefined;
     this.actions = [...this.actions, newAction];
 
@@ -71,7 +91,7 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
   }
 
   addBreadcrumbParam() {
-    const newParam = { [this.breadcrumbParams.property]: this.breadcrumbParams.value };
+    const newParam = { [this.breadcrumbParams.property || '']: this.breadcrumbParams.value };
 
     if (this.breadcrumb.params) {
       this.breadcrumb.params = Object.assign(this.breadcrumb.params, newParam);
@@ -90,22 +110,30 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
     }
   }
 
+  onBack() {
+    this.poNotification.information('Back button clicked (p-back event)');
+  }
+
   restore() {
+    this.action = { label: '' };
     this.actions = [];
     this.breadcrumb = { items: [] };
     this.breadcrumbItem = { label: undefined, link: undefined };
     this.breadcrumbParams = {};
     this.componentsSize = 'medium';
+    this.customLiterals = undefined;
     this.literals = '';
-    this.title = 'PO Page Default';
+    this.pageActionsLayout = 'default';
+    this.pageHeaderType = 'primary';
     this.subtitle = '';
+    this.title = 'PO Page Default';
     this.restoreActionForm();
   }
 
   restoreActionForm() {
     this.action = {
-      label: undefined,
-      visible: null
+      label: '',
+      visible: true
     };
   }
 

--- a/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.ts
@@ -21,6 +21,9 @@ export class PoPageHeaderBaseComponent {
   /** Subtítulo da página. */
   @Input('p-subtitle') subtitle: string;
 
+  /** Define o tipo de header: `primary`, `secondary` ou `tertiary`. */
+  @Input('p-type') type: string = 'primary';
+
   private _breadcrumb: PoBreadcrumb;
 
   /** Objeto com propriedades do breadcrumb. */

--- a/projects/ui/src/lib/components/po-page/po-page-header/po-page-header.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-header/po-page-header.component.html
@@ -1,6 +1,10 @@
-<div class="po-page-header">
-  <!-- Breadcrumb -->
-  @if (breadcrumb && breadcrumb.items.length) {
+<div
+  class="po-page-header"
+  [class.po-page-header-secondary]="type === 'secondary'"
+  [class.po-page-header-tertiary]="type === 'tertiary'"
+>
+  <!-- Breadcrumb - only shown for primary -->
+  @if (type === 'primary' && breadcrumb && breadcrumb.items.length) {
     <div class="po-page-header-breadcrumb">
       <po-breadcrumb
         [p-favorite-service]="breadcrumb.favorite"
@@ -13,15 +17,24 @@
   }
 
   <div class="po-page-header-container">
+    <!-- Back navigation button - only for secondary, projected from parent -->
+    <ng-content select="[po-page-header-navigation]"></ng-content>
+
     <!-- Titulo e SubTitulo-->
-    @if (title || subtitle) {
+    @if (title) {
       <div class="po-page-header-title-container">
         @if (title) {
-          <h1 class="po-page-header-title">
-            {{ title }}
-          </h1>
+          @if (type === 'secondary' || type === 'tertiary') {
+            <h3 class="po-page-header-title">
+              {{ title }}
+            </h3>
+          } @else {
+            <h2 class="po-page-header-title">
+              {{ title }}
+            </h2>
+          }
         }
-        @if (subtitle) {
+        @if (title && subtitle) {
           <div class="po-page-header-subtitle">
             {{ subtitle }}
           </div>

--- a/projects/ui/src/lib/components/po-page/po-page.module.ts
+++ b/projects/ui/src/lib/components/po-page/po-page.module.ts
@@ -23,8 +23,9 @@ import { PoPageSlideModule } from './po-page-slide/po-page-slide.module';
 
 /**
  * @description
- * Módulo dos componentes po-page-default, po-page-detail, po-page-edit,
- * po-page-list e po-page-slide.
+ *
+ * Módulo responsável pelos componentes de estrutura de página: `po-page-default`, `po-page-detail`,
+ * `po-page-edit`, `po-page-list` e `po-page-slide`.
  */
 @NgModule({
   imports: [

--- a/projects/ui/src/lib/components/po-popup/po-popup-action.interface.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup-action.interface.ts
@@ -18,122 +18,97 @@ export interface PoPopupAction {
   label: string;
 
   /**
+   * @optional
+   *
    * @description
    *
    * Ação que será executada, sendo possível passar o nome ou a referência da função.
    *
    * No componente `po-dropdown`, a action também pode ser executada para o agrupador de subitens.
    *
-   * > Para que a função seja executada no contexto do elemento filho o mesmo deve ser passado utilizando *bind*.
-   *
-   * Exemplo: `action: this.myFunction.bind(this)`
+   * > Para que a função seja executada no contexto do componente, utilize *bind*:
+   * `action: this.myFunction.bind(this)`
    */
   action?: Function;
 
   /**
+   * @optional
+   *
    * @description
    *
-   * Define um ícone que será exibido ao lado esquerdo do rótulo.
+   * Ícone exibido ao lado esquerdo do rótulo.
    *
-   * É possível usar qualquer um dos ícones da [Biblioteca de ícones](https://po-ui.io/icons). conforme exemplo abaixo:
-   * ```
-   * <po-component
-   *  [p-property]="[{ label: 'PHOSPHOR ICON', icon: 'an an-newspaper' }]">
-   * </po-component>
-   * ```
+   * Aceita ícones da [Biblioteca de ícones](https://po-ui.io/icons), fontes externas (ex: Font Awesome)
+   * ou um `TemplateRef` para ícones customizados.
    *
-   * Também é possível utilizar outras fontes de ícones, por exemplo a biblioteca Font Awesome, da seguinte forma:
    * ```
-   * <po-component
-   *  [p-property]="[{ label: 'FA ICON', icon: 'fa fa-icon-podcast' }]">
-   * </po-component>
-   * ```
-   *
-   * Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
-   * component.html:
-   * ```
-   * <ng-template #iconTemplate>
-   *   <ion-icon name="heart"></ion-icon>
-   * </ng-template>
-   *
-   * <po-component [p-property]="myProperty"></po-component>
-   * ```
-   * component.ts:
-   * ```
-   * @ViewChild('iconTemplate', { static: true } ) iconTemplate : TemplateRef<void>;
-   *
-   * myProperty = [
-   *  {
-   *    label: 'FA ICON',
-   *    icon: this.iconTemplate
-   *  }
-   * ];
+   * { label: 'Ação', icon: 'an an-newspaper' }
    * ```
    */
   icon?: string | TemplateRef<void>;
 
   /**
+   * @optional
+   *
    * @description
    *
    * Atribui uma linha separadora acima do item.
-   *
-   * */
+   */
   separator?: boolean;
 
   /**
+   * @optional
+   *
    * @description
    *
-   * Função que deve retornar um booleano para habilitar ou desabilitar a ação para o registro selecionado.
-   *
-   * Também é possível informar diretamente um valor booleano que vai habilitar ou desabilitar a ação para todos os registros.
-   *
+   * Desabilita a ação. Aceita um valor booleano ou uma função que retorna booleano.
    */
   disabled?: boolean | Function;
 
   /**
+   * @optional
+   *
    * @description
    *
-   * Define a cor do item, sendo `default` o padrão.
+   * Define a cor do item.
    *
    * Valores válidos:
    *  - `default`
-   *  - `danger` - indicado para ações exclusivas (excluir, sair).
+   *  - `danger`
    */
   type?: string;
 
   /**
+   * @optional
+   *
    * @description
    *
-   * URL utilizada para redirecionamento das páginas.
+   * URL para redirecionamento. Aceita rotas internas e links externos.
    *
-   * No componente `po-dropdown`, a url também pode ser configurada para o agrupador de subitens.
-   * Entretanto, quando a `url` é informada em um agrupador, o clique **não abrirá os subitens**, pois o item será
-   * tratado como um link e o redirecionamento terá prioridade sobre a exibição da lista.
+   * No componente `po-dropdown`, quando informada em um agrupador com `subItems`, o clique
+   * redireciona ao invés de abrir os subitens.
    *
+   * > Quando informada, tem prioridade sobre a propriedade `action`.
    */
   url?: string;
 
   /**
+   * @optional
+   *
    * @description
    *
    * Define se a ação está selecionada.
-   *
    */
   selected?: boolean;
 
   /**
+   * @optional
+   *
    * @description
    *
-   * Define se a ação será visível.
+   * Define a visibilidade da ação. Aceita um valor booleano ou uma função que retorna booleano.
    *
-   * > Caso o valor não seja especificado a ação será visível.
-   *
-   * Opções para tornar a ação visível ou não:
-   *
-   *  - Função que deve retornar um booleano.
-   *
-   *  - Informar diretamente um valor booleano.
-   *
+   * @default `true`
    */
   visible?: boolean | Function;
 


### PR DESCRIPTION
**PAGE**

**DTHFUI-12541**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**
Remove cálculo JS de altura e adota flexbox via CSS
Inclui propriedades `p-header-type` e `p-actions-layout`.
Adiciona propriedade `kind` em `PoPageAction`.

**Simulação**
Samples, Portal

**Custom:**
```
@import url('https://fonts.googleapis.com/css2?family=Lumanosimo&family=Playfair+Display+SC&display=swap');

/*------------------------------------*\
  PAGE
\*------------------------------------*/
po-page-default {
  --background: #ff00ff;  /** novo token */
}

po-page-header {
  --padding: 80px;
  --gap: 50px;
  --gap-actions: 30px;
}
po-page-header .po-page-header-title {
  --font-family: 'Courier New', Courier, monospace;
}

po-page-content {
  --padding-content: 100px;
}
```