### PR TITLE
fix(button-group): ajusta visualização do tooltip

### DIFF
--- a/projects/ui/src/lib/components/po-button-group/po-button-group.component.html
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group.component.html
@@ -4,12 +4,13 @@
       class="po-sm-12 po-button-group"
       [class.po-button-group-button-selected]="button.selected"
       [class.po-button-group-disabled]="button.disabled"
-      p-tooltip-position="bottom"
       [p-disabled]="button.disabled"
       [p-icon]="button.icon"
       [p-label]="button.label"
       [p-size]="size"
       [p-tooltip]="!button.disabled ? button.tooltip : undefined"
+      p-tooltip-position="bottom"
+      [p-append-in-body]="true"
       (p-click)="onButtonClick(button, i); button.action(button)"
     >
     </po-button>

--- a/projects/ui/src/lib/components/po-button-group/po-button-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group.component.spec.ts
@@ -3,12 +3,10 @@ import { By } from '@angular/platform-browser';
 
 import { configureTestSuite } from './../../util-test/util-expect.spec';
 
-import { PoButtonModule } from '../po-button/po-button.module';
-
 import { PoButtonGroupBaseComponent } from './po-button-group-base.component';
 import { PoButtonGroupComponent } from './po-button-group.component';
 import { PoButtonGroupItem } from './po-button-group-item.interface';
-import { PoTooltipModule } from './../../directives/po-tooltip/po-tooltip.module';
+import { PoButtonGroupModule } from './po-button-group.module';
 
 describe('PoButtonGroupComponent:', () => {
   let component: PoButtonGroupComponent;
@@ -38,8 +36,7 @@ describe('PoButtonGroupComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [PoButtonModule, PoTooltipModule],
-      declarations: [PoButtonGroupComponent]
+      imports: [PoButtonGroupModule]
     });
   });
 
@@ -124,7 +121,7 @@ describe('PoButtonGroupComponent:', () => {
       expect(buttonEnabled.outerHTML).toContain('p-tooltip');
     });
 
-    it(`should contain 'tooltip' in button if button is 'enabled' and contains 'tooltip' property.`, fakeAsync(() => {
+    it(`should contain 'tooltip' in body if button is 'enabled' and contains 'tooltip' property.`, fakeAsync(() => {
       const button = fixture.debugElement.query(By.css('.po-button-group'));
 
       button.triggerEventHandler('mouseenter', null);
@@ -133,12 +130,14 @@ describe('PoButtonGroupComponent:', () => {
 
       tick(100);
 
-      const poTooltip = containerButtons.querySelector('.po-tooltip');
+      const poTooltip = document.body.querySelector('.po-tooltip');
 
       expect(poTooltip).toBeTruthy();
     }));
 
-    it(`shouldn't contain 'tooltip' in button if button is 'disabled' and contains 'tooltip' property.`, waitForAsync(() => {
+    it(`shouldn't contain 'tooltip' in body if button is 'disabled' and contains 'tooltip' property.`, waitForAsync(() => {
+      document.body.querySelectorAll('.po-tooltip').forEach(el => el.remove());
+
       const buttons = containerButtons.querySelectorAll('.po-button-group');
       const buttonDisabled = buttons[1];
 
@@ -146,7 +145,7 @@ describe('PoButtonGroupComponent:', () => {
 
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        const poTooltip = containerButtons.querySelector('.po-tooltip');
+        const poTooltip = document.body.querySelector('.po-tooltip');
 
         expect(poTooltip).toBeNull();
       });

--- a/projects/ui/src/lib/components/po-button-group/po-button-group.component.ts
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group.component.ts
@@ -23,6 +23,11 @@ import { PoButtonGroupBaseComponent } from './po-button-group-base.component';
  *  <file name="sample-po-button-group-attendance/sample-po-button-group-attendance.component.ts"> </file>
  * </example>
  *
+ * <example name="po-button-group-opening-service-ticket" title="PO Button Group - Opening Service Ticket">
+ *  <file name="sample-po-button-group-opening-service-ticket/sample-po-button-group-opening-service-ticket.component.html"> </file>
+ *  <file name="sample-po-button-group-opening-service-ticket/sample-po-button-group-opening-service-ticket.component.ts"> </file>
+ * </example>
+ *
  * <example name="po-button-group-post" title="PO Button Group - Post">
  *  <file name="sample-po-button-group-post/sample-po-button-group-post.component.html"> </file>
  *  <file name="sample-po-button-group-post/sample-po-button-group-post.component.ts"> </file>

--- a/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-opening-service-ticket/sample-po-button-group-opening-service-ticket.component.html
+++ b/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-opening-service-ticket/sample-po-button-group-opening-service-ticket.component.html
@@ -1,0 +1,19 @@
+<div class="po-font-title po-mb-2">Opening Service Ticket</div>
+
+<po-widget>
+  <div class="po-row">
+    <div class="po-md-12 po-mb-1 po-font-text-bold">Day of the week</div>
+    <div class="po-md-12 po-mb-3">
+      <po-button-group p-toggle="single" [p-buttons]="weekDays"> </po-button-group>
+    </div>
+
+    <div class="po-md-12 po-mb-3">
+      <po-button-group p-toggle="single" [p-buttons]="periods"> </po-button-group>
+    </div>
+
+    <po-divider></po-divider>
+
+    <div class="po-md-12 po-font-text"><strong>Selected day:</strong> {{ selectedWeekDay || 'None' }}</div>
+    <div class="po-md-12 po-font-text"><strong>Selected period:</strong> {{ selectedPeriod || 'None' }}</div>
+  </div>
+</po-widget>

--- a/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-opening-service-ticket/sample-po-button-group-opening-service-ticket.component.ts
+++ b/projects/ui/src/lib/components/po-button-group/samples/sample-po-button-group-opening-service-ticket/sample-po-button-group-opening-service-ticket.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+
+import { PoButtonGroupItem } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-button-group-opening-service-ticket',
+  templateUrl: './sample-po-button-group-opening-service-ticket.component.html',
+  standalone: false
+})
+export class SamplePoButtonGroupOpeningServiceTicketComponent {
+  selectedWeekDay: string = '';
+  selectedPeriod: string = '';
+
+  weekDays: Array<PoButtonGroupItem> = [
+    { label: 'Mon', tooltip: 'Monday', action: this.selectWeekDay.bind(this) },
+    { label: 'Tue', tooltip: 'Tuesday', action: this.selectWeekDay.bind(this) },
+    { label: 'Wed', tooltip: 'Wednesday', action: this.selectWeekDay.bind(this) },
+    { label: 'Thu', tooltip: 'Thursday', action: this.selectWeekDay.bind(this) },
+    { label: 'Fri', tooltip: 'Friday', action: this.selectWeekDay.bind(this) }
+  ];
+
+  periods: Array<PoButtonGroupItem> = [
+    { label: 'Morning', action: this.selectPeriod.bind(this) },
+    { label: 'Afternoon', action: this.selectPeriod.bind(this) },
+    { label: 'Evening', action: this.selectPeriod.bind(this) }
+  ];
+
+  selectWeekDay(button: PoButtonGroupItem): void {
+    this.selectedWeekDay = button.selected ? button.label! : '';
+  }
+
+  selectPeriod(button: PoButtonGroupItem): void {
+    this.selectedPeriod = button.selected ? button.label! : '';
+  }
+}

--- a/projects/ui/src/lib/components/po-field/po-search-ai/po-search-ai.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-search-ai/po-search-ai.component.spec.ts
@@ -28,6 +28,8 @@ describe('PoSearchAiComponent: ', () => {
     fixture = TestBed.createComponent(PoSearchAiComponent);
     component = fixture.componentInstance;
 
+    (component as any).language = 'en';
+
     serviceSpy = (component as any).searchAiService;
     spyOn(serviceSpy, 'sendQuery').and.returnValue(of({} as PoSearchAiResponse));
     spyOn(serviceSpy, 'extractColumnsMetadata').and.returnValue([]);


### PR DESCRIPTION
Ajusta a visualização do tooltip aplicado ao botão, para que ele não seja sobreposto por outros componentes que estejam com foco ativo.

Fixes DTHFUI-13364

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
