### PR TITLE
feat(page-default): habilita ação p-refresh no header

### DIFF
--- a/projects/ui/src/lib/components/po-helper/interfaces/po-helper-custom-action.interface.ts
+++ b/projects/ui/src/lib/components/po-helper/interfaces/po-helper-custom-action.interface.ts
@@ -1,0 +1,18 @@
+/**
+ * @docsPrivate
+ *
+ * @description
+ *
+ * Interface interna para configuração de ações customizadas no po-helper.
+ * Utilizada exclusivamente para repasse de configuração entre os componentes de página (po-page-default, po-page-header) e o po-helper.
+ */
+export interface PoHelperCustomAction {
+  /** Ícone a ser exibido no botão. */
+  icon: string;
+
+  /** Label de acessibilidade para o botão. */
+  ariaLabel?: string;
+
+  /** Função callback a ser executada ao clicar no botão. */
+  action: Function;
+}

--- a/projects/ui/src/lib/components/po-helper/po-helper-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper-base.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PoHelperBaseComponent } from './po-helper-base.component';
 import { PoHelperOptions } from './interfaces/po-helper.interface';
+import { PoHelperCustomAction } from './interfaces/po-helper-custom-action.interface';
 
 describe('PoHelperBaseComponent:', () => {
   let component: PoHelperBaseComponent;
@@ -33,6 +34,42 @@ describe('PoHelperBaseComponent:', () => {
       };
       fixture.componentRef.setInput('p-helper', options);
       expect(component.helper()).toEqual(options);
+    });
+
+    describe('p-custom-action:', () => {
+      it('should have customAction input with undefined as default value', () => {
+        expect(component.customAction()).toBeUndefined();
+      });
+
+      it('should accept a valid PoHelperCustomAction object', () => {
+        const action: PoHelperCustomAction = {
+          icon: 'ICON_REFRESH',
+          ariaLabel: 'Refresh',
+          action: () => {}
+        };
+        fixture.componentRef.setInput('p-custom-action', action);
+        expect(component.customAction()).toEqual(action);
+      });
+
+      it('should accept a PoHelperCustomAction without ariaLabel', () => {
+        const action: PoHelperCustomAction = {
+          icon: 'ICON_REFRESH',
+          action: () => {}
+        };
+        fixture.componentRef.setInput('p-custom-action', action);
+        expect(component.customAction()).toEqual(action);
+        expect(component.customAction().ariaLabel).toBeUndefined();
+      });
+
+      it('should accept undefined value', () => {
+        fixture.componentRef.setInput('p-custom-action', undefined);
+        expect(component.customAction()).toBeUndefined();
+      });
+
+      it('should accept null value', () => {
+        fixture.componentRef.setInput('p-custom-action', null);
+        expect(component.customAction()).toBeNull();
+      });
     });
   });
 

--- a/projects/ui/src/lib/components/po-helper/po-helper-base.component.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper-base.component.ts
@@ -1,7 +1,9 @@
 import { Component, HostBinding, input } from '@angular/core';
-import { PoHelperOptions } from './interfaces/po-helper.interface';
+
 import { validateSizeFn } from '../../utils/util';
 import { PoFieldSize } from '../../enums/po-field-size.enum';
+import { PoHelperOptions } from './interfaces/po-helper.interface';
+import { PoHelperCustomAction } from './interfaces/po-helper-custom-action.interface';
 /**
  * @description
  *
@@ -85,6 +87,9 @@ export class PoHelperBaseComponent {
     alias: 'p-helper',
     transform: this.transformHelper.bind(this)
   });
+
+  /** @docsPrivate */
+  customAction = input<PoHelperCustomAction>(undefined, { alias: 'p-custom-action' });
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-helper/po-helper.component.html
+++ b/projects/ui/src/lib/components/po-helper/po-helper.component.html
@@ -1,52 +1,68 @@
-<div
-  class="po-helper-container po-helper-target"
-  #target
-  [attr.tabindex]="disabled() ? null : 0"
-  role="button"
-  [attr.aria-label]="ariaLabel()"
-  [attr.aria-haspopup]="'dialog'"
-  [attr.aria-expanded]="!popover.isHidden"
-  [attr.aria-controls]="'popover-content-' + id"
-  [attr.aria-describedby]="!popover.isHidden ? 'popover-content-' + id : null"
-  [class.po-helper-disabled]="disabled()"
-  (keydown)="onKeyDown($event)"
-  (click)="openHelperPopover(); emitClick($event)"
->
-  <po-icon [p-icon]="helper()?.type === 'info' ? 'ICON_INFO' : 'ICON_HELP'"></po-icon>
-  <po-popover
-    #popover
-    [p-position]="popoverPosition"
-    [p-target]="target"
-    [p-title]="helper()?.title"
-    [p-append-in-body]="appendBox()"
-    [p-offset]="8"
-    p-custom-classes="po-helper-popover"
-    p-trigger="function"
-    (p-close)="handleClose()"
-    (p-open)="handleOpen()"
+@if (customAction()) {
+  <div
+    class="po-helper-container po-helper-target"
+    [class.po-helper-refresh-animating]="refreshAnimating"
+    [attr.tabindex]="0"
+    role="button"
+    [attr.aria-label]="customAction().ariaLabel || ''"
+    (keydown.enter)="executeCustomAction($event)"
+    (keydown.space)="executeCustomAction($event)"
+    (click)="executeCustomAction($event)"
+    (animationend)="onRefreshAnimationEnd()"
   >
-    <div [id]="'popover-content-' + id" role="dialog" aria-modal="false" tabindex="-1">
-      <span class="po-helper-content-text">
-        @for (fragment of contentFragments(); track $index) {
-          <span
-            [class.po-text-bold]="fragment.bold"
-            [class.po-text-italic]="fragment.italic"
-            [class.po-text-underline]="fragment.underline"
-            >{{ fragment.text }}</span
+    <po-icon [p-icon]="customAction().icon"></po-icon>
+  </div>
+} @else {
+  <div
+    class="po-helper-container po-helper-target"
+    #target
+    [attr.tabindex]="disabled() ? null : 0"
+    role="button"
+    [attr.aria-label]="ariaLabel()"
+    [attr.aria-haspopup]="'dialog'"
+    [attr.aria-expanded]="!popover.isHidden"
+    [attr.aria-controls]="'popover-content-' + id"
+    [attr.aria-describedby]="!popover.isHidden ? 'popover-content-' + id : null"
+    [class.po-helper-disabled]="disabled()"
+    (keydown)="onKeyDown($event)"
+    (click)="openHelperPopover(); emitClick($event)"
+  >
+    <po-icon [p-icon]="helper()?.type === 'info' ? 'ICON_INFO' : 'ICON_HELP'"></po-icon>
+    <po-popover
+      #popover
+      [p-position]="popoverPosition"
+      [p-target]="target"
+      [p-title]="helper()?.title"
+      [p-append-in-body]="appendBox()"
+      [p-offset]="8"
+      p-custom-classes="po-helper-popover"
+      p-trigger="function"
+      (p-close)="handleClose()"
+      (p-open)="handleOpen()"
+    >
+      <div [id]="'popover-content-' + id" role="dialog" aria-modal="false" tabindex="-1">
+        <span class="po-helper-content-text">
+          @for (fragment of contentFragments(); track $index) {
+            <span
+              [class.po-text-bold]="fragment.bold"
+              [class.po-text-italic]="fragment.italic"
+              [class.po-text-underline]="fragment.underline"
+              >{{ fragment.text }}</span
+            >
+          }
+        </span>
+        @if (helper()?.type === 'help' && helper()?.footerAction) {
+          <po-divider></po-divider>
+          <po-link
+            class="po-helper-footer-action-link"
+            (keydown.enter)="$event.stopPropagation()"
+            (keydown.space)="$event.stopPropagation()"
+            (p-action)="helper()?.footerAction?.action()"
+            [p-label]="helper()?.footerAction?.label"
           >
+          </po-link>
         }
-      </span>
-      @if (helper()?.type === 'help' && helper()?.footerAction) {
-        <po-divider></po-divider>
-        <po-link
-          class="po-helper-footer-action-link"
-          (keydown.enter)="$event.stopPropagation()"
-          (keydown.space)="$event.stopPropagation()"
-          (p-action)="helper()?.footerAction?.action()"
-          [p-label]="helper()?.footerAction?.label"
-        >
-        </po-link>
-      }
-    </div>
-  </po-popover>
-</div>
+      </div>
+    </po-popover>
+  </div>
+}

--- a/projects/ui/src/lib/components/po-helper/po-helper.component.spec.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper.component.spec.ts
@@ -609,4 +609,80 @@ describe('PoHelperComponent', () => {
       expect(component['contentFragments']()).toEqual([]);
     });
   });
+
+  describe('executeCustomAction:', () => {
+    it('should call action function from customAction', () => {
+      const actionSpy = jasmine.createSpy('action');
+      (component as any).customAction = () => ({ icon: 'ICON_REFRESH', action: actionSpy });
+
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+      spyOn(event, 'preventDefault');
+      spyOn(event, 'stopPropagation');
+
+      (component as any).executeCustomAction(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.stopPropagation).toHaveBeenCalled();
+      expect(actionSpy).toHaveBeenCalled();
+    });
+
+    it('should set refreshAnimating to true when action is called', () => {
+      const actionSpy = jasmine.createSpy('action');
+      (component as any).customAction = () => ({ icon: 'ICON_REFRESH', action: actionSpy });
+
+      const event = new MouseEvent('click');
+      (component as any).executeCustomAction(event);
+
+      expect(component.refreshAnimating).toBeTrue();
+    });
+
+    it('should not call action if customAction is undefined', () => {
+      (component as any).customAction = () => undefined;
+
+      const event = new MouseEvent('click');
+      expect(() => (component as any).executeCustomAction(event)).not.toThrow();
+      expect(component.refreshAnimating).toBeFalse();
+    });
+
+    it('should not call action if action is not a function', () => {
+      (component as any).customAction = () => ({ icon: 'ICON_REFRESH', action: 'not a function' });
+
+      const event = new MouseEvent('click');
+      expect(() => (component as any).executeCustomAction(event)).not.toThrow();
+      expect(component.refreshAnimating).toBeFalse();
+    });
+
+    it('should reset and retrigger animation on rapid successive clicks', () => {
+      const actionSpy = jasmine.createSpy('action');
+      (component as any).customAction = () => ({ icon: 'ICON_REFRESH', action: actionSpy });
+      const cdrSpy = spyOn(component['cdr'], 'detectChanges');
+
+      const event = new MouseEvent('click');
+
+      // First click
+      (component as any).executeCustomAction(event);
+      expect(component.refreshAnimating).toBeTrue();
+      expect(cdrSpy).not.toHaveBeenCalled();
+
+      // Second click while animation is still running
+      (component as any).executeCustomAction(event);
+      expect(cdrSpy).toHaveBeenCalled();
+      expect(component.refreshAnimating).toBeTrue();
+      expect(actionSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('onRefreshAnimationEnd:', () => {
+    it('should set refreshAnimating to false', () => {
+      component.refreshAnimating = true;
+      (component as any).onRefreshAnimationEnd();
+      expect(component.refreshAnimating).toBeFalse();
+    });
+  });
+
+  describe('refreshAnimating:', () => {
+    it('should be false by default', () => {
+      expect(component.refreshAnimating).toBeFalse();
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-helper/po-helper.component.ts
+++ b/projects/ui/src/lib/components/po-helper/po-helper.component.ts
@@ -1,18 +1,19 @@
 import {
+  computed,
   Component,
-  ElementRef,
-  ViewChild,
-  AfterViewInit,
   OnDestroy,
   OnChanges,
+  ViewChild,
+  ElementRef,
+  AfterViewInit,
   SimpleChanges,
-  ChangeDetectorRef,
-  computed
+  ChangeDetectorRef
 } from '@angular/core';
+
+import { PoButtonComponent } from '../po-button';
 import { PoHelperBaseComponent } from './po-helper-base.component';
 import { PoHelperOptions } from './interfaces/po-helper.interface';
 import { PoPopoverComponent } from '../po-popover/po-popover.component';
-import { PoButtonComponent } from '../po-button';
 import { parseSafeText, PoTextFragment, PoFormattingTag } from '../../utils/safe-text-parser';
 
 /** Tags de formatação aceitas pelo po-helper. */
@@ -49,6 +50,7 @@ export class PoHelperComponent extends PoHelperBaseComponent implements AfterVie
   @ViewChild('popover', { static: false }) popover: PoPopoverComponent;
   @ViewChild(PoButtonComponent, { read: ElementRef, static: true }) poButton: PoButtonComponent;
 
+  refreshAnimating = false;
   private static instances: Array<PoHelperComponent> = [];
   private static idCounter = 0;
   protected popoverPosition = 'right';
@@ -223,5 +225,23 @@ export class PoHelperComponent extends PoHelperBaseComponent implements AfterVie
     if (this.boundFocusIn) {
       window.removeEventListener('focusin', this.boundFocusIn, true);
     }
+  }
+
+  protected executeCustomAction(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const action = this.customAction();
+    if (action && typeof action.action === 'function') {
+      if (this.refreshAnimating) {
+        this.refreshAnimating = false;
+        this.cdr.detectChanges();
+      }
+      this.refreshAnimating = true;
+      action.action();
+    }
+  }
+
+  protected onRefreshAnimationEnd(): void {
+    this.refreshAnimating = false;
   }
 }

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.spec.ts
@@ -1,5 +1,5 @@
-import { Directive } from '@angular/core';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Component, Directive } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
@@ -15,12 +15,21 @@ class PoPageDefaultComponent extends PoPageDefaultBaseComponent {
   getVisibleActions() {}
 }
 
+@Component({
+  selector: 'po-page-default-test-host',
+  template: '',
+  standalone: false
+})
+class PoPageDefaultTestHostComponent extends PoPageDefaultComponent {}
+
 describe('PoPageDefaultBaseComponent:', () => {
   let languageService: PoLanguageService;
   let component: PoPageDefaultComponent;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({}).compileComponents();
+    await TestBed.configureTestingModule({
+      declarations: [PoPageDefaultTestHostComponent]
+    }).compileComponents();
 
     languageService = new PoLanguageService();
 
@@ -292,6 +301,109 @@ describe('PoPageDefaultBaseComponent:', () => {
       it('should handle null value', () => {
         const result = component['transformPageHelper'](null);
         expect(result).toBeNull();
+      });
+    });
+
+    describe('p-refresh:', () => {
+      let fixtureHost: ComponentFixture<PoPageDefaultTestHostComponent>;
+      let hostComponent: PoPageDefaultTestHostComponent;
+
+      beforeEach(() => {
+        fixtureHost = TestBed.createComponent(PoPageDefaultTestHostComponent);
+        hostComponent = fixtureHost.componentInstance;
+        fixtureHost.detectChanges();
+      });
+
+      it('should have refresh input with undefined as default value', () => {
+        expect(hostComponent.refresh()).toBeUndefined();
+      });
+
+      it('should accept a function value', () => {
+        const fn = () => {};
+        fixtureHost.componentRef.setInput('p-refresh', fn);
+        expect(hostComponent.refresh()).toBe(fn);
+      });
+
+      it('should accept null value', () => {
+        fixtureHost.componentRef.setInput('p-refresh', null);
+        expect(hostComponent.refresh()).toBeNull();
+      });
+    });
+
+    describe('refreshCustomAction:', () => {
+      let fixtureHost: ComponentFixture<PoPageDefaultTestHostComponent>;
+      let hostComponent: PoPageDefaultTestHostComponent;
+
+      beforeEach(() => {
+        fixtureHost = TestBed.createComponent(PoPageDefaultTestHostComponent);
+        hostComponent = fixtureHost.componentInstance;
+        fixtureHost.detectChanges();
+      });
+
+      it('should return undefined when refresh is null', () => {
+        fixtureHost.componentRef.setInput('p-refresh', null);
+        expect((hostComponent as any).refreshCustomAction()).toBeUndefined();
+      });
+
+      it('should return undefined when refresh is not a function', () => {
+        fixtureHost.componentRef.setInput('p-refresh', 'not a function');
+        expect((hostComponent as any).refreshCustomAction()).toBeUndefined();
+      });
+
+      it('should return PoHelperCustomAction when refresh is a valid function', () => {
+        const fn = () => {};
+        fixtureHost.componentRef.setInput('p-refresh', fn);
+
+        const result = (hostComponent as any).refreshCustomAction();
+
+        expect(result).toBeDefined();
+        expect(result.icon).toBe('ICON_REFRESH');
+        expect(result.action).toBe(fn);
+      });
+
+      it('should return ariaLabel based on language (pt)', () => {
+        hostComponent['language'] = 'pt';
+        const fn = () => {};
+        fixtureHost.componentRef.setInput('p-refresh', fn);
+
+        const result = (hostComponent as any).refreshCustomAction();
+        expect(result.ariaLabel).toBe('Atualizar');
+      });
+
+      it('should return ariaLabel based on language (en)', () => {
+        hostComponent['language'] = 'en';
+        const fn = () => {};
+        fixtureHost.componentRef.setInput('p-refresh', fn);
+
+        const result = (hostComponent as any).refreshCustomAction();
+        expect(result.ariaLabel).toBe('Refresh');
+      });
+
+      it('should return ariaLabel based on language (es)', () => {
+        hostComponent['language'] = 'es';
+        const fn = () => {};
+        fixtureHost.componentRef.setInput('p-refresh', fn);
+
+        const result = (hostComponent as any).refreshCustomAction();
+        expect(result.ariaLabel).toBe('Actualizar');
+      });
+
+      it('should return ariaLabel based on language (ru)', () => {
+        hostComponent['language'] = 'ru';
+        const fn = () => {};
+        fixtureHost.componentRef.setInput('p-refresh', fn);
+
+        const result = (hostComponent as any).refreshCustomAction();
+        expect(result.ariaLabel).toBe('Обновить');
+      });
+
+      it('should fallback to EN ariaLabel for unsupported language', () => {
+        hostComponent['language'] = 'zw';
+        const fn = () => {};
+        fixtureHost.componentRef.setInput('p-refresh', fn);
+
+        const result = (hostComponent as any).refreshCustomAction();
+        expect(result.ariaLabel).toBe('Refresh');
       });
     });
   });

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default-base.component.ts
@@ -1,17 +1,17 @@
-import { Directive, HostBinding, HostListener, Input, ViewChild, input, output } from '@angular/core';
-
-import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
-import { PoLanguageService } from './../../../services/po-language/po-language.service';
+import { Directive, HostBinding, HostListener, Input, ViewChild, computed, input, output } from '@angular/core';
 
 import { PoFieldSize } from '../../../enums/po-field-size.enum';
-import { getDefaultSizeFn, validateSizeFn } from '../../../utils/util';
-import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
-import { PoHelperOptions } from '../../po-helper/interfaces/po-helper.interface';
-import { PoPageAction } from '../interfaces/po-page-action.interface';
-import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
-import { PoPageActionsLayout } from './enums/po-page-actions-layout.enum';
 import { PoPageHeaderType } from './enums/po-page-header-type.enum';
+import { PoPageAction } from '../interfaces/po-page-action.interface';
+import { getDefaultSizeFn, validateSizeFn } from '../../../utils/util';
+import { PoPageActionsLayout } from './enums/po-page-actions-layout.enum';
+import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
 import { PoPageDefaultLiterals } from './po-page-default-literals.interface';
+import { PoHelperOptions } from '../../po-helper/interfaces/po-helper.interface';
+import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
+import { poLocaleDefault } from './../../../services/po-language/po-language.constant';
+import { PoLanguageService } from './../../../services/po-language/po-language.service';
+import { PoHelperCustomAction } from '../../po-helper/interfaces/po-helper-custom-action.interface';
 
 export const poPageDefaultLiteralsDefault = {
   en: <PoPageDefaultLiterals>{
@@ -33,6 +33,13 @@ export const backNavigationAriaLabels = {
   es: 'Volver',
   pt: 'Voltar',
   ru: 'Назад'
+};
+
+export const refreshAriaLabels = {
+  en: 'Refresh',
+  es: 'Actualizar',
+  pt: 'Atualizar',
+  ru: 'Обновить'
 };
 
 /**
@@ -259,6 +266,39 @@ export abstract class PoPageDefaultBaseComponent {
   get pageHeaderType(): string {
     return this._pageHeaderType;
   }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define a função de callback executada ao clicar no botão de atualização (refresh) ao lado do subtítulo da página.
+   *
+   * Quando não houver subtítulo (`p-subtitle`), o refresh será exibido logo abaixo do título.
+   *
+   * > Esta propriedade possui precedência sobre a configuração de `p-helper`.
+   *
+   * Exemplo de uso:
+   * ```html
+   * <po-page-default
+   *   p-title="Dashboard"
+   *   [p-refresh]="onRefresh"
+   * ></po-page-default>
+   * ```
+   */
+  refresh = input<Function>(undefined, { alias: 'p-refresh' });
+
+  protected readonly refreshCustomAction = computed<PoHelperCustomAction | undefined>(() => {
+    const fn = this.refresh();
+    if (fn && typeof fn === 'function') {
+      return {
+        icon: 'ICON_REFRESH',
+        ariaLabel: refreshAriaLabels[this.language] || refreshAriaLabels['en'],
+        action: fn
+      };
+    }
+    return undefined;
+  });
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.html
@@ -83,7 +83,8 @@
       @case ('secondary') {
         <po-page-header
           [p-type]="'secondary'"
-          [p-helper]="helper()"
+          [p-helper]="refreshCustomAction() ? undefined : helper()"
+          [p-custom-action]="refreshCustomAction()"
           [p-size]="componentsSize"
           [p-subtitle]="subtitle"
           [p-title]="title"
@@ -116,7 +117,8 @@
       @case ('tertiary') {
         <po-page-header
           [p-type]="'tertiary'"
-          [p-helper]="helper()"
+          [p-helper]="refreshCustomAction() ? undefined : helper()"
+          [p-custom-action]="refreshCustomAction()"
           [p-size]="componentsSize"
           [p-subtitle]="subtitle"
           [p-title]="title"
@@ -139,7 +141,8 @@
       @default {
         <po-page-header
           [p-breadcrumb]="breadcrumb"
-          [p-helper]="helper()"
+          [p-helper]="refreshCustomAction() ? undefined : helper()"
+          [p-custom-action]="refreshCustomAction()"
           [p-size]="componentsSize"
           [p-subtitle]="subtitle"
           [p-title]="title"

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.ts
@@ -30,6 +30,11 @@ import { backNavigationAriaLabels, PoPageDefaultBaseComponent } from './po-page-
  *  <file name="sample-po-page-default-dashboard/sample-po-page-default-dashboard.component.css"> </file>
  *  <file name="sample-po-page-default-dashboard/sample-po-page-default-dashboard.service.ts"> </file>
  * </example>
+ *
+ * <example name="po-page-default-refresh" title="PO Page Default - Refresh">
+ *  <file name="sample-po-page-default-refresh/sample-po-page-default-refresh.component.html"> </file>
+ *  <file name="sample-po-page-default-refresh/sample-po-page-default-refresh.component.ts"> </file>
+ * </example>
  */
 @Component({
   selector: 'po-page-default',

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.html
@@ -6,6 +6,7 @@
   [p-literals]="customLiterals ?? {}"
   [p-page-actions-layout]="pageActionsLayout"
   [p-page-header-type]="pageHeaderType"
+  [p-refresh]="showRefresh ? onRefresh : null"
   [p-title]="title"
   [p-subtitle]="subtitle"
   (p-back)="onBack()"
@@ -20,7 +21,10 @@
 
     <po-input class="po-md-6" name="subtitle" [(ngModel)]="subtitle" p-label="Subtitle"> </po-input>
 
-    <po-checkbox class="po-md-12 po-pt-2 po-pb-2" name="showHelper" [(ngModel)]="showHelper" p-label="Helper">
+    <po-checkbox class="po-md-6 po-pt-2 po-pb-2" name="showHelper" [(ngModel)]="showHelper" p-label="Helper">
+    </po-checkbox>
+
+    <po-checkbox class="po-md-6 po-pt-2 po-pb-2" name="showRefresh" [(ngModel)]="showRefresh" p-label="Refresh">
     </po-checkbox>
 
     @if (showHelper) {

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-labs/sample-po-page-default-labs.component.ts
@@ -43,6 +43,7 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
   helperTitle: string = '';
   helperType: 'help' | 'info' = 'info';
   showHelper: boolean = false;
+  showRefresh: boolean = false;
 
   public readonly helperTypeOptions: Array<PoSelectOption> = [
     { label: 'help', value: 'help' },
@@ -155,6 +156,10 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
     this.poNotification.information('Back button clicked (p-back event)');
   }
 
+  onRefresh = (): void => {
+    this.poNotification.success('Page refreshed (p-refresh event)');
+  };
+
   restore() {
     this.actions = [];
     this.breadcrumb = { items: [] };
@@ -170,6 +175,7 @@ export class SamplePoPageDefaultLabsComponent implements OnInit {
     this.pageActionsLayout = 'default';
     this.pageHeaderType = 'primary';
     this.showHelper = false;
+    this.showRefresh = false;
     this.subtitle = '';
     this.title = 'PO Page Default';
     this.restoreActionForm();

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-refresh/sample-po-page-default-refresh.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-refresh/sample-po-page-default-refresh.component.html
@@ -1,0 +1,3 @@
+<po-page-default p-title="Inventory" p-subtitle="Product stock management" [p-refresh]="onRefresh">
+  <po-table [p-columns]="columns" [p-items]="items" [p-loading]="loading" p-striped> </po-table>
+</po-page-default>

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-refresh/sample-po-page-default-refresh.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-refresh/sample-po-page-default-refresh.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnInit } from '@angular/core';
+
+import { PoNotificationService, PoTableColumn } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-page-default-refresh',
+  templateUrl: './sample-po-page-default-refresh.component.html',
+  standalone: false
+})
+export class SamplePoPageDefaultRefreshComponent implements OnInit {
+  columns: Array<PoTableColumn> = [];
+  items: Array<any> = [];
+  loading: boolean = false;
+
+  private readonly allItems: Array<any> = [
+    { id: 1, product: 'Notebook Pro', quantity: 12, price: 4599.9, status: 'Available' },
+    { id: 2, product: 'Wireless Mouse', quantity: 85, price: 129.9, status: 'Available' },
+    { id: 3, product: 'Mechanical Keyboard', quantity: 34, price: 459.9, status: 'Available' },
+    { id: 4, product: 'Monitor 27"', quantity: 7, price: 2199.9, status: 'Low stock' },
+    { id: 5, product: 'USB-C Hub', quantity: 0, price: 249.9, status: 'Out of stock' },
+    { id: 6, product: 'Webcam HD', quantity: 23, price: 349.9, status: 'Available' },
+    { id: 7, product: 'Headset Bluetooth', quantity: 41, price: 599.9, status: 'Available' },
+    { id: 8, product: 'External SSD 1TB', quantity: 3, price: 689.9, status: 'Low stock' }
+  ];
+
+  constructor(private readonly poNotification: PoNotificationService) {}
+
+  ngOnInit(): void {
+    this.columns = this.getColumns();
+    this.loadItems();
+  }
+
+  onRefresh = (): void => {
+    this.loading = true;
+
+    setTimeout(() => {
+      this.refreshItems();
+      this.loading = false;
+      this.poNotification.success('Inventory data refreshed successfully.');
+    }, 1000);
+  };
+
+  private getColumns(): Array<PoTableColumn> {
+    return [
+      { property: 'id', label: 'ID', width: '60px' },
+      { property: 'product', label: 'Product' },
+      { property: 'quantity', label: 'Quantity', width: '100px' },
+      { property: 'price', label: 'Price', type: 'currency', format: 'BRL', width: '140px' },
+      {
+        property: 'status',
+        label: 'Status',
+        type: 'label',
+        width: '130px',
+        labels: [
+          { value: 'Available', color: 'color-10', label: 'Available' },
+          { value: 'Low stock', color: 'color-08', label: 'Low stock' },
+          { value: 'Out of stock', color: 'color-07', label: 'Out of stock' }
+        ]
+      }
+    ];
+  }
+
+  private loadItems(): void {
+    this.items = [...this.allItems];
+  }
+
+  private refreshItems(): void {
+    this.items = this.allItems.map(item => ({
+      ...item,
+      quantity: item.quantity + Math.floor(Math.random() * 10),
+      status: this.getStatus(item.quantity + Math.floor(Math.random() * 10))
+    }));
+  }
+
+  private getStatus(quantity: number): string {
+    if (quantity === 0) {
+      return 'Out of stock';
+    }
+    return quantity <= 5 ? 'Low stock' : 'Available';
+  }
+}

--- a/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.spec.ts
@@ -19,6 +19,12 @@ describe('PoPageHeaderBaseComponent', () => {
     });
   });
 
+  describe('customAction property:', () => {
+    it('should have customAction input with undefined as default value', () => {
+      expect(component.customAction()).toBeUndefined();
+    });
+  });
+
   describe('subtitle property:', () => {
     it('should store the raw subtitle value', () => {
       component.subtitle = 'Texto simples';

--- a/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-header/po-page-header-base.component.ts
@@ -3,6 +3,7 @@ import { Directive, Input, input } from '@angular/core';
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
 import { PoHelperOptions } from '../../po-helper/interfaces/po-helper.interface';
 import { parseSafeText, PoFormattingTag, PoTextFragment } from '../../../utils/safe-text-parser';
+import { PoHelperCustomAction } from '../../po-helper/interfaces/po-helper-custom-action.interface';
 
 /** Tags aceitas pelo subtítulo do po-page-header. */
 const PAGE_SUBTITLE_ALLOWED_TAGS: Array<PoFormattingTag> = ['b', 'i', 'u', 'strong', 'em'];
@@ -22,6 +23,9 @@ export class PoPageHeaderBaseComponent {
 
   /** Define o conteúdo do po-helper. */
   helper = input<PoHelperOptions | string>(undefined, { alias: 'p-helper' });
+
+  /** Define a ação customizada para o po-helper (uso interno entre componentes). */
+  customAction = input<PoHelperCustomAction>(undefined, { alias: 'p-custom-action' });
 
   /** Define o tamanho dos componentes no header. */
   @Input('p-size') size: string;

--- a/projects/ui/src/lib/components/po-page/po-page-header/po-page-header.component.html
+++ b/projects/ui/src/lib/components/po-page/po-page-header/po-page-header.component.html
@@ -46,15 +46,23 @@
                 >
               }
             </span>
-            @if (helper()) {
+            @if (customAction()) {
+              <po-helper [p-custom-action]="customAction()" [p-size]="size"></po-helper>
+            } @else if (helper()) {
               <po-helper [p-helper]="helper()" [p-size]="size"></po-helper>
             }
           </div>
         }
-        @if (title && !subtitle && helper()) {
-          <div class="po-page-header-subtitle">
-            <po-helper [p-helper]="helper()" [p-size]="size"></po-helper>
-          </div>
+        @if (title && !subtitle) {
+          @if (customAction()) {
+            <div class="po-page-header-subtitle">
+              <po-helper [p-custom-action]="customAction()" [p-size]="size"></po-helper>
+            </div>
+          } @else if (helper()) {
+            <div class="po-page-header-subtitle">
+              <po-helper [p-helper]="helper()" [p-size]="size"></po-helper>
+            </div>
+          }
         }
       </div>
     }


### PR DESCRIPTION
Adiciona suporte à ação p-refresh no header.

Fixes: DTHFUI-13396

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
