### PR TITLE
docs(mcp): adiciona documentação completa para o NPM

### DIFF
--- a/projects/mcp/README.md
+++ b/projects/mcp/README.md
@@ -1,0 +1,304 @@
+# @po-ui/mcp
+
+Servidor [Model Context Protocol](https://modelcontextprotocol.io) que expõe a documentação oficial do **PO UI** para agentes de IA.
+
+[![npm version](https://img.shields.io/npm/v/@po-ui/mcp.svg)](https://www.npmjs.com/package/@po-ui/mcp)
+[![license](https://img.shields.io/npm/l/@po-ui/mcp.svg)](https://github.com/po-ui/po-angular/blob/master/LICENSE)
+[![node](https://img.shields.io/node/v/@po-ui/mcp.svg)](https://nodejs.org)
+
+</div>
+
+---
+
+## Sumário
+
+- [Visão geral](#visão-geral)
+- [Por que usar](#por-que-usar)
+- [Instalação](#instalação)
+- [Configuração nos clientes MCP](#configuração-nos-clientes-mcp)
+  - [Claude Desktop](#claude-desktop)
+  - [Cursor](#cursor)
+  - [VS Code (GitHub Copilot Chat)](#vs-code-github-copilot-chat)
+  - [Kiro](#kiro)
+  - [Continue.dev](#continuedev)
+- [Ferramentas disponíveis](#ferramentas-disponíveis)
+  - [`list_components`](#list_components)
+  - [`get_component_docs`](#get_component_docs)
+  - [`search_docs`](#search_docs)
+  - [`get_guide`](#get_guide)
+- [Exemplos de prompts](#exemplos-de-prompts)
+- [Fontes de dados](#fontes-de-dados)
+- [Requisitos](#requisitos)
+- [Troubleshooting](#troubleshooting)
+- [Contribuindo](#contribuindo)
+- [Licença](#licença)
+
+---
+
+## Visão geral
+
+O `@po-ui/mcp` é um servidor [MCP](https://modelcontextprotocol.io) que conecta assistentes de IA (Claude, Cursor, GitHub Copilot, Kiro, Continue, entre outros) à base de conhecimento oficial do **[PO UI](https://po-ui.io)**
+
+Em vez de copiar e colar trechos de documentação no chat, o agente passa a consultar diretamente o portal `po-ui.io` em tempo real, retornando descrições, tabelas de inputs/outputs, exemplos de uso e guias atualizados de mais de **80 componentes, diretivas, serviços, interfaces e enums**.
+
+```
+┌──────────────────┐      stdio      ┌─────────────────┐     HTTPS    ┌──────────────┐
+│ Cliente MCP      │ ◄─────────────► │ @po-ui/mcp      │ ◄──────────► │ po-ui.io     │
+│ (Claude/Cursor)  │                 │ (servidor Node) │              │ (llms.txt)   │
+└──────────────────┘                 └─────────────────┘              └──────────────┘
+```
+
+## Por que usar
+
+- **Documentação sempre atualizada**: o servidor consome `llms.txt`, `llms-full.txt` e `llms-generated/*.md` direto do `po-ui.io`, sem versão congelada no pacote.
+- **Respostas precisas**: o agente recebe o conteúdo oficial em Markdown, com tabelas de propriedades, tipos e exemplos, reduzindo alucinação.
+- **Busca semântica simples**: pesquise por comportamento (`"upload de arquivo"`), propriedade (`"p-loading"`) ou padrão (`"lazy load"`) e descubra qual componente atende.
+- **Zero configuração**: roda via `npx`, sem clone, sem build, sem instalação global.
+- **Resiliente**: faz fallback automático para `raw.githubusercontent.com` quando o portal está fora do ar.
+
+## Instalação
+
+Não é necessário instalar globalmente. Os clientes MCP executam o pacote sob demanda via `npx`:
+
+```bash
+npx -y @po-ui/mcp
+```
+
+> O comando inicia o servidor em modo `stdio`. Em uso normal, quem invoca o processo é o cliente MCP — o usuário apenas configura o JSON de cada ferramenta.
+
+Se preferir instalar localmente para inspecionar ou rodar em modo offline-first:
+
+```bash
+npm install -g @po-ui/mcp
+po-ui-mcp
+```
+
+## Configuração nos clientes MCP
+
+A configuração é a mesma em todos os clientes que seguem a especificação MCP: um bloco `mcpServers` apontando para o `npx`.
+
+### Claude Desktop
+
+Edite o arquivo de configuração:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "po-ui": {
+      "command": "npx",
+      "args": ["-y", "@po-ui/mcp"]
+    }
+  }
+}
+```
+
+Reinicie o Claude Desktop. O ícone de ferramentas (🔌) deve indicar o servidor `po-ui` ativo.
+
+### Cursor
+
+Em **Settings → MCP → Add new MCP server**, ou editando `.cursor/mcp.json` na raiz do projeto:
+
+```json
+{
+  "mcpServers": {
+    "po-ui": {
+      "command": "npx",
+      "args": ["-y", "@po-ui/mcp"]
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot Chat)
+
+Em `.vscode/mcp.json` no workspace, ou nas Settings (`chat.mcp.servers`):
+
+```json
+{
+  "servers": {
+    "po-ui": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@po-ui/mcp"]
+    }
+  }
+}
+```
+
+### Kiro
+
+Em `.kiro/settings/mcp.json` (workspace) ou `~/.kiro/settings/mcp.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "po-ui": {
+      "command": "npx",
+      "args": ["-y", "@po-ui/mcp"],
+      "disabled": false,
+      "autoApprove": ["list_components", "get_component_docs", "search_docs", "get_guide"]
+    }
+  }
+}
+```
+
+### Continue.dev
+
+Em `~/.continue/config.json`, dentro de `experimental.modelContextProtocolServers`:
+
+```json
+{
+  "experimental": {
+    "modelContextProtocolServers": [
+      {
+        "transport": {
+          "type": "stdio",
+          "command": "npx",
+          "args": ["-y", "@po-ui/mcp"]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Ferramentas disponíveis
+
+O servidor expõe quatro ferramentas (`tools`) ao cliente MCP.
+
+### `list_components`
+
+Lista todos os componentes, diretivas, serviços, interfaces, enums e guias do PO UI com descrição resumida. Use como ponto de partida para descobrir o que existe antes de pedir detalhes.
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+|-----------|------|-------------|-----------|
+| `section` | `"components" \| "services" \| "interfaces" \| "enums" \| "guides" \| "all"` | não | Filtra por seção. Padrão: `all`. |
+| `filter`  | `string` | não | Texto livre aplicado a nome e descrição (case-insensitive). |
+
+**Exemplo de chamada:**
+
+```json
+{ "section": "components", "filter": "table" }
+```
+
+### `get_component_docs`
+
+Retorna a documentação completa em Markdown de um componente, serviço, interface ou enum — incluindo descrição, tabelas de inputs/outputs/propriedades, tipos e exemplos.
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+|-----------|------|-------------|-----------|
+| `slug` | `string` | sim | Identificador do recurso. Aceita slug (`po-button`), seletor (`<po-button>`) e nome de classe (`PoButtonComponent`, `PoDialogService`). |
+
+A entrada é normalizada automaticamente: angle brackets são removidos, `CamelCase` é convertido para `kebab-case` e o sufixo `-component` é descartado. Se o slug não for encontrado, o servidor responde com sugestões similares baseadas no índice.
+
+**Exemplo:**
+
+```json
+{ "slug": "PoButtonComponent" }
+```
+
+### `search_docs`
+
+Busca textual em toda a documentação do PO UI (arquivo `llms-full.txt`). Útil para encontrar componentes que suportem uma propriedade específica, um comportamento ou um padrão de uso.
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+|-----------|------|-------------|-----------|
+| `query` | `string` (mínimo 2 caracteres) | sim | Texto a buscar (case-insensitive). |
+| `max_results` | `number` (1–50) | não | Limite de resultados. Padrão: `10`. |
+
+Cada resultado traz o nome do componente identificado e um trecho com até três regiões de contexto (±2 linhas em torno de cada ocorrência).
+
+**Exemplo:**
+
+```json
+{ "query": "lazy load", "max_results": 5 }
+```
+
+### `get_guide`
+
+Retorna o conteúdo completo de um guia da documentação (ex.: `getting-started`, `schematics`, `theme-customization`, `browser-support`, `llms`).
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+|-----------|------|-------------|-----------|
+| `guide` | `string` | sim | Nome do guia, com ou sem extensão `.md`. |
+
+**Exemplo:**
+
+```json
+{ "guide": "getting-started" }
+```
+
+> Para descobrir os guias disponíveis, chame `list_components` com `section: "guides"`.
+
+## Exemplos de prompts
+
+Depois de configurar o servidor, basta conversar naturalmente com o agente. Algumas sugestões:
+
+- *"Quais componentes do PO UI permitem upload de arquivo?"*
+- *"Mostre as propriedades do `po-table` e como habilitar paginação por requisição."*
+- *"Como configuro o tema escuro com o `PoThemeService`?"*
+- *"Existe um componente para exibir uma timeline ou stepper?"*
+- *"Liste todos os enums do PO UI e suas finalidades."*
+- *"Traga o guia de `schematics` e explique o `ng add @po-ui/ng-components`."*
+
+## Fontes de dados
+
+O servidor consome documentação pública diretamente das seguintes URLs:
+
+| Recurso | URL |
+|---------|-----|
+| Índice de APIs e guias | `https://po-ui.io/llms.txt` |
+| Documentação consolidada (full text) | `https://po-ui.io/llms-full.txt` |
+| Documentação por componente | `https://po-ui.io/llms-generated/{slug}.md` |
+| Guias | `https://raw.githubusercontent.com/po-ui/po-angular/master/docs/guides/{name}.md` |
+| Fallback dos componentes | `https://raw.githubusercontent.com/po-ui/po-angular/master/projects/portal/src/llms-generated/{slug}.md` |
+
+O índice (`llms.txt`) é cacheado em memória pelo tempo de vida do processo. Não há cache em disco — basta reiniciar o cliente MCP para atualizar.
+
+## Requisitos
+
+- **Node.js** 18 ou superior
+- Conexão de internet com acesso a `po-ui.io` e `raw.githubusercontent.com`
+
+Dependências de runtime:
+
+- [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk) — implementação oficial do protocolo
+- [`zod`](https://www.npmjs.com/package/zod) — validação de schemas das ferramentas
+
+## Troubleshooting
+
+**O cliente não encontra o servidor.**
+Verifique se o `npx` está no `PATH` do processo que executa o cliente MCP. No Windows, prefira o caminho completo (`C:\\Program Files\\nodejs\\npx.cmd`) quando o cliente roda fora do shell padrão.
+
+**Resposta `Falha ao buscar llms.txt`.**
+Indica bloqueio de rede ou portal indisponível. O servidor tem timeout de 10 s por requisição. Verifique acesso a `https://po-ui.io/llms.txt` e tente novamente.
+
+**`Componente "..." não encontrado`.**
+Confirme o slug com `list_components`. Lembre-se de que componentes usam o seletor (`po-*`), não o nome da classe interna.
+
+**O agente não está acionando as ferramentas.**
+Alguns clientes exigem aprovação manual na primeira chamada. Em Kiro, adicione as quatro ferramentas ao `autoApprove`. Em Cursor/Claude, verifique o painel de ferramentas conectadas.
+
+**Logs do servidor.**
+Mensagens de erro fatais são escritas em `stderr` com o prefixo `[po-ui-mcp]`. A maioria dos clientes expõe esse log em uma aba dedicada (em Cursor: *Output → MCP*).
+
+## Contribuindo
+
+O código-fonte vive no monorepo principal: [`po-ui/po-angular`](https://github.com/po-ui/po-angular), pasta [`projects/mcp`](https://github.com/po-ui/po-angular/tree/master/projects/mcp).
+
+```bash
+git clone https://github.com/po-ui/po-angular.git
+cd po-angular
+npm install
+npm run build --workspace projects/mcp   # ou: cd projects/mcp && npm run build
+npm test --workspace projects/mcp
+```
+
+Issues, sugestões de novas ferramentas e PRs são bem-vindos. Antes de abrir um PR, leia o [guia de contribuição](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md).
+
+## Licença
+
+[MIT](https://github.com/po-ui/po-angular/blob/master/LICENSE) © PO UI

--- a/projects/mcp/README.md
+++ b/projects/mcp/README.md
@@ -1,0 +1,242 @@
+# @po-ui/mcp
+
+Servidor [Model Context Protocol (MCP)](https://modelcontextprotocol.io) que disponibiliza a documentação oficial do [PO UI](https://po-ui.io) para assistentes de IA.
+
+[![npm version](https://img.shields.io/npm/v/@po-ui/mcp.svg)](https://www.npmjs.com/package/@po-ui/mcp)
+[![license](https://img.shields.io/npm/l/@po-ui/mcp.svg)](https://github.com/po-ui/po-angular/blob/master/LICENSE)
+[![node](https://img.shields.io/node/v/@po-ui/mcp.svg)](https://nodejs.org)
+
+## Visão geral
+
+O `@po-ui/mcp` conecta clientes compatíveis com MCP à documentação pública do PO UI. Com ele, um agente pode listar APIs e guias, obter a documentação completa de um recurso e pesquisar termos em toda a documentação consolidada.
+
+O conteúdo é consultado nas fontes oficiais do PO UI durante a execução. Assim, o cliente não depende de uma cópia da documentação incluída no pacote.
+
+## Requisitos
+
+- Node.js 18 ou superior;
+- acesso a `po-ui.io` e `raw.githubusercontent.com`.
+
+## Uso com `npx`
+
+Não é necessário instalar o pacote globalmente. Configure o cliente MCP para executar:
+
+```bash
+npx -y @po-ui/mcp
+```
+
+O servidor utiliza o transporte `stdio`; normalmente, o próprio cliente MCP inicia e encerra o processo.
+
+## Configuração
+
+### Claude Desktop
+
+Adicione o servidor ao arquivo `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "po-ui": {
+      "command": "npx",
+      "args": ["-y", "@po-ui/mcp"]
+    }
+  }
+}
+```
+
+Depois de salvar o arquivo, reinicie o Claude Desktop.
+
+### Cursor
+
+Adicione o servidor em **Settings > MCP** ou crie o arquivo `.cursor/mcp.json` no projeto:
+
+```json
+{
+  "mcpServers": {
+    "po-ui": {
+      "command": "npx",
+      "args": ["-y", "@po-ui/mcp"]
+    }
+  }
+}
+```
+
+### Kiro
+
+Abra a paleta de comandos e execute **Kiro: Open workspace MCP config (JSON)** ou crie o arquivo `.kiro/settings/mcp.json` no projeto:
+
+```json
+{
+  "mcpServers": {
+    "po-ui": {
+      "command": "npx",
+      "args": ["-y", "@po-ui/mcp"],
+      "disabled": false
+    }
+  }
+}
+```
+
+Depois de salvar o arquivo, o Kiro reconecta o servidor automaticamente. Confirme a conexão na seção **MCP Servers** do painel do Kiro.
+
+### VS Code com GitHub Copilot
+
+Execute **MCP: Add Server** na paleta de comandos ou adicione o servidor ao arquivo `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "po-ui": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@po-ui/mcp"]
+    }
+  }
+}
+```
+
+### Continue
+
+Crie o arquivo `.continue/mcpServers/po-ui.yaml` no projeto:
+
+```yaml
+name: PO UI MCP
+version: 0.0.1
+schema: v1
+mcpServers:
+  - name: PO UI
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@po-ui/mcp"
+```
+
+As ferramentas MCP ficam disponíveis no modo Agent do Continue.
+
+### Outros clientes
+
+Em clientes compatíveis com servidores MCP locais, configure um servidor `stdio` com o comando `npx` e os argumentos `-y` e `@po-ui/mcp`. Consulte a documentação do cliente para confirmar o formato e o local do arquivo de configuração.
+
+## Ferramentas disponíveis
+
+O servidor expõe quatro ferramentas somente de leitura.
+
+### `list_components`
+
+Lista componentes, diretivas, serviços, interfaces, enums e guias disponíveis no índice do PO UI.
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+| --- | --- | --- | --- |
+| `section` | `"components" \| "services" \| "interfaces" \| "enums" \| "guides" \| "all"` | não | Seção consultada. O padrão é `all`. |
+| `filter` | `string` | não | Texto procurado no nome ou na descrição, sem diferenciar maiúsculas e minúsculas. |
+
+Exemplo:
+
+```json
+{ "section": "components", "filter": "table" }
+```
+
+### `get_component_docs`
+
+Retorna, em Markdown, a documentação de um componente, uma diretiva, um serviço, uma interface ou um enum.
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+| --- | --- | --- | --- |
+| `slug` | `string` | sim | Identificador do recurso. Aceita um slug, como `po-button`; um seletor, como `<po-button>`; ou um nome de classe, como `PoButtonComponent`. |
+
+O valor informado é normalizado antes da consulta. Seletores perdem os sinais de maior e menor, nomes em `CamelCase` são convertidos para `kebab-case` e o sufixo `Component` é removido.
+
+Exemplo:
+
+```json
+{ "slug": "PoButtonComponent" }
+```
+
+### `search_docs`
+
+Realiza uma busca textual, sem diferenciar maiúsculas e minúsculas, no arquivo `llms-full.txt`.
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+| --- | --- | --- | --- |
+| `query` | `string` com pelo menos 2 caracteres | sim | Texto procurado na documentação. |
+| `max_results` | número inteiro de 1 a 50 | não | Quantidade máxima de resultados. O padrão é `10`. |
+
+Cada resultado contém o título da seção encontrada e trechos de contexto ao redor das ocorrências.
+
+Exemplo:
+
+```json
+{ "query": "lazy load", "max_results": 5 }
+```
+
+### `get_guide`
+
+Retorna o conteúdo completo de um guia da documentação.
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+| --- | --- | --- | --- |
+| `guide` | `string` | sim | Nome do guia, com ou sem a extensão `.md`. |
+
+Para conhecer os guias disponíveis, use `list_components` com `section` igual a `guides`.
+
+Exemplo:
+
+```json
+{ "guide": "getting-started" }
+```
+
+## Exemplos de prompts
+
+- “Quais componentes do PO UI permitem upload de arquivos?”
+- “Mostre a documentação do `po-table`.”
+- “Como usar o `PoThemeService`?”
+- “Pesquise por `p-loading` na documentação do PO UI.”
+- “Liste os guias disponíveis e traga o guia de schematics.”
+
+## Fontes de dados
+
+| Conteúdo | Fonte principal | Fallback |
+| --- | --- | --- |
+| Índice de APIs e guias | `https://po-ui.io/llms.txt` | — |
+| Documentação consolidada | `https://po-ui.io/llms-full.txt` | — |
+| Documentação por recurso | `https://po-ui.io/llms-generated/{slug}.md` | `https://raw.githubusercontent.com/po-ui/po-angular/master/projects/portal/src/llms-generated/{slug}.md` |
+| Guias | `https://raw.githubusercontent.com/po-ui/po-angular/master/docs/guides/{name}.md` | — |
+
+O índice `llms.txt` é mantido em memória durante a execução do servidor. Para forçar uma nova leitura, reinicie o servidor no cliente MCP.
+
+## Solução de problemas
+
+### O cliente não inicia o servidor
+
+Confirme que o Node.js 18 ou superior está instalado e que `npx` está disponível no `PATH` do processo que executa o cliente. No Windows, alguns clientes podem exigir o caminho completo para `npx.cmd`.
+
+### Erro ao carregar o índice ou a documentação
+
+Verifique se o ambiente permite acesso HTTPS a `po-ui.io` e `raw.githubusercontent.com`. Cada requisição possui timeout de 10 segundos.
+
+### Recurso não encontrado
+
+Use `list_components` para localizar o slug aceito pelo servidor e, em seguida, informe esse valor a `get_component_docs`.
+
+### As ferramentas não aparecem no cliente
+
+Reinicie o servidor após alterar a configuração e verifique o painel ou o log de servidores MCP do cliente. Algumas aplicações também solicitam autorização antes de disponibilizar as ferramentas.
+
+## Desenvolvimento
+
+O código-fonte está no monorepo [`po-ui/po-angular`](https://github.com/po-ui/po-angular), em [`projects/mcp`](https://github.com/po-ui/po-angular/tree/master/projects/mcp).
+
+Na raiz do repositório, execute:
+
+```bash
+npm install
+npm run build:mcp
+npm run test:mcp
+```
+
+Antes de contribuir, consulte o [guia de contribuição](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md).
+
+## Licença
+
+[MIT](https://github.com/po-ui/po-angular/blob/master/LICENSE) © PO UI


### PR DESCRIPTION
## Objetivo

Adicionar a documentação do pacote `@po-ui/mcp`, que será exibida na página do pacote no npm.

## Alterações

- apresenta o propósito e os requisitos do servidor MCP;
- orienta a configuração nos principais clientes compatíveis;
- documenta as ferramentas `list_components`, `get_component_docs`, `search_docs` e `get_guide`;
- descreve as fontes de dados, exemplos de uso e soluções para problemas comuns;
- inclui os comandos de build e testes para desenvolvimento.

## Validação

Alteração exclusivamente documental, revisada de acordo com o comportamento atual do MCP.