### PR TITLE
fix(table): corrige tabela piscando ao realizar scroll

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -256,7 +256,7 @@
               }"
               [ngStyle]="{
                 'width':
-                  height > 0 && !virtualScroll ? (!hasItems ? '100%' : applyFixedColumns() ? column.width : 'auto') : ''
+                  height > 0 && !virtualScroll ? (!hasItems ? '100%' : applyFixedColumns() ? column.width : null) : null
               }"
               [class.po-table-header-subtitle]="column.type === 'subtitle'"
               [class.po-table-column-drag-box]="this.isDraggable"
@@ -315,7 +315,7 @@
               }"
               [ngStyle]="{
                 'width':
-                  height > 0 && !virtualScroll ? (!hasItems ? '100%' : applyFixedColumns() ? column.width : 'auto') : ''
+                  height > 0 && !virtualScroll ? (!hasItems ? '100%' : applyFixedColumns() ? column.width : null) : null
               }"
               [class.po-table-header-subtitle]="column.type === 'subtitle'"
               (click)="sortColumn(column)"
@@ -550,384 +550,396 @@
   </table>
 </ng-template>
 
-<!-- Table with virtual scroll -->
 <ng-template #tableVirtualScrollTemplate>
-  <cdk-virtual-scroll-viewport
-    #tableVirtualScroll
-    [itemSize]="itemSize"
-    [style.height.px]="heightTableContainer"
-    [minBufferPx]="heightTableContainer < 100 ? 100 : heightTableContainer"
-    [maxBufferPx]="heightTableContainer < 200 ? 200 : heightTableContainer"
-  >
-    <table
-      class="po-table"
-      [ngClass]="{
-        'po-table-interactive': selectable || sort,
-        'po-table-selectable': selectable,
-        'po-table-striped': striped,
-        'po-table-data-fixed-columns': applyFixedColumns(),
-        'po-table-text-wrap-enabled': textWrap
-      }"
-      [attr.p-spacing]="spacing"
-    >
-      <thead
-        class="po-table-header-sticky"
-        [style.top]="inverseOfTranslation"
-        [attr.p-spacing]="spacing ?? (componentsSize === 'small' ? 'extraSmall' : 'medium')"
+  <div class="po-table-virtual-scroll-wrapper" #virtualScrollWrapper [style.height.px]="heightTableContainer">
+    <div class="po-table-header-virtual-scroll" #headerScrollContainer>
+      <table
+        #headerTable
+        class="po-table"
+        [ngClass]="{
+          'po-table-interactive': selectable || sort,
+          'po-table-selectable': selectable,
+          'po-table-striped': striped,
+          'po-table-data-fixed-columns': applyFixedColumns(),
+          'po-table-text-wrap-enabled': textWrap
+        }"
+        [attr.p-spacing]="spacing"
       >
-        <tr
-          [class.po-table-header]="!height"
-          cdkDropList
-          cdkDropListOrientation="horizontal"
-          (cdkDropListDropped)="drop($event)"
-        >
-          @if (hasSelectableColumn) {
-            <th [style.pointer-events]="hideSelectAll ? 'none' : 'auto'" class="po-table-column-selectable">
-              <div [class.po-table-header-fixed-inner]="height">
-                @if (!hideSelectAll) {
-                  <po-checkbox
-                    name="selectAll"
-                    (p-change)="selectAllRows()"
-                    [p-checkboxValue]="selectAll === null ? 'mixed' : selectAll"
-                    [p-size]="componentsSize"
-                  ></po-checkbox>
-                }
-              </div>
-            </th>
-          }
-
-          @if ((hasMasterDetailColumn || hasRowTemplate) && hasMainColumns && !hasRowTemplateWithArrowDirectionRight) {
-            <th class="po-table-header-column po-table-header-master-detail"></th>
-          }
-
-          <!-- Coluna criada para caso as ações fiquem no lado esquerdo -->
-          @if (!actionRight && hasItems && hasMainColumns && (visibleActions.length > 1 || isSingleAction)) {
-            <th
-              #columnActionLeft
-              [class.po-table-header-master-detail]="!isSingleAction"
-              [class.po-table-header-single-action]="isSingleAction"
-            ></th>
-          }
-
-          @if (!hasMainColumns) {
-            <th #noColumnsHeader class="po-table-header-column po-text-center" [attr.colspan]="columnCount">
-              @if (height) {
-                <div class="po-table-header-fixed-inner" [style.width.px]="hasValidColumns ? headerWidth : null">
-                  {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
-                </div>
-              } @else {
-                {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
-              }
-            </th>
-          }
-
-          @if (this.isDraggable || hasSomeFixed()) {
-            @for (column of mainColumns; track trackBy(i); let i = $index) {
-              <th
-                class="po-table-header-ellipsis p-element po-frozen-column"
-                [style.width]="column.width"
-                [style.max-width]="column.width"
-                [style.min-width]="column.width"
-                [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
-                [class.po-clickable]="(sort && column.sortable !== false) || hasService"
-                [ngClass]="{
-                  'po-table-header-sorted':
-                    sort &&
-                    JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
-                    (sortedColumn.ascending || !sortedColumn.ascending)
-                }"
-                [ngStyle]="{ 'width': !hasItems ? '100%' : applyFixedColumns() ? column.width : 'auto' }"
-                [class.po-table-header-subtitle]="column.type === 'subtitle'"
-                [class.po-table-column-drag-box]="this.isDraggable"
-                (click)="sortColumn(column)"
-                cdkDrag
-                cdkDragLockAxis="x"
-                [cdkDragDisabled]="column.fixed ? 'true' : 'false'"
-                [pFrozenColumn]="column.fixed"
-              >
-                <div
-                  class="po-table-header-flex"
-                  [class.po-table-header-fixed-inner]="height"
-                  [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
-                  [class.po-table-header-flex-center]="column.type === 'subtitle'"
-                >
-                  @if (this.isDraggable && !column.fixed) {
-                    @if (iconNameLib === 'AnimaliaIcon') {
-                      <po-icon cdkDragHandle p-icon="ICON_DRAG"></po-icon>
-                    }
-                    @if (iconNameLib === 'PoIcon') {
-                      <svg
-                        cdkDragHandle
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <circle cx="9" cy="6" r="2" fill="black" />
-                        <circle cx="15" cy="6" r="2" fill="black" />
-                        <circle cx="9" cy="12" r="2" fill="black" />
-                        <circle cx="15" cy="12" r="2" fill="black" />
-                        <circle cx="9" cy="18" r="2" fill="black" />
-                        <circle cx="15" cy="18" r="2" fill="black" />
-                      </svg>
-                    }
-                  }
-                  <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }">
-                  </ng-container>
-                </div>
-              </th>
-            }
-          } @else {
-            @for (column of mainColumns; track trackBy(i); let i = $index) {
-              <th
-                class="po-table-header-ellipsis p-element po-frozen-column example-box"
-                [style.width]="column.width"
-                [style.max-width]="column.width"
-                [style.min-width]="column.width"
-                [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
-                [class.po-clickable]="(sort && column.sortable !== false) || hasService"
-                [ngClass]="{
-                  'po-table-header-sorted':
-                    sort &&
-                    JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
-                    (sortedColumn.ascending || !sortedColumn.ascending)
-                }"
-                [ngStyle]="{ 'width': !hasItems ? '100%' : applyFixedColumns() ? column.width : 'auto' }"
-                [class.po-table-header-subtitle]="column.type === 'subtitle'"
-                (click)="sortColumn(column)"
-                [pFrozenColumn]="column.fixed"
-              >
-                <div
-                  class="po-table-header-flex"
-                  [class.po-table-header-fixed-inner]="height"
-                  [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
-                  [class.po-table-header-flex-center]="column.type === 'subtitle'"
-                >
-                  <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }">
-                  </ng-container>
-                </div>
-              </th>
-            }
-          }
-
-          @if (hasRowTemplateWithArrowDirectionRight && hasMainColumns && (hasVisibleActions || hideColumnsManager)) {
-            <th class="po-table-header-column po-table-header-master-detail"></th>
-          }
-
-          @if (
-            hasVisibleActions &&
-            actionRight &&
-            hasItems &&
-            hasMainColumns &&
-            (visibleActions.length > 1 || isSingleAction)
-          ) {
-            <th
-              [class.po-table-header-single-action]="isSingleAction"
-              [class.po-table-header-actions]="!isSingleAction"
-            ></th>
-          }
-        </tr>
-      </thead>
-
-      @if (!hasItems || !hasMainColumns) {
-        <tbody class="po-table-group-row">
-          <tr class="po-table-row po-table-row-no-data">
-            <td [colSpan]="columnCount" class="po-table-no-data po-text-center">
-              <span> {{ literals.noData }} </span>
-            </td>
-          </tr>
-        </tbody>
-      }
-
-      @if (hasMainColumns) {
-        <tbody
-          class="po-table-group-row"
-          *cdkVirtualFor="let row of filteredItems; let rowIndex = index; trackBy: trackBy"
+        <thead
+          class="po-table-header-relative"
+          [attr.p-spacing]="spacing ?? (componentsSize === 'small' ? 'extraSmall' : 'medium')"
         >
           <tr
-            class="po-table-row"
-            [class.po-table-row-active]="row.$selected || (row.$selected === null && selectable)"
+            [class.po-table-header]="!height"
+            cdkDropList
+            cdkDropListOrientation="horizontal"
+            (cdkDropListDropped)="drop($event)"
           >
-            @if (selectable) {
-              <td class="po-table-column-selectable">
-                <ng-container
-                  *ngTemplateOutlet="singleSelect ? inputRadio : inputCheckbox; context: { $implicit: row }"
-                >
-                </ng-container>
-              </td>
-            }
-            <!-- Valida se a origem do detail é pelo input do po-table pela diretiva -->
-            @if (
-              (columnMasterDetail && !hideDetail && !hasRowTemplate) ||
-              (hasRowTemplate && !hasRowTemplateWithArrowDirectionRight)
-            ) {
-              <td class="po-table-column-detail-toggle" (click)="toggleDetail(row)">
-                <ng-template
-                  [ngTemplateOutlet]="poTableColumnDetail"
-                  [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-                >
-                </ng-template>
-              </td>
-            }
-            <!-- Coluna com as ações na esquerda (padrão)-->
-            @if (!actionRight && (visibleActions.length > 1 || isSingleAction)) {
-              <ng-template
-                [ngTemplateOutlet]="ActionsColumnTemplate"
-                [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-              >
-              </ng-template>
-            }
-            @for (column of mainColumns; track trackBy(columnIndex); let columnIndex = $index) {
-              <td
-                [style.width]="column.width"
-                [style.max-width]="column.width"
-                [style.min-width]="column.width"
-                [class.po-table-column]="column.type !== 'icon'"
-                [class.po-table-column-right]="column.type === 'currency' || column.type === 'number'"
-                [class.po-table-column-center]="column.type === 'subtitle'"
-                [class.po-table-column-icons]="column.type === 'icon'"
-                [ngClass]="getClassColor(row, column)"
-                [pFrozenColumn]="column.fixed"
-                class="p-element po-frozen-column"
-                (click)="hasSelectableRow() ? selectRow(row) : 'javascript:;'"
-              >
-                <div
-                  class="po-table-column-cell po-table-body-ellipsis notranslate"
-                  [p-tooltip]="tooltipText"
-                  [p-append-in-body]="true"
-                  (mouseenter)="tooltipMouseEnter($event, column, row)"
-                  (mouseleave)="tooltipMouseLeave()"
-                >
-                  @switch (column.type) {
-                    @case ('columnTemplate') {
-                      <span>
-                        <ng-container
-                          *ngTemplateOutlet="getTemplate(column); context: { $implicit: getCellData(row, column) }"
-                        >
-                        </ng-container>
-                      </span>
-                    }
-                    @case ('cellTemplate') {
-                      <span>
-                        <ng-container
-                          *ngTemplateOutlet="tableCellTemplate?.templateRef; context: { row: row, column: column }"
-                        >
-                        </ng-container>
-                      </span>
-                    }
-                    @case ('boolean') {
-                      <span>
-                        {{ getBooleanLabel(getCellData(row, column), column) }}
-                      </span>
-                    }
-                    @case ('currency') {
-                      <span>
-                        {{ getCellData(row, column) | currency: column.format : 'symbol' : '1.2-2' }}
-                      </span>
-                    }
-                    @case ('date') {
-                      <span>
-                        {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy' }}
-                      </span>
-                    }
-                    @case ('time') {
-                      <span>
-                        {{ getCellData(row, column) | po_time: column.format || 'HH:mm:ss.ffffff' }}
-                      </span>
-                    }
-                    @case ('dateTime') {
-                      <span>
-                        {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy HH:mm:ss' }}
-                      </span>
-                    }
-                    @case ('number') {
-                      <span>
-                        {{ formatNumber(getCellData(row, column), column.format) }}
-                      </span>
-                    }
-                    @case ('link') {
-                      <po-table-column-link
-                        [p-action]="column.action"
-                        [p-disabled]="checkDisabled(row, column)"
-                        [p-link]="row[column.link]"
-                        [p-row]="row"
-                        [p-value]="getCellData(row, column)"
-                        (click)="onClickLink($event, row, column)"
-                      >
-                      </po-table-column-link>
-                    }
-                    @case ('icon') {
-                      <po-table-column-icon [p-column]="column" [p-icons]="getColumnIcons(row, column)" [p-row]="row">
-                      </po-table-column-icon>
-                    }
-                    @case ('subtitle') {
-                      <span>
-                        <po-table-subtitle-circle
-                          [p-subtitle]="getSubtitleColumn(row, column)"
-                        ></po-table-subtitle-circle>
-                      </span>
-                    }
-                    @case ('label') {
-                      <span>
-                        <po-table-column-label [p-value]="getColumnLabel(row, column)"> </po-table-column-label>
-                      </span>
-                    }
-                    @default {
-                      <span>{{ getCellData(row, column) }}</span>
-                    }
+            @if (hasSelectableColumn) {
+              <th [style.pointer-events]="hideSelectAll ? 'none' : 'auto'" class="po-table-column-selectable">
+                <div [class.po-table-header-fixed-inner]="height">
+                  @if (!hideSelectAll) {
+                    <po-checkbox
+                      name="selectAll"
+                      (p-change)="selectAllRows()"
+                      [p-checkboxValue]="selectAll === null ? 'mixed' : selectAll"
+                      [p-size]="componentsSize"
+                    ></po-checkbox>
                   }
                 </div>
-              </td>
+              </th>
             }
-            @if (hasRowTemplateWithArrowDirectionRight) {
-              <td class="po-table-column-detail-toggle" (click)="toggleDetail(row)">
+
+            @if (
+              (hasMasterDetailColumn || hasRowTemplate) && hasMainColumns && !hasRowTemplateWithArrowDirectionRight
+            ) {
+              <th class="po-table-header-column po-table-header-master-detail"></th>
+            }
+
+            @if (!actionRight && hasItems && hasMainColumns && (visibleActions.length > 1 || isSingleAction)) {
+              <th
+                #columnActionLeft
+                [class.po-table-header-master-detail]="!isSingleAction"
+                [class.po-table-header-single-action]="isSingleAction"
+              ></th>
+            }
+
+            @if (!hasMainColumns) {
+              <th #noColumnsHeader class="po-table-header-column po-text-center" [attr.colspan]="columnCount">
+                @if (height) {
+                  <div class="po-table-header-fixed-inner" [style.width.px]="hasValidColumns ? headerWidth : null">
+                    {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
+                  </div>
+                } @else {
+                  {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
+                }
+              </th>
+            }
+
+            @if (this.isDraggable || hasSomeFixed()) {
+              @for (column of mainColumns; track trackBy(i); let i = $index) {
+                <th
+                  class="po-table-header-ellipsis p-element po-frozen-column"
+                  [style.width]="getColumnWidth(column, i)"
+                  [style.max-width]="column.width || computedColumnWidths[i]"
+                  [style.min-width]="column.width || computedColumnWidths[i]"
+                  [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
+                  [class.po-clickable]="(sort && column.sortable !== false) || hasService"
+                  [ngClass]="{
+                    'po-table-header-sorted':
+                      sort &&
+                      JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
+                      (sortedColumn.ascending || !sortedColumn.ascending)
+                  }"
+                  [class.po-table-header-subtitle]="column.type === 'subtitle'"
+                  [class.po-table-column-drag-box]="this.isDraggable"
+                  (click)="sortColumn(column)"
+                  cdkDrag
+                  cdkDragLockAxis="x"
+                  [cdkDragDisabled]="column.fixed ? 'true' : 'false'"
+                  [pFrozenColumn]="column.fixed"
+                >
+                  <div
+                    class="po-table-header-flex"
+                    [class.po-table-header-fixed-inner]="height"
+                    [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
+                    [class.po-table-header-flex-center]="column.type === 'subtitle'"
+                  >
+                    @if (this.isDraggable && !column.fixed) {
+                      @if (iconNameLib === 'AnimaliaIcon') {
+                        <po-icon cdkDragHandle p-icon="ICON_DRAG"></po-icon>
+                      }
+                      @if (iconNameLib === 'PoIcon') {
+                        <svg
+                          cdkDragHandle
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle cx="9" cy="6" r="2" fill="black" />
+                          <circle cx="15" cy="6" r="2" fill="black" />
+                          <circle cx="9" cy="12" r="2" fill="black" />
+                          <circle cx="15" cy="12" r="2" fill="black" />
+                          <circle cx="9" cy="18" r="2" fill="black" />
+                          <circle cx="15" cy="18" r="2" fill="black" />
+                        </svg>
+                      }
+                    }
+                    <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }">
+                    </ng-container>
+                  </div>
+                </th>
+              }
+            } @else {
+              @for (column of mainColumns; track trackBy(i); let i = $index) {
+                <th
+                  class="po-table-header-ellipsis p-element po-frozen-column"
+                  [style.width]="getColumnWidth(column, i)"
+                  [style.max-width]="column.width || computedColumnWidths[i]"
+                  [style.min-width]="column.width || computedColumnWidths[i]"
+                  [attr.data-po-table-column-name]="column.label || (column.property | titlecase) | lowercase"
+                  [class.po-clickable]="(sort && column.sortable !== false) || hasService"
+                  [ngClass]="{
+                    'po-table-header-sorted':
+                      sort &&
+                      JSON.stringify(sortedColumn?.property) === JSON.stringify(column) &&
+                      (sortedColumn.ascending || !sortedColumn.ascending)
+                  }"
+                  [class.po-table-header-subtitle]="column.type === 'subtitle'"
+                  (click)="sortColumn(column)"
+                  [pFrozenColumn]="column.fixed"
+                >
+                  <div
+                    class="po-table-header-flex"
+                    [class.po-table-header-fixed-inner]="height"
+                    [class.po-table-header-flex-right]="column.type === 'currency' || column.type === 'number'"
+                    [class.po-table-header-flex-center]="column.type === 'subtitle'"
+                  >
+                    <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }">
+                    </ng-container>
+                  </div>
+                </th>
+              }
+            }
+
+            @if (hasRowTemplateWithArrowDirectionRight && hasMainColumns && (hasVisibleActions || hideColumnsManager)) {
+              <th class="po-table-header-column po-table-header-master-detail"></th>
+            }
+
+            @if (
+              hasVisibleActions &&
+              actionRight &&
+              hasItems &&
+              hasMainColumns &&
+              (visibleActions.length > 1 || isSingleAction)
+            ) {
+              <th
+                [class.po-table-header-single-action]="isSingleAction"
+                [class.po-table-header-actions]="!isSingleAction"
+              ></th>
+            }
+          </tr>
+        </thead>
+      </table>
+    </div>
+
+    <cdk-virtual-scroll-viewport
+      #tableVirtualScroll
+      [itemSize]="itemSize"
+      [style.height.px]="heightTableVirtual"
+      [minBufferPx]="heightTableVirtual < 100 ? 100 : heightTableVirtual"
+      [maxBufferPx]="heightTableVirtual < 200 ? 200 : heightTableVirtual"
+    >
+      <table
+        #bodyTable
+        class="po-table po-table-virtual-scroll"
+        [ngClass]="{
+          'po-table-interactive': selectable || sort,
+          'po-table-selectable': selectable,
+          'po-table-striped': striped,
+          'po-table-data-fixed-columns': applyFixedColumns(),
+          'po-table-text-wrap-enabled': textWrap
+        }"
+        [attr.p-spacing]="spacing"
+      >
+        @if (!hasItems || !hasMainColumns) {
+          <tbody class="po-table-group-row">
+            <tr class="po-table-row po-table-row-no-data">
+              <td [colSpan]="columnCount" class="po-table-no-data po-text-center">
+                <span> {{ literals.noData }} </span>
+              </td>
+            </tr>
+          </tbody>
+        }
+
+        @if (hasMainColumns) {
+          <tbody
+            class="po-table-group-row"
+            *cdkVirtualFor="let row of filteredItems; let rowIndex = index; trackBy: trackBy"
+          >
+            <tr
+              class="po-table-row"
+              [class.po-table-row-active]="row.$selected || (row.$selected === null && selectable)"
+            >
+              @if (selectable) {
+                <td class="po-table-column-selectable">
+                  <ng-container
+                    *ngTemplateOutlet="singleSelect ? inputRadio : inputCheckbox; context: { $implicit: row }"
+                  >
+                  </ng-container>
+                </td>
+              }
+              @if (
+                (columnMasterDetail && !hideDetail && !hasRowTemplate) ||
+                (hasRowTemplate && !hasRowTemplateWithArrowDirectionRight)
+              ) {
+                <td class="po-table-column-detail-toggle" (click)="toggleDetail(row)">
+                  <ng-template
+                    [ngTemplateOutlet]="poTableColumnDetail"
+                    [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+                  >
+                  </ng-template>
+                </td>
+              }
+              @if (!actionRight && (visibleActions.length > 1 || isSingleAction)) {
                 <ng-template
-                  [ngTemplateOutlet]="poTableColumnDetail"
+                  [ngTemplateOutlet]="ActionsColumnTemplate"
                   [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
                 >
                 </ng-template>
-              </td>
-            }
-            <!-- Coluna de açoes na direita -->
-            @if (actionRight) {
-              <ng-template
-                [ngTemplateOutlet]="ActionsColumnTemplate"
-                [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
-              >
-              </ng-template>
-            }
-          </tr>
-          @if (hasMainColumns && hasRowTemplate && row.$showDetail && isShowRowTemplate(row, rowIndex)) {
-            <tr>
-              <td class="po-table-row-template-container" [colSpan]="columnCountForMasterDetail">
+              }
+              @for (column of mainColumns; track trackBy(columnIndex); let columnIndex = $index) {
+                <td
+                  [style.width]="getColumnWidth(column, columnIndex)"
+                  [style.max-width]="column.width || computedColumnWidths[columnIndex]"
+                  [style.min-width]="column.width || computedColumnWidths[columnIndex]"
+                  [class.po-table-column]="column.type !== 'icon'"
+                  [class.po-table-column-right]="column.type === 'currency' || column.type === 'number'"
+                  [class.po-table-column-center]="column.type === 'subtitle'"
+                  [class.po-table-column-icons]="column.type === 'icon'"
+                  [ngClass]="getClassColor(row, column)"
+                  [pFrozenColumn]="column.fixed"
+                  class="p-element po-frozen-column"
+                  (click)="hasSelectableRow() ? selectRow(row) : 'javascript:;'"
+                >
+                  <div
+                    class="po-table-column-cell po-table-body-ellipsis notranslate"
+                    [p-tooltip]="tooltipText"
+                    [p-append-in-body]="true"
+                    (mouseenter)="tooltipMouseEnter($event, column, row)"
+                    (mouseleave)="tooltipMouseLeave()"
+                  >
+                    @switch (column.type) {
+                      @case ('columnTemplate') {
+                        <span>
+                          <ng-container
+                            *ngTemplateOutlet="getTemplate(column); context: { $implicit: getCellData(row, column) }"
+                          >
+                          </ng-container>
+                        </span>
+                      }
+                      @case ('cellTemplate') {
+                        <span>
+                          <ng-container
+                            *ngTemplateOutlet="tableCellTemplate?.templateRef; context: { row: row, column: column }"
+                          >
+                          </ng-container>
+                        </span>
+                      }
+                      @case ('boolean') {
+                        <span>
+                          {{ getBooleanLabel(getCellData(row, column), column) }}
+                        </span>
+                      }
+                      @case ('currency') {
+                        <span>
+                          {{ getCellData(row, column) | currency: column.format : 'symbol' : '1.2-2' }}
+                        </span>
+                      }
+                      @case ('date') {
+                        <span>
+                          {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy' }}
+                        </span>
+                      }
+                      @case ('time') {
+                        <span>
+                          {{ getCellData(row, column) | po_time: column.format || 'HH:mm:ss.ffffff' }}
+                        </span>
+                      }
+                      @case ('dateTime') {
+                        <span>
+                          {{ getCellData(row, column) | date: column.format || 'dd/MM/yyyy HH:mm:ss' }}
+                        </span>
+                      }
+                      @case ('number') {
+                        <span>
+                          {{ formatNumber(getCellData(row, column), column.format) }}
+                        </span>
+                      }
+                      @case ('link') {
+                        <po-table-column-link
+                          [p-action]="column.action"
+                          [p-disabled]="checkDisabled(row, column)"
+                          [p-link]="row[column.link]"
+                          [p-row]="row"
+                          [p-value]="getCellData(row, column)"
+                          (click)="onClickLink($event, row, column)"
+                        >
+                        </po-table-column-link>
+                      }
+                      @case ('icon') {
+                        <po-table-column-icon [p-column]="column" [p-icons]="getColumnIcons(row, column)" [p-row]="row">
+                        </po-table-column-icon>
+                      }
+                      @case ('subtitle') {
+                        <span>
+                          <po-table-subtitle-circle
+                            [p-subtitle]="getSubtitleColumn(row, column)"
+                          ></po-table-subtitle-circle>
+                        </span>
+                      }
+                      @case ('label') {
+                        <span>
+                          <po-table-column-label [p-value]="getColumnLabel(row, column)"> </po-table-column-label>
+                        </span>
+                      }
+                      @default {
+                        <span>{{ getCellData(row, column) }}</span>
+                      }
+                    }
+                  </div>
+                </td>
+              }
+              @if (hasRowTemplateWithArrowDirectionRight) {
+                <td class="po-table-column-detail-toggle" (click)="toggleDetail(row)">
+                  <ng-template
+                    [ngTemplateOutlet]="poTableColumnDetail"
+                    [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
+                  >
+                  </ng-template>
+                </td>
+              }
+              @if (actionRight) {
                 <ng-template
-                  [ngTemplateOutlet]="tableRowTemplate.templateRef"
-                  [ngTemplateOutletContext]="{ $implicit: row, rowIndex: rowIndex }"
+                  [ngTemplateOutlet]="ActionsColumnTemplate"
+                  [ngTemplateOutletContext]="{ row: row, rowIndex: rowIndex }"
                 >
                 </ng-template>
-              </td>
+              }
             </tr>
-          }
-          @if (hasMainColumns && isShowMasterDetail(row)) {
-            <tr>
-              <td class="po-table-column-detail" [colSpan]="columnCountForMasterDetail">
-                <po-table-detail
-                  [p-selectable]="selectable && !detailHideSelect"
-                  [p-detail]="columnMasterDetail.detail"
-                  [p-items]="row[nameColumnDetail]"
-                  [p-parent-row]="row"
-                  [p-components-size]="componentsSize"
-                  (p-select-row)="selectDetailRow($event)"
-                >
-                </po-table-detail>
-              </td>
-            </tr>
-          }
-        </tbody>
-      }
-    </table>
-  </cdk-virtual-scroll-viewport>
+            @if (hasMainColumns && hasRowTemplate && row.$showDetail && isShowRowTemplate(row, rowIndex)) {
+              <tr>
+                <td class="po-table-row-template-container" [colSpan]="columnCountForMasterDetail">
+                  <ng-template
+                    [ngTemplateOutlet]="tableRowTemplate.templateRef"
+                    [ngTemplateOutletContext]="{ $implicit: row, rowIndex: rowIndex }"
+                  >
+                  </ng-template>
+                </td>
+              </tr>
+            }
+            @if (hasMainColumns && isShowMasterDetail(row)) {
+              <tr>
+                <td class="po-table-column-detail" [colSpan]="columnCountForMasterDetail">
+                  <po-table-detail
+                    [p-selectable]="selectable && !detailHideSelect"
+                    [p-detail]="columnMasterDetail.detail"
+                    [p-items]="row[nameColumnDetail]"
+                    [p-parent-row]="row"
+                    [p-components-size]="componentsSize"
+                    (p-select-row)="selectDetailRow($event)"
+                  >
+                  </po-table-detail>
+                </td>
+              </tr>
+            }
+          </tbody>
+        }
+      </table>
+    </cdk-virtual-scroll-viewport>
+  </div>
 </ng-template>
 
 <po-popup #popup [p-actions]="actions" [p-size]="componentsSize" [p-target]="popupTarget"> </po-popup>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -219,7 +219,19 @@ describe('PoTableComponent:', () => {
       checkChangesItems: () => {},
       debounceResize: () => true,
       checkInfiniteScroll: () => {},
-      applyFixedColumns: () => {}
+      applyFixedColumns: () => {},
+      initializeVisibleElement() {
+        if (this.tableWrapperElement?.nativeElement.offsetWidth && !this.visibleElement) {
+          this.debounceResize();
+          this.checkInfiniteScroll();
+          this.visibleElement = true;
+        }
+      },
+      clearColumnWidths: () => {},
+      syncHeaderTableWidth: () => {},
+      mainColumns: [],
+      virtualScroll: false,
+      hasItems: false
     };
   }
 
@@ -880,10 +892,10 @@ describe('PoTableComponent:', () => {
 
       component.drop(event as any);
 
-      expect(component.newOrderColumns[previousIndex]).toEqual(mockColumns[currentIndex]);
-      expect(component.newOrderColumns[currentIndex]).toEqual(mockColumns[previousIndex]);
-      expect(component.newOrderColumns[2]).toEqual(mockColumns[2]);
-      expect(component.onVisibleColumnsChange).toHaveBeenCalledWith(component.newOrderColumns);
+      expect(component.mainColumns[previousIndex]).toEqual(mockColumns[currentIndex]);
+      expect(component.mainColumns[currentIndex]).toEqual(mockColumns[previousIndex]);
+      expect(component.mainColumns[2]).toEqual(mockColumns[2]);
+      expect(component.onVisibleColumnsChange).toHaveBeenCalledWith(component.mainColumns);
     });
 
     it('drop: should update mainColumns when `hideColumnsManager` is true', () => {
@@ -1111,6 +1123,15 @@ describe('PoTableComponent:', () => {
       window.dispatchEvent(eventResize);
 
       expect(component['debounceResize']).toHaveBeenCalled();
+    });
+
+    it('constructor: should register click listener on document', () => {
+      expect(component['clickListener']).toBeDefined();
+
+      const eventClick = document.createEvent('Event');
+      eventClick.initEvent('click', true, true);
+
+      expect(() => document.dispatchEvent(eventClick)).not.toThrow();
     });
 
     it('ngAfterViewInit: should set initialize to true`', () => {
@@ -1509,16 +1530,18 @@ describe('PoTableComponent:', () => {
       expect(component['getDefaultColumns']).not.toHaveBeenCalled();
     });
 
-    it('onVisibleColumnsChange: should set `columns` and call `detectChanges`', () => {
+    it('onVisibleColumnsChange: should call `clearColumnWidths` and `markForCheck`', () => {
       const newColumns: Array<PoTableColumn> = [{ property: 'age', visible: false }];
 
       component.columns = [];
 
-      const spyDetectChanges = spyOn(component['changeDetector'], 'detectChanges');
+      const spyClearColumnWidths = spyOn(component as any, 'clearColumnWidths');
+      const spyMarkForCheck = spyOn(component['changeDetector'], 'markForCheck');
 
       component.onVisibleColumnsChange(newColumns);
 
-      expect(spyDetectChanges).toHaveBeenCalled();
+      expect(spyClearColumnWidths).toHaveBeenCalled();
+      expect(spyMarkForCheck).toHaveBeenCalled();
     });
 
     it('trackBy: should return index param', () => {
@@ -1934,6 +1957,8 @@ describe('PoTableComponent:', () => {
           { id: 1, name: 'teste', $selected: true },
           { id: 2, name: 'teste2' }
         ];
+        component['modalDelete'] = { close: () => {} } as any;
+        spyOn(component['poNotification'], 'success');
         spyOn(component['eventDelete'], 'emit');
 
         component.deleteItems();
@@ -1950,6 +1975,8 @@ describe('PoTableComponent:', () => {
           { id: 1, name: 'teste', $selected: true },
           { id: 2, name: 'teste2' }
         ];
+        component['modalDelete'] = { close: () => {} } as any;
+        spyOn(component['poNotification'], 'success');
         spyOn(component, 'removeItem');
 
         component.deleteItems();
@@ -1967,7 +1994,9 @@ describe('PoTableComponent:', () => {
           { id: 2, name: 'teste2' }
         ];
         component.itemsSelected = [{ id: 1, name: 'teste', $selected: true }];
+        component['modalDelete'] = { close: () => {} } as any;
 
+        spyOn(component['poNotification'], 'success');
         spyOn(component, 'setTableResponseProperties');
         spyOn(component['defaultService'], <any>'deleteItem').and.returnValue(of({}));
         spyOn(component['defaultService'], <any>'getFilteredItems').and.returnValue(
@@ -1988,6 +2017,8 @@ describe('PoTableComponent:', () => {
           { id: 2, name: 'teste2' }
         ];
         component.itemsSelected = [{ id: 1, name: 'teste', $selected: true }];
+        component['modalDelete'] = { close: () => {} } as any;
+        spyOn(component['poNotification'], 'success');
         spyOn(component['defaultService'], <any>'deleteItem').and.returnValue(of({}));
 
         spyOn(component['eventDelete'], 'emit');
@@ -2023,6 +2054,8 @@ describe('PoTableComponent:', () => {
           { id: 1, name: 'teste', $selected: true },
           { id: 2, name: 'teste2' }
         ];
+        component['modalDelete'] = { close: () => {} } as any;
+        spyOn(component['poNotification'], 'success');
         component['changesAfterDelete'](newItems);
         expect(component.selectAll).toBeFalsy();
       });
@@ -2055,25 +2088,1050 @@ describe('PoTableComponent:', () => {
         expect(result).toBe(expectedValue);
       });
 
-      it('inverseOfTranslation: should return the correct value of inverseOfTranslation', () => {
-        const mockRenderedContentOffset = 10;
+      it('configureVirtualScrollOverflow: should fix content wrapper and add scroll sync listener', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        const mockContentWrapper = document.createElement('div');
+        mockContentWrapper.classList.add('cdk-virtual-scroll-content-wrapper');
+        mockViewportEl.appendChild(mockContentWrapper);
 
-        component.viewPort = { _renderedContentOffset: mockRenderedContentOffset } as any;
+        const mockHeaderContainer = document.createElement('div');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.headerScrollContainer = { nativeElement: mockHeaderContainer } as any;
 
-        const resultado = component.inverseOfTranslation;
-        expect(resultado).toEqual('-10px');
+        component['configureVirtualScrollOverflow']();
+
+        expect(mockContentWrapper.style.contain).toBe('layout style');
+        expect(mockHeaderContainer.style.overflow).toBe('hidden');
+        expect(component['scrollSyncListener']).toBeTruthy();
+        expect(component['virtualScrollOverflowConfigured']).toBe(true);
       });
 
-      it('inverseOfTranslation: should return "-0px" if viewPort or _renderedContentOffset are not set', () => {
-        component.viewPort = null;
+      it('configureVirtualScrollOverflow: should not apply styles when tableVirtualScroll is not available', () => {
+        component.tableVirtualScroll = null;
+        component['virtualScrollOverflowConfigured'] = false;
 
-        const resultado1 = component.inverseOfTranslation;
-        expect(resultado1).toEqual('-0px');
+        component['configureVirtualScrollOverflow']();
 
-        component.viewPort = { _renderedContentOffset: null } as any;
+        expect(component['virtualScrollOverflowConfigured']).toBe(false);
+      });
 
-        const resultado2 = component.inverseOfTranslation;
-        expect(resultado2).toEqual('-0px');
+      it('syncHeaderScrollLeft: should set scrollLeft on headerScrollContainer when nativeElement is available', () => {
+        const mockHeaderContainer = {} as any;
+        let assignedScrollLeft = 0;
+        Object.defineProperty(mockHeaderContainer, 'scrollLeft', {
+          get: () => assignedScrollLeft,
+          set: (v: number) => {
+            assignedScrollLeft = v;
+          },
+          configurable: true
+        });
+        component.headerScrollContainer = { nativeElement: mockHeaderContainer } as any;
+
+        component['syncHeaderScrollLeft'](150);
+
+        expect(mockHeaderContainer.scrollLeft).toBe(150);
+      });
+
+      it('syncHeaderScrollLeft: should not throw when headerScrollContainer is null', () => {
+        component.headerScrollContainer = null;
+
+        expect(() => component['syncHeaderScrollLeft'](100)).not.toThrow();
+      });
+
+      it('registerScrollSyncListeners: viewport scroll callback should call syncHeaderScrollLeft with viewport scrollLeft', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        Object.defineProperty(mockViewportEl, 'scrollLeft', { value: 75, writable: true, configurable: true });
+        component['scrollSyncListener'] = null;
+        component['containerScrollSyncListener'] = null;
+
+        const syncSpy = spyOn<any>(component, 'syncHeaderScrollLeft');
+
+        component['registerScrollSyncListeners'](mockViewportEl);
+
+        // Dispara o evento de scroll no viewport para acionar o listener nativo registrado
+        mockViewportEl.dispatchEvent(new Event('scroll'));
+
+        expect(syncSpy).toHaveBeenCalledWith(75);
+      });
+
+      it('registerScrollSyncListeners: container scroll callback should call syncHeaderScrollLeft with container scrollLeft', () => {
+        const fixedInnerContainer = document.createElement('div');
+        fixedInnerContainer.classList.add('po-table-container-fixed-inner');
+        Object.defineProperty(fixedInnerContainer, 'scrollLeft', { value: 200, writable: true, configurable: true });
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        fixedInnerContainer.appendChild(mockViewportEl);
+        document.body.appendChild(fixedInnerContainer);
+
+        component['scrollSyncListener'] = null;
+        component['containerScrollSyncListener'] = null;
+
+        let containerScrollCallback: Function;
+        spyOn(component['renderer'], 'listen').and.callFake((target: any, event: string, callback: Function) => {
+          if (target === fixedInnerContainer && event === 'scroll') {
+            containerScrollCallback = callback;
+          }
+          return () => {};
+        });
+        const syncSpy = spyOn<any>(component, 'syncHeaderScrollLeft');
+
+        component['registerScrollSyncListeners'](mockViewportEl);
+
+        // Dispara o evento de scroll no container para acionar o listener nativo registrado
+        fixedInnerContainer.dispatchEvent(new Event('scroll'));
+
+        expect(syncSpy).toHaveBeenCalledWith(200);
+
+        document.body.removeChild(fixedInnerContainer);
+      });
+
+      it('syncColumnWidths: should not apply styles when header or body table is not available', () => {
+        component.headerTableElement = null;
+        component.bodyTableElement = null;
+
+        expect(() => component['syncColumnWidths']()).not.toThrow();
+      });
+
+      it('syncColumnWidths: should not apply styles when body has no rows', () => {
+        const mockHeaderTable = document.createElement('table');
+        const mockThead = document.createElement('thead');
+        const mockTh = document.createElement('th');
+        mockThead.appendChild(mockTh);
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+        const mockTbody = document.createElement('tbody');
+        mockBodyTable.appendChild(mockTbody);
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+
+        expect(() => component['syncColumnWidths']()).not.toThrow();
+      });
+
+      it('syncColumnWidths: should not apply styles when cells are empty', () => {
+        const mockHeaderTable = document.createElement('table');
+        const mockThead = document.createElement('thead');
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+        const mockTbody = document.createElement('tbody');
+        const mockTr = document.createElement('tr');
+        mockTbody.appendChild(mockTr);
+        mockBodyTable.appendChild(mockTbody);
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+
+        expect(() => component['syncColumnWidths']()).not.toThrow();
+      });
+
+      it('clearColumnWidths: should reset table layout on both tables, remove sync colgroup and reset computedColumnWidths', () => {
+        const mockHeaderTable = document.createElement('table');
+        mockHeaderTable.style.tableLayout = 'fixed';
+        mockHeaderTable.style.width = '500px';
+        mockHeaderTable.style.minWidth = '500px';
+        const headerColgroup = document.createElement('colgroup');
+        headerColgroup.setAttribute('data-po-sync', 'true');
+        mockHeaderTable.appendChild(headerColgroup);
+        const mockThead = document.createElement('thead');
+        const mockHeaderTr = document.createElement('tr');
+        const mockTh = document.createElement('th');
+        mockTh.style.width = '200px';
+        mockTh.style.minWidth = '200px';
+        mockTh.style.maxWidth = '200px';
+        mockHeaderTr.appendChild(mockTh);
+        mockThead.appendChild(mockHeaderTr);
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+        mockBodyTable.style.tableLayout = 'fixed';
+        mockBodyTable.style.width = '500px';
+        mockBodyTable.style.minWidth = '500px';
+        const bodyColgroup = document.createElement('colgroup');
+        bodyColgroup.setAttribute('data-po-sync', 'true');
+        mockBodyTable.appendChild(bodyColgroup);
+        const mockTbody = document.createElement('tbody');
+        const mockTr = document.createElement('tr');
+        const mockTd = document.createElement('td');
+        mockTd.style.width = '200px';
+        mockTr.appendChild(mockTd);
+        mockTbody.appendChild(mockTr);
+        mockBodyTable.appendChild(mockTbody);
+
+        document.body.appendChild(mockHeaderTable);
+        document.body.appendChild(mockBodyTable);
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+        component.computedColumnWidths = ['200px'];
+        component['columnWidthsSynced'] = true;
+
+        component['clearColumnWidths']();
+
+        // resetTableLayout remove table-layout, width, min-width e colgroup das duas tabelas
+        expect(mockHeaderTable.style.tableLayout).toBe('');
+        expect(mockHeaderTable.style.width).toBe('');
+        expect(mockHeaderTable.style.minWidth).toBe('');
+        expect(mockHeaderTable.querySelector('colgroup[data-po-sync="true"]')).toBeNull();
+        expect(mockBodyTable.style.tableLayout).toBe('');
+        expect(mockBodyTable.style.width).toBe('');
+        expect(mockBodyTable.style.minWidth).toBe('');
+        expect(mockBodyTable.querySelector('colgroup[data-po-sync="true"]')).toBeNull();
+        // NÃO remove estilos inline de células individuais
+        expect(mockTh.style.width).toBe('200px');
+        expect(mockTd.style.width).toBe('200px');
+        expect(component.computedColumnWidths).toEqual([]);
+        expect(component['columnWidthsSynced']).toBe(false);
+
+        document.body.removeChild(mockHeaderTable);
+        document.body.removeChild(mockBodyTable);
+      });
+
+      it('clearColumnWidths: should not fail when tables are not available', () => {
+        component.headerTableElement = null;
+        component.bodyTableElement = null;
+
+        expect(() => component['clearColumnWidths']()).not.toThrow();
+      });
+
+      it('clearColumnWidths: should not fail when body has no rows', () => {
+        const mockHeaderTable = document.createElement('table');
+        const mockThead = document.createElement('thead');
+        const mockTh = document.createElement('th');
+        mockThead.appendChild(mockTh);
+        mockHeaderTable.appendChild(mockThead);
+
+        const mockBodyTable = document.createElement('table');
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+
+        expect(() => component['clearColumnWidths']()).not.toThrow();
+      });
+
+      it('applyColgroup: should create a colgroup with col elements matching widths array', () => {
+        const table = document.createElement('table');
+        document.body.appendChild(table);
+
+        component['applyColgroup'](table, [100, 200, 300]);
+
+        const colgroup = table.querySelector('colgroup[data-po-sync="true"]');
+        expect(colgroup).toBeTruthy();
+        expect(colgroup.children.length).toBe(3);
+        expect((colgroup.children[0] as HTMLElement).style.width).toBe('100px');
+        expect((colgroup.children[1] as HTMLElement).style.width).toBe('200px');
+        expect((colgroup.children[2] as HTMLElement).style.width).toBe('300px');
+
+        document.body.removeChild(table);
+      });
+
+      it('applyColgroup: should replace existing colgroup with same data-po-sync attribute', () => {
+        const table = document.createElement('table');
+        document.body.appendChild(table);
+
+        component['applyColgroup'](table, [100]);
+        component['applyColgroup'](table, [200, 300]);
+
+        const colgroups = table.querySelectorAll('colgroup[data-po-sync="true"]');
+        expect(colgroups.length).toBe(1);
+        expect(colgroups[0].children.length).toBe(2);
+
+        document.body.removeChild(table);
+      });
+
+      it('applyColgroup: should insert colgroup before any other table children', () => {
+        const table = document.createElement('table');
+        const thead = document.createElement('thead');
+        table.appendChild(thead);
+        document.body.appendChild(table);
+
+        component['applyColgroup'](table, [100]);
+
+        expect(table.firstElementChild.tagName).toBe('COLGROUP');
+
+        document.body.removeChild(table);
+      });
+
+      it('removeColgroup: should remove colgroup with data-po-sync="true" attribute', () => {
+        const table = document.createElement('table');
+        const colgroup = document.createElement('colgroup');
+        colgroup.setAttribute('data-po-sync', 'true');
+        table.appendChild(colgroup);
+        document.body.appendChild(table);
+
+        component['removeColgroup'](table);
+
+        expect(table.querySelector('colgroup')).toBeNull();
+
+        document.body.removeChild(table);
+      });
+
+      it('removeColgroup: should not remove colgroup without data-po-sync attribute', () => {
+        const table = document.createElement('table');
+        const colgroup = document.createElement('colgroup');
+        table.appendChild(colgroup);
+        document.body.appendChild(table);
+
+        component['removeColgroup'](table);
+
+        expect(table.querySelector('colgroup')).toBeTruthy();
+
+        document.body.removeChild(table);
+      });
+
+      it('removeColgroup: should not throw when no colgroup exists in table', () => {
+        const table = document.createElement('table');
+
+        expect(() => component['removeColgroup'](table)).not.toThrow();
+      });
+
+      it('clearColumnWidths: should preserve inline width styles on body cells', () => {
+        const mockHeaderTable = document.createElement('table');
+        mockHeaderTable.innerHTML = '<thead><tr><th></th></tr></thead>';
+
+        const mockBodyTable = document.createElement('table');
+        mockBodyTable.innerHTML = '<tbody><tr class="po-table-row"><td style="width:100px"></td></tr></tbody>';
+
+        component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+
+        component['clearColumnWidths']();
+
+        const bodyTd = mockBodyTable.querySelector('td') as HTMLElement;
+        expect(bodyTd.style.width).toBe('100px');
+      });
+
+      it('clearColumnWidths: should remove only colgroup with data-po-sync attribute from body table', () => {
+        const mockBodyTable = document.createElement('table');
+        const colgroupSync = document.createElement('colgroup');
+        colgroupSync.setAttribute('data-po-sync', 'true');
+        const colgroupOther = document.createElement('colgroup');
+        mockBodyTable.appendChild(colgroupSync);
+        mockBodyTable.appendChild(colgroupOther);
+        document.body.appendChild(mockBodyTable);
+
+        component.headerTableElement = null;
+        component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+
+        component['clearColumnWidths']();
+
+        expect(mockBodyTable.querySelector('colgroup[data-po-sync="true"]')).toBeNull();
+        expect(mockBodyTable.querySelectorAll('colgroup').length).toBe(1);
+
+        document.body.removeChild(mockBodyTable);
+      });
+
+      it('setupColumnWidthSync: should return early when virtualScroll is false', () => {
+        component.virtualScroll = false;
+        component['resizeObserver'] = undefined;
+
+        component['setupColumnWidthSync']();
+
+        expect(component['resizeObserver']).toBeUndefined();
+      });
+
+      it('setupColumnWidthSync: should return early when resizeObserver is already configured', () => {
+        component.virtualScroll = true;
+        const existingObserver = { observe: () => {}, disconnect: () => {}, unobserve: () => {} } as any;
+        component['resizeObserver'] = existingObserver;
+
+        component['setupColumnWidthSync']();
+
+        expect(component['resizeObserver']).toBe(existingObserver);
+      });
+
+      describe('syncColumnWidths (updated behavior):', () => {
+        let syncMockHeaderTable: HTMLElement;
+        let syncMockBodyTable: HTMLElement;
+
+        function setupSyncTables(headerCellsCount: number, bodyCellsCount: number) {
+          syncMockHeaderTable = document.createElement('table');
+          const thead = document.createElement('thead');
+          const headerTr = document.createElement('tr');
+          for (let i = 0; i < headerCellsCount; i++) {
+            const th = document.createElement('th');
+            if (i >= 2) th.classList.add('po-table-header-ellipsis');
+            else if (i === 0) th.classList.add('po-table-column-selectable');
+            else th.classList.add('po-table-header-master-detail');
+            headerTr.appendChild(th);
+          }
+          thead.appendChild(headerTr);
+          syncMockHeaderTable.appendChild(thead);
+
+          syncMockBodyTable = document.createElement('table');
+          const tbody = document.createElement('tbody');
+          const bodyTr = document.createElement('tr');
+          bodyTr.classList.add('po-table-row');
+          for (let i = 0; i < bodyCellsCount; i++) {
+            const td = document.createElement('td');
+            if (i >= 2) td.classList.add('p-element');
+            bodyTr.appendChild(td);
+          }
+          tbody.appendChild(bodyTr);
+          syncMockBodyTable.appendChild(tbody);
+
+          document.body.appendChild(syncMockHeaderTable);
+          document.body.appendChild(syncMockBodyTable);
+
+          component.headerTableElement = { nativeElement: syncMockHeaderTable } as any;
+          component.bodyTableElement = { nativeElement: syncMockBodyTable } as any;
+          // As 2 primeiras células do mock são estruturais (selectable/master-detail); as demais são
+          // colunas de dados (`po-table-header-ellipsis`). `mainColumns` precisa refletir a mesma
+          // quantidade para que a guarda `allDataColumnsRendered` de `syncColumnWidths` não interprete
+          // o mock como uma renderização parcial do virtual scroll horizontal.
+          const dataColumnsCount = Math.max(headerCellsCount - 2, 0);
+          component.mainColumns = Array.from({ length: dataColumnsCount }, (_, i) => ({ property: `col${i}` }));
+        }
+
+        afterEach(() => {
+          if (syncMockHeaderTable?.parentNode) {
+            document.body.removeChild(syncMockHeaderTable);
+          }
+          if (syncMockBodyTable?.parentNode) {
+            document.body.removeChild(syncMockBodyTable);
+          }
+        });
+
+        it('should run sync regardless of applyFixedColumns return value', () => {
+          setupSyncTables(5, 5);
+          spyOn(component, 'applyFixedColumns').and.returnValue(true);
+
+          component['syncColumnWidths']();
+
+          expect(syncMockHeaderTable.style.tableLayout).toBe('fixed');
+        });
+
+        it('should apply colgroup on both header and body tables', () => {
+          setupSyncTables(5, 5);
+
+          component['syncColumnWidths']();
+
+          expect(syncMockHeaderTable.querySelector('colgroup[data-po-sync="true"]')).toBeTruthy();
+          expect(syncMockBodyTable.querySelector('colgroup[data-po-sync="true"]')).toBeTruthy();
+        });
+
+        it('should apply table-layout fixed on both header and body tables', () => {
+          setupSyncTables(5, 5);
+
+          component['syncColumnWidths']();
+
+          expect(syncMockHeaderTable.style.tableLayout).toBe('fixed');
+          expect(syncMockBodyTable.style.tableLayout).toBe('fixed');
+        });
+
+        it('should set columnWidthsSynced to true after sync', () => {
+          setupSyncTables(5, 5);
+
+          component['syncColumnWidths']();
+
+          expect(component['columnWidthsSynced']).toBe(true);
+        });
+
+        it('should set width and min-width on header table based on body table width', () => {
+          setupSyncTables(5, 5);
+
+          component['syncColumnWidths']();
+
+          expect(syncMockHeaderTable.style.width).toMatch(/^\d+(\.\d+)?px$/);
+          expect(syncMockHeaderTable.style.minWidth).toBe(syncMockHeaderTable.style.width);
+        });
+
+        it('should not throw when body has no rendered rows', () => {
+          setupSyncTables(5, 0);
+          syncMockBodyTable.querySelector('tbody').innerHTML = '';
+
+          expect(() => component['syncColumnWidths']()).not.toThrow();
+        });
+
+        it('should not throw when only no-data row is present in body', () => {
+          setupSyncTables(5, 5);
+          const tbody = syncMockBodyTable.querySelector('tbody');
+          tbody.innerHTML = '<tr class="po-table-row po-table-row-no-data"><td colspan="5"></td></tr>';
+
+          expect(() => component['syncColumnWidths']()).not.toThrow();
+        });
+
+        it('should call syncHeaderTableWidth and changeDetector markForCheck', () => {
+          setupSyncTables(5, 5);
+          const syncHeaderSpy = spyOn<any>(component, 'syncHeaderTableWidth');
+          const markForCheckSpy = spyOn(component['changeDetector'], 'markForCheck');
+
+          component['syncColumnWidths']();
+
+          expect(syncHeaderSpy).toHaveBeenCalled();
+          expect(markForCheckSpy).toHaveBeenCalled();
+        });
+
+        it('should match number of columns in colgroup with header cells count', () => {
+          setupSyncTables(5, 5);
+
+          component['syncColumnWidths']();
+
+          const colgroup = syncMockHeaderTable.querySelector('colgroup[data-po-sync="true"]');
+          expect(colgroup.children.length).toBe(5);
+        });
+
+        it('should not apply styles when headerTableElement is null', () => {
+          component.headerTableElement = null;
+          component.bodyTableElement = { nativeElement: document.createElement('table') } as any;
+
+          expect(() => component['syncColumnWidths']()).not.toThrow();
+        });
+
+        it('should not apply styles when bodyTableElement is null', () => {
+          component.headerTableElement = { nativeElement: document.createElement('table') } as any;
+          component.bodyTableElement = null;
+
+          expect(() => component['syncColumnWidths']()).not.toThrow();
+        });
+
+        it('should return when header row has no cells', () => {
+          const mockHeaderTable = document.createElement('table');
+          mockHeaderTable.innerHTML = '<thead><tr></tr></thead>';
+
+          const mockBodyTable = document.createElement('table');
+          mockBodyTable.innerHTML = '<tbody><tr class="po-table-row"><td></td></tr></tbody>';
+
+          document.body.appendChild(mockHeaderTable);
+          document.body.appendChild(mockBodyTable);
+
+          component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+          component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+
+          component['syncColumnWidths']();
+
+          expect(mockHeaderTable.querySelector('colgroup[data-po-sync="true"]')).toBeNull();
+          expect(mockHeaderTable.style.tableLayout).toBe('');
+
+          document.body.removeChild(mockHeaderTable);
+          document.body.removeChild(mockBodyTable);
+        });
+
+        it('should apply colgroup even when no header cell has ellipsis class', () => {
+          const mockHeaderTable = document.createElement('table');
+          mockHeaderTable.innerHTML =
+            '<thead><tr><th class="po-table-column-selectable"></th><th class="po-table-header-master-detail"></th></tr></thead>';
+
+          const mockBodyTable = document.createElement('table');
+          mockBodyTable.innerHTML =
+            '<tbody><tr class="po-table-row"><td class="po-table-column-selectable"></td><td class="po-table-column-actions"></td></tr></tbody>';
+
+          document.body.appendChild(mockHeaderTable);
+          document.body.appendChild(mockBodyTable);
+
+          component.headerTableElement = { nativeElement: mockHeaderTable } as any;
+          component.bodyTableElement = { nativeElement: mockBodyTable } as any;
+          // Nenhuma célula do header tem `po-table-header-ellipsis` (0 colunas de dados no DOM);
+          // `mainColumns` precisa ser vazio para casar com a guarda `allDataColumnsRendered`.
+          component.mainColumns = [];
+
+          component['syncColumnWidths']();
+
+          expect(mockHeaderTable.querySelector('colgroup[data-po-sync="true"]')).toBeTruthy();
+          expect(mockBodyTable.querySelector('colgroup[data-po-sync="true"]')).toBeTruthy();
+          expect(component['columnWidthsSynced']).toBe(true);
+
+          document.body.removeChild(mockHeaderTable);
+          document.body.removeChild(mockBodyTable);
+        });
+      });
+
+      describe('resetVirtualScrollState:', () => {
+        it('should disconnect resizeObserver and clear it when defined', () => {
+          const disconnectSpy = jasmine.createSpy('disconnect');
+          component['resizeObserver'] = { disconnect: disconnectSpy } as any;
+
+          component['resetVirtualScrollState']();
+
+          expect(disconnectSpy).toHaveBeenCalled();
+          expect(component['resizeObserver']).toBeUndefined();
+        });
+
+        it('should not throw when resizeObserver is undefined', () => {
+          component['resizeObserver'] = undefined;
+
+          expect(() => component['resetVirtualScrollState']()).not.toThrow();
+        });
+
+        it('should call and clear scrollSyncListener when defined', () => {
+          const scrollSyncListenerSpy = jasmine.createSpy('scrollSyncListener');
+          component['scrollSyncListener'] = scrollSyncListenerSpy;
+
+          component['resetVirtualScrollState']();
+
+          expect(scrollSyncListenerSpy).toHaveBeenCalled();
+          expect(component['scrollSyncListener']).toBeNull();
+        });
+
+        it('should not throw when scrollSyncListener is null', () => {
+          component['scrollSyncListener'] = null;
+
+          expect(() => component['resetVirtualScrollState']()).not.toThrow();
+        });
+
+        it('should call and clear containerScrollSyncListener when defined', () => {
+          const containerScrollSyncListenerSpy = jasmine.createSpy('containerScrollSyncListener');
+          component['containerScrollSyncListener'] = containerScrollSyncListenerSpy;
+
+          component['resetVirtualScrollState']();
+
+          expect(containerScrollSyncListenerSpy).toHaveBeenCalled();
+          expect(component['containerScrollSyncListener']).toBeNull();
+        });
+
+        it('should not throw when containerScrollSyncListener is null', () => {
+          component['containerScrollSyncListener'] = null;
+
+          expect(() => component['resetVirtualScrollState']()).not.toThrow();
+        });
+
+        it('should reset virtualScrollOverflowConfigured, syncScheduled and call clearColumnWidths', () => {
+          component['virtualScrollOverflowConfigured'] = true;
+          component['syncScheduled'] = true;
+          const clearSpy = spyOn<any>(component, 'clearColumnWidths');
+
+          component['resetVirtualScrollState']();
+
+          expect(component['virtualScrollOverflowConfigured']).toBe(false);
+          expect(component['syncScheduled']).toBe(false);
+          expect(clearSpy).toHaveBeenCalled();
+        });
+      });
+
+      describe('syncColumnWidths (auxiliary columns coverage):', () => {
+        let auxMockHeaderTable: HTMLElement;
+        let auxMockBodyTable: HTMLElement;
+
+        function createFullVirtualScrollMock(columnsConfig: Array<{ width?: string }>) {
+          auxMockHeaderTable = document.createElement('table');
+          let headerHtml = '<thead><tr>';
+          headerHtml += '<th class="po-table-column-selectable" style="width:56px"></th>';
+          headerHtml += '<th class="po-table-header-master-detail" style="width:56px"></th>';
+          columnsConfig.forEach(col => {
+            const widthStyle = col.width ? `style="width:${col.width}"` : '';
+            headerHtml += `<th class="po-table-header-ellipsis p-element po-frozen-column" ${widthStyle}></th>`;
+          });
+          headerHtml += '</tr></thead>';
+          auxMockHeaderTable.innerHTML = headerHtml;
+
+          auxMockBodyTable = document.createElement('table');
+          let bodyHtml = '<tbody><tr class="po-table-row">';
+          bodyHtml += '<td class="po-table-column-selectable" style="width:56px"></td>';
+          bodyHtml += '<td class="po-table-column-actions" style="width:56px"></td>';
+          columnsConfig.forEach(col => {
+            const widthStyle = col.width ? `style="width:${col.width}"` : '';
+            bodyHtml += `<td class="p-element po-frozen-column" ${widthStyle}></td>`;
+          });
+          bodyHtml += '</tr></tbody>';
+          auxMockBodyTable.innerHTML = bodyHtml;
+
+          document.body.appendChild(auxMockHeaderTable);
+          document.body.appendChild(auxMockBodyTable);
+
+          component.headerTableElement = { nativeElement: auxMockHeaderTable } as any;
+          component.bodyTableElement = { nativeElement: auxMockBodyTable } as any;
+          // `mainColumns` precisa ter a mesma quantidade de colunas de dados do mock, para que a
+          // guarda `allDataColumnsRendered` de `syncColumnWidths` não trate o mock como renderização
+          // parcial do virtual scroll horizontal.
+          component.mainColumns = columnsConfig.map((col, i) => ({ property: `col${i}`, width: col.width }));
+        }
+
+        afterEach(() => {
+          if (auxMockHeaderTable?.parentNode) {
+            document.body.removeChild(auxMockHeaderTable);
+          }
+          if (auxMockBodyTable?.parentNode) {
+            document.body.removeChild(auxMockBodyTable);
+          }
+        });
+
+        it('should include auxiliary columns when applying colgroup on header', () => {
+          createFullVirtualScrollMock([{ width: '100px' }, { width: '200px' }, { width: '200px' }]);
+
+          component['syncColumnWidths']();
+
+          const colgroup = auxMockHeaderTable.querySelector('colgroup[data-po-sync="true"]');
+          expect(colgroup).toBeTruthy();
+          expect(colgroup.children.length).toBe(5);
+        });
+
+        it('should apply colgroup even when applyFixedColumns returns true', () => {
+          createFullVirtualScrollMock([{ width: '100px' }, { width: '200px' }]);
+          spyOn(component, 'applyFixedColumns').and.returnValue(true);
+
+          component['syncColumnWidths']();
+
+          expect(auxMockHeaderTable.querySelector('colgroup[data-po-sync="true"]')).toBeTruthy();
+        });
+
+        it('should include label-type columns without width in colgroup', () => {
+          createFullVirtualScrollMock([{ width: '100px' }, { width: '200px' }, {}]);
+
+          component['syncColumnWidths']();
+
+          const colgroup = auxMockHeaderTable.querySelector('colgroup[data-po-sync="true"]');
+          expect(colgroup.children.length).toBe(5);
+        });
+
+        it('should set columnWidthsSynced to true after sync with auxiliary columns', () => {
+          createFullVirtualScrollMock([{ width: '100px' }, { width: '200px' }, { width: '200px' }]);
+
+          component['syncColumnWidths']();
+
+          expect(component['columnWidthsSynced']).toBe(true);
+        });
+
+        it('should apply table-layout fixed and width on body table', () => {
+          createFullVirtualScrollMock([{ width: '100px' }, { width: '200px' }]);
+
+          component['syncColumnWidths']();
+
+          expect(auxMockBodyTable.style.tableLayout).toBe('fixed');
+          expect(auxMockBodyTable.style.width).toMatch(/^\d+(\.\d+)?px$/);
+          expect(auxMockBodyTable.style.minWidth).toMatch(/^\d+(\.\d+)?px$/);
+        });
+      });
+
+      describe('expandDataColumnWidthsForFullDataset:', () => {
+        function buildHeaderCell(): HTMLElement {
+          const th = document.createElement('th');
+          th.classList.add('po-table-header-ellipsis');
+          return th;
+        }
+
+        function buildBodyCell(text: string): HTMLElement {
+          const td = document.createElement('td');
+          const content = document.createElement('div');
+          content.classList.add('po-table-column-cell');
+          content.textContent = text;
+          td.appendChild(content);
+          document.body.appendChild(td);
+          return td;
+        }
+
+        afterEach(() => {
+          document.querySelectorAll('td').forEach(td => td.remove());
+          component['datasetTextCache'].clear();
+          component['datasetTextCacheToken'] = null;
+          component['measureCanvasContext'] = undefined;
+        });
+
+        it('getMeasureContext: should return undefined when canvas getContext returns null', () => {
+          component['measureCanvasContext'] = undefined;
+          spyOn(document, 'createElement').and.callFake((tag: string) => {
+            if (tag === 'canvas') {
+              return { getContext: () => null } as any;
+            }
+            return document.createElementNS('http://www.w3.org/1999/xhtml', tag) as any;
+          });
+
+          const result = component['getMeasureContext']();
+
+          expect(result).toBeUndefined();
+        });
+
+        it('should return early when filteredItems is empty', () => {
+          component.filteredItems = [];
+          const naturalWidths = [100];
+
+          component['expandDataColumnWidthsForFullDataset']([buildHeaderCell()], [buildBodyCell('a')], naturalWidths);
+
+          expect(naturalWidths).toEqual([100]);
+        });
+
+        it('should return early when there are no data columns in headerCells', () => {
+          component.filteredItems = [{ name: 'John' }];
+          const nonDataHeaderCell = document.createElement('th');
+          const naturalWidths = [100];
+
+          component['expandDataColumnWidthsForFullDataset']([nonDataHeaderCell], [buildBodyCell('a')], naturalWidths);
+
+          expect(naturalWidths).toEqual([100]);
+        });
+
+        it('should return early when getMeasureContext returns undefined', () => {
+          component.filteredItems = [{ name: 'John' }];
+          component.mainColumns = [{ property: 'name' }];
+          spyOn<any>(component, 'getMeasureContext').and.returnValue(undefined);
+          const naturalWidths = [100];
+
+          component['expandDataColumnWidthsForFullDataset'](
+            [buildHeaderCell()],
+            [buildBodyCell('John')],
+            naturalWidths
+          );
+
+          expect(naturalWidths).toEqual([100]);
+        });
+
+        it('should skip column when column or cell is missing', () => {
+          component.filteredItems = [{ name: 'John' }];
+          component.mainColumns = [];
+          const naturalWidths = [100];
+
+          component['expandDataColumnWidthsForFullDataset'](
+            [buildHeaderCell()],
+            [buildBodyCell('John')],
+            naturalWidths
+          );
+
+          expect(naturalWidths).toEqual([100]);
+        });
+
+        it('should skip column with explicit px width (not elastic nor percent)', () => {
+          component.filteredItems = [{ name: 'John Very Long Name Indeed' }];
+          component.mainColumns = [{ property: 'name', width: '80px' }];
+          const naturalWidths = [50];
+
+          component['expandDataColumnWidthsForFullDataset'](
+            [buildHeaderCell()],
+            [buildBodyCell('John')],
+            naturalWidths
+          );
+
+          expect(naturalWidths).toEqual([50]);
+        });
+
+        it('should expand elastic column width to fit widest content in dataset', () => {
+          component.filteredItems = [{ name: 'A' }, { name: 'A Much Longer Name Than The Rendered One' }];
+          component.mainColumns = [{ property: 'name' }];
+          const naturalWidths = [10];
+
+          component['expandDataColumnWidthsForFullDataset']([buildHeaderCell()], [buildBodyCell('A')], naturalWidths);
+
+          expect(naturalWidths[0]).toBeGreaterThan(10);
+        });
+
+        it('should expand percent column width to fit widest content in dataset', () => {
+          component.filteredItems = [{ email: 'short@x.co' }, { email: 'a.much.longer.email.address@example.com' }];
+          component.mainColumns = [{ property: 'email', width: '20%' }];
+          const naturalWidths = [10];
+
+          component['expandDataColumnWidthsForFullDataset'](
+            [buildHeaderCell()],
+            [buildBodyCell('short@x.co')],
+            naturalWidths
+          );
+
+          expect(naturalWidths[0]).toBeGreaterThan(10);
+        });
+
+        it('should not shrink naturalWidths when dataset content is narrower than sample', () => {
+          component.filteredItems = [{ name: 'A' }];
+          component.mainColumns = [{ property: 'name' }];
+          const naturalWidths = [500];
+
+          component['expandDataColumnWidthsForFullDataset']([buildHeaderCell()], [buildBodyCell('A')], naturalWidths);
+
+          expect(naturalWidths[0]).toBe(500);
+        });
+
+        it('should reuse cache on second call with the same filteredItems reference', () => {
+          const items = [{ name: 'A' }, { name: 'A Much Longer Name Than The Rendered One' }];
+          component.filteredItems = items;
+          component.mainColumns = [{ property: 'name' }];
+          const context = component['getMeasureContext']();
+          const measureSpy = spyOn(context, 'measureText').and.callThrough();
+
+          component['expandDataColumnWidthsForFullDataset']([buildHeaderCell()], [buildBodyCell('A')], [10]);
+          const firstCallCount = measureSpy.calls.count();
+
+          component['expandDataColumnWidthsForFullDataset']([buildHeaderCell()], [buildBodyCell('A')], [10]);
+
+          // Na 2ª chamada, o texto do dataset já está em cache — measureText é chamado apenas
+          // para o texto amostra da célula renderizada (não para os itens do dataset de novo).
+          expect(measureSpy.calls.count()).toBeLessThan(firstCallCount * 2);
+        });
+
+        it('should invalidate cache when filteredItems reference changes', () => {
+          component.mainColumns = [{ property: 'name' }];
+          component.filteredItems = [{ name: 'A' }];
+          component['expandDataColumnWidthsForFullDataset']([buildHeaderCell()], [buildBodyCell('A')], [10]);
+
+          component.filteredItems = [{ name: 'A Brand New And Much Longer Dataset Value' }];
+          const naturalWidths = [10];
+          component['expandDataColumnWidthsForFullDataset']([buildHeaderCell()], [buildBodyCell('A')], naturalWidths);
+
+          expect(naturalWidths[0]).toBeGreaterThan(10);
+        });
+
+        it('should handle cell with null textContent gracefully', () => {
+          component.filteredItems = [{ name: 'Some Long Text Value' }];
+          component.mainColumns = [{ property: 'name' }];
+          const cell = buildBodyCell('');
+          const contentEl = cell.querySelector('.po-table-column-cell');
+          Object.defineProperty(contentEl, 'textContent', { value: null, configurable: true });
+          const naturalWidths = [10];
+
+          expect(() =>
+            component['expandDataColumnWidthsForFullDataset']([buildHeaderCell()], [cell], naturalWidths)
+          ).not.toThrow();
+          expect(naturalWidths[0]).toBeGreaterThan(10);
+        });
+      });
+
+      it('drop: should schedule syncColumnWidths after clearing and reordering', done => {
+        const event = {
+          previousIndex: 0,
+          currentIndex: 1
+        };
+
+        component.mainColumns = [{ property: 'column1' }, { property: 'column2' }];
+        spyOn<any>(component, 'clearColumnWidths');
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+
+        component.drop(event as any);
+
+        expect(component['clearColumnWidths']).toHaveBeenCalled();
+        expect(syncSpy).not.toHaveBeenCalled();
+
+        setTimeout(() => {
+          expect(syncSpy).toHaveBeenCalled();
+          done();
+        });
+      });
+
+      it('drop: should schedule syncColumnWidths via else branch when hideColumnsManager is true and virtualScroll is active', fakeAsync(() => {
+        const event = { previousIndex: 0, currentIndex: 1 };
+
+        component.mainColumns = [{ property: 'column1' }, { property: 'column2' }];
+        component['_virtualScroll'] = true;
+        component.hideColumnsManager = true;
+        component.computedColumnWidths = ['100px', '200px'];
+        component['resizeObserver']?.disconnect();
+        component['resizeObserver'] = jasmine.createSpyObj('ResizeObserver', ['observe', 'disconnect', 'unobserve']);
+        spyOn<any>(component, 'clearColumnWidths');
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+        const visibleSpy = spyOn(component, 'onVisibleColumnsChange');
+
+        component.drop(event as any);
+
+        expect(visibleSpy).not.toHaveBeenCalled();
+        expect(syncSpy).not.toHaveBeenCalled();
+
+        tick(0);
+
+        expect(syncSpy).toHaveBeenCalledTimes(1);
+      }));
+
+      it('drop: should not schedule syncColumnWidths twice when hideColumnsManager is false and virtualScroll is active', fakeAsync(() => {
+        const event = { previousIndex: 0, currentIndex: 1 };
+
+        component.mainColumns = [{ property: 'column1' }, { property: 'column2' }];
+        component['_virtualScroll'] = true;
+        component.hideColumnsManager = false;
+        component.computedColumnWidths = ['100px', '200px'];
+        component['resizeObserver']?.disconnect();
+        component['resizeObserver'] = jasmine.createSpyObj('ResizeObserver', ['observe', 'disconnect', 'unobserve']);
+        spyOn<any>(component, 'clearColumnWidths');
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+
+        component.drop(event as any);
+
+        tick(0);
+
+        expect(syncSpy).toHaveBeenCalledTimes(1);
+      }));
+
+      it('ngDoCheck: should clear computedColumnWidths when columns structure changes via onVisibleColumnsChange', () => {
+        component.computedColumnWidths = ['100px', '200px'];
+        component.mainColumns = [{ property: 'col1' }, { property: 'col2' }];
+
+        component.onVisibleColumnsChange([{ property: 'col1' }, { property: 'col2' }, { property: 'col3' }]);
+
+        expect(component.computedColumnWidths).toEqual([]);
+      });
+
+      it('ngAfterViewChecked: should schedule syncColumnWidths when computedColumnWidths is empty and viewport has rendered rows', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [{ id: 1 }];
+        component.computedColumnWidths = [];
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 1 }) } as any;
+        component.tableVirtualScroll = null;
+        component['virtualScrollOverflowConfigured'] = true;
+        component['resizeObserver'] = { observe: () => {}, disconnect: () => {}, unobserve: () => {} };
+        component['syncScheduled'] = false;
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+        spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+          cb(0);
+          return 0;
+        });
+
+        component.ngAfterViewChecked();
+
+        expect(syncSpy).toHaveBeenCalled();
+        expect(component['syncScheduled']).toBe(false);
+      });
+
+      it('ngAfterViewChecked: should not schedule syncColumnWidths when sync is already scheduled', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [{ id: 1 }];
+        component.computedColumnWidths = [];
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 1 }) } as any;
+        component.tableVirtualScroll = null;
+        component['virtualScrollOverflowConfigured'] = true;
+        component['resizeObserver'] = { observe: () => {}, disconnect: () => {}, unobserve: () => {} };
+        component['syncScheduled'] = true;
+        const syncSpy = spyOn<any>(component, 'syncColumnWidths');
+        const rafSpy = spyOn(window, 'requestAnimationFrame');
+
+        component.ngAfterViewChecked();
+
+        expect(rafSpy).not.toHaveBeenCalled();
+        expect(syncSpy).not.toHaveBeenCalled();
+      });
+
+      it('ngAfterViewChecked: should update heightTableVirtual when header height changes in virtual scroll', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.heightTableContainer = 500;
+        component['lastHeaderHeight'] = 0;
+        component.heightTableVirtual = 0;
+        component.headerScrollContainer = { nativeElement: { offsetHeight: 40 } } as any;
+        component['virtualScrollOverflowConfigured'] = true;
+        component['resizeObserver'] = { observe: () => {}, disconnect: () => {}, unobserve: () => {} };
+        spyOn(component['changeDetector'], 'markForCheck');
+        spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+          cb(0);
+          return 0;
+        });
+
+        component.ngAfterViewChecked();
+
+        expect(component['lastHeaderHeight']).toBe(40);
+        expect(component.heightTableVirtual).toBe(460);
+        expect(component['changeDetector'].markForCheck).toHaveBeenCalled();
+      });
+
+      it('ngAfterViewChecked: should not update heightTableVirtual when header height is unchanged', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.heightTableContainer = 500;
+        component['lastHeaderHeight'] = 40;
+        component.headerScrollContainer = { nativeElement: { offsetHeight: 40 } } as any;
+        component['virtualScrollOverflowConfigured'] = true;
+        component['resizeObserver'] = { observe: () => {}, disconnect: () => {}, unobserve: () => {} };
+        const rafSpy = spyOn(window, 'requestAnimationFrame');
+
+        component.ngAfterViewChecked();
+
+        expect(rafSpy).not.toHaveBeenCalled();
+      });
+
+      it('ngAfterViewChecked: should call configureVirtualScrollOverflow when virtualScroll is active and not yet configured', () => {
+        const mockViewportEl = document.createElement('cdk-virtual-scroll-viewport');
+        component.tableVirtualScroll = { nativeElement: mockViewportEl } as any;
+        component.height = 400;
+        component.virtualScroll = true;
+        component['virtualScrollOverflowConfigured'] = false;
+
+        spyOn<any>(component, 'configureVirtualScrollOverflow');
+
+        component.ngAfterViewChecked();
+
+        expect(component['configureVirtualScrollOverflow']).toHaveBeenCalled();
       });
 
       it('should update filteredItems on onFilteredItemsChange call', () => {
@@ -2101,6 +3159,939 @@ describe('PoTableComponent:', () => {
         component.onFilteredItemsChange(items);
 
         expect(component.sortArray).toHaveBeenCalled();
+      });
+    });
+    describe('Column width distribution methods:', () => {
+      it('measureNaturalColumnWidths: should measure max width across all body rows', () => {
+        const headerTable = document.createElement('table');
+        headerTable.innerHTML = '<thead><tr><th class="po-table-header-ellipsis">Header</th></tr></thead>';
+
+        const bodyTable = document.createElement('table');
+        bodyTable.innerHTML = `<tbody>
+          <tr class="po-table-row"><td>Short</td></tr>
+          <tr class="po-table-row"><td>A much longer text value</td></tr>
+        </tbody>`;
+
+        document.body.appendChild(headerTable);
+        document.body.appendChild(bodyTable);
+
+        component.headerTableElement = { nativeElement: headerTable } as any;
+        component.bodyTableElement = { nativeElement: bodyTable } as any;
+
+        const headerCells: Array<HTMLElement> = Array.from(headerTable.querySelectorAll('thead > tr > th'));
+        const bodyCells: Array<HTMLElement> = Array.from(bodyTable.querySelectorAll('tbody tr.po-table-row > td'));
+
+        const widths = component['measureNaturalColumnWidths'](headerTable, bodyTable, headerCells, bodyCells, 1);
+
+        expect(widths.length).toBe(1);
+        expect(widths[0]).toBeGreaterThanOrEqual(0);
+
+        document.body.removeChild(headerTable);
+        document.body.removeChild(bodyTable);
+      });
+
+      it('measureNaturalColumnWidths: should set tables to max-content during measurement', () => {
+        const headerTable = document.createElement('table');
+        headerTable.innerHTML = '<thead><tr><th>Col</th></tr></thead>';
+
+        const bodyTable = document.createElement('table');
+        bodyTable.innerHTML = '<tbody><tr class="po-table-row"><td>Data</td></tr></tbody>';
+
+        document.body.appendChild(headerTable);
+        document.body.appendChild(bodyTable);
+
+        component.headerTableElement = { nativeElement: headerTable } as any;
+        component.bodyTableElement = { nativeElement: bodyTable } as any;
+
+        const headerCells: Array<HTMLElement> = Array.from(headerTable.querySelectorAll('th'));
+        const bodyCells: Array<HTMLElement> = Array.from(bodyTable.querySelectorAll('tr > td'));
+
+        component['measureNaturalColumnWidths'](headerTable, bodyTable, headerCells, bodyCells, 1);
+
+        // Após measureNaturalColumnWidths, as tabelas ficam em max-content (resetadas depois por applySharedColumnLayout)
+        expect(headerTable.style.width).toBe('max-content');
+        expect(bodyTable.style.width).toBe('max-content');
+
+        document.body.removeChild(headerTable);
+        document.body.removeChild(bodyTable);
+      });
+
+      it('distributeColumnWidths: should distribute extra width among elastic columns', () => {
+        const headerCells = [
+          createMockCell('po-table-header-ellipsis'),
+          createMockCell('po-table-header-ellipsis'),
+          createMockCell('po-table-header-ellipsis')
+        ];
+
+        component.mainColumns = [{ property: 'col1', width: '100px' }, { property: 'col2' }, { property: 'col3' }];
+        component.tableVirtualScroll = { nativeElement: createMockViewport(600) } as any;
+
+        const naturalWidths = [100, 50, 50];
+        const result = component['distributeColumnWidths'](headerCells, naturalWidths);
+
+        const total = result.reduce((s, w) => s + w, 0);
+        expect(total).toBe(600);
+      });
+
+      it('distributeColumnWidths: should not fill when content exceeds container', () => {
+        const headerCells = [createMockCell('po-table-header-ellipsis'), createMockCell('po-table-header-ellipsis')];
+
+        component.mainColumns = [
+          { property: 'col1', width: '400px' },
+          { property: 'col2', width: '400px' }
+        ];
+        component.tableVirtualScroll = { nativeElement: createMockViewport(500) } as any;
+
+        const naturalWidths = [400, 400];
+        const result = component['distributeColumnWidths'](headerCells, naturalWidths);
+
+        expect(result[0]).toBe(400);
+        expect(result[1]).toBe(400);
+      });
+
+      it('distributeColumnWidths: should distribute proportionally when all columns have width and extra space remains', () => {
+        const headerCells = [
+          createMockCell('po-table-header-ellipsis'),
+          createMockCell('po-table-header-ellipsis'),
+          createMockCell('po-table-header-ellipsis')
+        ];
+
+        // Todas as colunas têm width definido → sem elásticas → cai no distributeProportionally
+        component.mainColumns = [
+          { property: 'col1', width: '100px' },
+          { property: 'col2', width: '200px' },
+          { property: 'col3', width: '100px' }
+        ];
+        component.tableVirtualScroll = { nativeElement: createMockViewport(600) } as any;
+
+        const naturalWidths = [100, 200, 100]; // total = 400, container = 600, extra = 200
+        const result = component['distributeColumnWidths'](headerCells, naturalWidths);
+
+        const total = result.reduce((s, w) => s + w, 0);
+        expect(total).toBe(600);
+        // Distribuição proporcional: col2 (200) recebe mais que col1/col3 (100)
+        expect(result[1]).toBeGreaterThan(result[0]);
+      });
+
+      it('distributeProportionally: should distribute extra width proportionally among data columns', () => {
+        const widths = [100, 200, 300];
+        const dataIndexes = [0, 1, 2];
+
+        component['distributeProportionally'](widths, dataIndexes, 60);
+
+        expect(widths[0]).toBe(110);
+        expect(widths[1]).toBe(220);
+        expect(widths[2]).toBe(330);
+      });
+
+      it('distributeProportionally: should not modify widths when dataTotal is 0', () => {
+        const widths = [0, 0, 0];
+        const dataIndexes = [0, 1, 2];
+
+        component['distributeProportionally'](widths, dataIndexes, 100);
+
+        expect(widths[0]).toBe(0);
+        expect(widths[1]).toBe(0);
+        expect(widths[2]).toBe(0);
+      });
+
+      it('distributeAmong: should divide extra width equally among indexes', () => {
+        const widths = [100, 100, 100];
+        const indexes = [0, 2];
+
+        component['distributeAmong'](widths, indexes, 60);
+
+        expect(widths[0]).toBe(130);
+        expect(widths[1]).toBe(100);
+        expect(widths[2]).toBe(130);
+      });
+
+      it('distributeAmong: should not modify widths when indexes array is empty', () => {
+        const widths = [100, 200];
+
+        component['distributeAmong'](widths, [], 50);
+
+        expect(widths[0]).toBe(100);
+        expect(widths[1]).toBe(200);
+      });
+
+      it('roundWidthsToTarget: should round widths so total equals target exactly', () => {
+        const widths = [33.3, 33.3, 33.4];
+        const result = component['roundWidthsToTarget'](widths, 100, [0, 1, 2]);
+
+        const total = result.reduce((s, w) => s + w, 0);
+        expect(total).toBe(100);
+      });
+
+      it('roundWidthsToTarget: should distribute remainder to adjustIndexes from end', () => {
+        const widths = [50.1, 50.1];
+        const result = component['roundWidthsToTarget'](widths, 101, [0, 1]);
+
+        expect(result[1]).toBeGreaterThanOrEqual(result[0]);
+        expect(result[0] + result[1]).toBe(101);
+      });
+
+      it('roundWidthsToTarget: should use all indexes as fallback when adjustIndexes is empty', () => {
+        const widths = [33.3, 33.3, 33.4];
+        const result = component['roundWidthsToTarget'](widths, 100, []);
+
+        const total = result.reduce((s, w) => s + w, 0);
+        expect(total).toBe(100);
+      });
+
+      it('getColumnWidth: should return "auto" when column.width is a percentage string', () => {
+        const result = component.getColumnWidth({ width: '30%' }, 0);
+
+        expect(result).toBe('auto');
+      });
+
+      it('getColumnWidth: should return the computed value when column has no width and computedColumnWidths is set', () => {
+        // Sem width na coluna (elástica), o valor computado (px ou %) é usado como veio.
+        component.computedColumnWidths = ['40%'];
+
+        const result = component.getColumnWidth({}, 0);
+
+        expect(result).toBe('40%');
+      });
+
+      it('getColumnWidth: should return the literal value when width is in px', () => {
+        const result = component.getColumnWidth({ width: '200px' }, 0);
+
+        expect(result).toBe('200px');
+      });
+
+      it('getColumnWidth: should return "auto" when there is no width for the column nor computedColumnWidths', () => {
+        const result = component.getColumnWidth({}, 0);
+
+        expect(result).toBe('auto');
+      });
+
+      it('getColumnIndexes: should identify data columns and elastic columns', () => {
+        const headerCells = [
+          createMockCell('po-table-column-selectable'),
+          createMockCell('po-table-header-ellipsis'),
+          createMockCell('po-table-header-ellipsis'),
+          createMockCell('po-table-header-ellipsis')
+        ];
+
+        component.mainColumns = [
+          { property: 'col1', width: '100px' },
+          { property: 'col2' },
+          { property: 'col3', width: '200px' }
+        ];
+
+        const { dataIndexes, elasticIndexes } = component['getColumnIndexes'](headerCells);
+
+        expect(dataIndexes).toEqual([1, 2, 3]);
+        expect(elasticIndexes).toEqual([2]);
+      });
+
+      it('resolvePercentWidths: should resolve percentage widths against container', () => {
+        const headerCells = [createMockCell('po-table-header-ellipsis'), createMockCell('po-table-header-ellipsis')];
+
+        component.mainColumns = [
+          { property: 'col1', width: '50%' },
+          { property: 'col2', width: '50%' }
+        ];
+        spyOn(component, 'applyFixedColumns').and.returnValue(true);
+
+        const widths = [100, 100];
+        component['resolvePercentWidths'](headerCells, widths, 800);
+
+        expect(widths[0]).toBe(400);
+        expect(widths[1]).toBe(400);
+      });
+
+      it('resolvePercentWidths: should resolve percent widths against the full container when there is an elastic column (mixed)', () => {
+        // Com coluna elástica (col2 sem width), o % é resolvido contra o container TOTAL (como a
+        // master faz quando a tabela pode crescer), e nunca deixa a coluna menor que seu conteúdo
+        // já medido (piso de conteúdo) — por isso usa-se o máximo entre os dois.
+        const headerCells = [createMockCell('po-table-header-ellipsis'), createMockCell('po-table-header-ellipsis')];
+        component.mainColumns = [{ property: 'col1', width: '50%' }, { property: 'col2' }];
+
+        const widths = [100, 200];
+        component['resolvePercentWidths'](headerCells, widths, 800);
+
+        expect(widths[0]).toBe(400);
+        expect(widths[1]).toBe(200);
+      });
+
+      it('resolvePercentWidths: should apply the percent value without a content floor when all columns have width', () => {
+        // Quando TODAS as colunas têm width (nenhuma elástica), a tabela fica presa ao container e
+        // as colunas `%` dividem o espaço disponível — sem piso de conteúdo, pois a tabela não cresce
+        // para caber (comportamento idêntico à master, que também não cresce a tabela nesse cenário).
+        const headerCells = [createMockCell('po-table-header-ellipsis'), createMockCell('po-table-header-ellipsis')];
+
+        component.mainColumns = [
+          { property: 'col1', width: '10%' },
+          { property: 'col2', width: '400px' }
+        ];
+
+        const widths = [500, 400];
+        component['resolvePercentWidths'](headerCells, widths, 800);
+
+        expect(widths[0]).toBe(40);
+        expect(widths[1]).toBe(400);
+      });
+
+      it('resolvePercentWidths: should return early when no columns have percent width', () => {
+        const headerCells = [createMockCell('po-table-header-ellipsis'), createMockCell('po-table-header-ellipsis')];
+
+        // Todas com width em px → nenhuma coluna % → percentColumns vazio → return
+        component.mainColumns = [
+          { property: 'col1', width: '200px' },
+          { property: 'col2', width: '300px' }
+        ];
+        spyOn(component, 'applyFixedColumns').and.returnValue(true);
+
+        const widths = [200, 300];
+        component['resolvePercentWidths'](headerCells, widths, 800);
+
+        expect(widths[0]).toBe(200);
+        expect(widths[1]).toBe(300);
+      });
+
+      it('resolvePercentWidths: should not resolve when containerWidth is 0', () => {
+        const headerCells = [createMockCell('po-table-header-ellipsis')];
+        component.mainColumns = [{ property: 'col1', width: '50%' }];
+        spyOn(component, 'applyFixedColumns').and.returnValue(true);
+
+        const widths = [100];
+        component['resolvePercentWidths'](headerCells, widths, 0);
+
+        expect(widths[0]).toBe(100);
+      });
+
+      it('resolvePercentWidths: should resolve percent widths considering non-percent columns total', () => {
+        const headerCells = [
+          createMockCell('po-table-header-ellipsis'),
+          createMockCell('po-table-header-ellipsis'),
+          createMockCell('po-table-header-ellipsis')
+        ];
+
+        // col1 = px, col2 = %, col3 = px → nonPercentTotal = widths[0] + widths[2]
+        component.mainColumns = [
+          { property: 'col1', width: '200px' },
+          { property: 'col2', width: '50%' },
+          { property: 'col3', width: '100px' }
+        ];
+        spyOn(component, 'applyFixedColumns').and.returnValue(true);
+
+        const widths = [200, 80, 100]; // nonPercentTotal = 200 + 100 = 300, available = 800 - 300 = 500
+        component['resolvePercentWidths'](headerCells, widths, 800);
+
+        // col2 com 50% de 500 available = 250
+        expect(widths[0]).toBe(200);
+        expect(widths[1]).toBe(250);
+        expect(widths[2]).toBe(100);
+      });
+
+      it('resolvePercentWidths: should return early when available space is zero or negative', () => {
+        const headerCells = [createMockCell('po-table-header-ellipsis'), createMockCell('po-table-header-ellipsis')];
+
+        // col1 = px (ocupa tudo), col2 = % → available = 500 - 600 = -100 → return
+        component.mainColumns = [
+          { property: 'col1', width: '600px' },
+          { property: 'col2', width: '50%' }
+        ];
+        spyOn(component, 'applyFixedColumns').and.returnValue(true);
+
+        const widths = [600, 80];
+        component['resolvePercentWidths'](headerCells, widths, 500);
+
+        // Não modifica — available <= 0
+        expect(widths[0]).toBe(600);
+        expect(widths[1]).toBe(80);
+      });
+
+      function createMockCell(...classes: Array<string>): HTMLElement {
+        const cell = document.createElement('th');
+        classes.forEach(c => cell.classList.add(c));
+        return cell;
+      }
+
+      function createMockViewport(clientWidth: number): HTMLElement {
+        const el = document.createElement('div');
+        Object.defineProperty(el, 'clientWidth', { value: clientWidth, configurable: true });
+        return el;
+      }
+
+      function buildSyncTables() {
+        const headerTable = document.createElement('table');
+        headerTable.innerHTML =
+          '<thead><tr><th class="po-table-header-ellipsis"></th><th class="po-table-header-ellipsis"></th></tr></thead>';
+        const bodyTable = document.createElement('table');
+        bodyTable.innerHTML = '<tbody><tr class="po-table-row"><td></td><td></td></tr></tbody>';
+        document.body.appendChild(headerTable);
+        document.body.appendChild(bodyTable);
+        component.headerTableElement = { nativeElement: headerTable } as any;
+        component.bodyTableElement = { nativeElement: bodyTable } as any;
+        // O mock tem 2 colunas de dados no header; mainColumns precisa refletir a mesma quantidade
+        // para que a guarda allDataColumnsRendered de syncColumnWidths não trate o mock como
+        // renderização parcial do virtual scroll horizontal.
+        component.mainColumns = [{ property: 'col1' }, { property: 'col2' }];
+        component.tableVirtualScroll = { nativeElement: createMockViewport(600) } as any;
+        return { headerTable, bodyTable };
+      }
+
+      // --- applyMonotonicElasticWidths ---
+      it('applyMonotonicElasticWidths: should not change widths when there are no elastic columns', () => {
+        spyOn<any>(component, 'getColumnIndexes').and.returnValue({ dataIndexes: [1], elasticIndexes: [] });
+        const natural = [56, 100, 56];
+
+        component['applyMonotonicElasticWidths']([], natural);
+
+        expect(natural).toEqual([56, 100, 56]);
+        expect(component['elasticNaturalMaxWidths']).toEqual([]);
+      });
+
+      it('applyMonotonicElasticWidths: should grow the cache when the measured width is larger', () => {
+        spyOn<any>(component, 'getColumnIndexes').and.returnValue({ dataIndexes: [1], elasticIndexes: [1] });
+        component['elasticNaturalMaxWidths'] = [];
+        const natural = [56, 200, 56];
+
+        component['applyMonotonicElasticWidths']([], natural);
+
+        expect(component['elasticNaturalMaxWidths'][1]).toBe(200);
+        expect(natural[1]).toBe(200);
+      });
+
+      it('applyMonotonicElasticWidths: should keep the cached width (never shrink) when measured is smaller', () => {
+        spyOn<any>(component, 'getColumnIndexes').and.returnValue({ dataIndexes: [1], elasticIndexes: [1] });
+        component['elasticNaturalMaxWidths'] = [0, 300, 0];
+        const natural = [56, 200, 56];
+
+        component['applyMonotonicElasticWidths']([], natural);
+
+        expect(natural[1]).toBe(300);
+      });
+
+      it('applyMonotonicElasticWidths: should reset the cache array when its length differs', () => {
+        spyOn<any>(component, 'getColumnIndexes').and.returnValue({ dataIndexes: [1], elasticIndexes: [1] });
+        component['elasticNaturalMaxWidths'] = [10, 20];
+        const natural = [56, 200, 56];
+
+        component['applyMonotonicElasticWidths']([], natural);
+
+        expect(component['elasticNaturalMaxWidths'].length).toBe(3);
+        expect(component['elasticNaturalMaxWidths'][1]).toBe(200);
+      });
+
+      it('syncColumnWidths: elastic column width should grow across syncs and never shrink (monotonic)', () => {
+        const { headerTable, bodyTable } = buildSyncTables();
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 2 }) } as any;
+        spyOn(component, 'hasSomeFixed').and.returnValue(false);
+        spyOn<any>(component, 'getColumnIndexes').and.returnValue({ dataIndexes: [0, 1], elasticIndexes: [0, 1] });
+        spyOn<any>(component, 'getViewportContentWidth').and.returnValue(0);
+        const measureSpy = spyOn<any>(component, 'measureNaturalColumnWidths');
+
+        measureSpy.and.returnValue([100, 200]);
+        component['syncColumnWidths']();
+        expect(component['elasticNaturalMaxWidths']).toEqual([100, 200]);
+
+        component['columnWidthsSynced'] = false;
+        measureSpy.and.returnValue([100, 150]);
+        component['syncColumnWidths']();
+        expect(component['elasticNaturalMaxWidths'][1]).toBe(200);
+
+        document.body.removeChild(headerTable);
+        document.body.removeChild(bodyTable);
+      });
+
+      // --- checkChangesItems / clearColumnWidths (resets do virtual scroll) ---
+      it('checkChangesItems: should reset columnWidthsSynced when items change and virtualScroll is on', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component['columnWidthsSynced'] = true;
+        (component as any).differ = { diff: () => ({}) };
+
+        component['checkChangesItems']();
+
+        expect(component['columnWidthsSynced']).toBe(false);
+      });
+
+      it('checkChangesItems: should not touch columnWidthsSynced when virtualScroll is off', () => {
+        component.virtualScroll = false;
+        component['columnWidthsSynced'] = true;
+        (component as any).differ = { diff: () => ({}) };
+
+        component['checkChangesItems']();
+
+        expect(component['columnWidthsSynced']).toBe(true);
+      });
+
+      it('clearColumnWidths: should reset the elastic cache and dataset text cache', () => {
+        component['elasticNaturalMaxWidths'] = [1, 2, 3];
+        component['datasetTextCache'].set('foo', 100);
+        component['datasetTextCacheToken'] = [{ id: 1 }];
+        component.headerTableElement = null;
+        component.bodyTableElement = null;
+
+        component['clearColumnWidths']();
+
+        expect(component['elasticNaturalMaxWidths']).toEqual([]);
+        expect(component['datasetTextCache'].size).toBe(0);
+        expect(component['datasetTextCacheToken']).toBeNull();
+      });
+    });
+
+    describe('Table layout helper methods:', () => {
+      it('resetTableLayout: should remove colgroup, table-layout, width and min-width from table', () => {
+        const table = document.createElement('table');
+        table.style.tableLayout = 'fixed';
+        table.style.width = '500px';
+        table.style.minWidth = '500px';
+        const colgroup = document.createElement('colgroup');
+        colgroup.setAttribute('data-po-sync', 'true');
+        table.appendChild(colgroup);
+        document.body.appendChild(table);
+
+        component['resetTableLayout'](table);
+
+        expect(table.style.tableLayout).toBe('');
+        expect(table.style.width).toBe('');
+        expect(table.style.minWidth).toBe('');
+        expect(table.querySelector('colgroup[data-po-sync="true"]')).toBeNull();
+
+        document.body.removeChild(table);
+      });
+
+      it('applySharedColumnLayout: should apply colgroup, table-layout fixed, width and min-width', () => {
+        const table = document.createElement('table');
+        document.body.appendChild(table);
+
+        component['applySharedColumnLayout'](table, [100, 200, 300], 600);
+
+        expect(table.style.tableLayout).toBe('fixed');
+        expect(table.style.width).toBe('600px');
+        expect(table.style.minWidth).toBe('600px');
+        const colgroup = table.querySelector('colgroup[data-po-sync="true"]');
+        expect(colgroup).toBeTruthy();
+        expect(colgroup.children.length).toBe(3);
+
+        document.body.removeChild(table);
+      });
+
+      it('getViewportContentWidth: should return clientWidth of tableVirtualScroll', () => {
+        const el = document.createElement('div');
+        Object.defineProperty(el, 'clientWidth', { value: 750, configurable: true });
+        component.tableVirtualScroll = { nativeElement: el } as any;
+
+        expect(component['getViewportContentWidth']()).toBe(750);
+      });
+
+      it('getViewportContentWidth: should return 0 when tableVirtualScroll is null', () => {
+        component.tableVirtualScroll = null;
+
+        expect(component['getViewportContentWidth']()).toBe(0);
+      });
+    });
+
+    describe('Scrollbar gutter and header scroll sync:', () => {
+      it('updateScrollbarGutter: should not throw when elements are not available', () => {
+        component.tableVirtualScroll = null;
+        component.headerScrollContainer = null;
+
+        expect(() => component['updateScrollbarGutter']()).not.toThrow();
+      });
+
+      it('updateScrollbarGutter: should remove gutter styles when no vertical scroll', () => {
+        const viewportEl = document.createElement('div');
+        Object.defineProperty(viewportEl, 'scrollHeight', { value: 100, configurable: true });
+        Object.defineProperty(viewportEl, 'clientHeight', { value: 200, configurable: true });
+
+        const headerEl = document.createElement('div');
+        headerEl.style.borderRight = '15px solid transparent';
+        headerEl.style.boxSizing = 'border-box';
+
+        component.tableVirtualScroll = { nativeElement: viewportEl } as any;
+        component.headerScrollContainer = { nativeElement: headerEl } as any;
+
+        component['updateScrollbarGutter']();
+
+        expect(headerEl.style.borderRight).toBe('');
+        expect(headerEl.style.boxSizing).toBe('');
+      });
+
+      it('syncHeaderScrollFromViewport: should sync header scrollLeft from viewport', () => {
+        const viewportEl = document.createElement('div');
+        Object.defineProperty(viewportEl, 'scrollLeft', { value: 120, configurable: true });
+
+        const headerEl = {} as any;
+        let headerScrollLeft = 0;
+        Object.defineProperty(headerEl, 'scrollLeft', {
+          get: () => headerScrollLeft,
+          set: (v: number) => {
+            headerScrollLeft = v;
+          },
+          configurable: true
+        });
+        component.tableVirtualScroll = { nativeElement: viewportEl } as any;
+        component.headerScrollContainer = { nativeElement: headerEl } as any;
+
+        component['syncHeaderScrollFromViewport']();
+
+        expect(headerScrollLeft).toBe(120);
+      });
+
+      it('syncHeaderScrollFromViewport: should not throw when tableVirtualScroll is null', () => {
+        component.tableVirtualScroll = null;
+
+        expect(() => component['syncHeaderScrollFromViewport']()).not.toThrow();
+      });
+    });
+
+    describe('Infinite scroll reevaluation:', () => {
+      it('reevaluateInfiniteScroll: should restore infiniteScroll and call checkInfiniteScroll when conditions are met', () => {
+        component['requestedInfiniteScroll'] = true;
+        component['subscriptionScrollEvent'] = null;
+        component.height = 400;
+        component.infiniteScroll = false;
+
+        const checkSpy = spyOn<any>(component, 'checkInfiniteScroll');
+
+        component['reevaluateInfiniteScroll']();
+
+        expect(component.infiniteScroll).toBe(true);
+        expect(checkSpy).toHaveBeenCalled();
+      });
+
+      it('reevaluateInfiniteScroll: should not restore when requestedInfiniteScroll is false', () => {
+        component['requestedInfiniteScroll'] = false;
+        component['subscriptionScrollEvent'] = null;
+        component.height = 400;
+        component.infiniteScroll = false;
+
+        const checkSpy = spyOn<any>(component, 'checkInfiniteScroll');
+
+        component['reevaluateInfiniteScroll']();
+
+        expect(component.infiniteScroll).toBe(false);
+        expect(checkSpy).not.toHaveBeenCalled();
+      });
+
+      it('reevaluateInfiniteScroll: should not restore when subscriptionScrollEvent already exists', () => {
+        component['requestedInfiniteScroll'] = true;
+        component['subscriptionScrollEvent'] = { unsubscribe: () => {} } as any;
+        component.height = 400;
+
+        const checkSpy = spyOn<any>(component, 'checkInfiniteScroll');
+
+        component['reevaluateInfiniteScroll']();
+
+        expect(checkSpy).not.toHaveBeenCalled();
+      });
+
+      it('reevaluateInfiniteScroll: should not restore when height is 0', () => {
+        component['requestedInfiniteScroll'] = true;
+        component['subscriptionScrollEvent'] = null;
+        component.height = 0;
+
+        const checkSpy = spyOn<any>(component, 'checkInfiniteScroll');
+
+        component['reevaluateInfiniteScroll']();
+
+        expect(checkSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Column drag autoscroll:', () => {
+      it('onColumnDragMoved: should start autoscroll left when pointer is near left edge', () => {
+        const viewportEl = document.createElement('div');
+        Object.defineProperty(viewportEl, 'getBoundingClientRect', {
+          value: () => ({ left: 100, right: 500, top: 0, bottom: 400 })
+        });
+        component.tableVirtualScroll = { nativeElement: viewportEl } as any;
+
+        const startSpy = spyOn<any>(component, 'startDragAutoScroll');
+
+        component.onColumnDragMoved({ pointerPosition: { x: 120 } } as any);
+
+        expect(startSpy).toHaveBeenCalledWith(-1);
+      });
+
+      it('onColumnDragMoved: should start autoscroll right when pointer is near right edge', () => {
+        const viewportEl = document.createElement('div');
+        Object.defineProperty(viewportEl, 'getBoundingClientRect', {
+          value: () => ({ left: 100, right: 500, top: 0, bottom: 400 })
+        });
+        component.tableVirtualScroll = { nativeElement: viewportEl } as any;
+
+        const startSpy = spyOn<any>(component, 'startDragAutoScroll');
+
+        component.onColumnDragMoved({ pointerPosition: { x: 480 } } as any);
+
+        expect(startSpy).toHaveBeenCalledWith(1);
+      });
+
+      it('onColumnDragMoved: should stop autoscroll when pointer is in the middle', () => {
+        const viewportEl = document.createElement('div');
+        Object.defineProperty(viewportEl, 'getBoundingClientRect', {
+          value: () => ({ left: 100, right: 500, top: 0, bottom: 400 })
+        });
+        component.tableVirtualScroll = { nativeElement: viewportEl } as any;
+
+        const stopSpy = spyOn<any>(component, 'stopDragAutoScroll');
+
+        component.onColumnDragMoved({ pointerPosition: { x: 300 } } as any);
+
+        expect(stopSpy).toHaveBeenCalled();
+      });
+
+      it('onColumnDragMoved: should return early when tableVirtualScroll is null', () => {
+        component.tableVirtualScroll = null;
+
+        const startSpy = spyOn<any>(component, 'startDragAutoScroll');
+        const stopSpy = spyOn<any>(component, 'stopDragAutoScroll');
+
+        component.onColumnDragMoved({ pointerPosition: { x: 100 } } as any);
+
+        expect(startSpy).not.toHaveBeenCalled();
+        expect(stopSpy).not.toHaveBeenCalled();
+      });
+
+      it('onColumnDragEnded: should stop autoscroll and sync header scroll', () => {
+        const stopSpy = spyOn<any>(component, 'stopDragAutoScroll');
+        const syncSpy = spyOn<any>(component, 'syncHeaderScrollFromViewport');
+
+        component.onColumnDragEnded();
+
+        expect(stopSpy).toHaveBeenCalled();
+        expect(syncSpy).toHaveBeenCalled();
+      });
+
+      it('startDragAutoScroll: should set dragAutoScrollDirection and start animation frame', () => {
+        const viewportEl = document.createElement('div');
+        Object.defineProperty(viewportEl, 'scrollLeft', { value: 0, writable: true, configurable: true });
+        component.tableVirtualScroll = { nativeElement: viewportEl } as any;
+        component.headerScrollContainer = { nativeElement: document.createElement('div') } as any;
+        component['dragAutoScrollFrame'] = null;
+
+        spyOn(window, 'requestAnimationFrame').and.returnValue(123);
+
+        component['startDragAutoScroll'](1);
+
+        expect(component['dragAutoScrollDirection']).toBe(1);
+        expect(component['dragAutoScrollFrame']).toBe(123);
+      });
+
+      it('startDragAutoScroll: should not start new frame when already running', () => {
+        component['dragAutoScrollFrame'] = 456;
+        const rafSpy = spyOn(window, 'requestAnimationFrame');
+
+        component['startDragAutoScroll'](1);
+
+        expect(component['dragAutoScrollDirection']).toBe(1);
+        expect(rafSpy).not.toHaveBeenCalled();
+      });
+
+      it('startDragAutoScroll: step should scroll viewport, sync header and request next frame', () => {
+        let scrollLeft = 50;
+        const viewportEl = document.createElement('div');
+        Object.defineProperty(viewportEl, 'scrollLeft', {
+          get: () => scrollLeft,
+          set: (v: number) => {
+            scrollLeft = v;
+          },
+          configurable: true
+        });
+        component.tableVirtualScroll = { nativeElement: viewportEl } as any;
+        component.headerScrollContainer = { nativeElement: { scrollLeft: 0 } } as any;
+        component['dragAutoScrollFrame'] = null;
+        component['dragAutoScrollDirection'] = 0;
+
+        const syncSpy = spyOn<any>(component, 'syncHeaderScrollLeft');
+        let stepCallback: FrameRequestCallback;
+        spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+          if (!stepCallback) {
+            stepCallback = cb;
+          }
+          return 999;
+        });
+
+        component['startDragAutoScroll'](1);
+
+        // Executa o step callback manualmente
+        stepCallback(0);
+
+        expect(scrollLeft).toBe(62); // 50 + 12 * 1
+        expect(syncSpy).toHaveBeenCalledWith(62);
+        expect(component['dragAutoScrollFrame']).toBe(999);
+      });
+
+      it('startDragAutoScroll: step should stop when direction becomes 0', () => {
+        const viewportEl = document.createElement('div');
+        Object.defineProperty(viewportEl, 'scrollLeft', { value: 0, writable: true, configurable: true });
+        component.tableVirtualScroll = { nativeElement: viewportEl } as any;
+        component['dragAutoScrollFrame'] = null;
+
+        let stepCallback: FrameRequestCallback;
+        const rafSpy = spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+          stepCallback = cb;
+          return 111;
+        });
+
+        component['startDragAutoScroll'](1);
+        // Simula stopDragAutoScroll setando direction = 0
+        component['dragAutoScrollDirection'] = 0;
+
+        stepCallback(0);
+
+        expect(component['dragAutoScrollFrame']).toBeNull();
+      });
+
+      it('startDragAutoScroll: step should stop when viewportEl is not available', () => {
+        component.tableVirtualScroll = { nativeElement: document.createElement('div') } as any;
+        component['dragAutoScrollFrame'] = null;
+
+        let stepCallback: FrameRequestCallback;
+        spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+          stepCallback = cb;
+          return 222;
+        });
+
+        component['startDragAutoScroll'](1);
+        // Remove o viewport antes do step executar
+        component.tableVirtualScroll = null;
+
+        stepCallback(0);
+
+        expect(component['dragAutoScrollFrame']).toBeNull();
+      });
+
+      it('stopDragAutoScroll: should cancel animation frame and reset state', () => {
+        component['dragAutoScrollFrame'] = 789;
+        component['dragAutoScrollDirection'] = 1;
+
+        const cancelSpy = spyOn(window, 'cancelAnimationFrame');
+
+        component['stopDragAutoScroll']();
+
+        expect(component['dragAutoScrollDirection']).toBe(0);
+        expect(component['dragAutoScrollFrame']).toBeNull();
+        expect(cancelSpy).toHaveBeenCalledWith(789);
+      });
+
+      it('stopDragAutoScroll: should not call cancelAnimationFrame when no frame is active', () => {
+        component['dragAutoScrollFrame'] = null;
+        component['dragAutoScrollDirection'] = 1;
+
+        const cancelSpy = spyOn(window, 'cancelAnimationFrame');
+
+        component['stopDragAutoScroll']();
+
+        expect(component['dragAutoScrollDirection']).toBe(0);
+        expect(cancelSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('ngAfterViewInit and ngDoCheck changes:', () => {
+      it('ngAfterViewInit: should capture requestedInfiniteScroll from initial infiniteScroll value', () => {
+        component.height = 400;
+        component.infiniteScroll = true;
+        component['requestedInfiniteScroll'] = false;
+
+        // Simula o trecho específico do ngAfterViewInit que captura requestedInfiniteScroll
+        component['requestedInfiniteScroll'] = component.infiniteScroll;
+
+        expect(component['requestedInfiniteScroll']).toBe(true);
+      });
+
+      it('shouldScheduleVirtualScrollColumnSyncWithoutWidths: should return true when columnWidthsSynced is false and has rendered items', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [{ id: 1 }];
+        component['columnWidthsSynced'] = false;
+        component['syncScheduled'] = false;
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 1 }) } as any;
+
+        expect(component['shouldScheduleVirtualScrollColumnSyncWithoutWidths']()).toBe(true);
+      });
+
+      it('shouldScheduleVirtualScrollColumnSyncWithoutWidths: should return false when columnWidthsSynced is true', () => {
+        // Após a 1ª sincronização, o método não reagenda novo sync — a medição do dataset completo
+        // (Canvas) já entrega a largura final no primeiro sync, sem depender de rolar o virtual scroll.
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [{ id: 1 }];
+        component['columnWidthsSynced'] = true;
+        component['syncScheduled'] = false;
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 5 }) } as any;
+
+        expect(component['shouldScheduleVirtualScrollColumnSyncWithoutWidths']()).toBe(false);
+      });
+
+      it('shouldScheduleVirtualScrollColumnSyncWithoutWidths: should return false when virtualScroll is false', () => {
+        component.virtualScroll = false;
+        component.items = [{ id: 1 }];
+        component['syncScheduled'] = false;
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 1 }) } as any;
+
+        expect(component['shouldScheduleVirtualScrollColumnSyncWithoutWidths']()).toBe(false);
+      });
+
+      it('shouldScheduleVirtualScrollColumnSyncWithoutWidths: should return false when there are no items', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [];
+        component['syncScheduled'] = false;
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 1 }) } as any;
+
+        expect(component['shouldScheduleVirtualScrollColumnSyncWithoutWidths']()).toBe(false);
+      });
+
+      it('shouldScheduleVirtualScrollColumnSyncWithoutWidths: should return false when sync is already scheduled', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [{ id: 1 }];
+        component['syncScheduled'] = true;
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 1 }) } as any;
+
+        expect(component['shouldScheduleVirtualScrollColumnSyncWithoutWidths']()).toBe(false);
+      });
+
+      it('shouldScheduleVirtualScrollColumnSyncWithoutWidths: should return false when no rows are rendered yet', () => {
+        component.height = 400;
+        component.virtualScroll = true;
+        component.items = [{ id: 1 }];
+        component['columnWidthsSynced'] = false;
+        component['syncScheduled'] = false;
+        component.viewPort = { getRenderedRange: () => ({ start: 0, end: 0 }) } as any;
+
+        expect(component['shouldScheduleVirtualScrollColumnSyncWithoutWidths']()).toBe(false);
+      });
+
+      it('ngDoCheck: should call resetVirtualScrollState when virtualScroll toggles from false to true', () => {
+        component.height = 400;
+        component['previousVirtualScroll'] = false;
+        component['_virtualScroll'] = true;
+        const resetSpy = spyOn<any>(component, 'resetVirtualScrollState');
+
+        component.ngDoCheck();
+
+        expect(resetSpy).toHaveBeenCalled();
+      });
+
+      it('ngDoCheck: should call resetVirtualScrollState when virtualScroll toggles from true to false', () => {
+        component.height = 400;
+        component['previousVirtualScroll'] = true;
+        component['_virtualScroll'] = false;
+        const resetSpy = spyOn<any>(component, 'resetVirtualScrollState');
+
+        component.ngDoCheck();
+
+        expect(resetSpy).toHaveBeenCalled();
+      });
+
+      it('ngDoCheck: should not call resetVirtualScrollState when virtualScroll has not changed', () => {
+        component.height = 400;
+        component['previousVirtualScroll'] = true;
+        component['_virtualScroll'] = true;
+        const resetSpy = spyOn<any>(component, 'resetVirtualScrollState');
+
+        component.ngDoCheck();
+
+        expect(resetSpy).not.toHaveBeenCalled();
       });
     });
   });
@@ -2978,7 +4969,7 @@ describe('PoTableComponent:', () => {
   it(`ngOnDestroy: should unsubscribe 'subscriptionService'`, () => {
     const fakeSubscription = <any>{ unsubscribe: () => {} };
     spyOn(fakeSubscription, <any>'unsubscribe');
-    component['subscriptionService'] = fakeSubscription;
+    Object.defineProperty(component, 'subscriptionService', { value: fakeSubscription, configurable: true });
 
     component.ngOnDestroy();
 
@@ -2987,11 +4978,11 @@ describe('PoTableComponent:', () => {
 
   it(`ngOnDestroy: should not unsubscribe if 'subscriptionService' is falsy.`, () => {
     const fakeSubscription = <any>{ unsubscribe: () => {} };
-    component['subscriptionService'] = fakeSubscription;
+    Object.defineProperty(component, 'subscriptionService', { value: fakeSubscription, configurable: true });
 
     spyOn(fakeSubscription, <any>'unsubscribe');
 
-    component['subscriptionService'] = undefined;
+    Object.defineProperty(component, 'subscriptionService', { value: undefined, configurable: true });
     component.ngOnDestroy();
 
     expect(fakeSubscription.unsubscribe).not.toHaveBeenCalled();
@@ -3131,11 +5122,57 @@ describe('PoTableComponent:', () => {
     component.height = 1000;
     spyOnProperty(component, 'hasItems').and.returnValue(true);
     component.infiniteScroll = true;
+    component.virtualScroll = false;
+
+    // Mock tableScrollable com scrollHeight menor que height
+    component.tableScrollable = new ElementRef({ scrollHeight: 200, closest: () => null });
 
     component['checkInfiniteScroll']();
 
     expect(spyDetectChanges).toHaveBeenCalled();
     expect(spyIncludeInfiniteScroll).not.toHaveBeenCalled();
+  });
+
+  it('checkInfiniteScroll: should use heightTableVirtual as availableHeight when clientHeight is 0 in virtual scroll', () => {
+    const spyIncludeInfiniteScroll = spyOn(component, <any>'includeInfiniteScroll');
+
+    component.height = 400;
+    component.virtualScroll = true;
+    spyOnProperty(component, 'hasItems').and.returnValue(true);
+    component.infiniteScroll = true;
+    component.heightTableVirtual = 300;
+
+    // clientHeight = 0 → fallback para heightTableVirtual (300)
+    const mockViewport = document.createElement('div');
+    Object.defineProperty(mockViewport, 'scrollHeight', { value: 500, configurable: true });
+    Object.defineProperty(mockViewport, 'clientHeight', { value: 0, configurable: true });
+    component.tableVirtualScroll = { nativeElement: mockViewport } as any;
+
+    component['checkInfiniteScroll']();
+
+    // scrollHeight (500) >= availableHeight (300) → includeInfiniteScroll chamado
+    expect(spyIncludeInfiniteScroll).toHaveBeenCalled();
+  });
+
+  it('checkInfiniteScroll: should use this.height as availableHeight when both clientHeight and heightTableVirtual are 0 in virtual scroll', () => {
+    const spyIncludeInfiniteScroll = spyOn(component, <any>'includeInfiniteScroll');
+
+    component.height = 200;
+    component.virtualScroll = true;
+    spyOnProperty(component, 'hasItems').and.returnValue(true);
+    component.infiniteScroll = true;
+    component.heightTableVirtual = 0;
+
+    // clientHeight = 0, heightTableVirtual = 0 → fallback para this.height (200)
+    const mockViewport = document.createElement('div');
+    Object.defineProperty(mockViewport, 'scrollHeight', { value: 500, configurable: true });
+    Object.defineProperty(mockViewport, 'clientHeight', { value: 0, configurable: true });
+    component.tableVirtualScroll = { nativeElement: mockViewport } as any;
+
+    component['checkInfiniteScroll']();
+
+    // scrollHeight (500) >= availableHeight (200) → includeInfiniteScroll chamado
+    expect(spyIncludeInfiniteScroll).toHaveBeenCalled();
   });
 
   it('getWidthColumnManager, should return width of column manager', () => {

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -1,8 +1,9 @@
-import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { CdkDragDrop, CdkDragMove, moveItemInArray } from '@angular/cdk/drag-drop';
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 
 import { DecimalPipe } from '@angular/common';
 import {
+  AfterViewChecked,
   AfterViewInit,
   ChangeDetectorRef,
   Component,
@@ -12,6 +13,7 @@ import {
   ElementRef,
   Inject,
   IterableDiffers,
+  NgZone,
   OnDestroy,
   OnInit,
   Optional,
@@ -28,11 +30,11 @@ import { PoDateService } from '../../services/po-date/po-date.service';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
 import { PoNotificationService } from '../../services/po-notification/po-notification.service';
 import { convertToBoolean, getDefaultSizeFn, PO_TABLE_ROW_HEIGHT_BY_SPACING, uuid } from '../../utils/util';
+import { AnimaliaIconDictionary, ICONS_DICTIONARY } from '../po-icon';
 import { PoModalAction, PoModalComponent } from '../po-modal';
 import { PoPopupComponent } from '../po-popup/po-popup.component';
 import { PoTableColumnLabel } from './po-table-column-label/po-table-column-label.interface';
 
-import { AnimaliaIconDictionary, ICONS_DICTIONARY } from '../po-icon';
 import { PoTableRowTemplateArrowDirection } from './enums/po-table-row-template-arrow-direction.enum';
 import { PoTableAction } from './interfaces/po-table-action.interface';
 import { PoTableColumn } from './interfaces/po-table-column.interface';
@@ -103,11 +105,19 @@ import { PoFieldSize } from '../../enums/po-field-size.enum';
   providers: [PoDateService, PoTableService],
   standalone: false
 })
-export class PoTableComponent extends PoTableBaseComponent implements AfterViewInit, DoCheck, OnDestroy, OnInit {
+export class PoTableComponent
+  extends PoTableBaseComponent
+  implements AfterViewChecked, AfterViewInit, DoCheck, OnDestroy, OnInit
+{
   @ContentChild(PoTableRowTemplateDirective, { static: true }) tableRowTemplate: PoTableRowTemplateDirective;
   @ContentChild(PoTableCellTemplateDirective) tableCellTemplate: PoTableCellTemplateDirective;
 
   @ContentChildren(PoTableColumnTemplateDirective) tableColumnTemplates: QueryList<PoTableColumnTemplateDirective>;
+
+  @ViewChild('virtualScrollWrapper', { read: ElementRef, static: false }) virtualScrollWrapper: ElementRef;
+  @ViewChild('headerScrollContainer', { read: ElementRef, static: false }) headerScrollContainer: ElementRef;
+  @ViewChild('headerTable', { read: ElementRef, static: false }) headerTableElement: ElementRef;
+  @ViewChild('bodyTable', { read: ElementRef, static: false }) bodyTableElement: ElementRef;
 
   @ViewChild('noColumnsHeader', { read: ElementRef }) noColumnsHeader;
   @ViewChild('popup') poPopupComponent: PoPopupComponent;
@@ -130,6 +140,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   @ViewChild(CdkVirtualScrollViewport, { static: false }) public viewPort: CdkVirtualScrollViewport;
 
   poNotification = inject(PoNotificationService);
+  private readonly ngZone = inject(NgZone);
 
   heightTableContainer: number;
   heightTableVirtual: number;
@@ -142,9 +153,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   idRadio: string;
   inputFieldValue = '';
   JSON: JSON;
-  newOrderColumns: Array<PoTableColumn>;
   sizeLoading: string = 'sm';
   headerWidth: number;
+  headerTableScrollWidth: number;
+  computedColumnWidths: Array<string> = [];
 
   close: PoModalAction = {
     action: () => {
@@ -163,17 +175,38 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   private _columnManagerTarget: ElementRef;
   private _columnManagerTargetFixed: ElementRef;
-  private _iconToken: { [key: string]: string };
-  private differ;
+  private readonly differ;
   private footerHeight;
   private timeoutResize;
   private visibleElement = false;
   private scrollEvent$: Observable<any>;
   private subscriptionScrollEvent: Subscription;
-  private subscriptionService: Subscription = new Subscription();
+  private readonly subscriptionService: Subscription = new Subscription();
+  private resizeObserver: ResizeObserver;
+  private scrollSyncListener: (() => void) | null = null;
+  private containerScrollSyncListener: (() => void) | null = null;
+  private dragAutoScrollFrame: number | null = null;
+  private dragAutoScrollDirection = 0;
+  private virtualScrollOverflowConfigured = false;
+  private syncScheduled = false;
+  private columnWidthsSynced = false;
+  private partialColumnsRendered = false;
+  private elasticNaturalMaxWidths: Array<number> = [];
+  private measureCanvasContext?: CanvasRenderingContext2D;
+  private readonly datasetTextCache = new Map<string, number>();
+  private datasetTextCacheToken: Array<any> | null = null;
+  private requestedInfiniteScroll = false;
+  private lastHeaderHeight = 0;
+  private previousVirtualScroll: boolean | undefined = undefined;
+
+  private readonly SELECTOR_HEADER_ROW = 'thead > tr';
+  private readonly SELECTOR_BODY_DATA_ROW = 'tbody tr.po-table-row:not(.po-table-row-no-data)';
+  private readonly SELECTOR_CDK_CONTENT_WRAPPER = '.cdk-virtual-scroll-content-wrapper';
+  private readonly SELECTOR_FIXED_INNER_CONTAINER = '.po-table-container-fixed-inner';
 
   private clickListener: () => void;
   private resizeListener: () => void;
+  private _iconToken: { [key: string]: string };
 
   @ViewChild('columnManagerTarget') set columnManagerTarget(value: ElementRef) {
     this._columnManagerTarget = value;
@@ -193,25 +226,23 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return this._columnManagerTargetFixed;
   }
 
-  get iconNameLib() {
-    return this._iconToken.NAME_LIB;
-  }
-
   /* eslint-disable max-params */
 
   constructor(
     poDate: PoDateService,
     differs: IterableDiffers,
-    renderer: Renderer2,
+    private readonly renderer: Renderer2,
     poLanguageService: PoLanguageService,
-    private changeDetector: ChangeDetectorRef,
-    private decimalPipe: DecimalPipe,
-    private defaultService: PoTableService,
-    @Optional() @Inject(ICONS_DICTIONARY) value: { [key: string]: string }
+    private readonly changeDetector: ChangeDetectorRef,
+    private readonly decimalPipe: DecimalPipe,
+    private readonly defaultService: PoTableService,
+    @Optional() @Inject(ICONS_DICTIONARY) iconToken?: { [key: string]: string }
   ) {
     super(poDate, poLanguageService, defaultService);
     this.JSON = JSON;
     this.differ = differs.find([]).create(null);
+
+    this._iconToken = iconToken ?? AnimaliaIconDictionary;
 
     // TODO: #5550 ao remover este listener, no portal, quando as colunas forem fixas não sofrem
     // alteração de largura, pois o ngDoCheck não é executado.
@@ -220,10 +251,12 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.resizeListener = renderer.listen('window', 'resize', (event: any) => {
       this.debounceResize();
     });
-
-    this._iconToken = value ?? AnimaliaIconDictionary;
   }
   /* eslint-enable max-params */
+
+  get iconNameLib() {
+    return this._iconToken.NAME_LIB;
+  }
 
   get hasRowTemplateWithArrowDirectionRight() {
     return this.tableRowTemplate?.tableRowTemplateArrowDirection === PoTableRowTemplateArrowDirection.Right;
@@ -247,7 +280,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   get detailHideSelect() {
     const masterDetail = this.columnMasterDetail;
-    return masterDetail && masterDetail.detail ? masterDetail.detail.hideSelect : false;
+    return masterDetail?.detail ? masterDetail.detail.hideSelect : false;
   }
 
   get hasVisibleActions() {
@@ -292,16 +325,6 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return this.draggable;
   }
 
-  public get inverseOfTranslation(): string {
-    if (!this.viewPort || !this.viewPort['_renderedContentOffset']) {
-      return '-0px';
-    }
-
-    const offset = this.viewPort['_renderedContentOffset'];
-
-    return `-${offset}px`;
-  }
-
   ngOnInit() {
     this.idRadio = `po-radio-${uuid()}`;
   }
@@ -315,9 +338,56 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   ngAfterViewInit() {
     this.initialized = true;
+    // Captura a intenção original de infinite scroll antes que checkInfiniteScroll possa desligá-la
+    // prematuramente (no virtual scroll, quando o scrollHeight do viewport ainda é 0).
+    this.requestedInfiniteScroll = this.infiniteScroll;
     this.changeHeaderWidth();
     this.changeSizeLoading();
     this.applyFixedColumns();
+    this.initializeVisibleElement();
+    this.syncHeaderTableWidth();
+    this.setupColumnWidthSync();
+    this.configureVirtualScrollOverflow();
+  }
+
+  ngAfterViewChecked(): void {
+    if (this.virtualScroll && !this.virtualScrollOverflowConfigured && this.tableVirtualScroll?.nativeElement) {
+      this.configureVirtualScrollOverflow();
+    }
+
+    if (this.virtualScroll && !this.resizeObserver && this.tableVirtualScroll?.nativeElement) {
+      this.setupColumnWidthSync();
+    }
+
+    if (this.virtualScroll && this.heightTableContainer) {
+      const currentHeaderHeight = this.headerScrollContainer?.nativeElement?.offsetHeight;
+      if (currentHeaderHeight && currentHeaderHeight !== this.lastHeaderHeight) {
+        this.lastHeaderHeight = currentHeaderHeight;
+        requestAnimationFrame(() => {
+          this.heightTableVirtual = this.heightTableContainer - currentHeaderHeight;
+          this.changeDetector.markForCheck();
+        });
+      }
+    }
+
+    if (this.shouldScheduleVirtualScrollColumnSyncWithoutWidths()) {
+      this.syncScheduled = true;
+      requestAnimationFrame(() => {
+        this.syncColumnWidths();
+        this.syncScheduled = false;
+      });
+    }
+  }
+
+  private shouldScheduleVirtualScrollColumnSyncWithoutWidths(): boolean {
+    return (
+      this.virtualScroll &&
+      this.hasItems &&
+      !this.columnWidthsSynced &&
+      !this.syncScheduled &&
+      !this.partialColumnsRendered &&
+      (this.viewPort?.getRenderedRange().end ?? 0) > 0
+    );
   }
 
   showMoreInfiniteScroll({ target }): void {
@@ -329,21 +399,42 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   ngDoCheck() {
     this.applyFixedColumns();
+
+    // Detect virtualScroll toggle transition
+    if (this.previousVirtualScroll !== undefined && this.virtualScroll !== this.previousVirtualScroll) {
+      this.resetVirtualScrollState();
+    }
+    this.previousVirtualScroll = this.virtualScroll;
+
     this.checkChangesItems();
     this.verifyCalculateHeightTableContainer();
 
     // Permite que os cabeçalhos sejam calculados na primeira vez que o componente torna-se visível,
     // evitando com isso, problemas com Tabs ou Divs que iniciem escondidas.
-    if (this.tableWrapperElement?.nativeElement.offsetWidth && !this.visibleElement && this.initialized) {
-      this.debounceResize();
-      this.checkInfiniteScroll();
-      this.visibleElement = true;
+    if (this.initialized) {
+      this.initializeVisibleElement();
+    }
+
+    if (this.virtualScroll && this.hasItems) {
+      this.syncHeaderTableWidth();
     }
   }
 
   ngOnDestroy() {
     this.removeListeners();
     this.subscriptionService?.unsubscribe();
+    if (this.resizeObserver && typeof this.resizeObserver.disconnect === 'function') {
+      this.resizeObserver.disconnect();
+    }
+    if (this.scrollSyncListener) {
+      this.scrollSyncListener();
+      this.scrollSyncListener = null;
+    }
+    if (this.containerScrollSyncListener) {
+      this.containerScrollSyncListener();
+      this.containerScrollSyncListener = null;
+    }
+    this.stopDragAutoScroll();
   }
 
   /**
@@ -369,10 +460,29 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   /**
-   * Verifica se columns possuem a propriedade width.
+   * Verifica se todas as colunas de dados (mainColumns) possuem a propriedade width.
+   * Colunas estruturais (selectable, actions, master-detail) são ignoradas pois
+   * nunca têm width definido e não participam do cálculo de layout.
    */
   applyFixedColumns(): boolean {
-    return !this.columns.some(column => !column.width);
+    return !this.mainColumns.some(column => !column.width);
+  }
+
+  /**
+   * Retorna o valor de `width` inline para a célula. Colunas com largura declarada em `%` recebem
+   * `auto` (como o auto-layout nativo do master), permitindo que o browser dimensione pelo conteúdo
+   * e use o `%` apenas como `max-width`/`min-width`. Colunas com `px` ou `computedColumnWidths`
+   * recebem o valor literal. Colunas sem `width` (elásticas) também recebem `auto` para que o
+   * navegador dimensione pelo conteúdo, idêntico à master.
+   */
+  getColumnWidth(column: any, index: number): string | undefined {
+    if (typeof column.width === 'string') {
+      if (column.width.trim().endsWith('%')) {
+        return 'auto';
+      }
+      return column.width;
+    }
+    return this.computedColumnWidths?.[index] || 'auto';
   }
 
   /**
@@ -589,8 +699,13 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   onVisibleColumnsChange(columns: Array<PoTableColumn>) {
+    this.clearColumnWidths();
     this.columns = columns;
-    this.changeDetector.detectChanges();
+    this.changeDetector.markForCheck();
+
+    if (this.virtualScroll) {
+      setTimeout(() => this.syncColumnWidths());
+    }
   }
 
   tooltipMouseEnter(event: any, column?: PoTableColumn, row?: any) {
@@ -673,26 +788,62 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   drop(event: CdkDragDrop<Array<string>>) {
     if (!this.mainColumns[event.currentIndex].fixed) {
+      this.clearColumnWidths();
       moveItemInArray(this.mainColumns, event.previousIndex, event.currentIndex);
 
       if (this.hideColumnsManager === false) {
-        this.newOrderColumns = this.mainColumns;
+        const newOrderColumns = this.mainColumns;
         const detail = this.columns.filter(item => item.property === 'detail')[0];
 
         if (detail !== undefined) {
-          this.newOrderColumns.push(detail);
+          newOrderColumns.push(detail);
         }
 
-        this.columns.map((item, index) => {
+        this.columns.forEach((item, index) => {
           if (!item.visible) {
-            this.newOrderColumns.splice(index, 0, item);
+            newOrderColumns.splice(index, 0, item);
           }
         });
-        this.columns = this.newOrderColumns;
+        this.columns = newOrderColumns;
 
-        this.onVisibleColumnsChange(this.newOrderColumns);
+        this.onVisibleColumnsChange(newOrderColumns);
+      } else if (this.virtualScroll) {
+        // Re-sincroniza larguras após Angular renderizar a nova ordem
+        setTimeout(() => this.syncColumnWidths());
       }
     }
+  }
+
+  /**
+   * Durante o arraste de uma coluna, faz o autoscroll horizontal do **body** (viewport do CDK) quando o
+   * ponteiro se aproxima das bordas esquerda/direita. O header permanece com `overflow: hidden` e acompanha
+   * o body pelo listener de scroll já existente, sem exibir scrollbar próprio.
+   */
+  onColumnDragMoved(event: CdkDragMove): void {
+    const viewportEl = this.tableVirtualScroll?.nativeElement as HTMLElement | undefined;
+    if (!viewportEl) {
+      return;
+    }
+
+    const rect = viewportEl.getBoundingClientRect();
+    const edgeThreshold = 48;
+    const pointerX = event.pointerPosition.x;
+
+    if (pointerX < rect.left + edgeThreshold) {
+      this.startDragAutoScroll(-1);
+    } else if (pointerX > rect.right - edgeThreshold) {
+      this.startDragAutoScroll(1);
+    } else {
+      this.stopDragAutoScroll();
+    }
+  }
+
+  /**
+   * Finaliza o arraste: interrompe o autoscroll e re-espelha a posição do header a partir do viewport.
+   */
+  onColumnDragEnded(): void {
+    this.stopDragAutoScroll();
+    this.syncHeaderScrollFromViewport();
   }
 
   public getTemplate(column: PoTableColumn): TemplateRef<any> {
@@ -723,11 +874,42 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return this.columns.some(item => item.fixed === true);
   }
 
+  private startDragAutoScroll(direction: number): void {
+    this.dragAutoScrollDirection = direction;
+    if (this.dragAutoScrollFrame !== null) {
+      return;
+    }
+
+    const speed = 12;
+    const step = () => {
+      const viewportEl = this.tableVirtualScroll?.nativeElement as HTMLElement | undefined;
+      if (!viewportEl || this.dragAutoScrollDirection === 0) {
+        this.dragAutoScrollFrame = null;
+        return;
+      }
+      viewportEl.scrollLeft += this.dragAutoScrollDirection * speed;
+      // Garante o alinhamento do header mesmo se o evento de scroll programático atrasar.
+      this.syncHeaderScrollLeft(viewportEl.scrollLeft);
+      this.dragAutoScrollFrame = requestAnimationFrame(step);
+    };
+
+    this.dragAutoScrollFrame = requestAnimationFrame(step);
+  }
+
+  private stopDragAutoScroll(): void {
+    this.dragAutoScrollDirection = 0;
+    if (this.dragAutoScrollFrame !== null) {
+      cancelAnimationFrame(this.dragAutoScrollFrame);
+      this.dragAutoScrollFrame = null;
+    }
+  }
+
   protected calculateHeightTableContainer(height: number) {
     this.itemSize =
       PO_TABLE_ROW_HEIGHT_BY_SPACING[this.spacing] ?? PO_TABLE_ROW_HEIGHT_BY_SPACING[PoTableColumnSpacing.Medium];
     this.heightTableContainer = height ? height - this.getHeightTableFooter() : undefined;
-    this.heightTableVirtual = this.heightTableContainer ? this.heightTableContainer - this.itemSize : undefined;
+    const headerHeight = this.headerScrollContainer?.nativeElement?.offsetHeight || this.itemSize;
+    this.heightTableVirtual = this.heightTableContainer ? this.heightTableContainer - headerHeight : undefined;
     this.setTableOpacity(1);
     this.changeDetector.detectChanges();
   }
@@ -743,14 +925,19 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   protected checkInfiniteScroll(): void {
     if (this.hasInfiniteScroll()) {
       let scrollHeight = 0;
+      // Altura de referência para detectar overflow. No virtual scroll, o header fica FORA do viewport,
+      // então o scrollHeight do viewport não inclui o header — comparamos com a altura visível do próprio
+      // viewport (clientHeight) e não com this.height (que reserva espaço para o header).
+      let availableHeight = this.height;
 
       if (this.virtualScroll) {
         scrollHeight = this.tableVirtualScroll.nativeElement.scrollHeight;
+        availableHeight = this.tableVirtualScroll.nativeElement.clientHeight || this.heightTableVirtual || this.height;
       } else {
         scrollHeight = this.tableScrollable.nativeElement.scrollHeight;
       }
 
-      if (scrollHeight >= this.height) {
+      if (scrollHeight >= availableHeight) {
         this.includeInfiniteScroll();
       } else {
         this.infiniteScroll = false;
@@ -807,6 +994,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     if (changesItems && !this.hasColumns && this.hasItems) {
       this.columns = this.getDefaultColumns(this.items[0]);
     }
+
+    if (changesItems && this.virtualScroll) {
+      this.columnWidthsSynced = false;
+    }
   }
 
   private checkingIfColumnHasTooltip(column, row) {
@@ -846,8 +1037,8 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   private debounceResize() {
     clearTimeout(this.timeoutResize);
     this.timeoutResize = setTimeout(() => {
-      // show the table
       this.setTableOpacity(1);
+      this.changeDetector.markForCheck();
     });
   }
 
@@ -873,7 +1064,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   private deleteItemsService(newItemsFiltered: Array<any>) {
     this.subscriptionService.add(
       this.defaultService.deleteItem(this.paramDeleteApi, this.itemsSelected[0][this.paramDeleteApi]).subscribe({
-        next: value => {
+        next: () => {
           if (this.hasService) {
             const filteredParams = {
               ...this.paramsFilter,
@@ -890,7 +1081,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
           this.items = newItemsFiltered;
           this.changesAfterDelete(newItemsFiltered);
         },
-        error: error => {
+        error: () => {
           this.poNotification.error(this.literals.deleteApiError);
           this.modalDelete.close();
           this.eventDelete.emit(this.items);
@@ -951,6 +1142,14 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return mergedIcons;
   }
 
+  private initializeVisibleElement(): void {
+    if (this.tableWrapperElement?.nativeElement.offsetWidth && !this.visibleElement) {
+      this.debounceResize();
+      this.checkInfiniteScroll();
+      this.visibleElement = true;
+    }
+  }
+
   private removeListeners() {
     if (this.resizeListener) {
       this.resizeListener();
@@ -986,6 +1185,601 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
           item.$selected = selectValue;
         }
       });
+    }
+  }
+
+  private configureVirtualScrollOverflow(): void {
+    if (!this.tableVirtualScroll?.nativeElement) return;
+
+    const viewportEl = this.tableVirtualScroll.nativeElement;
+
+    this.applyVirtualScrollStyles(viewportEl);
+    this.registerScrollSyncListeners(viewportEl);
+
+    this.virtualScrollOverflowConfigured = true;
+  }
+
+  private applyVirtualScrollStyles(viewportEl: HTMLElement): void {
+    const contentWrapper = viewportEl.querySelector(this.SELECTOR_CDK_CONTENT_WRAPPER);
+    if (contentWrapper) this.renderer.setStyle(contentWrapper, 'contain', 'layout style');
+
+    if (this.headerScrollContainer?.nativeElement) {
+      this.renderer.setStyle(this.headerScrollContainer.nativeElement, 'overflow', 'hidden');
+      // Otimiza o repaint do header durante a sincronização de scroll horizontal.
+      // `scroll-position` não cria containing block, então não afeta o `position: sticky`.
+      this.renderer.setStyle(this.headerScrollContainer.nativeElement, 'will-change', 'scroll-position');
+    }
+  }
+
+  private registerScrollSyncListeners(viewportEl: HTMLElement): void {
+    const fixedInnerContainer = viewportEl.closest<HTMLElement>(this.SELECTOR_FIXED_INNER_CONTAINER);
+
+    // Registra os listeners de scroll FORA da zona do Angular para evitar change detection a cada evento
+    // de scroll. O scroll do header é atualizado de forma síncrona, eliminando o delay em relação ao body.
+    this.ngZone.runOutsideAngular(() => {
+      if (!this.scrollSyncListener) {
+        const handler = () => this.syncHeaderScrollLeft(viewportEl.scrollLeft);
+        viewportEl.addEventListener('scroll', handler, { passive: true });
+        this.scrollSyncListener = () => viewportEl.removeEventListener('scroll', handler);
+      }
+
+      if (fixedInnerContainer && !this.containerScrollSyncListener) {
+        const handler = () => this.syncHeaderScrollLeft(fixedInnerContainer.scrollLeft);
+        fixedInnerContainer.addEventListener('scroll', handler, { passive: true });
+        this.containerScrollSyncListener = () => fixedInnerContainer.removeEventListener('scroll', handler);
+      }
+    });
+  }
+
+  private syncHeaderScrollLeft(scrollLeft: number): void {
+    if (this.headerScrollContainer?.nativeElement) this.headerScrollContainer.nativeElement.scrollLeft = scrollLeft;
+  }
+
+  /**
+   * Reserva (ou remove) o espaço da scrollbar vertical de forma consistente entre o body e o header,
+   * para que a scrollbar não cubra a última coluna e o scroll horizontal permaneça alinhado.
+   *
+   * Condições: só atua no modo virtual scroll e apenas quando o body realmente tem overflow vertical
+   * (scrollbar presente). Caso contrário, remove a reserva para não criar uma faixa vazia à direita.
+   *
+   * O gutter é reservado no viewport via `scrollbar-gutter: stable` e replicado no header por uma borda
+   * direita transparente de mesma largura (com `box-sizing: border-box`), igualando as `clientWidth`.
+   */
+  private updateScrollbarGutter(): void {
+    const viewportEl = this.tableVirtualScroll?.nativeElement as HTMLElement | undefined;
+    const headerEl = this.headerScrollContainer?.nativeElement as HTMLElement | undefined;
+    if (!viewportEl || !headerEl) {
+      return;
+    }
+
+    const hasVerticalScroll = viewportEl.scrollHeight > viewportEl.clientHeight;
+
+    if (!hasVerticalScroll) {
+      this.renderer.removeStyle(viewportEl, 'scrollbar-gutter');
+      this.renderer.removeStyle(headerEl, 'border-right');
+      this.renderer.removeStyle(headerEl, 'box-sizing');
+      return;
+    }
+
+    this.renderer.setStyle(viewportEl, 'scrollbar-gutter', 'stable');
+    // Força reflow para medir o espaço efetivamente reservado pela scrollbar.
+    const forceReflow = viewportEl.offsetWidth;
+    const gutter = forceReflow - viewportEl.clientWidth;
+
+    this.renderer.setStyle(headerEl, 'box-sizing', 'border-box');
+    this.renderer.setStyle(headerEl, 'border-right', `${gutter}px solid transparent`);
+  }
+
+  private setupColumnWidthSync(): void {
+    if (!this.virtualScroll || this.resizeObserver) return;
+
+    const viewportEl = this.tableVirtualScroll?.nativeElement;
+    if (!viewportEl) return;
+
+    this.resizeObserver = new ResizeObserver(this.syncColumnWidths.bind(this));
+    this.resizeObserver.observe(viewportEl);
+  }
+
+  /**
+   * Reseta o estado interno do virtual scroll ao detectar uma transição
+   * (ex.: alternância `false` → `true`). Garante que o novo viewport será
+   * reconfigurado do zero, sem resíduos do ciclo anterior.
+   */
+  private resetVirtualScrollState(): void {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = undefined;
+    }
+
+    if (this.scrollSyncListener) {
+      this.scrollSyncListener();
+      this.scrollSyncListener = null;
+    }
+
+    if (this.containerScrollSyncListener) {
+      this.containerScrollSyncListener();
+      this.containerScrollSyncListener = null;
+    }
+
+    this.virtualScrollOverflowConfigured = false;
+    this.syncScheduled = false;
+    // Remove colgroup e layout fixo das tabelas para que a re-medição parta do zero
+    this.clearColumnWidths();
+  }
+
+  private clearColumnWidths(): void {
+    const headerTable = this.headerTableElement?.nativeElement as HTMLElement | undefined;
+    const bodyTable = this.bodyTableElement?.nativeElement as HTMLElement | undefined;
+
+    if (headerTable) this.resetTableLayout(headerTable);
+
+    if (bodyTable) this.resetTableLayout(bodyTable);
+
+    this.columnWidthsSynced = false;
+    this.partialColumnsRendered = false;
+    this.elasticNaturalMaxWidths = [];
+    this.datasetTextCache.clear();
+    this.datasetTextCacheToken = null;
+    this.computedColumnWidths = [];
+  }
+
+  private resetTableLayout(table: HTMLElement): void {
+    this.removeColgroup(table);
+    this.renderer.removeStyle(table, 'table-layout');
+    this.renderer.removeStyle(table, 'width');
+    this.renderer.removeStyle(table, 'min-width');
+  }
+
+  private removeColgroup(table: HTMLElement): void {
+    const existingColgroup = table.querySelector(':scope > colgroup[data-po-sync="true"]');
+    if (existingColgroup) {
+      existingColgroup.remove();
+    }
+  }
+
+  private applyColgroup(table: HTMLElement, widths: Array<number>): void {
+    this.removeColgroup(table);
+    const colgroup = this.renderer.createElement('colgroup');
+    this.renderer.setAttribute(colgroup, 'data-po-sync', 'true');
+    widths.forEach(width => {
+      const col = this.renderer.createElement('col');
+      this.renderer.setStyle(col, 'width', `${width}px`);
+      this.renderer.appendChild(colgroup, col);
+    });
+    this.renderer.insertBefore(table, colgroup, table.firstChild);
+  }
+
+  private syncColumnWidths(): void {
+    const headerTable = this.headerTableElement?.nativeElement as HTMLElement | undefined;
+    const bodyTable = this.bodyTableElement?.nativeElement as HTMLElement | undefined;
+
+    if (!headerTable || !bodyTable) return;
+
+    const headerRow = headerTable.querySelector<HTMLElement>(this.SELECTOR_HEADER_ROW);
+    const bodyRow = bodyTable.querySelector<HTMLElement>(this.SELECTOR_BODY_DATA_ROW);
+
+    if (!headerRow || !bodyRow) return;
+
+    const headerCells = Array.from(headerRow.children) as Array<HTMLElement>;
+    const bodyCells = Array.from(bodyRow.children) as Array<HTMLElement>;
+    const count = Math.min(headerCells.length, bodyCells.length);
+
+    if (!count) return;
+
+    // Verifica se todas as colunas de dados estão presentes no DOM.
+    // No virtual scroll horizontal, o CDK pode renderizar apenas as células visíveis.
+    // Quando faltam colunas no DOM, NÃO podemos forçar table-layout: fixed + colgroup,
+    // pois isso colapsaria as colunas não medidas para largura zero.
+    // Nesse caso mantém-se o layout natural (max-content) e o overflow-x do viewport
+    // cuida do scroll horizontal — comportamento idêntico à master.
+    const dataIndexes = headerCells.reduce((acc, cell, i) => {
+      if (cell.classList.contains('po-table-header-ellipsis')) acc.push(i);
+      return acc;
+    }, [] as Array<number>);
+    const allDataColumnsRendered = dataIndexes.length === this.mainColumns.length;
+
+    // Ajusta a reserva da scrollbar vertical antes de medir, para que a largura do container já reflita o gutter.
+    this.updateScrollbarGutter();
+
+    const naturalWidths = this.measureNaturalColumnWidths(headerTable, bodyTable, headerCells, bodyCells, count);
+
+    if (!allDataColumnsRendered) {
+      // Nem todas as colunas estão no DOM → mantém layout natural (max-content).
+      // Isso permite scroll horizontal legítimo sem truncar conteúdo.
+      // Reseta qualquer colgroup/layout fixo pré-existente para não interferir.
+      this.resetTableLayout(headerTable);
+      this.resetTableLayout(bodyTable);
+      this.renderer.setStyle(headerTable, 'width', 'max-content');
+      this.renderer.setStyle(bodyTable, 'width', 'max-content');
+      this.columnWidthsSynced = false;
+      this.syncScheduled = false;
+      this.partialColumnsRendered = true;
+      this.syncHeaderTableWidth();
+      this.syncHeaderScrollFromViewport();
+      this.changeDetector.markForCheck();
+      return;
+    }
+
+    // No virtual scroll só existem no DOM as linhas renderizadas no momento. Para que as colunas
+    // elásticas e percentuais já nasçam com a largura FINAL (sem depender de rolar até o conteúdo
+    // mais largo), mede-se o texto do dataset (`filteredItems`) fora do DOM via Canvas e
+    // usa-se esse valor como piso de conteúdo. Em seguida o crescimento monotônico garante que a
+    // coluna elástica nunca encolha entre re-sincronizações.
+    this.expandDataColumnWidthsForFullDataset(headerCells, bodyCells, naturalWidths);
+    this.applyMonotonicElasticWidths(headerCells, naturalWidths);
+
+    // SEMPRE aplica colgroup + table-layout: fixed para garantir que header e body
+    // tenham exatamente as mesmas larguras. resolvePercentWidths decide como preencher
+    // o espaço: com colgroup forçando px fixos, as % são respeitadas e a elástica
+    // recebe a largura calculada (não é colapsada).
+    this.resolvePercentWidths(headerCells, naturalWidths, this.getViewportContentWidth());
+
+    const finalWidths = this.distributeColumnWidths(headerCells, naturalWidths);
+    const totalWidth = finalWidths.reduce((total, width) => total + width, 0);
+
+    this.applySharedColumnLayout(headerTable, finalWidths, totalWidth);
+    this.applySharedColumnLayout(bodyTable, finalWidths, totalWidth);
+
+    this.columnWidthsSynced = true;
+    this.syncHeaderTableWidth();
+    // Re-espelha o scroll horizontal do header a partir do viewport, para que a posição seja preservada
+    // após qualquer re-sincronização (ex.: reordenação de colunas, resize), sem voltar para a posição zero.
+    this.syncHeaderScrollFromViewport();
+
+    // Reavalia o infinite scroll após o layout estar restaurado. Durante a medição, o scrollHeight pode
+    // ter sido temporariamente 0 (tabelas em max-content), fazendo checkInfiniteScroll setar
+    // infiniteScroll = false prematuramente. Aqui o layout fixo já está aplicado e o scrollHeight é real.
+    this.reevaluateInfiniteScroll();
+
+    this.changeDetector.markForCheck();
+  }
+
+  /**
+   * Mantém, por coluna elástica (sem `width`), a maior largura natural já medida. No virtual scroll
+   * só existem no DOM as linhas renderizadas no momento; conforme novas linhas entram no buffer (na
+   * carga inicial ou ao rolar), a coluna cresce para caber o conteúdo mais largo e nunca encolhe,
+   * evitando o truncamento causado por medir apenas um subconjunto das linhas.
+   */
+  private applyMonotonicElasticWidths(headerCells: Array<HTMLElement>, naturalWidths: Array<number>): void {
+    const { elasticIndexes } = this.getColumnIndexes(headerCells);
+    if (!elasticIndexes.length) return;
+
+    if (this.elasticNaturalMaxWidths.length !== naturalWidths.length) {
+      this.elasticNaturalMaxWidths = new Array(naturalWidths.length).fill(0);
+    }
+
+    elasticIndexes.forEach(index => {
+      if (naturalWidths[index] > this.elasticNaturalMaxWidths[index]) {
+        this.elasticNaturalMaxWidths[index] = naturalWidths[index];
+      } else {
+        naturalWidths[index] = this.elasticNaturalMaxWidths[index];
+      }
+    });
+  }
+
+  /**
+   * Calcula, por coluna elástica (sem `width`) e percentual (`%`), a maior largura de conteúdo
+   * considerando o dataset (`filteredItems`) — e não apenas as linhas renderizadas no virtual
+   * scroll — gravando-a em `naturalWidths` como piso de conteúdo. O texto é medido fora do DOM com
+   * Canvas `measureText`, usando a mesma fonte da célula; o espaço não-textual (padding/borda) é
+   * calibrado a partir de uma célula real já renderizada (largura do `td` em `max-content` menos a
+   * largura do seu texto no canvas). Assim a coluna já nasce na largura final, sem depender de rolar
+   * até o conteúdo mais largo — o que o auto-layout de tabela única da master faz de graça, mas o
+   * layout de tabelas separadas + colgroup fixo desta branch não permite. Colunas com px explícito
+   * são ignoradas (a largura fixa definida pelo usuário é respeitada).
+   */
+  private expandDataColumnWidthsForFullDataset(
+    headerCells: Array<HTMLElement>,
+    bodyCells: Array<HTMLElement>,
+    naturalWidths: Array<number>
+  ): void {
+    const items = this.filteredItems;
+    if (!items?.length) return;
+
+    const { dataIndexes } = this.getColumnIndexes(headerCells);
+    if (!dataIndexes.length) return;
+
+    const context = this.getMeasureContext();
+    if (!context) return;
+
+    // Cache do maior texto por coluna, invalidado quando a lista (referência) muda.
+    if (this.datasetTextCacheToken !== items) {
+      this.datasetTextCache.clear();
+      this.datasetTextCacheToken = items;
+    }
+
+    dataIndexes.forEach((cellIndex, dataColumnIndex) => {
+      const column = this.mainColumns[dataColumnIndex];
+      const cell = bodyCells[cellIndex];
+      if (!column || !cell) return;
+
+      // Apenas colunas elásticas (sem width) e percentuais recebem o piso de conteúdo do dataset
+      // completo. Colunas com px explícito mantêm a largura definida pelo usuário (podem truncar
+      // intencionalmente), então são ignoradas aqui.
+      const measuredWidth = typeof column.width === 'string' ? column.width.trim() : column.width;
+      const isPercent = typeof measuredWidth === 'string' && measuredWidth.endsWith('%');
+      const isElastic = !column.width;
+      if (!isElastic && !isPercent) return;
+
+      const contentEl = cell.querySelector('.po-table-column-cell') ?? cell;
+      const style = getComputedStyle(contentEl);
+      context.font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+
+      // Calibra padding + borda + eventuais ícones a partir da célula renderizada (em max-content).
+      const sampleText = (contentEl.textContent ?? '').trim();
+      const sampleTextWidth = context.measureText(sampleText).width;
+      const chrome = Math.max(0, cell.getBoundingClientRect().width - sampleTextWidth);
+
+      const cacheKey = `${column.property}|${context.font}`;
+      let maxTextWidth = this.datasetTextCache.get(cacheKey);
+      if (maxTextWidth === undefined) {
+        maxTextWidth = 0;
+
+        for (const item of items) {
+          const value = this.getCellData(item, column);
+          const text = value === null || value === undefined ? '' : String(value);
+          const width = context.measureText(text).width;
+          if (width > maxTextWidth) {
+            maxTextWidth = width;
+          }
+        }
+
+        this.datasetTextCache.set(cacheKey, maxTextWidth);
+      }
+
+      const needed = Math.ceil(Math.max(maxTextWidth, sampleTextWidth) + chrome);
+      if (needed > naturalWidths[cellIndex]) {
+        naturalWidths[cellIndex] = needed;
+      }
+    });
+  }
+
+  private getMeasureContext(): CanvasRenderingContext2D | undefined {
+    this.measureCanvasContext ??= document.createElement('canvas').getContext('2d') ?? undefined;
+    return this.measureCanvasContext;
+  }
+
+  private syncHeaderScrollFromViewport(): void {
+    const viewportEl = this.tableVirtualScroll?.nativeElement as HTMLElement | undefined;
+    if (viewportEl) this.syncHeaderScrollLeft(viewportEl.scrollLeft);
+  }
+
+  /**
+   * Reavalia o infinite scroll após o layout do virtual scroll estar pronto. O `checkInfiniteScroll`
+   * pode ter desligado `infiniteScroll` prematuramente quando o `scrollHeight` do viewport ainda era 0
+   * (antes da renderização). Aqui restaura a intenção original do usuário e reavalia com o layout real,
+   * registrando o listener de scroll (e ocultando o botão "carregar mais") quando há conteúdo rolável.
+   */
+  private reevaluateInfiniteScroll(): void {
+    if (this.requestedInfiniteScroll && !this.subscriptionScrollEvent && this.height > 0) {
+      this.infiniteScroll = true;
+      this.checkInfiniteScroll();
+    }
+  }
+
+  private measureNaturalColumnWidths(
+    headerTable: HTMLElement,
+    bodyTable: HTMLElement,
+    headerCells: Array<HTMLElement>,
+    bodyCells: Array<HTMLElement>,
+    count: number
+  ): Array<number> {
+    this.resetTableLayout(headerTable);
+    this.resetTableLayout(bodyTable);
+    this.renderer.setStyle(headerTable, 'width', 'max-content');
+    this.renderer.setStyle(bodyTable, 'width', 'max-content');
+
+    // Força reflow para que as medições reflitam o layout natural já recalculado.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    bodyTable.offsetWidth;
+
+    // Mede o header (uma row).
+    const widths: Array<number> = [];
+    for (let i = 0; i < count; i++) {
+      widths.push(headerCells[i].getBoundingClientRect().width);
+    }
+
+    // Mede TODAS as rows renderizadas do body e pega o máximo por coluna. Isso garante que colunas
+    // com conteúdo largo em rows fora da 1ª (ex.: emails longos, nomes completos) definam a largura
+    // mínima — reproduzindo o comportamento do `table-layout: auto` da master, onde o browser
+    // considerava todas as linhas simultaneamente.
+    const bodyRows = bodyTable.querySelectorAll(this.SELECTOR_BODY_DATA_ROW);
+    bodyRows.forEach(row => {
+      const cells = row.children;
+      const cellCount = Math.min(cells.length, count);
+      for (let i = 0; i < cellCount; i++) {
+        const cellWidth = (cells[i] as HTMLElement).getBoundingClientRect().width;
+        if (cellWidth > widths[i]) {
+          widths[i] = cellWidth;
+        }
+      }
+    });
+
+    return widths;
+  }
+
+  /**
+   * Aplica a política de distribuição de largura sobre as larguras naturais medidas:
+   * - Quando há colunas elásticas (sem `width`), elas absorvem toda a diferença em relação ao container
+   *   (crescem quando sobra espaço, encolhem quando falta), fazendo a tabela caber exatamente no viewport.
+   * - Quando não há elásticas (todas com `width` px ou %) e sobra espaço, o restante é distribuído
+   *   proporcionalmente entre as colunas de dados, preenchendo o viewport (equivalente à master).
+   * - Quando não há elásticas e as larguras excedem o container, a tabela mantém a largura natural
+   *   (scroll horizontal legítimo).
+   *
+   * As larguras medidas já refletem o `width` explícito (px ou %), pois a medição ocorre com as células
+   * carregando o `width` definido; por isso não há nova resolução de valores aqui.
+   */
+  private distributeColumnWidths(headerCells: Array<HTMLElement>, naturalWidths: Array<number>): Array<number> {
+    const widths = naturalWidths.slice();
+    const containerWidth = this.getViewportContentWidth();
+
+    // Resolve colunas com width em `%` contra o espaço disponível (container menos colunas não-%),
+    // reproduzindo o comportamento do `table-layout: fixed` da master. Sem isso, a medição em max-content
+    // dimensionaria as colunas `%` pelo conteúdo, gerando overflow indevido.
+    this.resolvePercentWidths(headerCells, widths, containerWidth);
+
+    const { dataIndexes, elasticIndexes } = this.getColumnIndexes(headerCells);
+    const naturalTotal = widths.reduce((total, width) => total + width, 0);
+    const extraWidth = containerWidth - naturalTotal;
+
+    let target = Math.round(naturalTotal);
+    let shouldFill = false;
+
+    if (containerWidth > 0 && extraWidth > 0) {
+      shouldFill = true;
+      if (elasticIndexes.length) {
+        this.distributeAmong(widths, elasticIndexes, extraWidth);
+        target = containerWidth;
+      } else if (dataIndexes.length) {
+        this.distributeProportionally(widths, dataIndexes, extraWidth);
+        target = containerWidth;
+      }
+    }
+
+    if (!shouldFill) return widths;
+
+    const adjustIndexes = elasticIndexes.length ? elasticIndexes : dataIndexes;
+    return this.roundWidthsToTarget(widths, target, adjustIndexes);
+  }
+
+  /**
+   * Mapeia as células do header em índices de colunas de dados (`po-table-header-ellipsis`) e, dentre elas,
+   * as elásticas (sem `width` definido em `mainColumns`).
+   */
+  private getColumnIndexes(headerCells: Array<HTMLElement>): {
+    dataIndexes: Array<number>;
+    elasticIndexes: Array<number>;
+  } {
+    const dataIndexes: Array<number> = [];
+    const elasticIndexes: Array<number> = [];
+    let dataColumnIndex = 0;
+
+    headerCells.forEach((cell, index) => {
+      if (cell.classList.contains('po-table-header-ellipsis')) {
+        dataIndexes.push(index);
+        const column = this.mainColumns[dataColumnIndex];
+        if (column && !column.width) {
+          elasticIndexes.push(index);
+        }
+        dataColumnIndex++;
+      }
+    });
+
+    return { dataIndexes, elasticIndexes };
+  }
+
+  /**
+   * Resolve as larguras das colunas de dados com `width` em porcentagem. O `%` é resolvido contra o
+   * espaço disponível (container menos a soma das demais colunas: estruturais, elásticas e px),
+   * reproduzindo o `table-layout: fixed` + `width: 100%` da master. Quando a soma dos percentuais excede
+   * 100, normaliza para caber; quando não há colunas `%`, é no-op.
+   */
+  private resolvePercentWidths(headerCells: Array<HTMLElement>, widths: Array<number>, containerWidth: number): void {
+    if (containerWidth <= 0) return;
+
+    const percentColumns: Array<{ index: number; percent: number }> = [];
+    let dataColumnIndex = 0;
+
+    headerCells.forEach((cell, index) => {
+      if (cell.classList.contains('po-table-header-ellipsis')) {
+        const width = this.mainColumns[dataColumnIndex]?.width;
+        if (typeof width === 'string' && width.trim().endsWith('%')) {
+          const percent = Number.parseFloat(width);
+          if (!Number.isNaN(percent) && percent > 0) {
+            percentColumns.push({ index, percent });
+          }
+        }
+        dataColumnIndex++;
+      }
+    });
+
+    if (!percentColumns.length) return;
+
+    const totalPercent = percentColumns.reduce((total, column) => total + column.percent, 0);
+    const divisor = Math.max(totalPercent, 100);
+
+    if (this.applyFixedColumns()) {
+      // TODAS as colunas tem width → resolve % contra espaço disponível.
+      const percentIndexes = new Set(percentColumns.map(column => column.index));
+      const nonPercentTotal = widths.reduce(
+        (total, width, index) => (percentIndexes.has(index) ? total : total + width),
+        0
+      );
+      const available = containerWidth - nonPercentTotal;
+      if (available <= 0) return;
+
+      // TODAS as colunas têm width (nenhuma elástica): a tabela fica presa ao container e as colunas
+      // `%` dividem o espaço disponível — o conteúdo pode truncar (idêntico à master, que também não
+      // cresce a tabela nesse cenário). Por isso aqui NÃO se aplica piso de conteúdo.
+      percentColumns.forEach(column => {
+        widths[column.index] = (column.percent / divisor) * available;
+      });
+    } else {
+      // Ha colunas elasticas → resolve % contra o container TOTAL, respeitando o conteúdo como piso.
+      percentColumns.forEach(column => {
+        widths[column.index] = Math.max((column.percent / divisor) * containerWidth, widths[column.index]);
+      });
+    }
+  }
+
+  /**
+   * Divide `extraWidth` igualmente entre as colunas informadas (pode ser negativo para encolher).
+   */
+  private distributeAmong(widths: Array<number>, indexes: Array<number>, extraWidth: number): void {
+    if (!indexes.length) return;
+
+    const share = extraWidth / indexes.length;
+    indexes.forEach(index => (widths[index] += share));
+  }
+
+  /**
+   * Distribui `extraWidth` proporcionalmente entre as colunas de dados, preservando suas proporções.
+   */
+  private distributeProportionally(widths: Array<number>, dataIndexes: Array<number>, extraWidth: number): void {
+    const dataTotal = dataIndexes.reduce((total, index) => total + widths[index], 0);
+    if (dataTotal > 0) {
+      dataIndexes.forEach(index => (widths[index] += extraWidth * (widths[index] / dataTotal)));
+    }
+  }
+
+  /**
+   * Converte larguras fracionárias em inteiros cuja soma é exatamente `target`, evitando que a soma
+   * ultrapasse o alvo (o que provocaria scroll horizontal por sub-pixel). O resto é somado 1px por vez,
+   * do fim para o início, priorizando as colunas indicadas em `adjustIndexes`.
+   */
+  private roundWidthsToTarget(widths: Array<number>, target: number, adjustIndexes: Array<number>): Array<number> {
+    const rounded = widths.map(width => Math.max(0, Math.floor(width)));
+    const currentTotal = rounded.reduce((total, width) => total + width, 0);
+    let remainder = Math.round(target) - currentTotal;
+
+    const fillIndexes = adjustIndexes.length ? adjustIndexes : rounded.map((_, index) => index);
+    for (let position = fillIndexes.length - 1; remainder > 0 && position >= 0; position--, remainder--) {
+      rounded[fillIndexes[position]] += 1;
+    }
+
+    return rounded;
+  }
+
+  private getViewportContentWidth(): number {
+    const viewportEl = this.tableVirtualScroll?.nativeElement as HTMLElement | undefined;
+    return viewportEl ? viewportEl.clientWidth : 0;
+  }
+
+  private applySharedColumnLayout(table: HTMLElement, widths: Array<number>, totalWidth: number): void {
+    this.applyColgroup(table, widths);
+    this.renderer.setStyle(table, 'table-layout', 'fixed');
+    this.renderer.setStyle(table, 'width', `${totalWidth}px`);
+    this.renderer.setStyle(table, 'min-width', `${totalWidth}px`);
+  }
+
+  private syncHeaderTableWidth(): void {
+    if (this.headerTableElement?.nativeElement) {
+      const newWidth = this.headerTableElement.nativeElement.scrollWidth;
+      if (newWidth !== this.headerTableScrollWidth) {
+        this.headerTableScrollWidth = newWidth;
+        this.changeDetector.markForCheck();
+      }
     }
   }
 }


### PR DESCRIPTION
Tabela com muitos itens ao realizar o scroll acontece flickering (piscar) em toda tabela. Extrai o de dentro do 'cdk-virtual-scroll-viewport' mantendo a visualização da tag ao realizar o scroll.

Feat: DTHFUI-11105

PO-TABLE

DTHFUI-13182
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

Qual o comportamento atual?
Tabela com muitos itens ao realizar o scroll acontece flickering (piscar) em toda tabela.

Qual o novo comportamento?
Extrai o de dentro do 'cdk-virtual-scroll-viewport' mantendo a visualização da tag ao realizar o scroll. COMPONENTE

