### PR TITLE
fix(combo): limpa seleção anterior ao atualizar valor via ngModel

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/interfaces/po-combo-option-group.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/interfaces/po-combo-option-group.interface.ts
@@ -8,7 +8,12 @@ import { PoComboOption } from './po-combo-option.interface';
  * Interface dos agrupamentos da coleção que será exibida no dropdown do `po-combo`.
  */
 export interface PoComboOptionGroup {
-  /** Título para cada grupo de opções. */
+  /**
+   * Título para cada grupo de opções.
+   *
+   * Recomendação: evite usar labels idênticos em diferentes grupos. Labels iguais podem
+   * causar ambiguidade para usuários e dificultar a identificação/seleção dos itens.
+   */
   label: string;
 
   /** Lista de itens a serem exibidos. */

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -715,6 +715,53 @@ describe('PoComboBaseComponent:', () => {
       expect(component['fromWriteValue']).toBe(false);
     });
 
+    it('should clear `selected` from previous option when writeValue is called with a new value', () => {
+      component.options = [
+        { label: 'Test 1', value: 1 },
+        { label: 'Test 2', value: 2 },
+        { label: 'Test 3', value: 3 }
+      ];
+
+      component.writeValue(1);
+
+      expect(component['comboOptionsList'].filter(o => o.selected).length).toBe(1);
+      expect(component['comboOptionsList'].find(o => o.value === 1).selected).toBe(true);
+
+      component.writeValue(3);
+
+      expect(component['comboOptionsList'].filter(o => o.selected).length).toBe(1);
+      expect(component['comboOptionsList'].find(o => o.value === 1).selected).toBe(false);
+      expect(component['comboOptionsList'].find(o => o.value === 3).selected).toBe(true);
+    });
+
+    it('should keep `cacheStaticOptions` in sync with `comboOptionsList` after writeValue, avoiding stale `selected` from previous manual clicks', () => {
+      component.options = [
+        { label: 'Florianópolis', value: 'florianopolis' },
+        { label: 'São Paulo', value: 'sao_paulo' },
+        { label: 'Curitiba', value: 'curitiba' }
+      ];
+
+      // simula clique manual em Florianópolis (po-listbox.optionClicked muta selected nos itens da lista)
+      component['comboOptionsList'].forEach(o => (o.selected = o.value === 'florianopolis'));
+
+      // simula clique manual em São Paulo
+      component['comboOptionsList'].forEach(o => (o.selected = o.value === 'sao_paulo'));
+
+      // troca via ngModel para Florianópolis
+      component.writeValue('florianopolis');
+
+      const cache = component['cacheStaticOptions'];
+      expect(cache.filter(o => o.selected).length).toBe(1);
+      expect(cache.find(o => o.value === 'florianopolis').selected).toBe(true);
+      expect(cache.find(o => o.value === 'sao_paulo').selected).toBe(false);
+
+      // garante que comboOptionsList e cacheStaticOptions continuam compartilhando referências
+      expect(component['comboOptionsList']).toBe(cache);
+      component['comboOptionsList'].forEach((option, index) => {
+        expect(option).toBe(cache[index]);
+      });
+    });
+
     describe('controlValueWithLabel', () => {
       it('should return the object when controlValueWithLabel is true', () => {
         const selectedOption = { value: 1, label: 'Xpto' };
@@ -1244,6 +1291,35 @@ describe('PoComboBaseComponent:', () => {
       expect(spyUpdateInternalVariables).toHaveBeenCalledWith(option);
 
       expect(spyUpdateModel).not.toHaveBeenCalled();
+    });
+
+    it('updateSelectedValue: should select only the selected group title by dynamicLabel', () => {
+      component['comboOptionsList'] = [
+        { label: 'Sul', options: true, selected: false },
+        { label: 'Paraná', value: 'PR', selected: false },
+        { label: 'Santa Catarina', value: 'SC', selected: false },
+        { label: 'Sudeste', options: true, selected: true },
+        { label: 'São Paulo', value: 'SP', selected: false },
+        { label: 'Rio de Janeiro', value: 'RJ', selected: false }
+      ];
+
+      component.updateSelectedValue({ label: 'Sul', options: true });
+
+      expect(component['comboOptionsList'].find(option => option.label === 'Sul').selected).toBeTrue();
+      expect(component['comboOptionsList'].find(option => option.label === 'Sudeste').selected).toBeFalse();
+      expect(component['comboOptionsList'].filter(option => option.options === true && option.selected).length).toBe(1);
+    });
+
+    it('updateSelectedValue(null): should clear `selected` from all previously selected options', () => {
+      component['comboOptionsList'] = [
+        { label: 'A', value: 'a', selected: true },
+        { label: 'B', value: 'b', selected: false },
+        { label: 'Grupo', options: true, selected: true }
+      ];
+
+      component.updateSelectedValue(null);
+
+      expect(component['comboOptionsList'].every(o => !o.selected)).toBeTrue();
     });
 
     describe('VisibleOptions:', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -922,9 +922,9 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
 
   updateSelectedValue(option: any, isUpdateModel: boolean = true) {
     const optionLabel = (option && option[this.dynamicLabel]) || '';
-
+    const optionValue = option?.[this.dynamicValue] !== undefined ? option[this.dynamicValue] : undefined;
     this.updateInternalVariables(option);
-
+    this.updateOptionsSelectedState(option, optionValue);
     // atualiza o valor do input quando for changeOnEnter apenas se for para atualizar o model.
     if (this.changeOnEnter && isUpdateModel) {
       this.setInputValue(optionLabel);
@@ -933,9 +933,26 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     }
 
     if (isUpdateModel) {
-      const optionValue = option?.[this.dynamicValue] !== undefined ? option[this.dynamicValue] : undefined;
       this.updateModel(optionValue);
     }
+  }
+
+  private isGroupTitle(option: any): boolean {
+    return option?.options === true;
+  }
+
+  private updateOptionsSelectedState(selectedOption: any, value: any): void {
+    this.comboOptionsList.forEach((option: any) => {
+      const isSelectedGroup =
+        this.isGroupTitle(option) &&
+        this.isGroupTitle(selectedOption) &&
+        option[this.dynamicLabel] === selectedOption[this.dynamicLabel];
+
+      const isSelectedOption =
+        !this.isGroupTitle(option) && validValue(value) && this.isEqual(option[this.dynamicValue], value);
+
+      option.selected = isSelectedGroup || isSelectedOption;
+    });
   }
 
   callModelChange(value: any) {
@@ -1079,12 +1096,6 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
       const option = this.getOptionFromValue(value, this.comboOptionsList);
       this.updateSelectedValue(option);
       this.normalizeModelIfNeeded(originalValue, option);
-      this.comboOptionsList = this.comboOptionsList.map((option: any) => {
-        if (this.isEqual(option[this.dynamicValue], value)) {
-          return { ...option, selected: true };
-        }
-        return option;
-      });
       this.updateComboList();
       this.removeInitialFilter = false;
       return;


### PR DESCRIPTION
Garante que apenas a opção atual seja marcada como selecionada no 'writeValue', evitando que múltiplos itens fiquem com o estado 'selected: true' na lista do combo. Garante que apenas o grupo de opções correspondente ao valor atualizado seja marcado como selecionado, evitando que múltiplos grupos fiquem com o estado 'selected: true' na lista do combo. 

fix DTHFUI-12964
[dthfui-12964.zip](https://github.com/user-attachments/files/27542901/dthfui-12964.zip)

