### PR TITLE
fix(multiselect): corrige validação ao remover tags compactadas

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -442,6 +442,32 @@ describe('PoMultiselectComponent:', () => {
     expect(component.selectedOptions.some(opt => opt.value === 0)).toBeFalse();
   });
 
+  it('closeTag: should remove items not in visibleTags when value is empty string', () => {
+    component.visibleTags = [
+      { label: 'label', value: 1 },
+      { label: 'label2', value: 2 },
+      { label: '+2', value: '' }
+    ];
+
+    component.selectedOptions = [
+      component.visibleTags[0],
+      component.visibleTags[1],
+      { label: 'label3', value: 3 },
+      { label: 'label4', value: 4 }
+    ];
+
+    spyOn(component, 'updateVisibleItems');
+    spyOn(component, 'callOnChange');
+
+    component['closeTag']('', 'click');
+
+    expect(component.updateVisibleItems).toHaveBeenCalled();
+    expect(component.callOnChange).toHaveBeenCalled();
+    expect(component.selectedOptions.length).toBe(2);
+    expect(component.selectedOptions[0].value).toBe(1);
+    expect(component.selectedOptions[1].value).toBe(2);
+  });
+
   describe('showAdditionalHelp:', () => {
     let helperEl: any;
     beforeEach(() => {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -486,7 +486,7 @@ export class PoMultiselectComponent
   closeTag(value, event) {
     let index;
     this.enterCloseTag = true;
-    if (value === null || value === undefined || (typeof value === 'string' && value.includes('+'))) {
+    if (value == null || value === '' || (typeof value === 'string' && value.includes('+'))) {
       index = null;
       const itemsNotInVisibleTags = this.selectedOptions.filter(option => !this.visibleTags.includes(option));
       for (const option of this.visibleTags) {


### PR DESCRIPTION
Ajusta a validação da remoção de tags compactadas.

Fixes #2845

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
