### PR TITLE
feat(popup): adiciona suporte a subníveis

### DIFF
--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown-action.interface.ts
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown-action.interface.ts
@@ -7,17 +7,8 @@ import { PoPopupAction } from '../po-popup/po-popup-action.interface';
  *
  * @docsExtends PoPopupAction
  *
+ * @ignoreExtendedDescription
+ *
  * @usedBy PoDropdownComponent
  */
-export interface PoDropdownAction extends PoPopupAction {
-  /**
-   * @optional
-   *
-   * @description
-   *
-   * Array de ações (`PoDropdownAction`) usado para criar agrupadores de subitens (submenus).
-   *
-   * > Recomenda-se limitar a navegação a, no máximo, três níveis hierárquicos.
-   */
-  subItems?: Array<PoDropdownAction>;
-}
+export interface PoDropdownAction extends PoPopupAction {}

--- a/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-dropdown/po-dropdown.component.html
@@ -24,6 +24,5 @@
   [p-custom-positions]="popupCustomPositions"
   [p-size]="size"
   [p-target]="dropdownRef"
-  [p-listbox-subitems]="true"
 >
 </po-popup>

--- a/projects/ui/src/lib/components/po-list-view/interfaces/po-list-view-action.interface.ts
+++ b/projects/ui/src/lib/components/po-list-view/interfaces/po-list-view-action.interface.ts
@@ -5,10 +5,12 @@ import { PoPopupAction } from '../../po-popup/po-popup-action.interface';
  *
  * Interface que define as ações do componente `po-list-view`.
  *
- * > As propriedades `separator`, `url` e `selected` serão vistas a partir da terceira ação e somente quando
+ * > As propriedades `subItems`, `separator`, `url` e `selected` serão vistas a partir da terceira ação e somente quando
  * definir quatro ações ou mais.
  *
  * @docsExtends PoPopupAction
+ *
+ * @ignoreExtendedDescription
  *
  * @usedBy PoListViewComponent
  */

--- a/projects/ui/src/lib/components/po-popup/po-popup-action.interface.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup-action.interface.ts
@@ -13,7 +13,7 @@ export interface PoPopupAction {
    *
    * Rótulo da ação.
    *
-   * No componente `po-dropdown`, a label também pode representar o agrupador de subitens.
+   * A label também pode representar o agrupador de subitens quando a ação possuir `subItems`.
    */
   label: string;
 
@@ -24,7 +24,7 @@ export interface PoPopupAction {
    *
    * Ação que será executada, sendo possível passar o nome ou a referência da função.
    *
-   * No componente `po-dropdown`, a action também pode ser executada para o agrupador de subitens.
+   * A action também pode ser executada para o agrupador de subitens quando a ação possuir `subItems`.
    *
    * > Para que a função seja executada no contexto do componente, utilize *bind*:
    * `action: this.myFunction.bind(this)`
@@ -85,8 +85,9 @@ export interface PoPopupAction {
    *
    * URL para redirecionamento. Aceita rotas internas e links externos.
    *
-   * No componente `po-dropdown`, quando informada em um agrupador com `subItems`, o clique
-   * redireciona ao invés de abrir os subitens.
+   * A url também pode ser configurada para o agrupador de subitens.
+   * Entretanto, quando a `url` é informada em um agrupador, o clique **não abrirá os subitens**, pois o item será
+   * tratado como um link e o redirecionamento terá prioridade sobre a exibição da lista.
    *
    * > Quando informada, tem prioridade sobre a propriedade `action`.
    */
@@ -114,6 +115,24 @@ export interface PoPopupAction {
 
   // id interno
   $id?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define uma lista de subitens para criação de menus aninhados.
+   *
+   * Ao definir esta propriedade, o item exibirá um ícone indicador de subnível.
+   * Recomenda-se utilizar no máximo três níveis hierárquicos para garantir a usabilidade.
+   *
+   * > As propriedades `disabled`, `type` e `visible` não são aplicadas visualmente ao item agrupador.
+   *
+   * > Quando `url` é informada em um agrupador, o redirecionamento terá prioridade e os subitens não serão abertos.
+   *
+   * > Em subníveis aninhados, o `icon` do agrupador é substituído pelo indicador de navegação (seta).
+   */
+  subItems?: Array<PoPopupAction>;
 
   // template interno
   $subItemTemplate?: TemplateRef<any>;

--- a/projects/ui/src/lib/components/po-popup/po-popup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup-base.component.spec.ts
@@ -99,6 +99,55 @@ describe('PoPopupBaseComponent:', () => {
       expectPropertiesValues(component, 'customPositions', validValue, validValue);
     });
 
+    describe('computedListboxSubitems:', () => {
+      it('should return false when actions have no subItems', () => {
+        component.actions = [{ label: 'Action 1' }, { label: 'Action 2' }];
+
+        expect(component.computedListboxSubitems).toBeFalse();
+      });
+
+      it('should return true when at least one action has subItems', () => {
+        component.actions = [{ label: 'Action 1' }, { label: 'Group', subItems: [{ label: 'Sub 1' }] }];
+
+        expect(component.computedListboxSubitems).toBeTrue();
+      });
+
+      it('should return false when subItems is an empty array', () => {
+        component.actions = [{ label: 'Action 1', subItems: [] }];
+
+        expect(component.computedListboxSubitems).toBeFalse();
+      });
+
+      it('should return true when at least one action has $subItemTemplate', () => {
+        const templateRef = {} as any;
+        component.actions = [{ label: 'Action 1', $subItemTemplate: templateRef }];
+
+        expect(component.computedListboxSubitems).toBeTrue();
+      });
+
+      it('should return false when actions is empty', () => {
+        component.actions = [];
+
+        expect(component.computedListboxSubitems).toBeFalse();
+      });
+
+      it('should recalculate when actions change dynamically', () => {
+        component.actions = [{ label: 'Action 1' }];
+
+        expect(component.computedListboxSubitems).toBeFalse();
+
+        component.actions = [{ label: 'Group', subItems: [{ label: 'Sub 1' }] }];
+
+        expect(component.computedListboxSubitems).toBeTrue();
+      });
+
+      it('should return false when actions is set to invalid value', () => {
+        (component as { actions: any }).actions = undefined;
+
+        expect(component.computedListboxSubitems).toBeFalse();
+      });
+    });
+
     describe('p-size', () => {
       beforeEach(() => {
         document.documentElement.removeAttribute('data-a11y');

--- a/projects/ui/src/lib/components/po-popup/po-popup-base.component.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup-base.component.ts
@@ -14,6 +14,9 @@ const poPopupDefaultPosition = 'bottom-left';
  * O componente `po-popup` é um container pequeno recomendado para ações de navegação:
  * Ele abre sobreposto aos outros componentes.
  *
+ * Suporta subníveis (submenus) quando as ações possuem a propriedade `subItems`,
+ * habilitando navegação hierárquica automaticamente.
+ *
  * É possível escolher as posições do `po-popup` em relação ao componente alvo, para isto veja a propriedade `p-position`.
  *
  * Também é possível informar um _template_ _header_ para o `po-popup`, que será exibido acima das ações.
@@ -87,8 +90,14 @@ export class PoPopupBaseComponent {
   private _size?: string = undefined;
   private _target: any;
 
-  // Indica se há um listbox com subitens
-  @Input('p-listbox-subitems') listboxSubitems = false;
+  // Determina se o modo de subníveis deve ser ativado.
+  // Retorna true se alguma ação possuir subItems não vazio ou $subItemTemplate.
+  get computedListboxSubitems(): boolean {
+    if (!this._actions || this._actions.length === 0) {
+      return false;
+    }
+    return this._actions.some(action => (action.subItems && action.subItems.length > 0) || !!action.$subItemTemplate);
+  }
 
   // template-icon
   @Input('p-template-icon') templateIcon = false;

--- a/projects/ui/src/lib/components/po-popup/po-popup.component.html
+++ b/projects/ui/src/lib/components/po-popup/po-popup.component.html
@@ -11,7 +11,7 @@
         [p-items]="actions"
         [p-param]="param"
         [p-size]="size"
-        [p-listbox-subitems]="listboxSubitems"
+        [p-listbox-subitems]="computedListboxSubitems"
         (p-close)="close()"
         (p-click-item)="onClickItem($event)"
       >

--- a/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-labs/sample-po-popup-labs.component.html
+++ b/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-labs/sample-po-popup-labs.component.html
@@ -11,37 +11,47 @@
 
 <div class="po-row sample-button-container">
   <div class="po-offset-xl-5 po-offset-lg-5 po-md-2 po-lg-2">
-    <po-button #target p-label="PopUp" (p-click)="popup.toggle()"> </po-button>
+    <po-button #target p-label="Popup" (p-click)="popup.toggle()"> </po-button>
   </div>
 </div>
 
 <po-divider />
 
 <form #formAction="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="actionAction" [(ngModel)]="action.action" p-clean p-label="Action"> </po-input>
+  <po-input class="po-md-6 po-lg-4" name="actionLabel" [(ngModel)]="action.label" p-label="Label" p-required>
+  </po-input>
 
-    <po-input class="po-md-6" name="actionLabel" [(ngModel)]="action.label" p-label="Label" p-required> </po-input>
+  <po-input class="po-md-6 po-lg-4" name="actionAction" [(ngModel)]="action.action" p-clean p-label="Action">
+  </po-input>
 
-    <po-input class="po-md-6" name="actionURL" [(ngModel)]="action.url" p-label="URL"> </po-input>
+  <po-input class="po-md-6 po-lg-4" name="actionURL" [(ngModel)]="action.url" p-label="URL"> </po-input>
 
-    <po-select class="po-md-6 po-lg-3" name="type" [(ngModel)]="action.type" p-label="Type" [p-options]="typeOptions">
-    </po-select>
+  <po-select class="po-md-6 po-lg-4" name="type" [(ngModel)]="action.type" p-label="Type" [p-options]="typeOptions">
+  </po-select>
 
-    <po-select class="po-md-6 po-lg-3" name="icon" [(ngModel)]="action.icon" p-label="Icon" [p-options]="iconOptions">
-    </po-select>
+  <po-select class="po-md-6 po-lg-4" name="icon" [(ngModel)]="action.icon" p-label="Icon" [p-options]="iconOptions">
+  </po-select>
 
-    <po-checkbox-group
-      class="po-md-12"
-      name="action"
-      [(ngModel)]="action"
-      p-columns="4"
-      p-indeterminate
-      p-label="Action properties"
-      [p-options]="actionOptions"
-    >
-    </po-checkbox-group>
-  </div>
+  <po-select
+    class="po-md-6 po-lg-4"
+    name="parent"
+    [(ngModel)]="action.parent"
+    p-label="Subitems"
+    p-placeholder="Add subitems"
+    [p-options]="parentList"
+  >
+  </po-select>
+
+  <po-checkbox-group
+    class="po-md-12"
+    name="action"
+    [(ngModel)]="action"
+    p-columns="4"
+    p-indeterminate
+    p-label="Action properties"
+    [p-options]="actionOptions"
+  >
+  </po-checkbox-group>
 
   <div class="po-row">
     <po-button

--- a/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-labs/sample-po-popup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-popup/samples/sample-po-popup-labs/sample-po-popup-labs.component.ts
@@ -19,9 +19,10 @@ export class SamplePoPopupLabsComponent implements OnInit {
 
   @ViewChild('target', { read: ElementRef, static: true }) targetRef: ElementRef;
 
-  action: PoPopupAction;
+  action: PoPopupAction & { parent?: string };
   actions: Array<PoPopupAction>;
   customPositions: Array<string>;
+  parentList: Array<PoSelectOption>;
   position: string;
   positions: string;
   properties: Array<string>;
@@ -73,10 +74,23 @@ export class SamplePoPopupLabsComponent implements OnInit {
     this.restore();
   }
 
-  addAction(action: PoPopupAction) {
-    const newAction = Object.assign({}, action);
+  addAction(action: PoPopupAction & { parent?: string }) {
+    const newAction: PoPopupAction = { ...action };
     newAction.action = newAction.action ? this.showAction.bind(this, newAction.action) : undefined;
-    this.actions.push(newAction);
+
+    if (!action.parent) {
+      this.actions = [...this.actions, newAction];
+    } else {
+      const parentNode = this.getActionNode(this.actions, action.parent);
+      if (parentNode) {
+        parentNode.subItems = [...(parentNode.subItems || []), newAction];
+      } else {
+        this.actions = [...this.actions, newAction];
+      }
+    }
+
+    this.actions = [].concat(this.actions);
+    this.parentList = this.updateParentList(this.actions);
 
     this.restoreActionForm();
   }
@@ -88,6 +102,7 @@ export class SamplePoPopupLabsComponent implements OnInit {
   restore() {
     this.actions = [];
     this.customPositions = [];
+    this.parentList = [];
     this.position = undefined;
     this.positions = '';
     this.properties = [];
@@ -98,8 +113,51 @@ export class SamplePoPopupLabsComponent implements OnInit {
   restoreActionForm() {
     this.action = {
       label: undefined,
-      visible: null
-    };
+      visible: null,
+      parent: undefined
+    } as any;
+  }
+
+  private getActionNode(items: Array<PoPopupAction>, value: string): PoPopupAction | undefined {
+    if (!items || !Array.isArray(items) || !value) {
+      return undefined;
+    }
+
+    for (const item of items) {
+      if (item.label === value || (item as any).value === value) {
+        return item;
+      }
+
+      if (item.subItems && Array.isArray(item.subItems)) {
+        const found = this.getActionNode(item.subItems, value);
+        if (found) {
+          return found;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  private updateParentList(
+    items: Array<PoPopupAction>,
+    level = 0,
+    parentList: Array<PoSelectOption> = []
+  ): Array<PoSelectOption> {
+    if (!items || !Array.isArray(items)) {
+      return parentList;
+    }
+
+    items.forEach(item => {
+      const { label } = item;
+      parentList.push({ label: `${'-'.repeat(level)} ${label}`, value: label });
+
+      if (item.subItems && Array.isArray(item.subItems)) {
+        this.updateParentList(item.subItems, level + 1, parentList);
+      }
+    });
+
+    return parentList;
   }
 
   private showAction(action: string): any {


### PR DESCRIPTION
Adiciona propriedade subItems na interface PoPopupAction e implementa detecção automática de subníveis.

Fixes DTHFUI-12747

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Popup não tinha disponível a possibilidade de aplicar subníveis nas ações.

**Qual o novo comportamento?**
Agora o popup passa a ter essa propriedade disponível.

**Simulação**
[app-po-angular.zip](https://github.com/user-attachments/files/27445478/app-po-angular.zip)