### PR TITLE
fix(button-group): ajusta visualização do tooltip

### DIFF
--- a/projects/ui/src/lib/components/po-button-group/po-button-group.component.html
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group.component.html
@@ -4,12 +4,13 @@
       class="po-sm-12 po-button-group"
       [class.po-button-group-button-selected]="button.selected"
       [class.po-button-group-disabled]="button.disabled"
-      p-tooltip-position="bottom"
       [p-disabled]="button.disabled"
       [p-icon]="button.icon"
       [p-label]="button.label"
       [p-size]="size"
       [p-tooltip]="!button.disabled ? button.tooltip : undefined"
+      p-tooltip-position="bottom"
+      [p-append-in-body]="true"
       (p-click)="onButtonClick(button, i); button.action(button)"
     >
     </po-button>

--- a/projects/ui/src/lib/components/po-button-group/po-button-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button-group/po-button-group.component.spec.ts
@@ -3,12 +3,10 @@ import { By } from '@angular/platform-browser';
 
 import { configureTestSuite } from './../../util-test/util-expect.spec';
 
-import { PoButtonModule } from '../po-button/po-button.module';
-
 import { PoButtonGroupBaseComponent } from './po-button-group-base.component';
 import { PoButtonGroupComponent } from './po-button-group.component';
 import { PoButtonGroupItem } from './po-button-group-item.interface';
-import { PoTooltipModule } from './../../directives/po-tooltip/po-tooltip.module';
+import { PoButtonGroupModule } from './po-button-group.module';
 
 describe('PoButtonGroupComponent:', () => {
   let component: PoButtonGroupComponent;
@@ -38,8 +36,7 @@ describe('PoButtonGroupComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [PoButtonModule, PoTooltipModule],
-      declarations: [PoButtonGroupComponent]
+      imports: [PoButtonGroupModule]
     });
   });
 
@@ -124,7 +121,7 @@ describe('PoButtonGroupComponent:', () => {
       expect(buttonEnabled.outerHTML).toContain('p-tooltip');
     });
 
-    it(`should contain 'tooltip' in button if button is 'enabled' and contains 'tooltip' property.`, fakeAsync(() => {
+    it(`should contain 'tooltip' in body if button is 'enabled' and contains 'tooltip' property.`, fakeAsync(() => {
       const button = fixture.debugElement.query(By.css('.po-button-group'));
 
       button.triggerEventHandler('mouseenter', null);
@@ -133,12 +130,14 @@ describe('PoButtonGroupComponent:', () => {
 
       tick(100);
 
-      const poTooltip = containerButtons.querySelector('.po-tooltip');
+      const poTooltip = document.body.querySelector('.po-tooltip');
 
       expect(poTooltip).toBeTruthy();
     }));
 
-    it(`shouldn't contain 'tooltip' in button if button is 'disabled' and contains 'tooltip' property.`, waitForAsync(() => {
+    it(`shouldn't contain 'tooltip' in body if button is 'disabled' and contains 'tooltip' property.`, waitForAsync(() => {
+      document.body.querySelectorAll('.po-tooltip').forEach(el => el.remove());
+
       const buttons = containerButtons.querySelectorAll('.po-button-group');
       const buttonDisabled = buttons[1];
 
@@ -146,7 +145,7 @@ describe('PoButtonGroupComponent:', () => {
 
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        const poTooltip = containerButtons.querySelector('.po-tooltip');
+        const poTooltip = document.body.querySelector('.po-tooltip');
 
         expect(poTooltip).toBeNull();
       });


### PR DESCRIPTION
Ajusta a visualização do tooltip aplicado ao botão, para que ele não seja sobreposto por outros componentes que estejam com foco ativo.

Fixes DTHFUI-13364

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
