### PR TITLE
fix(multiselect): corrige validação ao remover tags compactadas 

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -442,6 +442,32 @@ describe('PoMultiselectComponent:', () => {
     expect(component.selectedOptions.some(opt => opt.value === 0)).toBeFalse();
   });
 
+  it('closeTag: should remove items not in visibleTags when value is empty string', () => {
+    component.visibleTags = [
+      { label: 'label', value: 1 },
+      { label: 'label2', value: 2 },
+      { label: '+2', value: '' }
+    ];
+
+    component.selectedOptions = [
+      component.visibleTags[0],
+      component.visibleTags[1],
+      { label: 'label3', value: 3 },
+      { label: 'label4', value: 4 }
+    ];
+
+    spyOn(component, 'updateVisibleItems');
+    spyOn(component, 'callOnChange');
+
+    component['closeTag']('', 'click');
+
+    expect(component.updateVisibleItems).toHaveBeenCalled();
+    expect(component.callOnChange).toHaveBeenCalled();
+    expect(component.selectedOptions.length).toBe(2);
+    expect(component.selectedOptions[0].value).toBe(1);
+    expect(component.selectedOptions[1].value).toBe(2);
+  });
+
   describe('showAdditionalHelp:', () => {
     let helperEl: any;
     beforeEach(() => {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -486,7 +486,7 @@ export class PoMultiselectComponent
   closeTag(value, event) {
     let index;
     this.enterCloseTag = true;
-    if (value === null || value === undefined || (typeof value === 'string' && value.includes('+'))) {
+    if (value == null || value === '' || (typeof value === 'string' && value.includes('+'))) {
       index = null;
       const itemsNotInVisibleTags = this.selectedOptions.filter(option => !this.visibleTags.includes(option));
       for (const option of this.visibleTags) {


### PR DESCRIPTION
**po-multiselect**

**#2842**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**

No po-multiselect, ao clicar para remover a tag das opções compactadas, era chamado a função closeTag(), que recebe o valor da tag, define se é tag compactada ou tag única e faz o processamento de remove-la.

O problema é que essa função identificava se era tag compactada caso o valor da tag fosse undefined, null ou fosse uma string que incluia o caractere "+".

`if (value === null || value === undefined || (typeof value === 'string' && value.includes('+'))) {`

Mas, no cenário atual, o valor dessa tag compactada estava sendo retornada como uma string vazia ("").

**Qual o novo comportamento?**

Houve duas mudanças:

- Agora é validado também se o valor recebido na função é uma string vazia:

`if (value == null || value === '' || (typeof value === 'string' && value.includes('+'))) {`

- Foi retirado a validação duplicada de null e undefined, pois para o javascript value == null já cobre esses dois cenários. Essa remoção foi feita para deixar a condição do bloco if mais simples e sem duplicidade.

<img width="270" height="94" alt="image" src="https://github.com/user-attachments/assets/75d395e2-b665-4f89-a9e0-87ef69e540eb" />

_OBS: A branch adicionada no bloco if já está sendo coberta nos testes atuais, garantindo já 100% coverage. Também não foi apenas ajustado a validação do if para apenas olhar se o valor é falsy, pois há cenário de testes no projeto que testam que o valor "0" pode ser aceito como sendo uma tag única, portanto não daria para apenas validar `!valor` pois isso faria o valor 0 cair nessa condição._

**Simulação**

1. Execute o portal localmente (npm run build:portal && ng serve portal).
2. Acesse o exemplo do componente po-multiselect com o título "PO Multiselect Labs".
3. Adicione várias opções para popular o array de opções do po-multiselect;
4. Selecione diversos itens até que as tags sejam agrupadas no formato compactado (ex: exibindo +3).
5. Clique no ícone de fechar ("x") da tag compactada.
6. Resultado esperado: A lista de itens selecionados deve ser limpa ou o agrupamento deve ser atualizado corretamente, sem erros no console ou falha na interface.
7. Verifique também a remoção de uma tag única (não compactada) para garantir que o comportamento padrão permanece íntegro.
8. Verifique também que uma tag com o valor de "0" é excluída corretamente quando necessário (há um teste unitário sobre isso no projeto).

Fixes #2842 