### PR TITLE
feat(po-table): adiciona output p-change-fixed-columns

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.spec.ts
@@ -1,10 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+
 import { PoPageDynamicListBaseComponent } from './po-page-dynamic-list-base.component';
 
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 
 describe('PoPageDynamicListBaseComponent:', () => {
-  const component = new PoPageDynamicListBaseComponent();
+  let component: PoPageDynamicListBaseComponent;
   const cityOptions = [{ label: 'São Paulo', value: 'sp' }];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({}).compileComponents();
+    component = TestBed.runInInjectionContext(() => new PoPageDynamicListBaseComponent());
+  });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
@@ -86,6 +93,15 @@ describe('PoPageDynamicListBaseComponent:', () => {
 
       expect(component.columns).toEqual(columns);
       expect(component.columns).not.toBe(columns);
+    });
+
+    it('changeFixedColumns: should be an output signal with alias `p-change-fixed-columns`', () => {
+      spyOn(component.changeFixedColumns, 'emit');
+      const fakeColumns = ['name', 'age'];
+
+      component.changeFixedColumns.emit(fakeColumns);
+
+      expect(component.changeFixedColumns.emit).toHaveBeenCalledWith(fakeColumns);
     });
   });
 

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
@@ -1,4 +1,4 @@
-import { Input, Directive, Output, EventEmitter } from '@angular/core';
+import { Input, Directive, Output, EventEmitter, output } from '@angular/core';
 
 import { InputBoolean, PoBreadcrumb, PoTableColumnSort } from '@po-ui/ng-components';
 
@@ -102,6 +102,19 @@ export class PoPageDynamicListBaseComponent {
    * Por exemplo: ["idCard", "name", "hireStatus", "age"].
    */
   @Output('p-change-visible-columns') changeVisibleColumns = new EventEmitter<Array<string>>();
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao alterar o estado de fixação de uma coluna no gerenciador de colunas.
+   *
+   * O componente envia como parâmetro um array de string com as propriedades das colunas fixas.
+   * Por exemplo: ["name", "age"].
+   *
+   * > Incompatível com `p-hide-action-fixed-columns`. Quando esta propriedade estiver ativa, o evento não será disparado.
+   */
+  changeFixedColumns = output<Array<string>>({ alias: 'p-change-fixed-columns' });
 
   /**
    * @optional

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -31,6 +31,7 @@
     (p-show-more)="showMore()"
     (p-sort-by)="onSort($event)"
     (p-change-visible-columns)="onChangeVisibleColumns($event)"
+    (p-change-fixed-columns)="onChangeFixedColumns($event)"
     (p-restore-column-manager)="onColumnRestoreManager($event)"
     (p-sort-by)="onSortBy($event)"
     [p-text-wrap]="textWrap"

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -2340,6 +2340,15 @@ describe('PoPageDynamicTableComponent:', () => {
       expect(component.changeVisibleColumns.emit).toHaveBeenCalledWith(fakeColumns);
     });
 
+    it('onChangeFixedColumns: should call `changeFixedColumns.emit`', () => {
+      spyOn(component.changeFixedColumns, 'emit');
+      const fakeColumns = ['name', 'age'];
+
+      component.onChangeFixedColumns(fakeColumns);
+
+      expect(component.changeFixedColumns.emit).toHaveBeenCalledWith(fakeColumns);
+    });
+
     it('onColumnRestoreManager: should call `columnRestoreManager.emit`', () => {
       spyOn(component.columnRestoreManager, 'emit');
       const fakeColumns = ['name', 'age'];

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -724,6 +724,10 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
     this.changeVisibleColumns.emit(value);
   }
 
+  onChangeFixedColumns(value: Array<string>) {
+    this.changeFixedColumns.emit(value);
+  }
+
   onColumnRestoreManager(value: Array<string>) {
     this.columnRestoreManager.emit(value);
   }

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -28,9 +28,6 @@ class PoTableComponent extends PoTableBaseComponent {
 }
 
 describe('PoTableBaseComponent:', () => {
-  let dateService: PoDateService;
-  let languageService: PoLanguageService;
-  let tableService: PoTableService;
   let component: PoTableComponent;
   let actions: Array<PoTableAction>;
   let columns: Array<PoTableColumn>;
@@ -48,10 +45,14 @@ describe('PoTableBaseComponent:', () => {
       ]
     }).compileComponents();
 
-    dateService = new PoDateService();
-    languageService = new PoLanguageService();
-    tableService = TestBed.inject(PoTableService);
-    component = new PoTableComponent(dateService, languageService, tableService);
+    component = TestBed.runInInjectionContext(
+      () =>
+        new PoTableComponent(
+          TestBed.inject(PoDateService),
+          TestBed.inject(PoLanguageService),
+          TestBed.inject(PoTableService)
+        )
+    );
 
     actions = [
       {

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -7,7 +7,8 @@ import {
   OnChanges,
   OnDestroy,
   Output,
-  SimpleChanges
+  SimpleChanges,
+  output
 } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 
@@ -470,6 +471,29 @@ export abstract class PoTableBaseComponent implements OnChanges, OnDestroy {
    * Por exemplo: ["idCard", "name", "hireStatus", "age"].
    */
   @Output('p-change-visible-columns') changeVisibleColumns = new EventEmitter<Array<string>>();
+
+  /**
+   * @optional
+   *
+   * @description
+   * Evento disparado ao alterar o estado de fixação de uma coluna no gerenciador de colunas.
+   *
+   * O componente envia como parâmetro um array de string com as propriedades das colunas fixas.
+   * Por exemplo: ["name", "age"].
+   *
+   * > Incompatível com `p-hide-action-fixed-columns`. Quando esta propriedade estiver ativa, o evento não será disparado.
+   *
+   * @example
+   *
+   * ```html
+   * <po-table
+   *   [p-columns]="columns"
+   *   [p-items]="items"
+   *   (p-change-fixed-columns)="onFixedColumnsChange($event)">
+   * </po-table>
+   * ```
+   */
+  changeFixedColumns = output<Array<string>>({ alias: 'p-change-fixed-columns' });
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.spec.ts
@@ -691,6 +691,29 @@ describe('PoTableColumnManagerComponent:', () => {
       expect(component.initialColumns.emit).toHaveBeenCalled();
     });
 
+    it(`restore: should emit 'changeFixedColumns' with empty array to signal fixed columns were cleared`, () => {
+      spyOn(component, <any>'getVisibleColumns').and.returnValue([]);
+      spyOn(component, <any>'checkChanges');
+      spyOn(component.initialColumns, 'emit');
+      spyOn(component.changeFixedColumns, 'emit');
+
+      component['restore']();
+
+      expect(component.changeFixedColumns.emit).toHaveBeenCalledWith([]);
+    });
+
+    it(`restore: should not emit 'changeFixedColumns' when hideActionFixedColumns is true`, () => {
+      spyOn(component, <any>'getVisibleColumns').and.returnValue([]);
+      spyOn(component, <any>'checkChanges');
+      spyOn(component.initialColumns, 'emit');
+      spyOn(component.changeFixedColumns, 'emit');
+      component.hideActionFixedColumns = true;
+
+      component['restore']();
+
+      expect(component.changeFixedColumns.emit).not.toHaveBeenCalled();
+    });
+
     describe('disableColumnsOptions:', () => {
       it('disableColumnsOptions: should return disable columns that exceeds the maximum value of columns', () => {
         component.maxColumns = 2;
@@ -1233,6 +1256,56 @@ describe('PoTableColumnManagerComponent:', () => {
         ]);
 
         expect(component.visibleColumnsChange.emit).toHaveBeenCalled();
+      });
+
+      it(`should emit changeFixedColumns with fixed column properties when a column is fixed`, () => {
+        component.columns = [
+          { property: 'Name', visible: true },
+          { property: 'City', visible: true }
+        ];
+        spyOn(component.changeFixedColumns, 'emit');
+
+        component.emitColumnFixed({ property: 'City', value: 'City', visible: true, fixed: true });
+
+        expect(component.changeFixedColumns.emit).toHaveBeenCalledWith(['City']);
+      });
+
+      it(`should emit changeFixedColumns with remaining fixed columns when a column is unfixed`, () => {
+        component.columns = [
+          { property: 'Name', visible: true, fixed: true },
+          { property: 'Age', visible: true, fixed: true },
+          { property: 'City', visible: true, fixed: true }
+        ];
+        spyOn(component.changeFixedColumns, 'emit');
+
+        component.emitColumnFixed({ property: 'Age', value: 'Age', visible: true, fixed: false });
+
+        expect(component.changeFixedColumns.emit).toHaveBeenCalledWith(['Name', 'City']);
+      });
+
+      it(`should emit changeFixedColumns with empty array when no columns are fixed`, () => {
+        component.columns = [
+          { property: 'Name', visible: true },
+          { property: 'City', visible: true }
+        ];
+        spyOn(component.changeFixedColumns, 'emit');
+
+        component.emitColumnFixed(null);
+
+        expect(component.changeFixedColumns.emit).toHaveBeenCalledWith([]);
+      });
+
+      it(`should not emit changeFixedColumns when hideActionFixedColumns is true`, () => {
+        component.columns = [
+          { property: 'Name', visible: true },
+          { property: 'City', visible: true }
+        ];
+        component.hideActionFixedColumns = true;
+        spyOn(component.changeFixedColumns, 'emit');
+
+        component.emitColumnFixed({ property: 'City', value: 'City', visible: true, fixed: true });
+
+        expect(component.changeFixedColumns.emit).not.toHaveBeenCalled();
       });
     });
 

--- a/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-manager/po-table-column-manager.component.ts
@@ -9,7 +9,8 @@ import {
   Renderer2,
   SimpleChange,
   SimpleChanges,
-  ViewChild
+  ViewChild,
+  output
 } from '@angular/core';
 
 import { PoFieldSize } from '../../../enums/po-field-size.enum';
@@ -66,6 +67,10 @@ export class PoTableColumnManagerComponent implements OnChanges, OnDestroy {
   // Evento disparado ao fechar o popover do gerenciador de colunas após alterar as colunas visíveis.
   // O po-table envia como parâmetro um array de string com as colunas visíveis atualizadas. Por exemplo: ["idCard", "name", "hireStatus", "age"].
   @Output('p-change-visible-columns') changeVisibleColumns = new EventEmitter<Array<string>>();
+
+  // Evento disparado ao alterar o estado de fixação de uma coluna no gerenciador de colunas.
+  // O po-table envia como parâmetro um array de string com as propriedades das colunas fixas. Por exemplo: ["name", "age"].
+  changeFixedColumns = output<Array<string>>({ alias: 'p-change-fixed-columns' });
 
   @Output('p-initial-columns') initialColumns = new EventEmitter<Array<string>>();
 
@@ -166,6 +171,9 @@ export class PoTableColumnManagerComponent implements OnChanges, OnDestroy {
     const defaultColumns = this.getVisibleColumns(this.defaultColumns);
     this.initialColumns.emit(this.getVisibleColumns(this.colunsDefault));
     this.checkChanges(defaultColumns, this.restoreDefaultEvent);
+    if (!this.hideActionFixedColumns) {
+      this.changeFixedColumns.emit([]);
+    }
   }
 
   changePosition({ option, direction }) {
@@ -202,6 +210,10 @@ export class PoTableColumnManagerComponent implements OnChanges, OnDestroy {
     }
 
     this.visibleColumnsChange.emit(newColumn);
+    if (!this.hideActionFixedColumns) {
+      const fixedColumns = newColumn.filter(col => col.fixed === true).map(col => col.property);
+      this.changeFixedColumns.emit(fixedColumns);
+    }
   }
 
   private changePositionColumn(array: Array<PoTableColumn>, index: number, direction: Direction) {

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -997,6 +997,7 @@
     [p-hide-action-fixed-columns]="hideActionFixedColumns"
     (p-visible-columns-change)="onVisibleColumnsChange($event)"
     (p-change-visible-columns)="onChangeVisibleColumns($event)"
+    (p-change-fixed-columns)="onChangeFixedColumns($event)"
     [p-columns-default]="initialColumns"
     [p-components-size]="componentsSize"
     (p-initial-columns)="onColumnRestoreManager($event)"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -1579,6 +1579,25 @@ describe('PoTableComponent:', () => {
       expect(component.changeVisibleColumns.emit).toHaveBeenCalledWith(fakeColumns);
     });
 
+    it('onChangeFixedColumns: should call `changeFixedColumns.emit`', () => {
+      spyOn(component.changeFixedColumns, 'emit');
+      const fakeColumns = ['name', 'age'];
+
+      component.onChangeFixedColumns(fakeColumns);
+
+      expect(component.changeFixedColumns.emit).toHaveBeenCalledWith(fakeColumns);
+    });
+
+    it('onChangeFixedColumns: should not call `changeFixedColumns.emit` when hideActionFixedColumns is true', () => {
+      spyOn(component.changeFixedColumns, 'emit');
+      component.hideActionFixedColumns = true;
+      const fakeColumns = ['name', 'age'];
+
+      component.onChangeFixedColumns(fakeColumns);
+
+      expect(component.changeFixedColumns.emit).not.toHaveBeenCalled();
+    });
+
     it('onColumnRestoreManager: should call `columnRestoreManager.emit`', () => {
       spyOn(component.columnRestoreManager, 'emit');
       const fakeColumns = ['name', 'age'];

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -573,6 +573,12 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.changeVisibleColumns.emit(columns);
   }
 
+  onChangeFixedColumns(columns: Array<string>) {
+    if (!this.hideActionFixedColumns) {
+      this.changeFixedColumns.emit(columns);
+    }
+  }
+
   onColumnRestoreManager(value: Array<string>) {
     this.columnRestoreManager.emit(value);
   }

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -26,6 +26,7 @@
   [p-virtual-scroll]="properties.includes('virtualScroll')"
   (p-all-selected)="changeEvent('p-all-selected')"
   (p-all-unselected)="changeEvent('p-all-unselected')"
+  (p-change-fixed-columns)="changeEvent('p-change-fixed-columns')"
   (p-collapsed)="changeEvent('p-collapsed')"
   (p-expanded)="changeEvent('p-expanded')"
   (p-selected)="changeEvent('p-selected')"


### PR DESCRIPTION
Adiciona o output `p-change-fixed-columns` ao `PoTableBaseComponent` e ao `PoTableColumnManagerComponent`, utilizando a API `output()` do Angular.

O evento é disparado em dois momentos:
- Ao alterar o estado de fixação de qualquer coluna no gerenciador de colunas, emitindo um array com as propriedades das colunas atualmente fixas.

O output também foi propagado ao `PoPageDynamicTableComponent` e à sua classe base (`PoPageDynamicListBaseComponent`) com alias `p-change-fixed-columns`, mantendo consistência com o padrão já existente do `p-change-visible-columns`.

Fixes DTHFUI-12398
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)


**Qual o novo comportamento?**
Novo output que é disparado ao alterar o testado de fixação de qualquer coluna no gerenciador de colunas

**Simulação**
[app12398.zip](https://github.com/user-attachments/files/26708539/app12398.zip)
