### PR TITLE
fix(page-dynamic-search): exibe label customizado em disclaimer boolean

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/interfaces/po-page-dynamic-search-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/interfaces/po-page-dynamic-search-literals.interface.ts
@@ -6,6 +6,18 @@
  * Interface para definição das literais usadas no `po-page-dynamic-search` e no `po-page-dynamic-table`.
  */
 export interface PoPageDynamicSearchLiterals {
+  /**
+   * Texto exibido no *disclaimer* de filtros do tipo `boolean` quando o valor for `false` e
+   * a propriedade `booleanFalse` do campo não estiver definida.
+   */
+  disclaimerBooleanFalse?: string;
+
+  /**
+   * Texto exibido no *disclaimer* de filtros do tipo `boolean` quando o valor for `true` e
+   * a propriedade `booleanTrue` do campo não estiver definida.
+   */
+  disclaimerBooleanTrue?: string;
+
   /** Título do grupo de *disclaimers* que será exibido após realizar alguma busca. */
   disclaimerGroupTitle?: string;
 

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
@@ -18,6 +18,8 @@ import { PoAdvancedFilterLiterals } from './po-advanced-filter/po-advanced-filte
 
 export const poPageDynamicSearchLiteralsDefault = {
   en: <PoPageDynamicSearchLiterals>{
+    disclaimerBooleanFalse: 'No',
+    disclaimerBooleanTrue: 'Yes',
     disclaimerGroupTitle: 'Displaying results filtered by:',
     filterTitle: poAdvancedFiltersLiteralsDefault.en.title,
     filterCancelLabel: poAdvancedFiltersLiteralsDefault.en.cancelLabel,
@@ -26,6 +28,8 @@ export const poPageDynamicSearchLiteralsDefault = {
     searchPlaceholder: 'Search'
   },
   es: <PoPageDynamicSearchLiterals>{
+    disclaimerBooleanFalse: 'No',
+    disclaimerBooleanTrue: 'Sí',
     disclaimerGroupTitle: 'Presentando resultados filtrados por:',
     filterTitle: poAdvancedFiltersLiteralsDefault.es.title,
     filterCancelLabel: poAdvancedFiltersLiteralsDefault.es.cancelLabel,
@@ -34,6 +38,8 @@ export const poPageDynamicSearchLiteralsDefault = {
     searchPlaceholder: 'Buscar'
   },
   pt: <PoPageDynamicSearchLiterals>{
+    disclaimerBooleanFalse: 'Não',
+    disclaimerBooleanTrue: 'Sim',
     disclaimerGroupTitle: 'Apresentando resultados filtrados por:',
     filterTitle: poAdvancedFiltersLiteralsDefault.pt.title,
     filterCancelLabel: poAdvancedFiltersLiteralsDefault.pt.cancelLabel,
@@ -42,6 +48,8 @@ export const poPageDynamicSearchLiteralsDefault = {
     searchPlaceholder: 'Pesquisar'
   },
   ru: <PoPageDynamicSearchLiterals>{
+    disclaimerBooleanFalse: 'Нет',
+    disclaimerBooleanTrue: 'Да',
     disclaimerGroupTitle: 'Отображение результатов, отфильтрованных по:',
     filterTitle: poAdvancedFiltersLiteralsDefault.ru.title,
     filterCancelLabel: poAdvancedFiltersLiteralsDefault.ru.cancelLabel,
@@ -273,6 +281,8 @@ export abstract class PoPageDynamicSearchBaseComponent {
    *
    * ```
    *  const customLiterals: PoPageDynamicSearchLiterals = {
+   *    disclaimerBooleanFalse: 'Inativo',
+   *    disclaimerBooleanTrue: 'Ativo',
    *    disclaimerGroupTitle: 'Filtros aplicados:',
    *    filterTitle: 'Filtro avançado',
    *    filterCancelLabel: 'Fechar',

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -880,6 +880,204 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(result).toBe(123);
     });
 
+    it('getFilterValueToDisclaimer: should return `booleanTrue` value when field type is `boolean` and value is `true`', () => {
+      const field = {
+        property: 'active',
+        type: PoDynamicFieldType.Boolean,
+        booleanTrue: 'Ativo',
+        booleanFalse: 'Inativo'
+      };
+
+      const result = component['getFilterValueToDisclaimer'](field, true);
+
+      expect(result).toBe('Ativo');
+    });
+
+    it('getFilterValueToDisclaimer: should return `booleanFalse` value when field type is `boolean` and value is `false`', () => {
+      const field = {
+        property: 'active',
+        type: PoDynamicFieldType.Boolean,
+        booleanTrue: 'Ativo',
+        booleanFalse: 'Inativo'
+      };
+
+      const result = component['getFilterValueToDisclaimer'](field, false);
+
+      expect(result).toBe('Inativo');
+    });
+
+    it('getFilterValueToDisclaimer: should return literal `disclaimerBooleanTrue` when value is `true` and `booleanTrue` is undefined', () => {
+      component['languageService'].setLanguage('pt');
+      const field = { property: 'active', type: PoDynamicFieldType.Boolean };
+
+      const result = component['getFilterValueToDisclaimer'](field, true);
+
+      expect(result).toBe('Sim');
+    });
+
+    it('getFilterValueToDisclaimer: should return literal `disclaimerBooleanFalse` when value is `false` and `booleanFalse` is undefined', () => {
+      component['languageService'].setLanguage('pt');
+      const field = { property: 'active', type: PoDynamicFieldType.Boolean };
+
+      const result = component['getFilterValueToDisclaimer'](field, false);
+
+      expect(result).toBe('Não');
+    });
+
+    it('getFilterValueToDisclaimer: should fall back to literals in english when language is `en`', () => {
+      component['languageService'].setLanguage('en');
+      const field = { property: 'active', type: PoDynamicFieldType.Boolean };
+
+      expect(component['getFilterValueToDisclaimer'](field, true)).toBe('Yes');
+      expect(component['getFilterValueToDisclaimer'](field, false)).toBe('No');
+    });
+
+    it('getFilterValueToDisclaimer: should fall back to literals in spanish when language is `es`', () => {
+      component['languageService'].setLanguage('es');
+      const field = { property: 'active', type: PoDynamicFieldType.Boolean };
+
+      expect(component['getFilterValueToDisclaimer'](field, true)).toBe('Sí');
+      expect(component['getFilterValueToDisclaimer'](field, false)).toBe('No');
+    });
+
+    it('getFilterValueToDisclaimer: should fall back to literals in russian when language is `ru`', () => {
+      component['languageService'].setLanguage('ru');
+      const field = { property: 'active', type: PoDynamicFieldType.Boolean };
+
+      expect(component['getFilterValueToDisclaimer'](field, true)).toBe('Да');
+      expect(component['getFilterValueToDisclaimer'](field, false)).toBe('Нет');
+    });
+
+    it('getFilterValueToDisclaimer: should fall back to default locale when current language is unsupported', () => {
+      spyOn(component['languageService'], 'getShortLanguage').and.returnValue('xx');
+      const field = { property: 'active', type: PoDynamicFieldType.Boolean };
+
+      expect(component['getFilterValueToDisclaimer'](field, true)).toBe('Sim');
+      expect(component['getFilterValueToDisclaimer'](field, false)).toBe('Não');
+    });
+
+    it('getFilterValueToDisclaimer: should ignore boolean handling when value is not a boolean primitive', () => {
+      const field = {
+        property: 'active',
+        type: PoDynamicFieldType.Boolean,
+        booleanTrue: 'Ativo',
+        booleanFalse: 'Inativo'
+      };
+
+      expect(component['getFilterValueToDisclaimer'](field, 'true')).toBe('true');
+      expect(component['getFilterValueToDisclaimer'](field, null)).toBeNull();
+      expect(component['getFilterValueToDisclaimer'](field, undefined)).toBeUndefined();
+    });
+
+    it('getFilterValueToDisclaimer: should prefer custom `booleanTrue/booleanFalse` over literals when both exist', () => {
+      component['languageService'].setLanguage('pt');
+      const field = {
+        property: 'active',
+        type: PoDynamicFieldType.Boolean,
+        booleanTrue: 'Ativo',
+        booleanFalse: 'Inativo'
+      };
+
+      expect(component['getFilterValueToDisclaimer'](field, true)).toBe('Ativo');
+      expect(component['getFilterValueToDisclaimer'](field, false)).toBe('Inativo');
+    });
+
+    it('formatValueToBoolean: should return `booleanTrue` value when value is `true` and `booleanTrue` is defined', () => {
+      const field = { property: 'active', booleanTrue: 'Ativo', booleanFalse: 'Inativo' };
+
+      expect(component['formatValueToBoolean'](field, true)).toBe('Ativo');
+    });
+
+    it('formatValueToBoolean: should return `booleanFalse` value when value is `false` and `booleanFalse` is defined', () => {
+      const field = { property: 'active', booleanTrue: 'Ativo', booleanFalse: 'Inativo' };
+
+      expect(component['formatValueToBoolean'](field, false)).toBe('Inativo');
+    });
+
+    it('formatValueToBoolean: should return literal `disclaimerBooleanTrue` when `booleanTrue` is undefined', () => {
+      component['languageService'].setLanguage('pt');
+      const field = { property: 'active' };
+
+      expect(component['formatValueToBoolean'](field, true)).toBe('Sim');
+    });
+
+    it('formatValueToBoolean: should return literal `disclaimerBooleanFalse` when `booleanFalse` is undefined', () => {
+      component['languageService'].setLanguage('pt');
+      const field = { property: 'active' };
+
+      expect(component['formatValueToBoolean'](field, false)).toBe('Não');
+    });
+
+    it('formatValueToBoolean: should never return raw boolean values as fallback', () => {
+      component['languageService'].setLanguage('en');
+      const field = { property: 'active' };
+
+      const trueResult = component['formatValueToBoolean'](field, true);
+      const falseResult = component['formatValueToBoolean'](field, false);
+
+      expect(typeof trueResult).toBe('string');
+      expect(typeof falseResult).toBe('string');
+      expect(trueResult).not.toBe('true');
+      expect(falseResult).not.toBe('false');
+    });
+
+    it('formatValueToBoolean: should respect `disclaimerBooleanTrue/False` from `p-literals` when defined', () => {
+      component.literals = {
+        disclaimerBooleanTrue: 'Habilitado',
+        disclaimerBooleanFalse: 'Desabilitado'
+      };
+      const field = { property: 'active' };
+
+      expect(component['formatValueToBoolean'](field, true)).toBe('Habilitado');
+      expect(component['formatValueToBoolean'](field, false)).toBe('Desabilitado');
+    });
+
+    it('formatValueToBoolean: should prefer field-level `booleanTrue/False` over `p-literals`', () => {
+      component.literals = {
+        disclaimerBooleanTrue: 'Habilitado',
+        disclaimerBooleanFalse: 'Desabilitado'
+      };
+      const field = { property: 'active', booleanTrue: 'Ativo', booleanFalse: 'Inativo' };
+
+      expect(component['formatValueToBoolean'](field, true)).toBe('Ativo');
+      expect(component['formatValueToBoolean'](field, false)).toBe('Inativo');
+    });
+
+    it('setDisclaimers: should generate disclaimer with custom `booleanTrue/booleanFalse` for boolean filters', () => {
+      component.filters = [
+        {
+          property: 'active',
+          label: 'Situação',
+          type: PoDynamicFieldType.Boolean,
+          booleanTrue: 'Ativo',
+          booleanFalse: 'Inativo'
+        }
+      ];
+
+      const trueDisclaimers = component['setDisclaimers']({ active: true }, undefined, component.filters);
+      const falseDisclaimers = component['setDisclaimers']({ active: false }, undefined, component.filters);
+
+      expect(trueDisclaimers).toEqual([
+        { label: 'Situação: Ativo', property: 'active', value: true, hideClose: false }
+      ]);
+      expect(falseDisclaimers).toEqual([
+        { label: 'Situação: Inativo', property: 'active', value: false, hideClose: false }
+      ]);
+    });
+
+    it('setDisclaimers: should generate disclaimer with i18n fallback when boolean field has no custom labels', () => {
+      component['languageService'].setLanguage('pt');
+      component.filters = [{ property: 'active', label: 'Situação', type: PoDynamicFieldType.Boolean }];
+
+      const trueDisclaimers = component['setDisclaimers']({ active: true }, undefined, component.filters);
+      const falseDisclaimers = component['setDisclaimers']({ active: false }, undefined, component.filters);
+
+      expect(trueDisclaimers).toEqual([{ label: 'Situação: Sim', property: 'active', value: true, hideClose: false }]);
+      expect(falseDisclaimers).toEqual([
+        { label: 'Situação: Não', property: 'active', value: false, hideClose: false }
+      ]);
+    });
+
     it('should return an array of disclaimers for filters with fixed property, initValue defined, and no duplicates', () => {
       component.filters = [
         { property: 'status', fixed: true, initValue: 'Active', label: 'Status' },

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -18,7 +18,8 @@ import {
   PoDynamicFormField,
   PoLanguageService,
   PoPageFilter,
-  PoPageListComponent
+  PoPageListComponent,
+  poLocaleDefault
 } from '@po-ui/ng-components';
 import { Observable, Subscription } from 'rxjs';
 
@@ -29,7 +30,10 @@ import { PoPageDynamicOptionsSchema } from '../../services';
 import { PoPageDynamicSearchFilters } from './interfaces/po-page-dynamic-search-filters.interface';
 import { PoPageDynamicSearchOptions } from './interfaces/po-page-dynamic-search-options.interface';
 import { PoAdvancedFilterComponent } from './po-advanced-filter/po-advanced-filter.component';
-import { PoPageDynamicSearchBaseComponent } from './po-page-dynamic-search-base.component';
+import {
+  PoPageDynamicSearchBaseComponent,
+  poPageDynamicSearchLiteralsDefault
+} from './po-page-dynamic-search-base.component';
 
 type UrlOrPoCustomizationFunction = string | (() => PoPageDynamicSearchOptions);
 
@@ -302,11 +306,35 @@ export class PoPageDynamicSearchComponent
       return field.range ? this.formatDate(value.start) + ' - ' + this.formatDate(value.end) : this.formatDate(value);
     }
 
+    if (field.type === PoDynamicFieldType.Boolean && typeof value === 'boolean') {
+      return this.formatValueToBoolean(field, value);
+    }
+
     if (field.options && value) {
       return this.applyDisclaimerLabelValue(field, value);
     }
 
     return value;
+  }
+
+  private formatValueToBoolean(field: PoDynamicFormField, value: boolean): string {
+    if (value && field.booleanTrue) {
+      return field.booleanTrue;
+    }
+
+    if (!value && field.booleanFalse) {
+      return field.booleanFalse;
+    }
+
+    const language = this.languageService.getShortLanguage();
+    const fallbackLiterals =
+      poPageDynamicSearchLiteralsDefault[language] ?? poPageDynamicSearchLiteralsDefault[poLocaleDefault];
+
+    const customLiterals = this['_literals'];
+    const trueLabel = customLiterals?.disclaimerBooleanTrue ?? fallbackLiterals.disclaimerBooleanTrue;
+    const falseLabel = customLiterals?.disclaimerBooleanFalse ?? fallbackLiterals.disclaimerBooleanFalse;
+
+    return value ? trueLabel : falseLabel;
   }
 
   private emitChangesDisclaimers(currentDisclaimers: any) {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
@@ -79,7 +79,8 @@ export class SamplePoPageDynamicSearchHiringProcessesComponent implements OnInit
     { property: 'hireStatus', label: 'Hire Status', options: this.statusOptions, gridColumns: 6 },
     { property: 'name', gridColumns: 6 },
     { property: 'city', gridColumns: 6 },
-    { property: 'job', label: 'Job Description', options: this.jobDescriptionOptions, gridColumns: 6 }
+    { property: 'job', label: 'Job Description', options: this.jobDescriptionOptions, gridColumns: 6 },
+    { property: 'active', label: 'Active', type: 'boolean', booleanTrue: 'Yes', booleanFalse: 'No', gridColumns: 6 }
   ];
 
   ngOnInit() {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.service.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.service.ts
@@ -38,7 +38,8 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
       { property: 'name', label: 'Name' },
       { property: 'age', label: 'Age' },
       { property: 'city', label: 'City' },
-      { property: 'jobDescription', label: 'Job description', type: 'string' }
+      { property: 'jobDescription', label: 'Job description', type: 'string' },
+      { property: 'active', label: 'Active', type: 'boolean', boolean: { trueLabel: 'Yes', falseLabel: 'No' } }
     ];
   }
 
@@ -59,7 +60,8 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
         age: 24,
         idCard: 'AB34lxi90',
         job: 'abc',
-        jobDescription: 'Systems Analyst'
+        jobDescription: 'Systems Analyst',
+        active: true
       },
       {
         hireStatus: '2',
@@ -68,7 +70,8 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
         age: 23,
         idCard: 'HG56lds54',
         job: 'def',
-        jobDescription: 'Trainee'
+        jobDescription: 'Trainee',
+        active: true
       },
       {
         hireStatus: '3',
@@ -77,7 +80,8 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
         age: 31,
         idCard: 'DF23cfr65',
         job: 'ghi',
-        jobDescription: 'Programmer'
+        jobDescription: 'Programmer',
+        active: false
       },
       {
         hireStatus: '1',
@@ -86,7 +90,8 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
         age: 29,
         idCard: 'GF45fgh34',
         job: 'jkl',
-        jobDescription: 'Web developer'
+        jobDescription: 'Web developer',
+        active: true
       },
       {
         hireStatus: '1',
@@ -95,7 +100,8 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
         age: 34,
         idCard: 'RF76jut21',
         job: 'mno',
-        jobDescription: 'Recruiter'
+        jobDescription: 'Recruiter',
+        active: true
       },
       {
         hireStatus: '2',
@@ -104,7 +110,8 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
         age: 32,
         idCard: 'HY21kgu65',
         job: 'pqr',
-        jobDescription: 'Consultant'
+        jobDescription: 'Consultant',
+        active: false
       },
       {
         hireStatus: '1',
@@ -113,7 +120,8 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
         age: 24,
         idCard: 'UL78flg68',
         job: 'stu',
-        jobDescription: 'DBA'
+        jobDescription: 'DBA',
+        active: true
       },
       {
         hireStatus: '2',
@@ -122,7 +130,8 @@ export class SamplePoPageDynamicSearchHiringProcessesService {
         age: 29,
         idCard: 'JH12oli98',
         job: 'ghi',
-        jobDescription: 'Programmer'
+        jobDescription: 'Programmer',
+        active: false
       }
     ];
   }

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -540,6 +540,8 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
    *
    * ```
    *  const customLiterals: PoPageDynamicSearchLiterals = {
+   *    disclaimerBooleanFalse: 'Inativo',
+   *    disclaimerBooleanTrue: 'Ativo',
    *    disclaimerGroupTitle: 'Filtros aplicados:',
    *    filterTitle: 'Filtro avançado',
    *    filterCancelLabel: 'Fechar',


### PR DESCRIPTION
page-dynamic-search

DTHFUI-11769
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao usar o parametro booleanTrue/booleanFalse da interface PoDynamicFormField, o disclaimer gerado nos filtros da busca avançada fica com o valor booleano e não o valor definido no booleanTrue/booleanFalse, conforme imagens anexadas. 

**Qual o novo comportamento?**
Que o disclaimer fique  com o mesmo valor da variavel booleanTrue/booleanFalse, sendo Sim/Não.

**Simulação**
