### PR TITLE
fix(input): preserva cursor ao aplicar upperCase no eventOnInput

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
@@ -240,18 +240,30 @@ describe('PoInputGeneric:', () => {
   });
 
   it('should call "callOnChange" on eventInput with uppercase', () => {
+    const fakeInputElement = {
+      value: '',
+      selectionStart: 1,
+      selectionEnd: 3,
+      setSelectionRange: (start: number, end: number) => {}
+    };
+
     const fakeThis = {
       upperCase: true,
       callOnChange: (v: any) => {},
       validMaxLength: component.validMaxLength,
-      inputEl: component.inputEl
+      inputEl: {
+        nativeElement: fakeInputElement
+      }
     };
     fakeEvent.target.value = 'teste';
+
+    spyOn(fakeInputElement, 'setSelectionRange');
 
     spyOn(fakeThis, 'callOnChange');
     component.eventOnInput.call(fakeThis, fakeEvent);
     expect(fakeThis.callOnChange).toHaveBeenCalledWith('TESTE');
-    expect(fakeThis.inputEl.nativeElement.value).toBe('TESTE');
+    expect(fakeInputElement.value).toBe('TESTE');
+    expect(fakeInputElement.setSelectionRange).toHaveBeenCalledWith(1, 3);
   });
 
   it('should call mask.blur on eventInput with mask', () => {

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -91,19 +91,36 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
 
   eventOnInput(e: any) {
     let value = '';
+
+    const inputElement = this.inputEl.nativeElement;
+    const selectionStart = inputElement.selectionStart;
+    const selectionEnd = inputElement.selectionEnd;
+
     if (!this.mask) {
       value = this.validMaxLength(this.maxlength, e.target.value);
-      this.inputEl.nativeElement.value = value;
+      inputElement.value = value;
     } else {
       this.objMask.blur(e);
-      this.inputEl.nativeElement.value = this.objMask.valueToInput;
+      inputElement.value = this.objMask.valueToInput;
       value = this.objMask.valueToModel;
     }
-    this.inputEl.nativeElement.value = this.upperCase
-      ? String(this.inputEl.nativeElement.value).toUpperCase()
-      : this.inputEl.nativeElement.value;
+
+    inputElement.value = this.upperCase ? String(inputElement.value).toUpperCase() : inputElement.value;
+
+    const shouldSetSelectionRange =
+      this.upperCase && typeof selectionStart === 'number' && typeof selectionEnd === 'number';
+
+    if (shouldSetSelectionRange) {
+      const cursorStart = Math.min(selectionStart, inputElement.value.length);
+      const cursorEnd = Math.min(selectionEnd, inputElement.value.length);
+
+      inputElement.setSelectionRange(cursorStart, cursorEnd);
+    }
+
     value = this.upperCase ? value.toUpperCase() : value;
+
     this.callOnChange(value);
+
     if (this.errorAsyncProperties?.triggerMode === 'changeModel') {
       this.verifyErrorAsync();
     }


### PR DESCRIPTION
Ao converter o valor para maiúsculas no método eventOnInput, o cursor era reposicionado para o final do campo, prejudicando a experiência do usuário ao editar textos no meio da string.

Captura a posição do cursor antes da transformação e restaura via setSelectionRange após aplicar o toUpperCase, garantindo que o cursor permaneça na posição correta.

Fixes #2387

**po-input**

**#2387**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao digitar no meio de uma frase no componente po-input com  o cursor ia para o fim da frase.

**Qual o novo comportamento?**
O cursor se mantém no lugar esperado ao digitar no meio da frase.

**Simulação**
Para simular necessário rodar o projeto, aplicar no arquivo no app.component o código encontrado no stackblitz fornecido na abertura da issue: https://stackblitz.com/edit/po-ui-beqs56bj?file=src%2Fapp%2Fapp.component.html,src%2Fapp%2Fapp.component.ts
