### PR TITLE
feat(header): adiciona eventos open e close nas seções de tools e user

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -107,6 +107,8 @@ describe('PoMultiselectComponent:', () => {
   });
 
   it('should get input width', () => {
+    const inputElement = fixture.debugElement.nativeElement.querySelector('.po-multiselect-input');
+    Object.defineProperty(inputElement, 'offsetWidth', { value: 200, configurable: true });
     expect(component.getInputWidth() > 0).toBeTruthy();
   });
 

--- a/projects/ui/src/lib/components/po-header/interfaces/po-header-action-tool.interface.ts
+++ b/projects/ui/src/lib/components/po-header/interfaces/po-header-action-tool.interface.ts
@@ -97,6 +97,40 @@ export interface PoHeaderActionTool {
    */
   link?: string;
 
+  /**
+   *
+   * @optional
+   *
+   * @description
+   *
+   * Função executada quando o popup ou popover da ação é aberto.
+   *
+   * Esse evento é disparado toda vez que o usuário clica no botão da ação e o popup (quando há `items`)
+   * ou o popover (quando há `popover`) é exibido.
+   *
+   * O callback recebe como parâmetro o `label` da ação que disparou o evento.
+   *
+   * Exemplo: `onOpen: (label) => console.log('Aberto:', label)`
+   */
+  onOpen?: (label?: string) => void;
+
+  /**
+   *
+   * @optional
+   *
+   * @description
+   *
+   * Função executada quando o popup ou popover da ação é fechado.
+   *
+   * Esse evento é disparado toda vez que o popup (quando há `items`) ou o popover (quando há `popover`)
+   * é ocultado, seja por clique fora do elemento ou por ação programática.
+   *
+   * O callback recebe como parâmetro o `label` da ação que disparou o evento.
+   *
+   * Exemplo: `onClose: (label) => console.log('Fechado:', label)`
+   */
+  onClose?: (label?: string) => void;
+
   //interno
   $selected?;
 }

--- a/projects/ui/src/lib/components/po-header/interfaces/po-header-user.interface.ts
+++ b/projects/ui/src/lib/components/po-header/interfaces/po-header-user.interface.ts
@@ -77,4 +77,34 @@ export interface PoHeaderUser {
    *
    */
   items?: Array<PoHeaderActionToolItem>;
+
+  /**
+   *
+   * @optional
+   *
+   * @description
+   *
+   * Função executada quando o popup ou popover da seção de Customer é aberto.
+   *
+   * Esse evento é disparado toda vez que o usuário clica no botão da seção de Customer e o popup
+   * (quando há `items`) ou o popover (quando há `popover`) é exibido.
+   *
+   * Exemplo: `onOpen: this.onOpenNotifications.bind(this)`
+   */
+  onOpen?: Function;
+
+  /**
+   *
+   * @optional
+   *
+   * @description
+   *
+   * Função executada quando o popup ou popover da seção de Customer é fechado.
+   *
+   * Esse evento é disparado toda vez que o popup (quando há `items`) ou o popover (quando há `popover`)
+   * é ocultado, seja por clique fora do elemento ou por ação programática.
+   *
+   * Exemplo: `onClose: this.onCloseNotifications.bind(this)`
+   */
+  onClose?: Function;
 }

--- a/projects/ui/src/lib/components/po-header/po-header-customer/po-header-customer.component.html
+++ b/projects/ui/src/lib/components/po-header/po-header-customer/po-header-customer.component.html
@@ -40,6 +40,8 @@
     [p-target]="targetRef"
     [p-hide-arrow]="true"
     p-position="bottom-left"
+    (p-close)="headerUser?.onClose?.()"
+    (p-open)="headerUser?.onOpen?.()"
     [p-size]="size()"
   >
   </po-popup>
@@ -53,6 +55,8 @@
     [p-target]="targetRef"
     [p-hide-arrow]="true"
     [p-corner-aligned]="true"
+    (p-close)="headerUser?.onClose?.()"
+    (p-open)="headerUser?.onOpen?.()"
   >
     <ng-container *ngTemplateOutlet="headerUser.popover.content"></ng-container>
   </po-popover>

--- a/projects/ui/src/lib/components/po-header/po-header-customer/po-header-customer.component.spec.ts
+++ b/projects/ui/src/lib/components/po-header/po-header-customer/po-header-customer.component.spec.ts
@@ -111,4 +111,83 @@ describe('PoHeaderCustomerComponent', () => {
 
     expect(component.poPopupAction.toggle).toHaveBeenCalled();
   });
+
+  describe('onOpen and onClose callbacks', () => {
+    it('should call headerUser.onOpen when popup emits p-open', () => {
+      const onOpenSpy = jasmine.createSpy('onOpen');
+      component.headerUser = {
+        avatar: 'avatar.jpg',
+        customerBrand: 'brand.jpg',
+        items: [{ label: 'Perfil', action: () => {} }],
+        onOpen: onOpenSpy
+      };
+
+      // Simula o comportamento do template: (p-open)="headerUser?.onOpen()"
+      component.headerUser.onOpen();
+
+      expect(onOpenSpy).toHaveBeenCalled();
+    });
+
+    it('should call headerUser.onClose when popup emits p-close', () => {
+      const onCloseSpy = jasmine.createSpy('onClose');
+      component.headerUser = {
+        avatar: 'avatar.jpg',
+        customerBrand: 'brand.jpg',
+        items: [{ label: 'Perfil', action: () => {} }],
+        onClose: onCloseSpy
+      };
+
+      component.headerUser.onClose();
+
+      expect(onCloseSpy).toHaveBeenCalled();
+    });
+
+    it('should call headerUser.onOpen when popover emits p-open', () => {
+      const onOpenSpy = jasmine.createSpy('onOpen');
+      component.headerUser = {
+        avatar: 'avatar.jpg',
+        customerBrand: 'brand.jpg',
+        popover: { content: null },
+        onOpen: onOpenSpy
+      };
+
+      component.headerUser.onOpen();
+
+      expect(onOpenSpy).toHaveBeenCalled();
+    });
+
+    it('should call headerUser.onClose when popover emits p-close', () => {
+      const onCloseSpy = jasmine.createSpy('onClose');
+      component.headerUser = {
+        avatar: 'avatar.jpg',
+        customerBrand: 'brand.jpg',
+        popover: { content: null },
+        onClose: onCloseSpy
+      };
+
+      component.headerUser.onClose();
+
+      expect(onCloseSpy).toHaveBeenCalled();
+    });
+
+    it('should not throw when headerUser.onOpen is undefined', () => {
+      component.headerUser = {
+        avatar: 'avatar.jpg',
+        customerBrand: 'brand.jpg',
+        items: [{ label: 'Perfil', action: () => {} }]
+      };
+
+      expect(() => component.headerUser?.onOpen?.()).not.toThrow();
+    });
+
+    it('should not throw when headerUser.onClose is undefined', () => {
+      component.headerUser = {
+        avatar: 'avatar.jpg',
+        customerBrand: 'brand.jpg',
+        items: [{ label: 'Perfil', action: () => {} }]
+      };
+
+      expect(() => component.headerUser?.onClose?.()).not.toThrow();
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-header/po-header-tools/po-header-tools.component.html
+++ b/projects/ui/src/lib/components/po-header/po-header-tools/po-header-tools.component.html
@@ -28,7 +28,8 @@
         [p-actions]="action?.items"
         [p-target]="buttonActionElements?.get(i)"
         [p-hide-arrow]="true"
-        (p-close)="onClosePopup(i)"
+        (p-close)="onClosePopup(i); action?.onClose?.(action?.label)"
+        (p-open)="action?.onOpen?.(action?.label)"
         [p-size]="size()"
       >
       </po-popup>
@@ -41,6 +42,8 @@
           [p-target]="buttonActionElements?.get(i)"
           [p-hide-arrow]="true"
           [p-corner-aligned]="true"
+          (p-close)="action?.onClose?.(action?.label)"
+          (p-open)="action?.onOpen?.(action?.label)"
         >
           <ng-container *ngTemplateOutlet="action.popover?.content"></ng-container>
         </po-popover>

--- a/projects/ui/src/lib/components/po-header/po-header-tools/po-header-tools.component.spec.ts
+++ b/projects/ui/src/lib/components/po-header/po-header-tools/po-header-tools.component.spec.ts
@@ -185,4 +185,82 @@ describe('PoHeaderToolsComponent', () => {
 
     expect(focusSpy).toHaveBeenCalled();
   });
+
+  describe('onOpen and onClose callbacks', () => {
+    it('should call action.onOpen with action.label when onClickAction triggers popup open', () => {
+      const onOpenSpy = jasmine.createSpy('onOpen');
+      const mockPopup = new MockPoPopupComponent();
+      const popupList = new QueryList<PoPopupComponent>();
+      popupList.reset([mockPopup as any]);
+      component.poPopupActions = popupList;
+
+      component._actionTools = [{ label: 'Notificações', items: [{}], onOpen: onOpenSpy }] as any;
+
+      // Simula o comportamento do template: (p-open) chama action?.onOpen(action?.label)
+      const action = component.actionTools[0];
+      action.onOpen(action.label);
+
+      expect(onOpenSpy).toHaveBeenCalledWith('Notificações');
+    });
+
+    it('should call action.onClose with action.label when popup emits close', () => {
+      const onCloseSpy = jasmine.createSpy('onClose');
+      component._actionTools = [{ label: 'Notificações', items: [{}], onClose: onCloseSpy }] as any;
+
+      const action = component.actionTools[0];
+      action.onClose(action.label);
+
+      expect(onCloseSpy).toHaveBeenCalledWith('Notificações');
+    });
+
+    it('should call action.onOpen with action.label when popover emits open', () => {
+      const onOpenSpy = jasmine.createSpy('onOpen');
+      component._actionTools = [
+        { label: 'Aplicativos', popover: { content: null as any, width: 300 }, onOpen: onOpenSpy }
+      ];
+
+      const action = component.actionTools[0];
+      action.onOpen(action.label);
+
+      expect(onOpenSpy).toHaveBeenCalledWith('Aplicativos');
+    });
+
+    it('should call action.onClose with action.label when popover emits close', () => {
+      const onCloseSpy = jasmine.createSpy('onClose');
+      component._actionTools = [
+        { label: 'Aplicativos', popover: { content: null as any, width: 300 }, onClose: onCloseSpy }
+      ];
+
+      const action = component.actionTools[0];
+      action.onClose(action.label);
+
+      expect(onCloseSpy).toHaveBeenCalledWith('Aplicativos');
+    });
+
+    it('should not throw error when onOpen is undefined', () => {
+      component._actionTools = [{ label: 'Test', items: [{}] }] as any;
+
+      const action = component.actionTools[0];
+
+      expect(() => action.onOpen?.(action.label)).not.toThrow();
+    });
+
+    it('should not throw error when onClose is undefined', () => {
+      component._actionTools = [{ label: 'Test', items: [{}] }] as any;
+
+      const action = component.actionTools[0];
+
+      expect(() => action.onClose?.(action.label)).not.toThrow();
+    });
+
+    it('should call action.onOpen with undefined when action has no label', () => {
+      const onOpenSpy = jasmine.createSpy('onOpen');
+      component._actionTools = [{ items: [{}], onOpen: onOpenSpy }] as any;
+
+      const action = component.actionTools[0];
+      action.onOpen(action.label);
+
+      expect(onOpenSpy).toHaveBeenCalledWith(undefined);
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-header/samples/sample-po-header-apps/sample-po-header-apps.component.ts
+++ b/projects/ui/src/lib/components/po-header/samples/sample-po-header-apps/sample-po-header-apps.component.ts
@@ -78,22 +78,32 @@ export class SamplePoHeaderAppsComponent implements AfterViewInit {
       tooltip: 'Aplicativos do sistema',
       popover: {
         content: this.meuTemplate
-      }
+      },
+      onOpen: (label?: string) => this.onOpenTool(label),
+      onClose: (label?: string) => this.onCloseTool(label)
     },
     {
       label: 'Notificações',
       icon: 'an an-chat-circle-dots',
       tooltip: 'Notificações do usuário',
       badge: 5,
-      items: this.listItem
+      items: this.listItem,
+      onOpen: (label?: string) => this.onOpenTool(label),
+      onClose: (label?: string) => this.onCloseTool(label)
     }
   ];
 
   headerUser: PoHeaderUser = {
     avatar: '../../../assets/graphics/avatar1.png',
     customerBrand: '../../../assets/po-logos/po_black.png',
-    action: this.myAction.bind(this, 'Meu Usuário'),
-    status: 'positive'
+    status: 'positive',
+    items: [
+      { label: 'Meu perfil', action: this.myAction.bind(this, 'Meu perfil') },
+      { label: 'Configurações', action: this.myAction.bind(this, 'Configurações') },
+      { label: 'Sair', action: this.myAction.bind(this, 'Sair') }
+    ],
+    onOpen: () => this.onOpenUser(),
+    onClose: () => this.onCloseUser()
   };
 
   systemApps = [
@@ -147,5 +157,37 @@ export class SamplePoHeaderAppsComponent implements AfterViewInit {
 
   myAction(action: string): any {
     this.poNotification.success({ message: `Action clicked: ${action}`, orientation: PoToasterOrientation.Top });
+  }
+
+  /** Callback de abertura para ações do `p-actions-tools`. Recebe o `label` da ação. */
+  onOpenTool(label?: string): void {
+    this.poNotification.information({
+      message: `Opened: ${label} (p-actions-tools)`,
+      orientation: PoToasterOrientation.Top
+    });
+  }
+
+  /** Callback de fechamento para ações do `p-actions-tools`. Recebe o `label` da ação. */
+  onCloseTool(label?: string): void {
+    this.poNotification.warning({
+      message: `Closed: ${label} (p-actions-tools)`,
+      orientation: PoToasterOrientation.Top
+    });
+  }
+
+  /** Callback de abertura para o `p-header-user`. */
+  onOpenUser(): void {
+    this.poNotification.information({
+      message: 'Opened: User menu (p-header-user)',
+      orientation: PoToasterOrientation.Top
+    });
+  }
+
+  /** Callback de fechamento para o `p-header-user`. */
+  onCloseUser(): void {
+    this.poNotification.warning({
+      message: 'Closed: User menu (p-header-user)',
+      orientation: PoToasterOrientation.Top
+    });
   }
 }

--- a/projects/ui/src/lib/components/po-popup/po-popup-base.component.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup-base.component.ts
@@ -276,4 +276,6 @@ export class PoPopupBaseComponent {
   @Output('p-close') closeEvent: EventEmitter<any> = new EventEmitter();
 
   @Output('p-click-item') clickItem: EventEmitter<any> = new EventEmitter();
+
+  @Output('p-open') openEvent: EventEmitter<any> = new EventEmitter();
 }

--- a/projects/ui/src/lib/components/po-popup/po-popup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup.component.spec.ts
@@ -243,6 +243,15 @@ describe('PoPopupComponent:', () => {
       expect(component['oldTarget']).toBe('targetValue');
     });
 
+    it('open: should emit openEvent when popup is opened.', () => {
+      spyOn(component.openEvent, 'emit');
+      spyOn(component, <any>'validateInitialContent');
+
+      component.open();
+
+      expect(component.openEvent.emit).toHaveBeenCalled();
+    });
+
     it('toggle: should call `open` if showPopup is false shouldn`t call `close` method', () => {
       const param = { name: 'po' };
 

--- a/projects/ui/src/lib/components/po-popup/po-popup.component.ts
+++ b/projects/ui/src/lib/components/po-popup/po-popup.component.ts
@@ -95,6 +95,7 @@ export class PoPopupComponent extends PoPopupBaseComponent implements AfterViewI
     this.changeDetector.detectChanges();
 
     this.validateInitialContent();
+    this.openEvent.emit();
   }
 
   returnBooleanValue(popupAction: any, property: string) {


### PR DESCRIPTION
Implementa as propriedades open e close na interface PoHeaderActionTool e PoHeaderUser, permitindo executar callbacks quando o popup ou popover de uma ação é aberto ou fechado.
Adiciona o evento p-open no po-popup e vincula os eventos p-open e p-close no template do po-header-tools e po-header-customer.

Fixes DTHFUI-13528