### PR TITLE
fix(fields): aceita boolean, number e string nas propriedades booleanas

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.spec.ts
@@ -381,22 +381,40 @@ describe('PoCheckboxGroupBaseComponent: ', () => {
   });
 
   describe('Properties: ', () => {
-    const trueValues = [true, 'true', 1, '', [], {}];
-    const falseValues = [false, 'false', 0, null, undefined, NaN];
-
-    it('p-disabled: should be update with valid and invalid values.', () => {
-      expectPropertiesValues(component, 'disabled', trueValues, true);
-      expectPropertiesValues(component, 'disabled', falseValues, false);
+    it('p-disabled: should update with true value.', () => {
+      component.disabled = true;
+      expect(component.disabled).toBeTrue();
     });
 
-    it('p-indeterminate: should be update with valid and invalid values.', () => {
-      expectPropertiesValues(component, 'indeterminate', trueValues, true);
-      expectPropertiesValues(component, 'indeterminate', falseValues, false);
+    it('p-disabled: should update with false value.', () => {
+      component.disabled = false;
+      expect(component.disabled).toBeFalse();
     });
 
-    it('p-required: should be update with valid and invalid values.', () => {
-      expectPropertiesValues(component, 'required', trueValues, true);
-      expectPropertiesValues(component, 'required', falseValues, false);
+    it('p-disabled: should coerce empty string to true via Angular transform', () => {
+      fixture.componentRef.setInput('p-disabled', '');
+      fixture.detectChanges();
+      expect(component.disabled).toBeTrue();
+    });
+
+    it('p-indeterminate: should update with true value.', () => {
+      component.indeterminate = true;
+      expect(component.indeterminate).toBeTrue();
+    });
+
+    it('p-indeterminate: should update with false value.', () => {
+      component.indeterminate = false;
+      expect(component.indeterminate).toBeFalse();
+    });
+
+    it('p-required: should update with true value.', () => {
+      component.required = true;
+      expect(component.required).toBeTrue();
+    });
+
+    it('p-required: should update with false value.', () => {
+      component.required = false;
+      expect(component.required).toBeFalse();
     });
 
     it('p-options: should be update with invalid values.', () => {
@@ -424,6 +442,7 @@ describe('PoCheckboxGroupBaseComponent: ', () => {
     });
 
     it('p-columns: should update property with `6` if invalid value', () => {
+      const falseValues = [false, 'false', 0, null, undefined, NaN];
       expectPropertiesValues(component, 'columns', falseValues, 6);
     });
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
@@ -299,8 +299,8 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
    *
    * @default `false`
    */
-  @Input('p-disabled') set disabled(value: boolean) {
-    this._disabled = convertToBoolean(value);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set disabled(value: boolean) {
+    this._disabled = value;
 
     this.validateModel(this.checkIndeterminate());
   }
@@ -322,8 +322,8 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
    *
    * @default `false`
    */
-  @Input('p-indeterminate') set indeterminate(indeterminate: boolean) {
-    this._indeterminate = convertToBoolean(indeterminate);
+  @Input({ alias: 'p-indeterminate', transform: convertToBoolean }) set indeterminate(indeterminate: boolean) {
+    this._indeterminate = indeterminate;
   }
 
   get indeterminate() {
@@ -356,8 +356,8 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
    *
    * @default `false`
    */
-  @Input('p-required') set required(required: boolean) {
-    this._required = convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(required: boolean) {
+    this._required = required;
 
     this.validateModel(this.checkIndeterminate());
   }

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.spec.ts
@@ -36,15 +36,19 @@ describe('PoCheckboxBaseComponent:', () => {
 
   describe('Properties:', () => {
     it('disabled: should update with true value', () => {
-      const booleanValidTrueValues = [true, 'true', 1, ''];
-
-      expectPropertiesValues(component, 'disabled', booleanValidTrueValues, true);
+      component.disabled = true;
+      expect(component.disabled).toBeTrue();
     });
 
     it('disabled: should update with false value', () => {
-      const booleanInvalidValues = [undefined, null, 2, 'string', 0, NaN, false];
+      component.disabled = false;
+      expect(component.disabled).toBeFalse();
+    });
 
-      expectPropertiesValues(component, 'disabled', booleanInvalidValues, false);
+    it('disabled: should coerce empty string to true via Angular transform', () => {
+      fixture.componentRef.setInput('p-disabled', '');
+      fixture.detectChanges();
+      expect(component.disabled).toBeTrue();
     });
 
     it('p-compact-label: should update property with `true` when input is true', () => {

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -227,8 +227,8 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
    *
    * @default `false`
    */
-  @Input('p-disabled') set disabled(value: boolean) {
-    this._disabled = convertToBoolean(value);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set disabled(value: boolean) {
+    this._disabled = value;
   }
 
   get disabled(): boolean {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -72,28 +72,39 @@ describe('PoComboBaseComponent:', () => {
   });
 
   describe('Properties:', () => {
-    const trueValues = [true, 'true', 1, '', [], {}];
-    const falseValues = [false, 'false', 0, null, undefined, NaN];
-
     it('p-compact-label: should have default value as false', () => {
       expect(component.compactLabel()).toBe(false);
     });
 
-    it('p-required: should be update with valid and invalid values and call validateModel with selectedValue.', () => {
+    it('p-required: should update with true value and call validateModel.', () => {
       spyOn(component, <any>'validateModel');
 
-      expectPropertiesValues(component, 'required', trueValues, true);
-      expectPropertiesValues(component, 'required', falseValues, false);
-
+      component.required = true;
+      expect(component.required).toBeTrue();
       expect(component['validateModel']).toHaveBeenCalledWith(component.selectedValue);
     });
 
-    it('p-disabled: should be update with valid and invalid values and call validateModel with selectedValue.', () => {
+    it('p-required: should update with false value and call validateModel.', () => {
       spyOn(component, <any>'validateModel');
 
-      expectPropertiesValues(component, 'disabled', trueValues, true);
-      expectPropertiesValues(component, 'disabled', falseValues, false);
+      component.required = false;
+      expect(component.required).toBeFalse();
+      expect(component['validateModel']).toHaveBeenCalledWith(component.selectedValue);
+    });
 
+    it('p-disabled: should update with true value and call validateModel.', () => {
+      spyOn(component, <any>'validateModel');
+
+      component.disabled = true;
+      expect(component.disabled).toBeTrue();
+      expect(component['validateModel']).toHaveBeenCalledWith(component.selectedValue);
+    });
+
+    it('p-disabled: should update with false value and call validateModel.', () => {
+      spyOn(component, <any>'validateModel');
+
+      component.disabled = false;
+      expect(component.disabled).toBeFalse();
       expect(component['validateModel']).toHaveBeenCalledWith(component.selectedValue);
     });
 
@@ -134,12 +145,14 @@ describe('PoComboBaseComponent:', () => {
       expect(spycomboListDefinitions).toHaveBeenCalled();
     });
 
-    it('p-infinite-scroll: should update property `p-infinite-scroll` with false.', () => {
-      expectPropertiesValues(component, 'infiniteScroll', falseValues, false);
+    it('p-infinite-scroll: should update property to false.', () => {
+      component.infiniteScroll = false;
+      expect(component.infiniteScroll).toBeFalse();
     });
 
-    it('p-infinite-scroll: should update property `p-infinite-scroll` with true.', () => {
-      expectPropertiesValues(component, 'infiniteScroll', trueValues, true);
+    it('p-infinite-scroll: should update property to true.', () => {
+      component.infiniteScroll = true;
+      expect(component.infiniteScroll).toBeTrue();
     });
 
     it('p-infinite-scroll-distance: should update property `p-infinite-scroll-distance` with valid values .', () => {
@@ -205,15 +218,14 @@ describe('PoComboBaseComponent:', () => {
       });
 
       describe('p-sort: ', () => {
-        const booleanInvalidValues = [undefined, null, 2, 'string'];
-        const booleanValidTrueValues = [true, 'true', 1, ''];
-
-        it('should update property `p-sort` with valid values.', () => {
-          expectPropertiesValues(component, 'sort', booleanValidTrueValues, true);
+        it('should update property `p-sort` to true.', () => {
+          component.sort = true;
+          expect(component.sort).toBeTrue();
         });
 
-        it('should update property `p-sort` with invalid values.', () => {
-          expectPropertiesValues(component, 'sort', booleanInvalidValues, false);
+        it('should update property `p-sort` to false.', () => {
+          component.sort = false;
+          expect(component.sort).toBeFalse();
         });
 
         it('should call `comboListDefinitions`', () => {
@@ -250,21 +262,6 @@ describe('PoComboBaseComponent:', () => {
         component.disabled = true;
         component.loading = false;
         expect(component.disabled).toBeTrue();
-      });
-
-      it('should set loading=true when input receives string empty', () => {
-        component.loading = '' as any;
-        expect(component.loading).toBeTrue();
-      });
-
-      it('should set loading=false when input receives string "false"', () => {
-        component.loading = 'false' as any;
-        expect(component.loading).toBeFalse();
-      });
-
-      it('should set loading=true when input receives string "true"', () => {
-        component.loading = 'true' as any;
-        expect(component.loading).toBeTrue();
       });
 
       it('should not throw when cd is undefined', () => {
@@ -411,16 +408,14 @@ describe('PoComboBaseComponent:', () => {
     expectSettersMethod(component, 'filterMode', PoComboFilterMode.endsWith, 'filterMode', PoComboFilterMode.endsWith);
   });
 
-  it('should update property `p-disabled-init-filter` with false when invalid values', () => {
-    const invalidValues = [undefined, null, 2, 'string'];
-
-    expectPropertiesValues(component, 'disabledInitFilter', invalidValues, false);
+  it('should update property `p-disabled-init-filter` to false', () => {
+    component.disabledInitFilter = false;
+    expect(component.disabledInitFilter).toBeFalse();
   });
 
-  it('should update property `p-disabled-init-filter` with valid values', () => {
-    const validValues = [true, 'true', 1, ''];
-
-    expectPropertiesValues(component, 'disabledInitFilter', validValues, true);
+  it('should update property `p-disabled-init-filter` to true', () => {
+    component.disabledInitFilter = true;
+    expect(component.disabledInitFilter).toBeTrue();
   });
 
   it('should update property `p-filter-minlength` with 0 when invalid values', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -218,8 +218,8 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @default `false`
    */
-  @Input('p-infinite-scroll') set infiniteScroll(value: boolean) {
-    this._infiniteScroll = convertToBoolean(value);
+  @Input({ alias: 'p-infinite-scroll', transform: convertToBoolean }) set infiniteScroll(value: boolean) {
+    this._infiniteScroll = value;
   }
 
   get infiniteScroll() {
@@ -323,7 +323,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @default `false`
    */
-  @Input('p-remove-initial-filter')
+  @Input({ alias: 'p-remove-initial-filter', transform: convertToBoolean })
   set removeInitialFilter(value: boolean) {
     this._removeInitialFilter = value;
     if (value) {
@@ -557,8 +557,8 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * @default `false`
    *
    */
-  @Input('p-disabled-init-filter') set disabledInitFilter(value: boolean) {
-    this._disabledInitFilter = convertToBoolean(value);
+  @Input({ alias: 'p-disabled-init-filter', transform: convertToBoolean }) set disabledInitFilter(value: boolean) {
+    this._disabledInitFilter = value;
   }
 
   get disabledInitFilter(): boolean {
@@ -647,8 +647,8 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @default `false`
    */
-  @Input('p-required') set required(required: boolean) {
-    this._required = convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(required: boolean) {
+    this._required = required;
 
     this.validateModel(this.selectedValue);
   }
@@ -698,8 +698,8 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @default `false`
    */
-  @Input('p-change-on-enter') set changeOnEnter(changeOnEnter: boolean) {
-    this._changeOnEnter = convertToBoolean(changeOnEnter);
+  @Input({ alias: 'p-change-on-enter', transform: convertToBoolean }) set changeOnEnter(changeOnEnter: boolean) {
+    this._changeOnEnter = changeOnEnter;
   }
 
   get changeOnEnter() {
@@ -714,8 +714,8 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    *
    * @default `false`
    */
-  @Input('p-disabled') set disabled(disabled: boolean) {
-    this._disabled = convertToBoolean(disabled);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set disabled(disabled: boolean) {
+    this._disabled = disabled;
 
     this.validateModel(this.selectedValue);
   }
@@ -733,9 +733,9 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * @default `false`
    */
   @HostBinding('attr.p-loading')
-  @Input('p-loading')
+  @Input({ alias: 'p-loading', transform: convertToBoolean })
   set loading(value: boolean) {
-    this._loading = convertToBoolean(value);
+    this._loading = value;
     this.changeDetector?.markForCheck();
   }
 
@@ -748,8 +748,8 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   }
 
   /** Indica que a lista definida na propriedade p-options será ordenada pela descrição. */
-  @Input('p-sort') set sort(sort: boolean) {
-    this._sort = convertToBoolean(sort);
+  @Input({ alias: 'p-sort', transform: convertToBoolean }) set sort(sort: boolean) {
+    this._sort = sort;
     this.comboListDefinitions();
   }
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -52,26 +52,24 @@ describe('PoDatepickerRangeBaseComponent:', () => {
       expect(component.compactLabel()).toBe(false);
     });
 
-    it('p-no-autocomplete: should update property with valid values with valid values.', () => {
-      const invalidValues = [undefined, null, 0, 'false', 'string'];
-      expectPropertiesValues(component, 'noAutocomplete', invalidValues, false);
+    it('p-no-autocomplete: should update property with false when set with invalid values.', () => {
+      component.noAutocomplete = false;
+      expect(component.noAutocomplete).toBeFalse();
     });
 
-    it('p-no-autocomplete: should update property with valid values with valid values.', () => {
-      const validValues = [true, 'true', 1, ' '];
-      expectPropertiesValues(component, 'noAutocomplete', validValues, true);
+    it('p-no-autocomplete: should update property with true when set with valid values.', () => {
+      component.noAutocomplete = true;
+      expect(component.noAutocomplete).toBeTrue();
     });
 
     it('clean: should update with true value.', () => {
-      const booleanValidTrueValues = [true, 'true', 1, ''];
-
-      expectPropertiesValues(component, 'clean', booleanValidTrueValues, true);
+      component.clean = true;
+      expect(component.clean).toBeTrue();
     });
 
     it('clean: should update with false value.', () => {
-      const booleanInvalidValues = [undefined, null, 2, 'string', 0, NaN, false];
-
-      expectPropertiesValues(component, 'clean', booleanInvalidValues, false);
+      component.clean = false;
+      expect(component.clean).toBeFalse();
     });
 
     it('max-date: should be update property p-max-date using string', () => {
@@ -140,15 +138,13 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('disabled: should update with true value.', () => {
-      const booleanValidTrueValues = [true, 'true', 1, ''];
-
-      expectPropertiesValues(component, 'disabled', booleanValidTrueValues, true);
+      component.disabled = true;
+      expect(component.disabled).toBeTrue();
     });
 
     it('disabled: should update with false value.', () => {
-      const booleanInvalidValues = [undefined, null, 2, 'string', 0, NaN, false];
-
-      expectPropertiesValues(component, 'disabled', booleanInvalidValues, false);
+      component.disabled = false;
+      expect(component.disabled).toBeFalse();
     });
 
     it('disabled: should call `validateModel` with `dateRange`.', () => {
@@ -250,7 +246,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         markForCheck: jasmine.createSpy('markForCheck')
       } as any;
 
-      component.loading = 'true' as any;
+      component.loading = true;
 
       expect(component['_loading']).toBeTrue();
       expect(component['changeDetector'].markForCheck).toHaveBeenCalled();
@@ -261,7 +257,7 @@ describe('PoDatepickerRangeBaseComponent:', () => {
         markForCheck: jasmine.createSpy('markForCheck')
       } as any;
 
-      component.loading = null;
+      component.loading = false;
 
       expect(component['_loading']).toBeFalse();
       expect(component['changeDetector'].markForCheck).toHaveBeenCalled();
@@ -274,15 +270,13 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('readonly: should update with true value.', () => {
-      const booleanValidTrueValues = [true, 'true', 1, ''];
-
-      expectPropertiesValues(component, 'readonly', booleanValidTrueValues, true);
+      component.readonly = true;
+      expect(component.readonly).toBeTrue();
     });
 
     it('readonly: should update with false value.', () => {
-      const booleanInvalidValues = [undefined, null, 2, 'string', 0, NaN, false];
-
-      expectPropertiesValues(component, 'readonly', booleanInvalidValues, false);
+      component.readonly = false;
+      expect(component.readonly).toBeFalse();
     });
 
     it('readonly: should call `validateModel`.', () => {
@@ -294,15 +288,13 @@ describe('PoDatepickerRangeBaseComponent:', () => {
     });
 
     it('required: should update with true value.', () => {
-      const booleanValidTrueValues = [true, 'true', 1, ''];
-
-      expectPropertiesValues(component, 'required', booleanValidTrueValues, true);
+      component.required = true;
+      expect(component.required).toBeTrue();
     });
 
     it('required: should update with false value.', () => {
-      const booleanInvalidValues = [undefined, null, 2, 'string', 0, NaN, false];
-
-      expectPropertiesValues(component, 'required', booleanInvalidValues, false);
+      component.required = false;
+      expect(component.required).toBeFalse();
     });
 
     it('required: should call `validateModel`.', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -417,8 +417,8 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    *
    * @default `false`
    */
-  @Input('p-clean') set clean(clean: boolean) {
-    this._clean = convertToBoolean(clean);
+  @Input({ alias: 'p-clean', transform: convertToBoolean }) set clean(clean: boolean) {
+    this._clean = clean;
   }
 
   get clean() {
@@ -434,8 +434,8 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    *
    * @default `false`
    */
-  @Input('p-disabled') set disabled(value: boolean) {
-    this._disabled = convertToBoolean(value);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set disabled(value: boolean) {
+    this._disabled = value;
 
     this.validateModel(this.dateRange);
   }
@@ -522,8 +522,8 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    *
    * @default `false`
    */
-  @Input('p-loading') set loading(value: boolean) {
-    this._loading = convertToBoolean(value);
+  @Input({ alias: 'p-loading', transform: convertToBoolean }) set loading(value: boolean) {
+    this._loading = value;
     this.changeDetector?.markForCheck();
   }
 
@@ -592,8 +592,8 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    *
    * @default `false`
    */
-  @Input('p-no-autocomplete') set noAutocomplete(value: boolean) {
-    this._noAutocomplete = convertToBoolean(value);
+  @Input({ alias: 'p-no-autocomplete', transform: convertToBoolean }) set noAutocomplete(value: boolean) {
+    this._noAutocomplete = value;
   }
 
   get noAutocomplete() {
@@ -609,8 +609,8 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    *
    * @default `false`
    */
-  @Input('p-readonly') set readonly(value: boolean) {
-    this._readonly = convertToBoolean(value);
+  @Input({ alias: 'p-readonly', transform: convertToBoolean }) set readonly(value: boolean) {
+    this._readonly = value;
 
     this.validateModel(this.dateRange);
   }
@@ -628,8 +628,8 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    *
    * @default `false`
    */
-  @Input('p-required') set required(required: boolean) {
-    this._required = convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(required: boolean) {
+    this._required = required;
 
     this.validateModel(this.dateRange);
   }

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -45,9 +45,8 @@ describe('PoDatepickerBaseComponent:', () => {
     spyOn(component, <any>'validateModel');
     spyOn(UtilsFunctions, 'convertDateToISOExtended');
 
-    expectSettersMethod(component, 'setDisabled', '', 'disabled', true);
-    expectSettersMethod(component, 'setDisabled', 'true', 'disabled', true);
-    expectSettersMethod(component, 'setDisabled', 'false', 'disabled', false);
+    expectSettersMethod(component, 'setDisabled', true, 'disabled', true);
+    expectSettersMethod(component, 'setDisabled', false, 'disabled', false);
 
     expect(component['validateModel']).toHaveBeenCalled();
     expect(UtilsFunctions.convertDateToISOExtended).toHaveBeenCalled();
@@ -57,24 +56,21 @@ describe('PoDatepickerBaseComponent:', () => {
     spyOn(component, <any>'validateModel');
     spyOn(UtilsFunctions, 'convertDateToISOExtended');
 
-    expectSettersMethod(component, 'setRequired', '', 'required', true);
-    expectSettersMethod(component, 'setRequired', 'true', 'required', true);
-    expectSettersMethod(component, 'setRequired', 'false', 'required', false);
+    expectSettersMethod(component, 'setRequired', true, 'required', true);
+    expectSettersMethod(component, 'setRequired', false, 'required', false);
 
     expect(component['validateModel']).toHaveBeenCalled();
     expect(UtilsFunctions.convertDateToISOExtended).toHaveBeenCalled();
   });
 
   it('should update property p-readonly', () => {
-    expectSettersMethod(component, 'setReadonly', '', 'readonly', true);
-    expectSettersMethod(component, 'setReadonly', 'true', 'readonly', true);
-    expectSettersMethod(component, 'setReadonly', 'false', 'readonly', false);
+    expectSettersMethod(component, 'setReadonly', true, 'readonly', true);
+    expectSettersMethod(component, 'setReadonly', false, 'readonly', false);
   });
 
   it('should update property p-clean', () => {
-    expectSettersMethod(component, 'setClean', '', 'clean', true);
-    expectSettersMethod(component, 'setClean', 'true', 'clean', true);
-    expectSettersMethod(component, 'setClean', 'false', 'clean', false);
+    expectSettersMethod(component, 'setClean', true, 'clean', true);
+    expectSettersMethod(component, 'setClean', false, 'clean', false);
   });
 
   it('should be update property p-min-date with 0 hours using string', () => {
@@ -150,7 +146,7 @@ describe('PoDatepickerBaseComponent:', () => {
   });
 
   it('should be null to invalid date', () => {
-    component['setRequired'] = 'false';
+    component['setRequired'] = false;
     component.format = 'dd/MM/yyyy';
 
     const date = component.getDateFromString('05/13/2017');
@@ -723,14 +719,14 @@ describe('PoDatepickerBaseComponent:', () => {
       expect(component.compactLabel()).toBe(false);
     });
 
-    it('p-no-autocomplete: should update property with valid values with valid values.', () => {
-      const invalidValues = [undefined, null, 0, 'false', 'string'];
-      expectPropertiesValues(component, 'noAutocomplete', invalidValues, false);
+    it('p-no-autocomplete: should update property to false.', () => {
+      component.noAutocomplete = false;
+      expect(component.noAutocomplete).toBeFalse();
     });
 
-    it('p-no-autocomplete: should update property with valid values with valid values.', () => {
-      const validValues = [true, 'true', 1, ' '];
-      expectPropertiesValues(component, 'noAutocomplete', validValues, true);
+    it('p-no-autocomplete: should update property to true.', () => {
+      component.noAutocomplete = true;
+      expect(component.noAutocomplete).toBeTrue();
     });
 
     it('isExtendedISO: should be false.', () => {
@@ -811,21 +807,21 @@ describe('PoDatepickerBaseComponent:', () => {
       expect(UtilsFunctions.setYearFrom0To100).toHaveBeenCalled();
     });
 
-    it('should convert value to boolean and call markForCheck', () => {
+    it('should set loading to true and call markForCheck', () => {
       const markForCheckSpy = spyOn(component['cd'], 'markForCheck');
 
-      component.loading = 'true' as any;
+      component.loading = true;
 
-      expect(component['_loading']).toBeTrue();
+      expect(component.loading).toBeTrue();
       expect(markForCheckSpy).toHaveBeenCalled();
     });
 
-    it('should set loading to false when value is falsy', () => {
+    it('should set loading to false and call markForCheck', () => {
       const markForCheckSpy = spyOn(component['cd'], 'markForCheck');
 
-      component.loading = null;
+      component.loading = false;
 
-      expect(component['_loading']).toBeFalse();
+      expect(component.loading).toBeFalse();
       expect(markForCheckSpy).toHaveBeenCalled();
     });
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -370,8 +370,8 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    *
    * @default `false`
    */
-  @Input('p-no-autocomplete') set noAutocomplete(value: boolean) {
-    this._noAutocomplete = convertToBoolean(value);
+  @Input({ alias: 'p-no-autocomplete', transform: convertToBoolean }) set noAutocomplete(value: boolean) {
+    this._noAutocomplete = value;
   }
 
   get noAutocomplete() {
@@ -396,8 +396,8 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   /** Desabilita o campo. */
   // eslint-disable-next-line @typescript-eslint/member-ordering
   disabled?: boolean = false;
-  @Input('p-disabled') set setDisabled(disabled: string) {
-    this.disabled = disabled === '' ? true : convertToBoolean(disabled);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set setDisabled(disabled: boolean) {
+    this.disabled = disabled;
 
     this.validateModel(PoUtils.convertDateToISOExtended(this.date, this.hour));
   }
@@ -405,8 +405,8 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   /** Torna o elemento somente leitura. */
   // eslint-disable-next-line @typescript-eslint/member-ordering
   readonly?: boolean = false;
-  @Input('p-readonly') set setReadonly(readonly: string) {
-    this.readonly = readonly === '' ? true : convertToBoolean(readonly);
+  @Input({ alias: 'p-readonly', transform: convertToBoolean }) set setReadonly(readonly: boolean) {
+    this.readonly = readonly;
   }
 
   /**
@@ -420,8 +420,8 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    */
   // eslint-disable-next-line @typescript-eslint/member-ordering
   required?: boolean = false;
-  @Input('p-required') set setRequired(required: string) {
-    this.required = required === '' ? true : convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set setRequired(required: boolean) {
+    this.required = required;
 
     this.validateModel(PoUtils.convertDateToISOExtended(this.date, this.hour));
   }
@@ -462,8 +462,8 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
   /** Habilita ação para limpar o campo. */
   // eslint-disable-next-line @typescript-eslint/member-ordering
   clean?: boolean = false;
-  @Input('p-clean') set setClean(clean: string) {
-    this.clean = clean === '' ? true : convertToBoolean(clean);
+  @Input({ alias: 'p-clean', transform: convertToBoolean }) set setClean(clean: boolean) {
+    this.clean = clean;
   }
 
   /**
@@ -615,8 +615,8 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    *
    * @default `false`
    */
-  @Input('p-loading') set loading(value: boolean) {
-    this._loading = convertToBoolean(value);
+  @Input({ alias: 'p-loading', transform: convertToBoolean }) set loading(value: boolean) {
+    this._loading = value;
     this.cd?.markForCheck();
   }
 

--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { configureTestSuite, expectPropertiesValues } from './../../../util-test/util-expect.spec';
+import { configureTestSuite } from './../../../util-test/util-expect.spec';
 
 import { PoFieldContainerComponent } from './po-field-container.component';
 import { poFieldContainerLiterals } from './po-field-container-literals';
@@ -29,40 +29,40 @@ describe('PoFieldContainerComponent:', () => {
   });
 
   describe('Properties: ', () => {
-    it('p-optional: should update property with `true` if valid values', () => {
-      const validValues = ['', true, 'true'];
-
-      expectPropertiesValues(component, 'optional', validValues, true);
+    it('p-optional: should update property with `true`', () => {
+      component.optional = true;
+      expect(component.optional).toBeTrue();
     });
 
-    it('p-optional: should update propert with `false` if invalid values', () => {
-      const invalidValues = ['false', false, 'abc', undefined, null];
-
-      expectPropertiesValues(component, 'optional', invalidValues, false);
+    it('p-optional: should update property with `false`', () => {
+      component.optional = false;
+      expect(component.optional).toBeFalse();
     });
 
-    it('p-required: should update property with `true` if valid values', () => {
-      const validValues = ['', true, 'true'];
-
-      expectPropertiesValues(component, 'required', validValues, true);
+    it('p-optional: should coerce empty string to true via Angular transform', () => {
+      fixture.componentRef.setInput('p-optional', '');
+      fixture.detectChanges();
+      expect(component.optional).toBeTrue();
     });
 
-    it('p-required: should update propert with `false` if invalid values', () => {
-      const invalidValues = ['false', false, 'abc', undefined, null];
-
-      expectPropertiesValues(component, 'required', invalidValues, false);
+    it('p-required: should update property with `true`', () => {
+      component.required = true;
+      expect(component.required).toBeTrue();
     });
 
-    it('p-show-required: should update property with `true` if valid values', () => {
-      const validValues = ['', true, 'true'];
-
-      expectPropertiesValues(component, 'required', validValues, true);
+    it('p-required: should update property with `false`', () => {
+      component.required = false;
+      expect(component.required).toBeFalse();
     });
 
-    it('p-show-required: should update propert with `false` if invalid values', () => {
-      const invalidValues = ['false', false, 'abc', undefined, null];
+    it('p-show-required: should update property with `true`', () => {
+      component.showRequired = true;
+      expect(component.showRequired).toBeTrue();
+    });
 
-      expectPropertiesValues(component, 'required', invalidValues, false);
+    it('p-show-required: should update property with `false`', () => {
+      component.showRequired = false;
+      expect(component.showRequired).toBeFalse();
     });
 
     it('p-compact-label: should update property with `true` when input is true', () => {

--- a/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-field-container/po-field-container.component.ts
@@ -70,8 +70,8 @@ export class PoFieldContainerComponent implements OnInit, OnChanges {
   private _required: boolean = false;
 
   /** Indica se o campo será opcional. */
-  @Input('p-optional') set optional(value: boolean) {
-    this._optional = convertToBoolean(value);
+  @Input({ alias: 'p-optional', transform: convertToBoolean }) set optional(value: boolean) {
+    this._optional = value;
   }
 
   get optional() {
@@ -79,8 +79,8 @@ export class PoFieldContainerComponent implements OnInit, OnChanges {
   }
 
   /** Indica se o campo será obrigatório. */
-  @Input('p-required') set required(value: boolean) {
-    this._required = convertToBoolean(value);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(value: boolean) {
+    this._required = value;
   }
 
   get required() {

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
@@ -53,33 +53,29 @@ describe('PoInputBase:', async () => {
   it('should set disabled', () => {
     spyOn(component, <any>'validateModel');
 
-    expectSettersMethod(component, 'setDisabled', '', 'disabled', true);
-    expectSettersMethod(component, 'setDisabled', 'true', 'disabled', true);
-    expectSettersMethod(component, 'setDisabled', 'false', 'disabled', false);
+    expectSettersMethod(component, 'setDisabled', true, 'disabled', true);
+    expectSettersMethod(component, 'setDisabled', false, 'disabled', false);
 
     expect(component['validateModel']).toHaveBeenCalled();
   });
 
   it('should set readonly', () => {
-    expectSettersMethod(component, 'setReadonly', '', 'readonly', true);
-    expectSettersMethod(component, 'setReadonly', 'true', 'readonly', true);
-    expectSettersMethod(component, 'setReadonly', 'false', 'readonly', false);
+    expectSettersMethod(component, 'setReadonly', true, 'readonly', true);
+    expectSettersMethod(component, 'setReadonly', false, 'readonly', false);
   });
 
   it('should set required', () => {
     spyOn(component, <any>'validateModel');
 
-    expectSettersMethod(component, 'setRequired', '', 'required', true);
-    expectSettersMethod(component, 'setRequired', 'true', 'required', true);
-    expectSettersMethod(component, 'setRequired', 'false', 'required', false);
+    expectSettersMethod(component, 'setRequired', true, 'required', true);
+    expectSettersMethod(component, 'setRequired', false, 'required', false);
 
     expect(component['validateModel']).toHaveBeenCalled();
   });
 
   it('should set clean', () => {
-    expectSettersMethod(component, 'setClean', '', 'clean', true);
-    expectSettersMethod(component, 'setClean', 'true', 'clean', true);
-    expectSettersMethod(component, 'setClean', 'false', 'clean', false);
+    expectSettersMethod(component, 'setClean', true, 'clean', true);
+    expectSettersMethod(component, 'setClean', false, 'clean', false);
   });
 
   it('should set pattern', () => {
@@ -99,13 +95,12 @@ describe('PoInputBase:', async () => {
   it('should set maskFormatModel', () => {
     spyOn(component, <any>'validateModel');
 
-    expectSettersMethod(component, 'setMaskFormatModel', '', 'maskFormatModel', true);
-    expectSettersMethod(component, 'setMaskFormatModel', 'true', 'maskFormatModel', true);
-    expectSettersMethod(component, 'setMaskFormatModel', 'false', 'maskFormatModel', false);
+    expectSettersMethod(component, 'setMaskFormatModel', true, 'maskFormatModel', true);
+    expectSettersMethod(component, 'setMaskFormatModel', false, 'maskFormatModel', false);
 
     component.objMask = new PoMask('', true);
 
-    expectSettersMethod(component, 'setMaskFormatModel', 'true', 'maskFormatModel', true);
+    expectSettersMethod(component, 'setMaskFormatModel', true, 'maskFormatModel', true);
     expect(component.objMask.formatModel).toBeTruthy();
 
     expect(component['validateModel']).toHaveBeenCalled();
@@ -265,14 +260,14 @@ describe('PoInputBase:', async () => {
       expectPropertiesValues(component, 'minlength', invalidValues, undefined);
     });
 
-    it('p-no-autocomplete: should update property with valid values with valid values.', () => {
-      const invalidValues = [undefined, null, 0, 'false', 'string'];
-      expectPropertiesValues(component, 'noAutocomplete', invalidValues, false);
+    it('p-no-autocomplete: should update property to false.', () => {
+      component.noAutocomplete = false;
+      expect(component.noAutocomplete).toBeFalse();
     });
 
-    it('p-no-autocomplete: should update property with valid values with valid values.', () => {
-      const validValues = [true, 'true', 1, ' '];
-      expectPropertiesValues(component, 'noAutocomplete', validValues, true);
+    it('p-no-autocomplete: should update property to true.', () => {
+      component.noAutocomplete = true;
+      expect(component.noAutocomplete).toBeTrue();
     });
 
     describe('p-mask-no-length-validation:', () => {
@@ -658,21 +653,6 @@ describe('PoInputBase:', async () => {
         component.disabled = true;
         component.loading = false;
         expect(component.disabled).toBeTrue();
-      });
-
-      it('should set loading=true when input receives string empty', () => {
-        component.loading = '' as any;
-        expect(component.loading).toBeTrue();
-      });
-
-      it('should set loading=false when input receives string "false"', () => {
-        component.loading = 'false' as any;
-        expect(component.loading).toBeFalse();
-      });
-
-      it('should set loading=true when input receives string "true"', () => {
-        component.loading = 'true' as any;
-        expect(component.loading).toBeTrue();
       });
 
       it('should not throw when cd is undefined', () => {

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -302,8 +302,10 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    *
    * @default `false`
    */
-  @Input('p-mask-no-length-validation') set maskNoLengthValidation(value: boolean) {
-    this._maskNoLengthValidation = convertToBoolean(value);
+  @Input({ alias: 'p-mask-no-length-validation', transform: convertToBoolean }) set maskNoLengthValidation(
+    value: boolean
+  ) {
+    this._maskNoLengthValidation = value;
 
     this.validateModel();
   }
@@ -405,8 +407,8 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    *
    * @default `false`
    */
-  @Input('p-no-autocomplete') set noAutocomplete(value: boolean) {
-    this._noAutocomplete = convertToBoolean(value);
+  @Input({ alias: 'p-no-autocomplete', transform: convertToBoolean }) set noAutocomplete(value: boolean) {
+    this._noAutocomplete = value;
   }
 
   get noAutocomplete() {
@@ -438,8 +440,8 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    */
   // eslint-disable-next-line @typescript-eslint/member-ordering
   disabled?: boolean = false;
-  @Input('p-disabled') set setDisabled(disabled: string) {
-    this.disabled = disabled === '' ? true : convertToBoolean(disabled);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set setDisabled(disabled: boolean) {
+    this.disabled = disabled;
 
     this.validateModel();
   }
@@ -453,9 +455,9 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    * @default `false`
    */
   @HostBinding('attr.p-loading')
-  @Input('p-loading')
+  @Input({ alias: 'p-loading', transform: convertToBoolean })
   set loading(value: boolean) {
-    this._loading = convertToBoolean(value);
+    this._loading = value;
     this.cd?.markForCheck();
   }
 
@@ -470,8 +472,8 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
   /** Indica que o campo será somente leitura. */
   // eslint-disable-next-line @typescript-eslint/member-ordering
   readonly?: boolean = false;
-  @Input('p-readonly') set setReadonly(readonly: string) {
-    this.readonly = readonly === '' ? true : convertToBoolean(readonly);
+  @Input({ alias: 'p-readonly', transform: convertToBoolean }) set setReadonly(readonly: boolean) {
+    this.readonly = readonly;
   }
 
   /**
@@ -486,8 +488,8 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    */
   // eslint-disable-next-line @typescript-eslint/member-ordering
   required?: boolean = false;
-  @Input('p-required') set setRequired(required: string) {
-    this.required = required === '' ? true : convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set setRequired(required: boolean) {
+    this.required = required;
 
     this.validateModel();
   }
@@ -528,8 +530,8 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
   /** Se verdadeiro, o campo receberá um botão para ser limpo. */
   // eslint-disable-next-line @typescript-eslint/member-ordering
   clean?: boolean = false;
-  @Input('p-clean') set setClean(clean: string) {
-    this.clean = clean === '' ? true : convertToBoolean(clean);
+  @Input({ alias: 'p-clean', transform: convertToBoolean }) set setClean(clean: boolean) {
+    this.clean = clean;
   }
 
   /**
@@ -620,8 +622,10 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    */
   // eslint-disable-next-line @typescript-eslint/member-ordering
   maskFormatModel?: boolean = false;
-  @Input('p-mask-format-model') set setMaskFormatModel(maskFormatModel: string) {
-    this.maskFormatModel = maskFormatModel === '' ? true : convertToBoolean(maskFormatModel);
+  @Input({ alias: 'p-mask-format-model', transform: convertToBoolean }) set setMaskFormatModel(
+    maskFormatModel: boolean
+  ) {
+    this.maskFormatModel = maskFormatModel;
 
     if (this.objMask instanceof PoMask) {
       this.objMask.formatModel = this.maskFormatModel;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -103,42 +103,34 @@ describe('PoLookupBaseComponent:', () => {
     expectSettersMethod(component, 'name', 'campo', 'name', 'campo');
   });
 
-  it('should set disabled', () => {
-    expectSettersMethod(component, 'disabled', '', '_disabled', true);
-    expectSettersMethod(component, 'disabled', 'true', 'disabled', true);
-    expectSettersMethod(component, 'disabled', true, 'disabled', true);
-    expectSettersMethod(component, 'disabled', 'false', '_disabled', false);
-    expectSettersMethod(component, 'disabled', false, '_disabled', false);
-    expectSettersMethod(component, 'disabled', 'null', 'disabled', false);
-    expectSettersMethod(component, 'disabled', null, 'disabled', false);
-    expectSettersMethod(component, 'disabled', 'undefined', 'disabled', false);
-    expectSettersMethod(component, 'disabled', undefined, 'disabled', false);
+  it('should set disabled to true', () => {
+    component.disabled = true;
+    expect(component.disabled).toBeTrue();
   });
 
-  it('should set required', () => {
-    expectSettersMethod(component, 'required', '', 'required', true);
-    expectSettersMethod(component, 'required', 'true', '_required', true);
-    expectSettersMethod(component, 'required', true, '_required', true);
-    expectSettersMethod(component, 'required', 'false', '_required', false);
-    expectSettersMethod(component, 'required', false, '_required', false);
-    expectSettersMethod(component, 'required', null, 'required', false);
-    expectSettersMethod(component, 'required', 'null', 'required', false);
-    expectSettersMethod(component, 'required', NaN, 'required', false);
-    expectSettersMethod(component, 'required', 'undefined', 'required', false);
-    expectSettersMethod(component, 'required', undefined, 'required', false);
+  it('should set disabled to false', () => {
+    component.disabled = false;
+    expect(component.disabled).toBeFalse();
   });
 
-  it('should set no autocomplete', () => {
-    expectSettersMethod(component, 'noAutocomplete', true, 'noAutocomplete', true);
-    expectSettersMethod(component, 'noAutocomplete', true, '_noAutocomplete', true);
-    expectSettersMethod(component, 'noAutocomplete', false, 'noAutocomplete', false);
-    expectSettersMethod(component, 'noAutocomplete', false, '_noAutocomplete', false);
-    expectSettersMethod(component, 'noAutocomplete', '', 'noAutocomplete', true);
-    expectSettersMethod(component, 'noAutocomplete', '', '_noAutocomplete', true);
-    expectSettersMethod(component, 'noAutocomplete', null, 'noAutocomplete', false);
-    expectSettersMethod(component, 'noAutocomplete', null, '_noAutocomplete', false);
-    expectSettersMethod(component, 'noAutocomplete', undefined, 'noAutocomplete', false);
-    expectSettersMethod(component, 'noAutocomplete', undefined, '_noAutocomplete', false);
+  it('should set required to true', () => {
+    component.required = true;
+    expect(component.required).toBeTrue();
+  });
+
+  it('should set required to false', () => {
+    component.required = false;
+    expect(component.required).toBeFalse();
+  });
+
+  it('should set noAutocomplete to true', () => {
+    component.noAutocomplete = true;
+    expect(component.noAutocomplete).toBeTrue();
+  });
+
+  it('should set noAutocomplete to false', () => {
+    component.noAutocomplete = false;
+    expect(component.noAutocomplete).toBeFalse();
   });
 
   it('p-hide-columns-manager: should update property `p-hide-columns-manager` with valid value', () => {
@@ -1027,9 +1019,6 @@ describe('PoLookupBaseComponent:', () => {
   });
 
   describe('Properties:', () => {
-    const trueValues = [true, 'true', 1, '', [], {}];
-    const falseValues = [false, 'false', 0, null, undefined, NaN];
-
     it('p-compact-label: should have default value as false', () => {
       expect(component.compactLabel()).toBe(false);
     });
@@ -1042,9 +1031,14 @@ describe('PoLookupBaseComponent:', () => {
       expect(component['setService']).toHaveBeenCalledWith(component.filterService);
     });
 
-    it('p-required: should be update with valid and invalid values.', () => {
-      expectPropertiesValues(component, 'required', trueValues, true);
-      expectPropertiesValues(component, 'required', falseValues, false);
+    it('p-required: should be update with true value.', () => {
+      component.required = true;
+      expect(component.required).toBeTrue();
+    });
+
+    it('p-required: should be update with false value.', () => {
+      component.required = false;
+      expect(component.required).toBeFalse();
     });
 
     it('p-field-label: should apply the received value to `keysDescription`', () => {
@@ -1084,21 +1078,6 @@ describe('PoLookupBaseComponent:', () => {
         component.disabled = true;
         component.loading = false;
         expect(component.disabled).toBeTrue();
-      });
-
-      it('should set loading=true when input receives empty string', () => {
-        component.loading = '' as any;
-        expect(component.loading).toBeTrue();
-      });
-
-      it('should set loading=false when input receives string "false"', () => {
-        component.loading = 'false' as any;
-        expect(component.loading).toBeFalse();
-      });
-
-      it('should set loading=true when input receives string "true"', () => {
-        component.loading = 'true' as any;
-        expect(component.loading).toBeTrue();
       });
 
       it('should not throw when cd is undefined', () => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -732,8 +732,8 @@ export abstract class PoLookupBaseComponent
    *
    * @default `false`
    */
-  @Input('p-no-autocomplete') set noAutocomplete(value: boolean) {
-    this._noAutocomplete = convertToBoolean(value);
+  @Input({ alias: 'p-no-autocomplete', transform: convertToBoolean }) set noAutocomplete(value: boolean) {
+    this._noAutocomplete = value;
   }
 
   get noAutocomplete() {
@@ -750,8 +750,8 @@ export abstract class PoLookupBaseComponent
    *
    * @default `false`
    */
-  @Input('p-required') set required(required: boolean) {
-    this._required = convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(required: boolean) {
+    this._required = required;
 
     this.validateModel(this.valueToModel);
   }
@@ -777,9 +777,9 @@ export abstract class PoLookupBaseComponent
    * @optional
    */
   @HostBinding('attr.p-disabled')
-  @Input('p-disabled')
+  @Input({ alias: 'p-disabled', transform: convertToBoolean })
   set disabled(disabled: boolean) {
-    this._disabled = <any>disabled === '' ? true : convertToBoolean(disabled);
+    this._disabled = disabled;
   }
 
   get disabled(): boolean {
@@ -795,9 +795,9 @@ export abstract class PoLookupBaseComponent
    * @default `false`
    */
   @HostBinding('attr.p-loading')
-  @Input('p-loading')
+  @Input({ alias: 'p-loading', transform: convertToBoolean })
   set loading(value: boolean) {
-    this._loading = convertToBoolean(value);
+    this._loading = value;
   }
 
   get loading(): boolean {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -62,28 +62,30 @@ describe('PoMultiselectBaseComponent:', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set required', () => {
-    expectSettersMethod(component, 'required', '', 'required', true);
-    expectSettersMethod(component, 'required', 'true', 'required', true);
-    expectSettersMethod(component, 'required', true, 'required', true);
-    expectSettersMethod(component, 'required', 'null', 'required', false);
-    expectSettersMethod(component, 'required', null, 'required', false);
-    expectSettersMethod(component, 'required', 'undefined', 'required', false);
-    expectSettersMethod(component, 'required', undefined, 'required', false);
+  it('should set required to true', () => {
+    component.required = true;
+    expect(component.required).toBeTrue();
+  });
 
+  it('should set required to false', () => {
+    component.required = false;
+    expect(component.required).toBeFalse();
+  });
+
+  it('should call validateModel when disabled is set', () => {
     spyOn(component, <any>'validateModel');
     component.disabled = true;
     expect(component['validateModel']).toHaveBeenCalled();
   });
 
-  it('should set disabled', () => {
-    expectSettersMethod(component, 'disabled', '', 'disabled', true);
-    expectSettersMethod(component, 'disabled', 'true', 'disabled', true);
-    expectSettersMethod(component, 'disabled', true, 'disabled', true);
-    expectSettersMethod(component, 'disabled', 'null', 'disabled', false);
-    expectSettersMethod(component, 'disabled', null, 'disabled', false);
-    expectSettersMethod(component, 'disabled', 'undefined', 'disabled', false);
-    expectSettersMethod(component, 'disabled', undefined, 'disabled', false);
+  it('should set disabled to true', () => {
+    component.disabled = true;
+    expect(component.disabled).toBeTrue();
+  });
+
+  it('should set disabled to false', () => {
+    component.disabled = false;
+    expect(component.disabled).toBeFalse();
 
     spyOn(component, <any>'validateModel');
     spyOn(component, 'updateVisibleItems');
@@ -92,14 +94,14 @@ describe('PoMultiselectBaseComponent:', () => {
     expect(component.updateVisibleItems).toHaveBeenCalled();
   });
 
-  it('should set hide-search', () => {
-    expectSettersMethod(component, 'hideSearch', '', 'hideSearch', true);
-    expectSettersMethod(component, 'hideSearch', 'true', 'hideSearch', true);
-    expectSettersMethod(component, 'hideSearch', true, 'hideSearch', true);
-    expectSettersMethod(component, 'hideSearch', 'null', 'hideSearch', false);
-    expectSettersMethod(component, 'hideSearch', null, 'hideSearch', false);
-    expectSettersMethod(component, 'hideSearch', 'undefined', 'hideSearch', false);
-    expectSettersMethod(component, 'hideSearch', undefined, 'hideSearch', false);
+  it('should set hide-search to true', () => {
+    component.hideSearch = true;
+    expect(component.hideSearch).toBeTrue();
+  });
+
+  it('should set hide-search to false', () => {
+    component.hideSearch = false;
+    expect(component.hideSearch).toBeFalse();
   });
 
   it('should set p-filter-mode', () => {
@@ -135,14 +137,14 @@ describe('PoMultiselectBaseComponent:', () => {
     expect(component.options.length).toBe(1);
   });
 
-  it('should set p-sort', () => {
-    expectSettersMethod(component, 'sort', '', 'sort', true);
-    expectSettersMethod(component, 'sort', 'true', 'sort', true);
-    expectSettersMethod(component, 'sort', true, 'sort', true);
-    expectSettersMethod(component, 'sort', 'null', 'sort', false);
-    expectSettersMethod(component, 'sort', null, 'sort', false);
-    expectSettersMethod(component, 'sort', 'undefined', 'sort', false);
-    expectSettersMethod(component, 'sort', undefined, 'sort', false);
+  it('should set p-sort to true', () => {
+    component.sort = true;
+    expect(component.sort).toBeTrue();
+  });
+
+  it('should set p-sort to false', () => {
+    component.sort = false;
+    expect(component.sort).toBeFalse();
 
     spyOn(component, 'validAndSortOptions');
     component.sort = true;
@@ -935,21 +937,6 @@ describe('PoMultiselectBaseComponent:', () => {
       component.disabled = true;
       component.loading = false;
       expect(component.disabled).toBeTrue();
-    });
-
-    it('should set loading=true when input receives string empty', () => {
-      component.loading = '' as any;
-      expect(component.loading).toBeTrue();
-    });
-
-    it('should set loading=false when input receives string "false"', () => {
-      component.loading = 'false' as any;
-      expect(component.loading).toBeFalse();
-    });
-
-    it('should set loading=true when input receives string "true"', () => {
-      component.loading = 'true' as any;
-      expect(component.loading).toBeTrue();
     });
 
     it('should not throw when cd is undefined', () => {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -558,8 +558,8 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    *
    * @default `false`
    */
-  @Input('p-required') set required(required: boolean) {
-    this._required = <any>required === '' ? true : convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(required: boolean) {
+    this._required = required;
     this.validateModel();
   }
 
@@ -609,8 +609,8 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    *
    * @default `false`
    */
-  @Input('p-disabled') set disabled(disabled: boolean) {
-    this._disabled = <any>disabled === '' ? true : convertToBoolean(disabled);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set disabled(disabled: boolean) {
+    this._disabled = disabled;
     this.validateModel();
 
     this.updateVisibleItems();
@@ -629,9 +629,9 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * @default `false`
    */
   @HostBinding('attr.p-loading')
-  @Input('p-loading')
+  @Input({ alias: 'p-loading', transform: convertToBoolean })
   set loading(value: boolean) {
-    this._loading = convertToBoolean(value);
+    this._loading = value;
     this.cd?.markForCheck();
   }
 
@@ -652,8 +652,8 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    *
    * @default `false`
    */
-  @Input('p-hide-search') set hideSearch(hideSearch: boolean) {
-    this._hideSearch = <any>hideSearch === '' ? true : convertToBoolean(hideSearch);
+  @Input({ alias: 'p-hide-search', transform: convertToBoolean }) set hideSearch(hideSearch: boolean) {
+    this._hideSearch = hideSearch;
   }
 
   get hideSearch() {
@@ -706,8 +706,8 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    *
    * @default `false`
    */
-  @Input('p-sort') set sort(sort: boolean) {
-    this._sort = <any>sort === '' ? true : convertToBoolean(sort);
+  @Input({ alias: 'p-sort', transform: convertToBoolean }) set sort(sort: boolean) {
+    this._sort = sort;
 
     this.validAndSortOptions();
   }

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { configureTestSuite } from './../../../util-test/util-expect.spec';
-import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 import { PoCleanComponent } from './../po-clean/po-clean.component';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
@@ -52,17 +51,20 @@ describe('PoNumberComponent:', () => {
   });
 
   describe('Properties:', () => {
-    it('p-hide-password-peek: should update property with valid values.', () => {
-      const validValues = [false, true, '', 'false', 'true'];
-      const expectedValues = [false, true, true, false, true];
-
-      expectPropertiesValues(component, 'hidePasswordPeek', validValues, expectedValues);
+    it('p-hide-password-peek: should update property to true.', () => {
+      component.hidePasswordPeek = true;
+      expect(component.hidePasswordPeek).toBeTrue();
     });
 
-    it('p-hide-password-peek: should update property with `false` if values are invalid.', () => {
-      const invalidValues = [0, null, undefined, 'undefined', 'null'];
+    it('p-hide-password-peek: should update property to false.', () => {
+      component.hidePasswordPeek = false;
+      expect(component.hidePasswordPeek).toBeFalse();
+    });
 
-      expectPropertiesValues(component, 'hidePasswordPeek', invalidValues, false);
+    it('p-hide-password-peek: should coerce empty string to true via Angular transform', () => {
+      fixture.componentRef.setInput('p-hide-password-peek', '');
+      fixture.detectChanges();
+      expect(component.hidePasswordPeek).toBeTrue();
     });
 
     it('p-hide-password-peek: should update `visiblePassword` with `false` if `hidePasswordPeek` is `true`.', () => {

--- a/projects/ui/src/lib/components/po-field/po-password/po-password.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-password/po-password.component.ts
@@ -72,16 +72,16 @@ export class PoPasswordComponent extends PoInputGeneric implements OnChanges {
    *
    * @default `false`
    */
-  @Input('p-hide-password-peek') set hidePasswordPeek(value: boolean) {
-    this._hidePasswordPeek = convertToBoolean(value);
+  @Input({ alias: 'p-hide-password-peek', transform: convertToBoolean }) set hidePasswordPeek(value: boolean) {
+    this._hidePasswordPeek = value;
     if (value) {
       this.visiblePassword = false;
       this.type = 'password';
     }
   }
 
-  @Input('p-no-autocomplete') override set noAutocomplete(value: boolean) {
-    this._noAutocompletePassword = convertToBoolean(value);
+  @Input({ alias: 'p-no-autocomplete', transform: convertToBoolean }) override set noAutocomplete(value: boolean) {
+    this._noAutocompletePassword = value;
   }
 
   override get noAutocomplete() {

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.spec.ts
@@ -216,23 +216,29 @@ describe('PoRadioGroupBase: ', () => {
   });
 
   describe('Properties:', () => {
-    const validValues = [true, 'true', 1, ''];
-    const invalidValues = [false, 'false', 0, null, undefined, NaN];
     const validateModel: any = 'validateModel';
 
     it('p-disabled: should be update with valid and invalid values.', () => {
       spyOn(component, validateModel);
 
-      expectPropertiesValues(component, 'disabled', validValues, true);
-      expectPropertiesValues(component, 'disabled', invalidValues, false);
+      component.disabled = true;
+      expect(component.disabled).toBeTrue();
+
+      component.disabled = false;
+      expect(component.disabled).toBeFalse();
+
       expect(component[validateModel]).toHaveBeenCalled();
     });
 
     it('p-required: should be update with valid and invalid values.', () => {
       spyOn(component, validateModel);
 
-      expectPropertiesValues(component, 'required', validValues, true);
-      expectPropertiesValues(component, 'required', invalidValues, false);
+      component.required = true;
+      expect(component.required).toBeTrue();
+
+      component.required = false;
+      expect(component.required).toBeFalse();
+
       expect(component[validateModel]).toHaveBeenCalled();
     });
 
@@ -244,6 +250,7 @@ describe('PoRadioGroupBase: ', () => {
     });
 
     it('p-columns: should update property with `6` if invalid value', () => {
+      const invalidValues = [false, 'false', 0, null, undefined, NaN];
       expectPropertiesValues(component, 'columns', invalidValues, 6);
     });
 

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
@@ -315,8 +315,8 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
    *
    * @default `false`
    */
-  @Input('p-disabled') set disabled(disabled: boolean) {
-    this._disabled = convertToBoolean(disabled);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set disabled(disabled: boolean) {
+    this._disabled = disabled;
 
     this.validateModel();
   }
@@ -334,8 +334,8 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
    *
    * @default `false`
    */
-  @Input('p-required') set required(required: boolean) {
-    this._required = convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(required: boolean) {
+    this._required = required;
 
     this.validateModel();
   }

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.spec.ts
@@ -39,9 +39,6 @@ describe('PoRichTextBaseComponent:', () => {
   });
 
   describe('Properties:', () => {
-    const booleanInvalidValues = [undefined, null, 2, 'string'];
-    const booleanValidTrueValues = [true, 'true', 1, ''];
-
     it('p-compact-label: should update property with `true` when input is true', () => {
       fixture.componentRef.setInput('p-compact-label', true);
       fixture.detectChanges();
@@ -72,18 +69,23 @@ describe('PoRichTextBaseComponent:', () => {
     });
 
     it('p-readonly: should update property with valid values.', () => {
-      expectPropertiesValues(component, 'readonly', booleanValidTrueValues, true);
+      component.readonly = true;
+      expect(component.readonly).toBeTrue();
     });
 
     it('p-readonly: should update property with invalid values.', () => {
-      expectPropertiesValues(component, 'readonly', booleanInvalidValues, false);
+      component.readonly = false;
+      expect(component.readonly).toBeFalse();
     });
 
     it('p-required: should update property with valid values, invalid values and call `validateModel`', () => {
       spyOn(component, <any>'validateModel');
 
-      expectPropertiesValues(component, 'required', booleanValidTrueValues, true);
-      expectPropertiesValues(component, 'required', booleanInvalidValues, false);
+      component.required = true;
+      expect(component.required).toBeTrue();
+
+      component.required = false;
+      expect(component.required).toBeFalse();
 
       expect(component['validateModel']).toHaveBeenCalledWith(component.value);
     });

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-base.component.ts
@@ -367,8 +367,8 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
    *
    * @default `false`
    */
-  @Input('p-readonly') set readonly(value: boolean) {
-    this._readonly = convertToBoolean(value);
+  @Input({ alias: 'p-readonly', transform: convertToBoolean }) set readonly(value: boolean) {
+    this._readonly = value;
   }
 
   get readonly() {
@@ -384,8 +384,8 @@ export abstract class PoRichTextBaseComponent implements ControlValueAccessor, V
    *
    * @default `false`
    */
-  @Input('p-required') set required(value: boolean) {
-    this._required = convertToBoolean(value);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(value: boolean) {
+    this._required = value;
 
     this.validateModel(this.value);
   }

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -20,10 +20,6 @@ describe('PoSelectComponent:', () => {
   let nativeElement;
   let changeDetectorRef: jasmine.SpyObj<any>;
 
-  const booleanValidFalseValues = [false, 'false'];
-  const booleanValidTrueValues = [true, 'true', ''];
-  const booleanInvalidValues = [undefined, null, 2, 'string'];
-
   const event = new MouseEvent('click', { 'bubbles': false, 'cancelable': true });
 
   beforeEach(() => {
@@ -93,6 +89,12 @@ describe('PoSelectComponent:', () => {
       expect(changeDetectorRef.markForCheck).toHaveBeenCalled();
     });
 
+    it('should coerce empty string to true via Angular transform', () => {
+      fixture.componentRef.setInput('p-loading', '');
+      fixture.detectChanges();
+      expect(component.loading).toBeTrue();
+    });
+
     it('loading should not affect disabled state', () => {
       component.disabled = false;
 
@@ -102,21 +104,6 @@ describe('PoSelectComponent:', () => {
       component.disabled = true;
       component.loading = false;
       expect(component.disabled).toBeTrue();
-    });
-
-    it('should set loading=true when input receives string empty', () => {
-      component.loading = '' as any;
-      expect(component.loading).toBeTrue();
-    });
-
-    it('should set loading=false when input receives string "false"', () => {
-      component.loading = 'false' as any;
-      expect(component.loading).toBeFalse();
-    });
-
-    it('should set loading=true when input receives string "true"', () => {
-      component.loading = 'true' as any;
-      expect(component.loading).toBeTrue();
     });
 
     it('should not throw when cd is undefined', () => {

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -353,9 +353,9 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
    * @default `false`
    */
   @HostBinding('attr.p-loading')
-  @Input('p-loading')
+  @Input({ alias: 'p-loading', transform: convertToBoolean })
   set loading(value: boolean) {
-    this._loading = convertToBoolean(value);
+    this._loading = value;
     this.changeDetector?.markForCheck();
   }
 

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
@@ -45,22 +45,27 @@ describe('PoTextareaBase:', () => {
   });
 
   it('should set disabled', () => {
-    expectSettersMethod(component, 'disabled', '', '_disabled', true);
-    expectSettersMethod(component, 'disabled', 'false', '_disabled', false);
-    expectSettersMethod(component, 'disabled', 'true', 'disabled', true);
+    component.disabled = true;
+    expect(component.disabled).toBeTrue();
+
+    component.disabled = false;
+    expect(component.disabled).toBeFalse();
   });
 
   it('should set readonly', () => {
-    expectSettersMethod(component, 'readonly', '', '_readonly', true);
-    expectSettersMethod(component, 'readonly', 'false', '_readonly', false);
-    expectSettersMethod(component, 'readonly', 'true', 'readonly', true);
+    component.readonly = true;
+    expect(component.readonly).toBeTrue();
+
+    component.readonly = false;
+    expect(component.readonly).toBeFalse();
   });
 
   it('should set required', () => {
-    expectSettersMethod(component, 'required', '', 'required', true);
-    expectSettersMethod(component, 'required', 'false', '_required', false);
-    expectSettersMethod(component, 'required', 'true', '_required', true);
-    expectSettersMethod(component, 'required', null, 'required', false);
+    component.required = true;
+    expect(component.required).toBeTrue();
+
+    component.required = false;
+    expect(component.required).toBeFalse();
   });
 
   it('should update property `p-rows` with valid values', () => {

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -324,8 +324,8 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
    *
    * @default `false`
    */
-  @Input('p-disabled') set disabled(disabled: boolean) {
-    this._disabled = convertToBoolean(disabled);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set disabled(disabled: boolean) {
+    this._disabled = disabled;
   }
 
   get disabled(): boolean {
@@ -363,8 +363,8 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
    *
    * @default `false`
    */
-  @Input('p-readonly') set readonly(readonly: boolean) {
-    this._readonly = convertToBoolean(readonly);
+  @Input({ alias: 'p-readonly', transform: convertToBoolean }) set readonly(readonly: boolean) {
+    this._readonly = readonly;
   }
 
   get readonly(): boolean {
@@ -381,8 +381,8 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
    *
    * @default `false`
    */
-  @Input('p-required') set required(required: boolean) {
-    this._required = convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(required: boolean) {
+    this._required = required;
 
     this.validateModel();
   }

--- a/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker-base.component.spec.ts
@@ -38,34 +38,34 @@ describe('PoTimepickerBaseComponent:', () => {
   });
 
   it('should be update property p-disabled', () => {
-    component.setDisabled = 'true';
+    component.setDisabled = true;
     expect(component.disabled).toBeTrue();
 
-    component.setDisabled = 'false';
+    component.setDisabled = false;
     expect(component.disabled).toBeFalse();
   });
 
   it('should update property p-required', () => {
-    component.setRequired = 'true';
+    component.setRequired = true;
     expect(component.required).toBeTrue();
 
-    component.setRequired = 'false';
+    component.setRequired = false;
     expect(component.required).toBeFalse();
   });
 
   it('should update property p-readonly', () => {
-    component.setReadonly = 'true';
+    component.setReadonly = true;
     expect(component.readonly).toBeTrue();
 
-    component.setReadonly = 'false';
+    component.setReadonly = false;
     expect(component.readonly).toBeFalse();
   });
 
   it('should update property p-clean', () => {
-    component.setClean = 'true';
+    component.setClean = true;
     expect(component.clean).toBeTrue();
 
-    component.setClean = 'false';
+    component.setClean = false;
     expect(component.clean).toBeFalse();
   });
 
@@ -109,21 +109,21 @@ describe('PoTimepickerBaseComponent:', () => {
     });
 
     describe('p-loading:', () => {
-      it('should convert value to boolean and call markForCheck', () => {
+      it('should set loading to true and call markForCheck', () => {
         const markForCheckSpy = spyOn(component['cd'], 'markForCheck');
 
-        component.loading = 'true' as any;
+        component.loading = true;
 
-        expect(component['_loading']).toBeTrue();
+        expect(component.loading).toBeTrue();
         expect(markForCheckSpy).toHaveBeenCalled();
       });
 
-      it('should set loading to false when value is falsy', () => {
+      it('should set loading to false and call markForCheck', () => {
         const markForCheckSpy = spyOn(component['cd'], 'markForCheck');
 
-        component.loading = null;
+        component.loading = false;
 
-        expect(component['_loading']).toBeFalse();
+        expect(component.loading).toBeFalse();
         expect(markForCheckSpy).toHaveBeenCalled();
       });
 
@@ -910,34 +910,6 @@ describe('PoTimepickerBaseComponent:', () => {
       it('should set noAutocomplete to true', () => {
         component.noAutocomplete = true;
         expect(component.noAutocomplete).toBeTrue();
-      });
-    });
-
-    describe('p-disabled - empty string branch:', () => {
-      it('should set disabled to true when empty string is passed', () => {
-        component.setDisabled = '';
-        expect(component.disabled).toBeTrue();
-      });
-    });
-
-    describe('p-readonly - empty string branch:', () => {
-      it('should set readonly to true when empty string is passed', () => {
-        component.setReadonly = '';
-        expect(component.readonly).toBeTrue();
-      });
-    });
-
-    describe('p-required - empty string branch:', () => {
-      it('should set required to true when empty string is passed', () => {
-        component.setRequired = '';
-        expect(component.required).toBeTrue();
-      });
-    });
-
-    describe('p-clean - empty string branch:', () => {
-      it('should set clean to true when empty string is passed', () => {
-        component.setClean = '';
-        expect(component.clean).toBeTrue();
       });
     });
 

--- a/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker-base.component.ts
@@ -237,8 +237,8 @@ export abstract class PoTimepickerBaseComponent implements ControlValueAccessor,
    *
    * @default `false`
    */
-  @Input('p-no-autocomplete') set noAutocomplete(value: boolean) {
-    this._noAutocomplete = convertToBoolean(value);
+  @Input({ alias: 'p-no-autocomplete', transform: convertToBoolean }) set noAutocomplete(value: boolean) {
+    this._noAutocomplete = value;
   }
 
   get noAutocomplete() {
@@ -262,17 +262,17 @@ export abstract class PoTimepickerBaseComponent implements ControlValueAccessor,
     return this._placeholder;
   }
 
-  @Input('p-disabled') set setDisabled(disabled: string) {
-    this.disabled = disabled === '' ? true : convertToBoolean(disabled);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set setDisabled(disabled: boolean) {
+    this.disabled = disabled;
     this.validateModel(this._timeValue);
   }
 
-  @Input('p-readonly') set setReadonly(readonly: string) {
-    this.readonly = readonly === '' ? true : convertToBoolean(readonly);
+  @Input({ alias: 'p-readonly', transform: convertToBoolean }) set setReadonly(readonly: boolean) {
+    this.readonly = readonly;
   }
 
-  @Input('p-required') set setRequired(required: string) {
-    this.required = required === '' ? true : convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set setRequired(required: boolean) {
+    this.required = required;
     this.validateModel(this._timeValue);
   }
 
@@ -301,8 +301,8 @@ export abstract class PoTimepickerBaseComponent implements ControlValueAccessor,
     return this._size ?? getDefaultSizeFn(PoFieldSize);
   }
 
-  @Input('p-clean') set setClean(clean: string) {
-    this.clean = clean === '' ? true : convertToBoolean(clean);
+  @Input({ alias: 'p-clean', transform: convertToBoolean }) set setClean(clean: boolean) {
+    this.clean = clean;
   }
 
   /**
@@ -405,8 +405,8 @@ export abstract class PoTimepickerBaseComponent implements ControlValueAccessor,
    *
    * @default `false`
    */
-  @Input('p-show-seconds') set showSeconds(value: boolean) {
-    this._showSeconds = value === true || <any>value === 'true' || <any>value === '';
+  @Input({ alias: 'p-show-seconds', transform: convertToBoolean }) set showSeconds(value: boolean) {
+    this._showSeconds = value;
     this.updateMask();
     this.refreshValue(this._timeValue);
   }
@@ -459,8 +459,8 @@ export abstract class PoTimepickerBaseComponent implements ControlValueAccessor,
    *
    * @default `false`
    */
-  @Input('p-loading') set loading(value: boolean) {
-    this._loading = convertToBoolean(value);
+  @Input({ alias: 'p-loading', transform: convertToBoolean }) set loading(value: boolean) {
+    this._loading = value;
     this.cd?.markForCheck();
   }
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
@@ -584,16 +584,14 @@ describe('PoUploadBaseComponent:', () => {
       expect(component.compactLabel()).toBe(false);
     });
 
-    it('p-drag-drop: should set `dragDrop` with valid values', () => {
-      const validValues = ['', true, 1, [], {}, 'true'];
-
-      expectPropertiesValues(component, 'dragDrop', validValues, true);
+    it('p-drag-drop: should set `dragDrop` to true', () => {
+      component.dragDrop = true;
+      expect(component.dragDrop).toBeTrue();
     });
 
-    it('p-drag-drop: should set `dragDrop` to false with invalid values', () => {
-      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
-
-      expectPropertiesValues(component, 'dragDrop', invalidValues, false);
+    it('p-drag-drop: should set `dragDrop` to false', () => {
+      component.dragDrop = false;
+      expect(component.dragDrop).toBeFalse();
     });
 
     it('formField: should set `formField` with valid values', () => {
@@ -608,16 +606,20 @@ describe('PoUploadBaseComponent:', () => {
       expectPropertiesValues(component, 'formField', invalidValues, 'files');
     });
 
-    it('disabled: should set `disabled` with valid values', () => {
-      const validValues = ['', true, 1, [], {}, 'true'];
-
-      expectPropertiesValues(component, 'disabled', validValues, true);
+    it('disabled: should set `disabled` to true', () => {
+      component.disabled = true;
+      expect(component.disabled).toBeTrue();
     });
 
-    it('disabled: should set `disabled` to false with invalid values', () => {
-      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
+    it('disabled: should set `disabled` to false', () => {
+      component.disabled = false;
+      expect(component.disabled).toBeFalse();
+    });
 
-      expectPropertiesValues(component, 'disabled', invalidValues, false);
+    it('disabled: should coerce empty string to true via Angular transform', () => {
+      fixture.componentRef.setInput('p-disabled', '');
+      fixture.detectChanges();
+      expect(component.disabled).toBeTrue();
     });
 
     it('fileRestrictions: should set `fileRestrictions` calling `initRestrictions` and call `setAllowedExtensions`', () => {
@@ -634,16 +636,14 @@ describe('PoUploadBaseComponent:', () => {
       expect(component['setAllowedExtensions']).toHaveBeenCalled();
     });
 
-    it('hideRestrictionsInfo: should set `hideRestrictionsInfo` with valid values', () => {
-      const validValues = ['', true, 1, [], {}, 'true'];
-
-      expectPropertiesValues(component, 'hideRestrictionsInfo', validValues, true);
+    it('hideRestrictionsInfo: should set `hideRestrictionsInfo` to true', () => {
+      component.hideRestrictionsInfo = true;
+      expect(component.hideRestrictionsInfo).toBeTrue();
     });
 
-    it('hideRestrictionsInfo: should set `hideRestrictionsInfo` to false with invalid values', () => {
-      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
-
-      expectPropertiesValues(component, 'hideRestrictionsInfo', invalidValues, false);
+    it('hideRestrictionsInfo: should set `hideRestrictionsInfo` to false', () => {
+      component.hideRestrictionsInfo = false;
+      expect(component.hideRestrictionsInfo).toBeFalse();
     });
 
     it('p-literals: should be in portuguese if browser is setted with an unsupported language', () => {
@@ -707,58 +707,52 @@ describe('PoUploadBaseComponent:', () => {
       expectPropertiesValues(component, 'literals', invalidValues, poUploadLiteralsDefault[poLocaleDefault]);
     });
 
-    it('required: should set `required` with valid values', () => {
-      const validValues = ['', true, 1, [], {}, 'true'];
-
+    it('required: should set `required` to true', () => {
       spyOn(component, <any>'validateModel');
 
-      expectPropertiesValues(component, 'required', validValues, true);
+      component.required = true;
+
+      expect(component.required).toBeTrue();
       expect(component['validateModel']).toHaveBeenCalled();
     });
 
-    it('required: should set `required` to false with invalid values', () => {
-      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
-
+    it('required: should set `required` to false', () => {
       spyOn(component, <any>'validateModel');
 
-      expectPropertiesValues(component, 'required', invalidValues, false);
+      component.required = false;
+
+      expect(component.required).toBeFalse();
       expect(component['validateModel']).toHaveBeenCalled();
     });
 
-    it('hideSelectButton: should set `hideSelectButton` with valid values', () => {
-      const validValues = ['', true, 1, [], {}, 'true'];
-
-      expectPropertiesValues(component, 'hideSelectButton', validValues, true);
+    it('hideSelectButton: should set `hideSelectButton` to true', () => {
+      component.hideSelectButton = true;
+      expect(component.hideSelectButton).toBeTrue();
     });
 
-    it('hideSelectButton: should set `hideSelectButton` to false with invalid values', () => {
-      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
-
-      expectPropertiesValues(component, 'hideSelectButton', invalidValues, false);
+    it('hideSelectButton: should set `hideSelectButton` to false', () => {
+      component.hideSelectButton = false;
+      expect(component.hideSelectButton).toBeFalse();
     });
 
-    it('hideSendButton: should set `hideSendButton` with valid values', () => {
-      const validValues = ['', true, 1, [], {}, 'true'];
-
-      expectPropertiesValues(component, 'hideSendButton', validValues, true);
+    it('hideSendButton: should set `hideSendButton` to true', () => {
+      component.hideSendButton = true;
+      expect(component.hideSendButton).toBeTrue();
     });
 
-    it('hideSendButton: should set `hideSendButton` to false with invalid values', () => {
-      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
-
-      expectPropertiesValues(component, 'hideSendButton', invalidValues, false);
+    it('hideSendButton: should set `hideSendButton` to false', () => {
+      component.hideSendButton = false;
+      expect(component.hideSendButton).toBeFalse();
     });
 
-    it('directory: should set `directory` with valid values', () => {
-      const validValues = ['', true, 1, [], {}, 'true'];
-
-      expectPropertiesValues(component, 'directory', validValues, true);
+    it('directory: should set `directory` to true', () => {
+      component.directory = true;
+      expect(component.directory).toBeTrue();
     });
 
-    it('directory: should set `directory` to false with invalid values', () => {
-      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
-
-      expectPropertiesValues(component, 'directory', invalidValues, false);
+    it('directory: should set `directory` to false', () => {
+      component.directory = false;
+      expect(component.directory).toBeFalse();
     });
 
     it('disabledRemoveFile: should set `disabledRemoveFile` with valid values', () => {
@@ -833,16 +827,14 @@ describe('PoUploadBaseComponent:', () => {
       expect(component.setDirectoryAttribute).toHaveBeenCalledWith(false);
     });
 
-    it('isMultiple: should set `isMultiple` with `true` if valid values', () => {
-      const validValues = ['', true, 1, [], {}, 'true'];
-
-      expectPropertiesValues(component, 'isMultiple', validValues, true);
+    it('isMultiple: should set `isMultiple` to true', () => {
+      component.isMultiple = true;
+      expect(component.isMultiple).toBeTrue();
     });
 
-    it('isMultiple: should set `isMultiple` with `false` if invalid values', () => {
-      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
-
-      expectPropertiesValues(component, 'isMultiple', invalidValues, false);
+    it('isMultiple: should set `isMultiple` to false', () => {
+      component.isMultiple = false;
+      expect(component.isMultiple).toBeFalse();
     });
 
     it('isMultiple: should return true if `diretory` is true', () => {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.ts
@@ -698,8 +698,8 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * @default `false`
    */
-  @Input('p-directory') set directory(value: boolean) {
-    this._directory = convertToBoolean(value);
+  @Input({ alias: 'p-directory', transform: convertToBoolean }) set directory(value: boolean) {
+    this._directory = value;
 
     this.canHandleDirectory = this._directory && !PoUtils.isIE() && !PoUtils.isMobile();
     this.setDirectoryAttribute(this.canHandleDirectory);
@@ -721,8 +721,8 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * @default `false`
    */
-  @Input('p-drag-drop') set dragDrop(value: boolean) {
-    this._dragDrop = convertToBoolean(value);
+  @Input({ alias: 'p-drag-drop', transform: convertToBoolean }) set dragDrop(value: boolean) {
+    this._dragDrop = value;
   }
 
   get dragDrop() {
@@ -738,8 +738,8 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * @default `false`
    */
-  @Input('p-hide-restrictions-info') set hideRestrictionsInfo(value: boolean) {
-    this._hideRestrictionsInfo = convertToBoolean(value);
+  @Input({ alias: 'p-hide-restrictions-info', transform: convertToBoolean }) set hideRestrictionsInfo(value: boolean) {
+    this._hideRestrictionsInfo = value;
   }
 
   get hideRestrictionsInfo() {
@@ -758,8 +758,8 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * @default `false`
    */
-  @Input('p-hide-select-button') set hideSelectButton(value: boolean) {
-    this._hideSelectButton = convertToBoolean(value);
+  @Input({ alias: 'p-hide-select-button', transform: convertToBoolean }) set hideSelectButton(value: boolean) {
+    this._hideSelectButton = value;
   }
   get hideSelectButton(): boolean {
     return this._hideSelectButton;
@@ -777,8 +777,8 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * @default `false`
    */
-  @Input('p-hide-send-button') set hideSendButton(value: boolean) {
-    this._hideSendButton = convertToBoolean(value);
+  @Input({ alias: 'p-hide-send-button', transform: convertToBoolean }) set hideSendButton(value: boolean) {
+    this._hideSendButton = value;
   }
   get hideSendButton(): boolean {
     return this._hideSendButton;
@@ -872,8 +872,8 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * Indica que o campo será desabilitado.
    */
-  @Input('p-disabled') set disabled(value: boolean) {
-    this._disabled = convertToBoolean(value);
+  @Input({ alias: 'p-disabled', transform: convertToBoolean }) set disabled(value: boolean) {
+    this._disabled = value;
 
     this.validateModel(this.currentFiles);
   }
@@ -915,8 +915,8 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * > Se utilizada a `p-directory`, habilita-se automaticamente esta propriedade.
    */
-  @Input('p-multiple') set isMultiple(value: boolean) {
-    this._isMultiple = convertToBoolean(value);
+  @Input({ alias: 'p-multiple', transform: convertToBoolean }) set isMultiple(value: boolean) {
+    this._isMultiple = value;
   }
 
   get isMultiple() {
@@ -932,8 +932,8 @@ export abstract class PoUploadBaseComponent implements ControlValueAccessor, Val
    *
    * @default `false`
    */
-  @Input('p-required') set required(required: boolean) {
-    this._required = convertToBoolean(required);
+  @Input({ alias: 'p-required', transform: convertToBoolean }) set required(required: boolean) {
+    this._required = required;
 
     this.validateModel(this.currentFiles);
   }


### PR DESCRIPTION
Migra os setters de p-disabled, p-readonly, p-required e demais propriedades booleanas de po-field para usar a opção transform do decorator @Input com convertToBoolean, garantindo coerção automática de boolean (true/false), number (0/1) e string ('true'/'false'/'') via Angular binding, mantendo compatibilidade com valores já existentes.

Fixes DTHFUI-11938

**PO-FIELD**

**DTHFUI-11938**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
