### PR TITLE
feat(page-default): adiciona propriedade p-helper no subtítulo

### DIFF
--- a/projects/ui/src/lib/components/po-helper/index.ts
+++ b/projects/ui/src/lib/components/po-helper/index.ts
@@ -1,3 +1,5 @@
 export * from './po-helper.module';
 export * from './po-helper.component';
 export * from './interfaces/po-helper.interface';
+export * from './po-helper-content-utils';
+export * from './po-helper-content.pipe';

--- a/projects/ui/src/lib/components/po-helper/interfaces/po-helper.interface.ts
+++ b/projects/ui/src/lib/components/po-helper/interfaces/po-helper.interface.ts
@@ -1,12 +1,9 @@
 /**
- * @usedBy PoHelperComponent
+ * @usedBy PoHelperComponent, PoPageDefaultComponent
  *
  * @description
  *
- * *Interface* que define as opções de configuração do componente po-helper.
- *
- * Permite customizar o conteúdo, título, tipo do ícone, modo de abertura do popover, ações customizadas e eventos.
- *
+ * Interface para configuração das opções de ajuda (*helper*).
  */
 export interface PoHelperOptions {
   /**
@@ -26,6 +23,14 @@ export interface PoHelperOptions {
    * @description
    *
    * Texto explicativo exibido no popover.
+   *
+   * Suporta formatação básica com as tags `<b>` (negrito), `<strong>` (negrito), `<i>` (itálico), `<em>` (itálico) e
+   * `<u>` (sublinhado).
+   *
+   * Exemplo:
+   * ```typescript
+   * content: 'Texto <b>importante</b> com <em>destaque</em> e <u>sublinhado</u>'
+   * ```
    */
   content?: string;
 

--- a/projects/ui/src/lib/components/po-helper/po-helper-content-utils.spec.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper-content-utils.spec.ts
@@ -1,0 +1,147 @@
+import { parseHelperContent } from './po-helper-content-utils';
+
+describe('PoHelperSafeParser', () => {
+  describe('parseHelperContent', () => {
+    it('should return empty array for null/undefined/empty content', () => {
+      expect(parseHelperContent(null)).toEqual([]);
+      expect(parseHelperContent(undefined)).toEqual([]);
+      expect(parseHelperContent('')).toEqual([]);
+    });
+
+    it('should return single fragment for plain text without tags', () => {
+      const result = parseHelperContent('Texto simples');
+      expect(result).toEqual([{ text: 'Texto simples', bold: false, italic: false, underline: false }]);
+    });
+
+    it('should parse bold tag correctly', () => {
+      const result = parseHelperContent('Texto <b>negrito</b> normal');
+      expect(result).toEqual([
+        { text: 'Texto ', bold: false, italic: false, underline: false },
+        { text: 'negrito', bold: true, italic: false, underline: false },
+        { text: ' normal', bold: false, italic: false, underline: false }
+      ]);
+    });
+
+    it('should parse italic tag correctly', () => {
+      const result = parseHelperContent('Texto <i>itálico</i> normal');
+      expect(result).toEqual([
+        { text: 'Texto ', bold: false, italic: false, underline: false },
+        { text: 'itálico', bold: false, italic: true, underline: false },
+        { text: ' normal', bold: false, italic: false, underline: false }
+      ]);
+    });
+
+    it('should parse underline tag correctly', () => {
+      const result = parseHelperContent('Texto <u>sublinhado</u> normal');
+      expect(result).toEqual([
+        { text: 'Texto ', bold: false, italic: false, underline: false },
+        { text: 'sublinhado', bold: false, italic: false, underline: true },
+        { text: ' normal', bold: false, italic: false, underline: false }
+      ]);
+    });
+
+    it('should parse nested tags correctly', () => {
+      const result = parseHelperContent('<b><i>negrito e itálico</i></b>');
+      expect(result).toEqual([{ text: 'negrito e itálico', bold: true, italic: true, underline: false }]);
+    });
+
+    it('should parse multiple nested tags', () => {
+      const result = parseHelperContent('<b><i><u>todos</u></i></b>');
+      expect(result).toEqual([{ text: 'todos', bold: true, italic: true, underline: true }]);
+    });
+
+    it('should handle mixed formatting in sequence', () => {
+      const result = parseHelperContent('<b>negrito</b> e <i>itálico</i>');
+      expect(result).toEqual([
+        { text: 'negrito', bold: true, italic: false, underline: false },
+        { text: ' e ', bold: false, italic: false, underline: false },
+        { text: 'itálico', bold: false, italic: true, underline: false }
+      ]);
+    });
+
+    it('should sanitize disallowed tags (script)', () => {
+      const result = parseHelperContent('Texto <script>alert("xss")</script> seguro');
+      expect(result).toEqual([{ text: 'Texto alert("xss") seguro', bold: false, italic: false, underline: false }]);
+    });
+
+    it('should sanitize disallowed tags (div, span, a)', () => {
+      const result = parseHelperContent('<div>conteúdo</div> <span>texto</span> <a href="x">link</a>');
+      expect(result).toEqual([{ text: 'conteúdo texto link', bold: false, italic: false, underline: false }]);
+    });
+
+    it('should sanitize tags with attributes', () => {
+      const result = parseHelperContent('<b style="color:red">negrito</b>');
+      expect(result).toEqual([{ text: 'negrito', bold: true, italic: false, underline: false }]);
+    });
+
+    it('should handle unclosed tags gracefully', () => {
+      const result = parseHelperContent('<b>negrito sem fechar');
+      expect(result).toEqual([{ text: 'negrito sem fechar', bold: true, italic: false, underline: false }]);
+    });
+
+    it('should handle extra closing tags gracefully', () => {
+      const result = parseHelperContent('texto</b> normal');
+      expect(result).toEqual([
+        { text: 'texto', bold: false, italic: false, underline: false },
+        { text: ' normal', bold: false, italic: false, underline: false }
+      ]);
+    });
+
+    it('should handle case-insensitive tags', () => {
+      const result = parseHelperContent('<B>negrito</B> <I>itálico</I>');
+      expect(result).toEqual([
+        { text: 'negrito', bold: true, italic: false, underline: false },
+        { text: ' ', bold: false, italic: false, underline: false },
+        { text: 'itálico', bold: false, italic: true, underline: false }
+      ]);
+    });
+
+    it('should prevent XSS via event handlers in allowed tags', () => {
+      const result = parseHelperContent('<b onmouseover="alert(1)">texto</b>');
+      expect(result).toEqual([{ text: 'texto', bold: true, italic: false, underline: false }]);
+    });
+
+    it('should prevent XSS via img tag with onerror', () => {
+      const result = parseHelperContent('<img src=x onerror="alert(1)">texto');
+      expect(result).toEqual([{ text: 'texto', bold: false, italic: false, underline: false }]);
+    });
+
+    it('should handle partially overlapping tags', () => {
+      const result = parseHelperContent('<b>bold <i>bold+italic</b> italic</i>');
+      expect(result).toEqual([
+        { text: 'bold ', bold: true, italic: false, underline: false },
+        { text: 'bold+italic', bold: true, italic: true, underline: false },
+        { text: ' italic', bold: false, italic: true, underline: false }
+      ]);
+    });
+
+    it('should parse <strong> as bold', () => {
+      const result = parseHelperContent('Texto <strong>importante</strong> normal');
+      expect(result).toEqual([
+        { text: 'Texto ', bold: false, italic: false, underline: false },
+        { text: 'importante', bold: true, italic: false, underline: false },
+        { text: ' normal', bold: false, italic: false, underline: false }
+      ]);
+    });
+
+    it('should parse <em> as italic', () => {
+      const result = parseHelperContent('Texto <em>enfatizado</em> normal');
+      expect(result).toEqual([
+        { text: 'Texto ', bold: false, italic: false, underline: false },
+        { text: 'enfatizado', bold: false, italic: true, underline: false },
+        { text: ' normal', bold: false, italic: false, underline: false }
+      ]);
+    });
+
+    it('should handle mixed <strong>, <em>, <b>, <i>, <u> together', () => {
+      const result = parseHelperContent('<strong>bold</strong> <em>italic</em> <u>underline</u>');
+      expect(result).toEqual([
+        { text: 'bold', bold: true, italic: false, underline: false },
+        { text: ' ', bold: false, italic: false, underline: false },
+        { text: 'italic', bold: false, italic: true, underline: false },
+        { text: ' ', bold: false, italic: false, underline: false },
+        { text: 'underline', bold: false, italic: false, underline: true }
+      ]);
+    });
+  });
+});

--- a/projects/ui/src/lib/components/po-helper/po-helper-content-utils.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper-content-utils.ts
@@ -1,0 +1,126 @@
+/**
+ * @description
+ *
+ * Utilitário de "Safe Parser" para o componente po-helper.
+ *
+ * Permite o uso de tags de formatação básica (`<b>`, `<strong>`, `<i>`, `<em>`, `<u>`) no conteúdo do helper, sem
+ * utilizar `innerHTML`, garantindo proteção contra ataques XSS.
+ *
+ * Qualquer tag HTML que não esteja na whitelist é sanitizada (removida), preservando apenas o texto interno.
+ */
+
+/**
+ * Representa um fragmento de texto com suas propriedades de formatação.
+ */
+export interface PoHelperTextFragment {
+  /** Conteúdo textual do fragmento */
+  text: string;
+  /** Indica se o fragmento deve ser exibido em negrito */
+  bold: boolean;
+  /** Indica se o fragmento deve ser exibido em itálico */
+  italic: boolean;
+  /** Indica se o fragmento deve ser exibido com sublinhado */
+  underline: boolean;
+}
+
+/** Tags permitidas pelo safe parser */
+const ALLOWED_TAGS = ['b', 'i', 'u', 'strong', 'em'];
+
+/** Mapa de normalização: tags semânticas são convertidas para suas equivalentes de formatação */
+const TAG_NORMALIZE_MAP: Record<string, string> = {
+  strong: 'b',
+  em: 'i'
+};
+
+/**
+ * Regex para capturar tags HTML (abertura e fechamento).
+ * Captura: tag name e se é fechamento (/).
+ */
+const TAG_REGEX = /<(\/?)(\w+)(?:\s[^>]*)?\/?>/gi;
+
+/**
+ * Remove todas as tags HTML que não estão na whitelist, preservando o texto interno.
+ *
+ * @param input String com possíveis tags HTML
+ * @returns String com apenas as tags permitidas
+ */
+function sanitizeContent(input: string): string {
+  return input.replace(TAG_REGEX, (_match, closing, tagName) => {
+    const normalizedTag = tagName.toLowerCase();
+    if (ALLOWED_TAGS.includes(normalizedTag)) {
+      const outputTag = TAG_NORMALIZE_MAP[normalizedTag] || normalizedTag;
+      return closing ? `</${outputTag}>` : `<${outputTag}>`;
+    }
+    return '';
+  });
+}
+
+/** Mapa de contadores por tag */
+interface TagCounters {
+  b: number;
+  i: number;
+  u: number;
+}
+
+/**
+ * Incrementa o contador da tag de abertura.
+ */
+function incrementTagCounter(counters: TagCounters, tag: string): void {
+  counters[tag]++;
+}
+
+/**
+ * Decrementa o contador da tag de fechamento.
+ */
+function decrementTagCounter(counters: TagCounters, tag: string): void {
+  counters[tag] = Math.max(0, counters[tag] - 1);
+}
+
+/**
+ * Faz o parsing de uma string com tags de formatação permitidas (`<b>`, `<i>`, `<u>`)
+ * e retorna um array de fragmentos com as propriedades de formatação aplicadas.
+ *
+ * Tags não permitidas são removidas (sanitizadas). Tags aninhadas são suportadas.
+ *
+ * @param content String de conteúdo com possíveis tags de formatação
+ * @returns Array de fragmentos de texto com informações de formatação
+ */
+export function parseHelperContent(content: string): Array<PoHelperTextFragment> {
+  if (!content) {
+    return [];
+  }
+
+  const sanitized = sanitizeContent(content);
+  const fragments: Array<PoHelperTextFragment> = [];
+  const counters: TagCounters = { b: 0, i: 0, u: 0 };
+
+  const splitRegex = /(<\/?[biu]>)/gi;
+  const parts = sanitized.split(splitRegex);
+
+  for (const part of parts) {
+    if (!part) {
+      continue;
+    }
+
+    const tagMatch = /^<(\/?)([biu])>$/i.exec(part);
+
+    if (tagMatch) {
+      const isClosing = tagMatch[1] === '/';
+      const tag = tagMatch[2].toLowerCase();
+      if (isClosing) {
+        decrementTagCounter(counters, tag);
+      } else {
+        incrementTagCounter(counters, tag);
+      }
+    } else {
+      fragments.push({
+        text: part,
+        bold: counters.b > 0,
+        italic: counters.i > 0,
+        underline: counters.u > 0
+      });
+    }
+  }
+
+  return fragments;
+}

--- a/projects/ui/src/lib/components/po-helper/po-helper-content.pipe.spec.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper-content.pipe.spec.ts
@@ -1,0 +1,62 @@
+import { PoHelperContentPipe } from './po-helper-content.pipe';
+
+describe('PoHelperContentPipe', () => {
+  let pipe: PoHelperContentPipe;
+
+  beforeEach(() => {
+    pipe = new PoHelperContentPipe();
+  });
+
+  it('should create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return empty array for null content', () => {
+    expect(pipe.transform(null)).toEqual([]);
+  });
+
+  it('should return empty array for undefined content', () => {
+    expect(pipe.transform(undefined)).toEqual([]);
+  });
+
+  it('should return empty array for empty string', () => {
+    expect(pipe.transform('')).toEqual([]);
+  });
+
+  it('should return single fragment for plain text', () => {
+    const result = pipe.transform('Texto simples');
+    expect(result).toEqual([{ text: 'Texto simples', bold: false, italic: false, underline: false }]);
+  });
+
+  it('should parse bold tag', () => {
+    const result = pipe.transform('Texto <b>negrito</b>');
+    expect(result[1]).toEqual({ text: 'negrito', bold: true, italic: false, underline: false });
+  });
+
+  it('should parse italic tag', () => {
+    const result = pipe.transform('Texto <i>itálico</i>');
+    expect(result[1]).toEqual({ text: 'itálico', bold: false, italic: true, underline: false });
+  });
+
+  it('should parse underline tag', () => {
+    const result = pipe.transform('Texto <u>sublinhado</u>');
+    expect(result[1]).toEqual({ text: 'sublinhado', bold: false, italic: false, underline: true });
+  });
+
+  it('should normalize strong to bold', () => {
+    const result = pipe.transform('<strong>bold</strong>');
+    expect(result[0]).toEqual({ text: 'bold', bold: true, italic: false, underline: false });
+  });
+
+  it('should normalize em to italic', () => {
+    const result = pipe.transform('<em>italic</em>');
+    expect(result[0]).toEqual({ text: 'italic', bold: false, italic: true, underline: false });
+  });
+
+  it('should sanitize script tags', () => {
+    const result = pipe.transform('<script>alert("xss")</script>safe');
+    const allText = result.map(f => f.text).join('');
+    expect(allText).not.toContain('<script>');
+    expect(allText).toContain('safe');
+  });
+});

--- a/projects/ui/src/lib/components/po-helper/po-helper-content.pipe.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper-content.pipe.ts
@@ -1,0 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { parseHelperContent, PoHelperTextFragment } from './po-helper-content-utils';
+
+/**
+ * @description
+ *
+ * Pipe que transforma o conteúdo do helper em fragmentos de texto formatados,
+ * utilizando o Safe Parser para garantir segurança contra XSS.
+ *
+ * Uso interno do componente `po-helper`.
+ */
+@Pipe({
+  name: 'poHelperContent',
+  standalone: false
+})
+export class PoHelperContentPipe implements PipeTransform {
+  transform(content: string): Array<PoHelperTextFragment> {
+    return parseHelperContent(content);
+  }
+}

--- a/projects/ui/src/lib/components/po-helper/po-helper.component.html
+++ b/projects/ui/src/lib/components/po-helper/po-helper.component.html
@@ -25,7 +25,16 @@
     (p-open)="handleOpen()"
   >
     <div [id]="'popover-content-' + id" role="dialog" aria-modal="false" tabindex="-1">
-      {{ helper()?.content }}
+      <span class="po-helper-content-text">
+        @for (fragment of contentFragments(); track $index) {
+          <span
+            [class.po-helper-text-bold]="fragment.bold"
+            [class.po-helper-text-italic]="fragment.italic"
+            [class.po-helper-text-underline]="fragment.underline"
+            >{{ fragment.text }}</span
+          >
+        }
+      </span>
       @if (helper()?.type === 'help' && helper()?.footerAction) {
         <po-divider></po-divider>
         <po-link

--- a/projects/ui/src/lib/components/po-helper/po-helper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper.component.spec.ts
@@ -282,7 +282,7 @@ describe('PoHelperComponent', () => {
     };
     fixture.componentRef.setInput('p-helper', options);
     spyOnProperty(navigator, 'language', 'get').and.returnValue('en-US');
-    expect(component['ariaLabel']()).toBe('Show Information');
+    expect(component['ariaLabel']()).toBe('Additional information');
   });
 
   it('should return correct ariaLabel for help type', () => {
@@ -295,14 +295,14 @@ describe('PoHelperComponent', () => {
     };
     fixture.componentRef.setInput('p-helper', options);
     spyOnProperty(navigator, 'language', 'get').and.returnValue('pt-BR');
-    expect(component['ariaLabel']()).toBe('Exibe ajuda');
+    expect(component['ariaLabel']()).toBe('Ajuda adicional');
   });
 
   it('should return correct ariaLabel for string helper', () => {
     const text = 'Texto explicativo';
     fixture.componentRef.setInput('p-helper', text);
     spyOnProperty(navigator, 'language', 'get').and.returnValue('es-ES');
-    expect(component['ariaLabel']()).toBe('Muestra ayuda');
+    expect(component['ariaLabel']()).toBe('Ayuda adicional');
   });
 
   it('should fallback to EN when navigator.language is falsy', () => {
@@ -316,7 +316,7 @@ describe('PoHelperComponent', () => {
 
     fixture.componentRef.setInput('p-helper', options);
     spyOnProperty(navigator, 'language', 'get').and.returnValue(undefined);
-    expect(component['ariaLabel']()).toBe('Show Information');
+    expect(component['ariaLabel']()).toBe('Additional information');
   });
 
   it('should fallback to EN literals when lang is unsupported', () => {
@@ -331,7 +331,7 @@ describe('PoHelperComponent', () => {
     fixture.componentRef.setInput('p-helper', options);
     spyOnProperty(navigator, 'language', 'get').and.returnValue('fr-FR');
 
-    expect(component['ariaLabel']()).toBe('Show Information');
+    expect(component['ariaLabel']()).toBe('Additional information');
   });
 
   describe('closePopoverOnFocusOut', () => {
@@ -607,6 +607,66 @@ describe('PoHelperComponent', () => {
 
       expect(() => (component as any).handleClose()).not.toThrow();
       expect(removeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('contentFragments', () => {
+    it('should return empty array when helper is undefined', () => {
+      fixture.componentRef.setInput('p-helper', undefined);
+      expect(component['contentFragments']()).toEqual([]);
+    });
+
+    it('should parse bold tags from helper content', () => {
+      fixture.componentRef.setInput('p-helper', { content: 'Texto <b>negrito</b> normal', type: 'info' });
+      const fragments = component['contentFragments']();
+      expect(fragments.length).toBe(3);
+      expect(fragments[0]).toEqual({ text: 'Texto ', bold: false, italic: false, underline: false });
+      expect(fragments[1]).toEqual({ text: 'negrito', bold: true, italic: false, underline: false });
+      expect(fragments[2]).toEqual({ text: ' normal', bold: false, italic: false, underline: false });
+    });
+
+    it('should parse italic and underline tags', () => {
+      fixture.componentRef.setInput('p-helper', { content: '<i>itálico</i> e <u>sublinhado</u>', type: 'help' });
+      const fragments = component['contentFragments']();
+      expect(fragments[0]).toEqual({ text: 'itálico', bold: false, italic: true, underline: false });
+      expect(fragments[2]).toEqual({ text: 'sublinhado', bold: false, italic: false, underline: true });
+    });
+
+    it('should normalize strong to bold and em to italic', () => {
+      fixture.componentRef.setInput('p-helper', { content: '<strong>bold</strong> <em>italic</em>', type: 'info' });
+      const fragments = component['contentFragments']();
+      expect(fragments[0]).toEqual({ text: 'bold', bold: true, italic: false, underline: false });
+      expect(fragments[2]).toEqual({ text: 'italic', bold: false, italic: true, underline: false });
+    });
+
+    it('should sanitize script tags (XSS protection)', () => {
+      fixture.componentRef.setInput('p-helper', {
+        content: '<script>alert("xss")</script>safe <b>text</b>',
+        type: 'info'
+      });
+      const fragments = component['contentFragments']();
+      const allText = fragments.map(f => f.text).join('');
+      expect(allText).toContain('safe');
+      expect(allText).toContain('text');
+      expect(allText).not.toContain('<script>');
+    });
+
+    it('should parse content from string helper', () => {
+      fixture.componentRef.setInput('p-helper', 'Texto <b>string</b> direto');
+      const fragments = component['contentFragments']();
+      expect(fragments[1]).toEqual({ text: 'string', bold: true, italic: false, underline: false });
+    });
+
+    it('should handle content property from object helper', () => {
+      fixture.componentRef.setInput('p-helper', { content: '<i>italic</i> text', type: 'info' });
+      const fragments = component['contentFragments']();
+      expect(fragments[0]).toEqual({ text: 'italic', bold: false, italic: true, underline: false });
+      expect(fragments[1]).toEqual({ text: ' text', bold: false, italic: false, underline: false });
+    });
+
+    it('should return empty array when helper content is empty', () => {
+      fixture.componentRef.setInput('p-helper', { content: '', type: 'info' });
+      expect(component['contentFragments']()).toEqual([]);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-helper/po-helper.component.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper.component.ts
@@ -6,11 +6,14 @@ import {
   OnDestroy,
   OnChanges,
   SimpleChanges,
-  ChangeDetectorRef
+  ChangeDetectorRef,
+  computed
 } from '@angular/core';
 import { PoHelperBaseComponent } from './po-helper-base.component';
+import { PoHelperOptions } from './interfaces/po-helper.interface';
 import { PoPopoverComponent } from '../po-popover/po-popover.component';
 import { PoButtonComponent } from '../po-button';
+import { parseHelperContent, PoHelperTextFragment } from './po-helper-content-utils';
 /**
  * @docsExtends PoHelperBaseComponent
  *
@@ -50,27 +53,36 @@ export class PoHelperComponent extends PoHelperBaseComponent implements AfterVie
   private boundFocusIn: (e: FocusEvent) => void;
   private readonly poHelperLiterals = {
     en: {
-      info: 'Show Information',
-      help: 'Show Help'
+      info: 'Additional information',
+      help: 'Additional help'
     },
     pt: {
-      info: 'Exibe informação',
-      help: 'Exibe ajuda'
+      info: 'Informação adicional',
+      help: 'Ajuda adicional'
     },
     es: {
-      info: 'Muestra información',
-      help: 'Muestra ayuda'
+      info: 'Información adicional',
+      help: 'Ayuda adicional'
     },
     ru: {
-      info: 'Показать информацию',
-      help: 'Показать справку'
+      info: 'Дополнительная информация',
+      help: 'Дополнительная помощь'
     }
   };
+
+  protected readonly contentFragments = computed<Array<PoHelperTextFragment>>(() => {
+    const helperValue = this.helper();
+    if (!helperValue) {
+      return [];
+    }
+    return parseHelperContent((helperValue as PoHelperOptions).content);
+  });
 
   constructor(private readonly cdr: ChangeDetectorRef) {
     super();
     this.id = 'po-helper-' + PoHelperComponent.idCounter++;
   }
+
   ngAfterViewInit(): void {
     PoHelperComponent.instances.push(this);
     queueMicrotask(() => {

--- a/projects/ui/src/lib/components/po-helper/po-helper.module.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { PoHelperComponent } from './po-helper.component';
+import { PoHelperContentPipe } from './po-helper-content.pipe';
 
 import { PoIconModule } from '../po-icon/index';
 import { PoLinkModule } from '../po-link/index';
@@ -14,7 +15,7 @@ import { PoDividerModule } from '../po-divider/index';
  */
 @NgModule({
   imports: [CommonModule, PoIconModule, PoPopoverModule, PoLinkModule, PoDividerModule],
-  declarations: [PoHelperComponent],
+  declarations: [PoHelperComponent, PoHelperContentPipe],
   exports: [PoHelperComponent]
 })
 export class PoHelperModule {}

--- a/projects/ui/src/lib/components/po-helper/samples/sample-po-helper-labs/sample-po-helper-labs.component.html
+++ b/projects/ui/src/lib/components/po-helper/samples/sample-po-helper-labs/sample-po-helper-labs.component.html
@@ -1,14 +1,25 @@
-<po-helper [p-helper]="helperOptions" [p-size]="helperSize"></po-helper>
+<po-helper [p-helper]="helperOptions" [p-size]="helperSize" [p-disabled]="helperDisabled"></po-helper>
+
+<po-divider></po-divider>
 
 <div class="po-row">
-  <po-input class="po-lg-6 po-md-6" name="title" [(ngModel)]="helperOptions.title" p-clean p-label="Título do Helper">
+  <po-input
+    class="po-md-6"
+    name="title"
+    [ngModel]="helperOptions.title"
+    (ngModelChange)="helperOptions = { ...helperOptions, title: $event }"
+    p-clean
+    p-label="Title"
+  >
   </po-input>
   <po-input
-    class="po-lg-6 po-md-6"
-    name="type"
-    [(ngModel)]="helperOptions.content"
+    class="po-md-6"
+    name="content"
+    [ngModel]="helperOptions.content"
+    (ngModelChange)="helperOptions = { ...helperOptions, content: $event }"
     p-clean
-    p-label="Conteúdo do Helper"
+    p-label="Content"
+    p-help="Consulte a <b>documentação</b> para mais detalhes."
   >
   </po-input>
 </div>
@@ -16,24 +27,25 @@
 <div class="po-row">
   @if (helperOptions.type === 'help') {
     <po-input
-      class="po-lg-6 po-md-6"
+      class="po-md-6"
       name="footerTitle"
       [(ngModel)]="footerTitle"
       (ngModelChange)="setFooterTitle($event)"
       p-clean
-      p-label="Título do Footer"
+      p-label="Footer Action"
     >
     </po-input>
   }
 </div>
-<po-divider></po-divider>
+
 <div class="po-row">
   <po-radio-group
     name="type"
-    class="po-md-12 po-lg-12"
-    p-columns="4"
+    class="po-md-12"
+    [p-columns]="4"
     p-label="Type"
-    [(ngModel)]="helperOptions.type"
+    [ngModel]="helperOptions.type"
+    (ngModelChange)="updateHelperType($event)"
     [p-options]="[
       { label: 'Help', value: 'help' },
       { label: 'Info', value: 'info' }
@@ -44,10 +56,10 @@
 
 <div class="po-row">
   <po-radio-group
-    class="po-md-12 po-lg-12"
+    class="po-md-12"
     name="size"
     [(ngModel)]="helperSize"
-    p-columns="4"
+    [p-columns]="4"
     p-label="Size"
     p-help="Para aplicar o tamanho small, configure o nível de acessibilidade para AA, ajustável no navbar ou serviço de tema (https://po-ui.io/documentation/po-theme)."
     [p-options]="[
@@ -57,7 +69,13 @@
   >
   </po-radio-group>
 </div>
-<po-divider></po-divider>
+
 <div class="po-row">
-  <po-button class="po-md-12 po-md-12" p-label="Reset" (p-click)="reset()"></po-button>
+  <po-checkbox class="po-md-12" name="disabled" [(ngModel)]="helperDisabled" p-label="Disabled"> </po-checkbox>
+</div>
+
+<po-divider></po-divider>
+
+<div class="po-row">
+  <po-button class="po-lg-3 po-md-6" p-label="Sample Restore" (p-click)="reset()"></po-button>
 </div>

--- a/projects/ui/src/lib/components/po-helper/samples/sample-po-helper-labs/sample-po-helper-labs.component.ts
+++ b/projects/ui/src/lib/components/po-helper/samples/sample-po-helper-labs/sample-po-helper-labs.component.ts
@@ -8,7 +8,8 @@ import { PoHelperOptions } from '@po-ui/ng-components';
   standalone: false
 })
 export class SamplePoHelperLabsComponent {
-  helperSize: 'medium';
+  helperDisabled: boolean = false;
+  helperSize: string = 'medium';
 
   helperOptions: PoHelperOptions = {
     title: '',
@@ -23,18 +24,29 @@ export class SamplePoHelperLabsComponent {
   }
 
   setFooterTitle(title: string) {
+    this.footerTitle = title;
     if (title.length === 0) {
-      this.footerTitle = '';
       delete this.helperOptions.footerAction;
     } else {
-      this.helperOptions.footerAction = {
-        label: this.footerTitle,
-        action: this.footerAction.bind(this)
+      this.helperOptions = {
+        ...this.helperOptions,
+        footerAction: {
+          label: this.footerTitle,
+          action: this.footerAction.bind(this)
+        }
       };
     }
   }
 
+  updateHelperType(type: string) {
+    this.helperOptions = {
+      ...this.helperOptions,
+      type: type as 'help' | 'info'
+    };
+  }
+
   reset() {
+    this.helperDisabled = false;
     this.helperOptions = {
       title: '',
       content: '',

--- a/projects/ui/src/lib/components/po-helper/samples/sample-po-helper-sales-performance/sample-po-helper-sales-performance.component.ts
+++ b/projects/ui/src/lib/components/po-helper/samples/sample-po-helper-sales-performance/sample-po-helper-sales-performance.component.ts
@@ -11,7 +11,7 @@ export class SamplePoHelperSalesPerformanceComponent {
   helperOptions: PoHelperOptions = {
     title: 'Sales Performance Overview',
     content:
-      'This section provides insights into employee turnover rate and sales performance. Hover over the chart for more details.',
+      'This section provides insights into <b>employee turnover rate</b> and <i>sales performance</i>. Hover over the chart for <u>more details</u>.',
     type: 'info'
   };
 

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.spec.ts
@@ -261,5 +261,38 @@ describe('PoPageDefaultBaseComponent:', () => {
         expect((component as any).applySizeBasedOnA11y).toHaveBeenCalled();
       });
     });
+
+    describe('p-helper:', () => {
+      it('should keep type when PoHelperOptions has type defined', () => {
+        const options = { title: 'Help', content: 'Content', type: 'help' as const };
+        const result = component['transformPageHelper'](options);
+        expect(result).toEqual(options);
+      });
+
+      it('should accept string value and transform to PoHelperOptions with type info', () => {
+        const result = component['transformPageHelper']('Simple text');
+        expect(result).toEqual({ content: 'Simple text', type: 'info' });
+      });
+
+      it('should default type to "info" when PoHelperOptions has no type', () => {
+        const result = component['transformPageHelper']({ title: 'Help', content: 'Content' });
+        expect((result as any).type).toBe('info');
+      });
+
+      it('should transform string values with HTML to PoHelperOptions with type info', () => {
+        const result = component['transformPageHelper']('<b>bold</b> text');
+        expect(result).toEqual({ content: '<b>bold</b> text', type: 'info' });
+      });
+
+      it('should handle undefined value', () => {
+        const result = component['transformPageHelper'](undefined);
+        expect(result).toBeUndefined();
+      });
+
+      it('should handle null value', () => {
+        const result = component['transformPageHelper'](null);
+        expect(result).toBeNull();
+      });
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.ts
@@ -1,4 +1,4 @@
-import { Directive, HostBinding, HostListener, Input, ViewChild, output } from '@angular/core';
+import { Directive, HostBinding, HostListener, Input, ViewChild, input, output } from '@angular/core';
 
 import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
 import { PoLanguageService } from './../../../services/po-language/po-language.service';
@@ -6,6 +6,7 @@ import { PoLanguageService } from './../../../services/po-language/po-language.s
 import { PoFieldSize } from '../../../enums/po-field-size.enum';
 import { getDefaultSizeFn, validateSizeFn } from '../../../utils/util';
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
+import { PoHelperOptions } from '../../po-helper/interfaces/po-helper.interface';
 import { PoPageAction } from '../interfaces/po-page-action.interface';
 import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
 import { PoPageActionsLayout } from './enums/po-page-actions-layout.enum';
@@ -145,6 +146,34 @@ export abstract class PoPageDefaultBaseComponent {
   get componentsSize(): string {
     return this._componentsSize ?? getDefaultSizeFn(PoFieldSize);
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o conteúdo do po-helper informativo exibido ao lado do subtítulo da página.
+   *
+   * Quando não houver subtítulo (`p-subtitle`), o po-helper será exibido logo abaixo do título.
+   *
+   * Aceita uma string simples (exibida como conteúdo) ou um objeto do tipo `PoHelperOptions`
+   * para configuração avançada (título, conteúdo, tipo, ações).
+   *
+   * Exemplo de uso:
+   * ```html
+   * <po-page-default
+   *   p-title="Cadastro"
+   *   p-subtitle="Preencha os dados"
+   *   [p-helper]="{ title: 'Ajuda', content: 'Informações sobre o cadastro' }"
+   * ></po-page-default>
+   * ```
+   *
+   * @default `info`
+   */
+  helper = input<PoHelperOptions | string, PoHelperOptions | string>(undefined, {
+    alias: 'p-helper',
+    transform: this.transformPageHelper.bind(this)
+  });
 
   /**
    * @optional
@@ -291,6 +320,16 @@ export abstract class PoPageDefaultBaseComponent {
   private applySizeBasedOnA11y(): void {
     const size = validateSizeFn(this._initialComponentsSize, PoFieldSize);
     this._componentsSize = size;
+  }
+
+  private transformPageHelper(value: PoHelperOptions | string): PoHelperOptions | string {
+    if (value && typeof value === 'string') {
+      return { content: value, type: 'info' };
+    }
+    if (value && typeof value === 'object' && !value.type) {
+      return { ...value, type: 'info' };
+    }
+    return value;
   }
 
   // Seta a lista de ações no dropdown.

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.html
@@ -81,7 +81,13 @@
   @if (hasPageHeader()) {
     @switch (pageHeaderType) {
       @case ('secondary') {
-        <po-page-header [p-type]="'secondary'" [p-size]="componentsSize" [p-subtitle]="subtitle" [p-title]="title">
+        <po-page-header
+          [p-type]="'secondary'"
+          [p-helper]="helper()"
+          [p-size]="componentsSize"
+          [p-subtitle]="subtitle"
+          [p-title]="title"
+        >
           <!-- Back navigation button (icon-only, aria-label for screen readers) -->
           <po-button
             po-page-header-navigation
@@ -108,7 +114,13 @@
         </po-page-header>
       }
       @case ('tertiary') {
-        <po-page-header [p-type]="'tertiary'" [p-size]="componentsSize" [p-subtitle]="subtitle" [p-title]="title">
+        <po-page-header
+          [p-type]="'tertiary'"
+          [p-helper]="helper()"
+          [p-size]="componentsSize"
+          [p-subtitle]="subtitle"
+          [p-title]="title"
+        >
           <div class="po-page-header-actions">
             @switch (pageActionsLayout) {
               @case ('dropdown') {
@@ -125,7 +137,13 @@
         </po-page-header>
       }
       @default {
-        <po-page-header [p-breadcrumb]="breadcrumb" [p-size]="componentsSize" [p-subtitle]="subtitle" [p-title]="title">
+        <po-page-header
+          [p-breadcrumb]="breadcrumb"
+          [p-helper]="helper()"
+          [p-size]="componentsSize"
+          [p-subtitle]="subtitle"
+          [p-title]="title"
+        >
           <div class="po-page-header-actions">
             @switch (pageActionsLayout) {
               @case ('dropdown') {

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.spec.ts
@@ -11,6 +11,7 @@ import { PoUtils as UtilsFunction } from '../../../utils/util';
 import { PoBreadcrumbModule } from '../../po-breadcrumb/po-breadcrumb.module';
 import { PoButtonModule } from '../../po-button';
 import { PoDropdownModule } from '../../po-dropdown/po-dropdown.module';
+import { PoHelperModule } from '../../po-helper/po-helper.module';
 
 import { PoLanguageService } from '../../../services/po-language/po-language.service';
 import { PoPageDefaultComponent } from './po-page-default.component';
@@ -158,7 +159,14 @@ describe('PoPageDefaultComponent desktop', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CommonModule, RouterTestingModule.withRoutes([]), PoBreadcrumbModule, PoButtonModule, PoDropdownModule],
+      imports: [
+        CommonModule,
+        RouterTestingModule.withRoutes([]),
+        PoBreadcrumbModule,
+        PoButtonModule,
+        PoDropdownModule,
+        PoHelperModule
+      ],
       declarations: [
         DesktopComponent,
         PoPageDefaultComponent,
@@ -614,6 +622,56 @@ describe('PoPageDefaultComponent desktop', () => {
       component.hasPageHeader();
       expect(component.getActionKind({ label: 'A', kind: 'primary' }, 'secondary')).toBe('primary');
       expect(component.getActionKind({ label: 'B', kind: 'primary' }, 'secondary')).toBe('secondary');
+    });
+  });
+
+  describe('helper integration', () => {
+    beforeEach(() => {
+      component.title = 'Test Title';
+    });
+
+    it('should pass helper value to po-page-header when helper is a PoHelperOptions object', () => {
+      fixture.componentRef.setInput('p-helper', { content: 'Help content', type: 'info' });
+      fixture.detectChanges();
+
+      const nativeElement = fixture.debugElement.nativeElement;
+      expect(nativeElement.querySelector('po-helper')).toBeTruthy();
+    });
+
+    it('should pass helper value to po-page-header when helper is a string', () => {
+      fixture.componentRef.setInput('p-helper', 'Simple help text');
+      fixture.detectChanges();
+
+      const nativeElement = fixture.debugElement.nativeElement;
+      expect(nativeElement.querySelector('po-helper')).toBeTruthy();
+    });
+
+    it('should not render po-helper when helper is not provided', () => {
+      fixture.detectChanges();
+
+      const nativeElement = fixture.debugElement.nativeElement;
+      expect(nativeElement.querySelector('po-helper')).toBeFalsy();
+    });
+
+    it('should transform string helper to PoHelperOptions with type info', () => {
+      fixture.componentRef.setInput('p-helper', 'Text content');
+      fixture.detectChanges();
+
+      expect(component.helper()).toEqual({ content: 'Text content', type: 'info' });
+    });
+
+    it('should set type to info when PoHelperOptions object has no type defined', () => {
+      fixture.componentRef.setInput('p-helper', { content: 'Help content' });
+      fixture.detectChanges();
+
+      expect(component.helper()).toEqual(jasmine.objectContaining({ content: 'Help content', type: 'info' }));
+    });
+
+    it('should preserve type when PoHelperOptions object already has type defined', () => {
+      fixture.componentRef.setInput('p-helper', { content: 'Help content', type: 'help' });
+      fixture.detectChanges();
+
+      expect(component.helper()).toEqual(jasmine.objectContaining({ content: 'Help content', type: 'help' }));
     });
   });
 });

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-dashboard/sample-po-page-default-dashboard.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-dashboard/sample-po-page-default-dashboard.component.html
@@ -1,4 +1,10 @@
-<po-page-default p-title="Dashboard" [p-actions]="actions" [p-breadcrumb]="breadcrumb">
+<po-page-default
+  p-title="Dashboard"
+  p-subtitle="Website analytics overview"
+  [p-actions]="actions"
+  [p-breadcrumb]="breadcrumb"
+  [p-helper]="helper"
+>
   <div class="po-row">
     <po-widget class="po-md-6 po-lg-4 po-mb-2" p-title="Daily visitors">
       <div class="po-font-subtitle po-text-center">540</div>

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-dashboard/sample-po-page-default-dashboard.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-dashboard/sample-po-page-default-dashboard.component.ts
@@ -1,11 +1,15 @@
 import { Component, ViewChild, OnInit, inject } from '@angular/core';
 import { NgForm } from '@angular/forms';
 
-import { PoBreadcrumb } from '@po-ui/ng-components';
-import { PoModalAction, PoModalComponent } from '@po-ui/ng-components';
-import { PoNotificationService } from '@po-ui/ng-components';
-import { PoPageAction } from '@po-ui/ng-components';
-import { PoTableColumn } from '@po-ui/ng-components';
+import {
+  PoBreadcrumb,
+  PoHelperOptions,
+  PoModalAction,
+  PoModalComponent,
+  PoNotificationService,
+  PoPageAction,
+  PoTableColumn
+} from '@po-ui/ng-components';
 
 import { SampleDashboardService } from './sample-po-page-default-dashboard.service';
 
@@ -20,13 +24,13 @@ export class SamplePoPageDefaultDashboardComponent implements OnInit {
   private poNotification = inject(PoNotificationService);
   private sampleDashboardService = inject(SampleDashboardService);
 
-  @ViewChild('formShare', { static: true }) formShare: NgForm;
-  @ViewChild(PoModalComponent, { static: true }) poModal: PoModalComponent;
+  @ViewChild('formShare', { static: true }) formShare!: NgForm;
+  @ViewChild(PoModalComponent, { static: true }) poModal!: PoModalComponent;
 
-  columns: Array<PoTableColumn>;
-  email: string = undefined;
+  columns!: Array<PoTableColumn>;
+  email: string = '';
   isSubscribed: boolean = false;
-  items: Array<object>;
+  items!: Array<object>;
 
   public readonly actions: Array<PoPageAction> = [
     { label: 'Share', action: this.modalOpen.bind(this), icon: 'an an-share' },
@@ -41,11 +45,21 @@ export class SamplePoPageDefaultDashboardComponent implements OnInit {
       ]
     },
     { label: 'Components', url: '/documentation' },
-    { label: 'Disable notification', action: this.disableNotification.bind(this), disabled: () => this.isSubscribed }
+    {
+      label: 'Disable notification',
+      action: this.disableNotification.bind(this),
+      disabled: () => this.isSubscribed
+    }
   ];
 
   public readonly breadcrumb: PoBreadcrumb = {
     items: [{ label: 'Home', link: '/' }, { label: 'Dashboard' }]
+  };
+
+  public readonly helper: PoHelperOptions = {
+    title: 'Dashboard Info',
+    content: 'View <b>real-time metrics</b> of your website. Data is updated <i>every 5 minutes</i>.',
+    type: 'info'
   };
 
   public readonly cancelAction: PoModalAction = {

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
@@ -2,7 +2,8 @@
   [p-actions]="actions"
   [p-breadcrumb]="breadcrumb"
   [p-components-size]="componentsSize"
-  [p-literals]="customLiterals"
+  [p-helper]="helper || ''"
+  [p-literals]="customLiterals ?? {}"
   [p-page-actions-layout]="pageActionsLayout"
   [p-page-header-type]="pageHeaderType"
   [p-title]="title"
@@ -19,10 +20,58 @@
 
     <po-input class="po-md-6" name="subtitle" [(ngModel)]="subtitle" p-label="Subtitle"> </po-input>
 
+    <po-checkbox class="po-md-12 po-pt-2 po-pb-2" name="showHelper" [(ngModel)]="showHelper" p-label="Helper">
+    </po-checkbox>
+
+    @if (showHelper) {
+      <po-widget class="po-md-12 po-pb-3" p-title="Helper">
+        <div class="po-row">
+          <po-input class="po-md-6" name="helperTitle" [(ngModel)]="helperTitle" p-clean p-label="Title"> </po-input>
+
+          <po-input
+            class="po-md-6"
+            name="helperContent"
+            [(ngModel)]="helperContent"
+            p-clean
+            p-label="Content"
+            p-help="Consulte a <b>documentação</b> para mais detalhes."
+          >
+          </po-input>
+        </div>
+
+        <div class="po-row">
+          <po-radio-group
+            name="helperType"
+            class="po-md-12"
+            [p-columns]="4"
+            p-label="Type"
+            [ngModel]="helperType"
+            (ngModelChange)="helperType = $event"
+            [p-options]="helperTypeOptions"
+          >
+          </po-radio-group>
+        </div>
+
+        <div class="po-row">
+          @if (helperType === 'help') {
+            <po-input
+              class="po-md-6"
+              name="helperFooterLabel"
+              [(ngModel)]="helperFooterLabel"
+              p-clean
+              p-label="Footer Action"
+            >
+            </po-input>
+          }
+        </div>
+      </po-widget>
+    }
+
     <po-select
       class="po-lg-3 po-md-6"
       name="pageHeaderType"
-      [(ngModel)]="pageHeaderType"
+      [ngModel]="pageHeaderType"
+      (ngModelChange)="pageHeaderType = $event"
       p-label="Page Header Type"
       [p-options]="pageHeaderTypeOptions"
     >
@@ -31,7 +80,8 @@
     <po-select
       class="po-lg-3 po-md-6"
       name="pageActionsLayout"
-      [(ngModel)]="pageActionsLayout"
+      [ngModel]="pageActionsLayout"
+      (ngModelChange)="pageActionsLayout = $event"
       p-label="Page Actions Layout"
       [p-options]="pageActionsLayoutOptions"
     >
@@ -51,7 +101,7 @@
       class="po-md-12"
       name="size"
       [(ngModel)]="componentsSize"
-      p-columns="4"
+      [p-columns]="4"
       p-label="Components size"
       p-help="Para aplicar o tamanho small, configure o nível de acessibilidade para AA, ajustável no navbar ou serviço de tema (https://po-ui.io/documentation/po-theme)."
       [p-options]="componentsSizeOptions"
@@ -62,51 +112,69 @@
 
 <po-divider></po-divider>
 
-<form #formAction="ngForm">
-  <div class="po-row">
-    <po-input class="po-md-6" name="actionLabel" [(ngModel)]="action.label" p-label="Label" p-required> </po-input>
+<po-widget p-title="Action">
+  <form #formAction="ngForm">
+    <div class="po-row">
+      <po-input class="po-md-6" name="actionLabel" [(ngModel)]="action.label" p-label="Label" p-required> </po-input>
 
-    <po-input class="po-md-6" name="actionAction" [(ngModel)]="action.action" p-clean p-label="Action"> </po-input>
+      <po-input class="po-md-6" name="actionAction" [(ngModel)]="action.action" p-clean p-label="Action"> </po-input>
 
-    <po-input class="po-md-6" name="actionURL" [(ngModel)]="action.url" p-label="URL"> </po-input>
+      <po-input class="po-md-6" name="actionURL" [(ngModel)]="action.url" p-label="URL"> </po-input>
 
-    <po-select class="po-lg-3 po-md-6" name="type" [(ngModel)]="action.type" p-label="Type" [p-options]="typeOptions">
-    </po-select>
+      <po-select
+        class="po-lg-3 po-md-6"
+        name="type"
+        [ngModel]="action.type"
+        (ngModelChange)="action.type = $event"
+        p-label="Type"
+        [p-options]="typeOptions"
+      >
+      </po-select>
 
-    <po-select class="po-lg-3 po-md-6" name="icon" [(ngModel)]="action.icon" p-label="Icon" [p-options]="iconOptions">
-    </po-select>
+      <po-select
+        class="po-lg-3 po-md-6"
+        name="icon"
+        [ngModel]="action.icon"
+        (ngModelChange)="action.icon = $event"
+        p-label="Icon"
+        [p-options]="iconOptions"
+      >
+      </po-select>
 
-    <po-select
-      class="po-lg-3 po-md-6"
-      name="kind"
-      [(ngModel)]="action.kind"
-      p-label="Kind"
-      [p-options]="actionKindOptions"
-    >
-    </po-select>
+      <po-select
+        class="po-lg-3 po-md-6"
+        name="kind"
+        [ngModel]="action.kind"
+        (ngModelChange)="action.kind = $event"
+        p-label="Kind"
+        [p-options]="actionKindOptions"
+      >
+      </po-select>
 
-    <po-checkbox-group
-      class="po-md-12"
-      name="action"
-      [(ngModel)]="action"
-      p-columns="4"
-      p-indeterminate
-      p-label="Action properties"
-      [p-options]="actionOptions"
-    >
-    </po-checkbox-group>
-  </div>
+      <po-checkbox-group
+        class="po-md-12"
+        name="action"
+        [ngModel]="action"
+        (ngModelChange)="action = $event"
+        [p-columns]="4"
+        [p-indeterminate]="true"
+        p-label="Properties"
+        [p-options]="actionOptions"
+      >
+      </po-checkbox-group>
+    </div>
 
-  <div class="po-row">
-    <po-button
-      class="po-lg-2 po-md-4"
-      p-label="Add Action"
-      [p-disabled]="formAction.form.invalid"
-      (p-click)="addAction(action)"
-    >
-    </po-button>
-  </div>
-</form>
+    <div class="po-row">
+      <po-button
+        class="po-lg-2 po-md-4"
+        p-label="Add Action"
+        [p-disabled]="formAction.form.invalid"
+        (p-click)="addAction(action)"
+      >
+      </po-button>
+    </div>
+  </form>
+</po-widget>
 
 <po-divider></po-divider>
 
@@ -151,7 +219,7 @@
     <po-button
       class="po-lg-3 po-md-4"
       p-label="Add breadcrumb item"
-      [p-disabled]="formBreadcrumbItems.invalid"
+      [p-disabled]="formBreadcrumbItems.invalid ?? false"
       (p-click)="addBreadcrumbItem()"
     >
     </po-button>
@@ -187,7 +255,7 @@
     <po-button
       class="po-lg-3 po-md-4"
       p-label="Add breadcrumb params"
-      [p-disabled]="formBreadcrumbParams.invalid"
+      [p-disabled]="formBreadcrumbParams.invalid ?? false"
       (p-click)="addBreadcrumbParam()"
     >
     </po-button>

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.ts
@@ -4,12 +4,18 @@ import {
   PoBreadcrumb,
   PoBreadcrumbItem,
   PoCheckboxGroupOption,
+  PoHelperOptions,
   PoNotificationService,
   PoPageAction,
   PoPageDefaultLiterals,
   PoRadioGroupOption,
   PoSelectOption
 } from '@po-ui/ng-components';
+
+interface EditableAction extends PoPageAction {
+  visible: boolean;
+  disabled?: boolean;
+}
 
 @Component({
   selector: 'sample-po-page-default-labs',
@@ -19,10 +25,10 @@ import {
 export class SamplePoPageDefaultLabsComponent implements OnInit {
   private poNotification = inject(PoNotificationService);
 
-  action: PoPageAction = { label: '' };
-  actions: Array<PoPageAction> = [];
+  action: EditableAction = { label: '', visible: true, disabled: false };
+  actions: Array<EditableAction> = [];
   breadcrumb: PoBreadcrumb = { items: [] };
-  breadcrumbItem: PoBreadcrumbItem = { label: undefined, link: undefined };
+  breadcrumbItem: PoBreadcrumbItem = { label: '', link: undefined };
   breadcrumbParams: { property?: string; value?: string } = {};
   componentsSize: string = 'medium';
   customLiterals: PoPageDefaultLiterals | undefined;
@@ -31,6 +37,35 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
   pageHeaderType: string = 'primary';
   subtitle: string = '';
   title: string = 'PO Page Default';
+
+  helperContent: string = '';
+  helperFooterLabel: string = '';
+  helperTitle: string = '';
+  helperType: 'help' | 'info' = 'info';
+  showHelper: boolean = false;
+
+  public readonly helperTypeOptions: Array<PoSelectOption> = [
+    { label: 'help', value: 'help' },
+    { label: 'info', value: 'info' }
+  ];
+
+  get helper(): PoHelperOptions | undefined {
+    if (!this.showHelper || !this.helperContent) {
+      return undefined;
+    }
+    const options: PoHelperOptions = {
+      title: this.helperTitle,
+      content: this.helperContent,
+      type: this.helperType
+    };
+    if (this.helperType === 'help' && this.helperFooterLabel) {
+      options.footerAction = {
+        label: this.helperFooterLabel,
+        action: () => this.poNotification.information('Footer action clicked')
+      };
+    }
+    return options;
+  }
 
   public readonly actionKindOptions: Array<PoSelectOption> = [
     { label: 'primary', value: 'primary' },
@@ -77,8 +112,12 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
     this.restore();
   }
 
-  addAction(action: PoPageAction) {
-    const newAction: PoPageAction = { ...action };
+  addAction(action: EditableAction) {
+    const newAction: EditableAction = {
+      ...action,
+      visible: action.visible !== undefined ? action.visible : true,
+      disabled: action.disabled !== undefined ? action.disabled : false
+    };
     newAction.action = newAction.action ? this.showAction.bind(this, newAction.action) : undefined;
     this.actions = [...this.actions, newAction];
 
@@ -87,11 +126,13 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
 
   addBreadcrumbItem() {
     this.breadcrumb.items = this.breadcrumb.items.concat([this.breadcrumbItem]);
-    this.breadcrumbItem = { label: undefined, link: undefined };
+    this.breadcrumbItem = { label: '', link: undefined };
   }
 
   addBreadcrumbParam() {
-    const newParam = { [this.breadcrumbParams.property || '']: this.breadcrumbParams.value };
+    const newParam = {
+      [this.breadcrumbParams.property || '']: this.breadcrumbParams.value
+    };
 
     if (this.breadcrumb.params) {
       this.breadcrumb.params = Object.assign(this.breadcrumb.params, newParam);
@@ -115,16 +156,20 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
   }
 
   restore() {
-    this.action = { label: '' };
     this.actions = [];
     this.breadcrumb = { items: [] };
-    this.breadcrumbItem = { label: undefined, link: undefined };
+    this.breadcrumbItem = { label: '', link: undefined };
     this.breadcrumbParams = {};
     this.componentsSize = 'medium';
     this.customLiterals = undefined;
+    this.helperContent = '';
+    this.helperFooterLabel = '';
+    this.helperTitle = '';
+    this.helperType = 'info';
     this.literals = '';
     this.pageActionsLayout = 'default';
     this.pageHeaderType = 'primary';
+    this.showHelper = false;
     this.subtitle = '';
     this.title = 'PO Page Default';
     this.restoreActionForm();
@@ -133,7 +178,8 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
   restoreActionForm() {
     this.action = {
       label: '',
-      visible: true
+      visible: true,
+      disabled: false
     };
   }
 

--- a/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.spec.ts
@@ -1,9 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+
 import { PoPageHeaderBaseComponent } from './po-page-header-base.component';
 
 describe('PoPageHeaderBaseComponent', () => {
-  const component = new PoPageHeaderBaseComponent();
+  let component: PoPageHeaderBaseComponent;
+
+  beforeEach(() => {
+    component = TestBed.runInInjectionContext(() => new PoPageHeaderBaseComponent());
+  });
 
   it('should be created', () => {
     expect(component instanceof PoPageHeaderBaseComponent).toBeTruthy();
+  });
+
+  describe('helper property:', () => {
+    it('should have helper input with undefined as default value', () => {
+      expect(component.helper()).toBeUndefined();
+    });
   });
 });

--- a/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.ts
@@ -1,6 +1,7 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, Input, input } from '@angular/core';
 
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
+import { PoHelperOptions } from '../../po-helper/interfaces/po-helper.interface';
 
 /**
  * @docsPrivate
@@ -14,6 +15,9 @@ import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
 export class PoPageHeaderBaseComponent {
   /** Título da página. */
   @Input('p-title') title: string;
+
+  /** Define o conteúdo do po-helper. */
+  helper = input<PoHelperOptions | string>(undefined, { alias: 'p-helper' });
 
   /** Define o tamanho dos componentes no header. */
   @Input('p-size') size: string;

--- a/projects/ui/src/lib/components/po-page/po-page-header/po-page-header.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-header/po-page-header.component.html
@@ -37,6 +37,14 @@
         @if (title && subtitle) {
           <div class="po-page-header-subtitle">
             {{ subtitle }}
+            @if (helper()) {
+              <po-helper [p-helper]="helper()" [p-size]="size"></po-helper>
+            }
+          </div>
+        }
+        @if (title && !subtitle && helper()) {
+          <div class="po-page-header-subtitle">
+            <po-helper [p-helper]="helper()" [p-size]="size"></po-helper>
           </div>
         }
       </div>

--- a/projects/ui/src/lib/components/po-page/po-page-header/po-page-header.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-header/po-page-header.component.spec.ts
@@ -5,6 +5,7 @@ import { Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { PoBreadcrumbModule } from '../../po-breadcrumb/po-breadcrumb.module';
+import { PoHelperModule } from '../../po-helper/po-helper.module';
 import { PoPageHeaderComponent } from './po-page-header.component';
 
 @Component({
@@ -22,7 +23,7 @@ describe('PoPageHeaderComponent:', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PoBreadcrumbModule, RouterTestingModule.withRoutes(routes)],
+      imports: [PoBreadcrumbModule, PoHelperModule, RouterTestingModule.withRoutes(routes)],
       declarations: [PoPageHeaderComponent, GuidesComponent],
       providers: [HttpClient, HttpHandler]
     }).compileComponents();
@@ -64,6 +65,60 @@ describe('PoPageHeaderComponent:', () => {
       fixture.detectChanges();
 
       expect(nativeElement.querySelector('.po-page-header-breadcrumb')).toBeFalsy();
+    });
+  });
+
+  describe('Helper rendering:', () => {
+    it('should not render po-helper when helper is not provided', () => {
+      component.title = 'Title';
+      component.subtitle = 'Subtitle';
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('po-helper')).toBeFalsy();
+    });
+
+    it('should render po-helper next to subtitle when both subtitle and helper are provided', () => {
+      component.title = 'Title';
+      component.subtitle = 'Subtitle';
+      fixture.componentRef.setInput('p-helper', { content: 'Help text', type: 'info' });
+
+      fixture.detectChanges();
+
+      expect(component.subtitle).toBe('Subtitle');
+      expect(nativeElement.querySelector('po-helper')).toBeTruthy();
+    });
+
+    it('should render po-helper below title when helper is provided but subtitle is not', () => {
+      component.title = 'Title';
+      component.subtitle = undefined;
+      fixture.componentRef.setInput('p-helper', { content: 'Help text', type: 'info' });
+
+      fixture.detectChanges();
+
+      expect(component.subtitle).toBeUndefined();
+      expect(nativeElement.querySelector('po-helper')).toBeTruthy();
+      expect(nativeElement.textContent).not.toContain('Subtitle');
+    });
+
+    it('should not render po-helper when title is not provided', () => {
+      component.title = undefined;
+      component.subtitle = undefined;
+      fixture.componentRef.setInput('p-helper', { content: 'Help text', type: 'info' });
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('po-helper')).toBeFalsy();
+    });
+
+    it('should render po-helper when helper is a string value', () => {
+      component.title = 'Title';
+      component.subtitle = 'Subtitle';
+      fixture.componentRef.setInput('p-helper', 'Simple help text');
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('po-helper')).toBeTruthy();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-page/po-page.module.ts
+++ b/projects/ui/src/lib/components/po-page/po-page.module.ts
@@ -8,6 +8,7 @@ import { PoButtonModule } from '../po-button/po-button.module';
 import { PoDisclaimerGroupModule } from '../po-disclaimer-group/po-disclaimer-group.module';
 import { PoDropdownModule } from '../po-dropdown/po-dropdown.module';
 import { PoFieldModule } from '../po-field/po-field.module';
+import { PoHelperModule } from '../po-helper/po-helper.module';
 import { PoIconModule } from '../po-icon';
 import { PoLanguageModule } from './../../services/po-language/po-language.module';
 import { PoModalModule } from './../po-modal/po-modal.module';
@@ -37,6 +38,7 @@ import { PoPageSlideModule } from './po-page-slide/po-page-slide.module';
     PoDisclaimerGroupModule,
     PoDropdownModule,
     PoFieldModule,
+    PoHelperModule,
     PoIconModule,
     PoLanguageModule,
     PoModalModule,


### PR DESCRIPTION
**PO-PAGE-DEFAULT**

**DTHFUI-13013**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**
Adiciona a propriedade 'p-helper' para exibição de mensagens de ajuda.
Permite a formatação de texto no conteúdo do helper utilizando as tags HTML básicas: ```<b>, <strong>, <i>, <em> e <u>```.

**Simulação**
Samples