### PR TITLE
docs(input): adiciona sample de máscara dinâmica para CPF e CNPJ

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input/po-input.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input.component.ts
@@ -34,6 +34,12 @@ import { PoInputGeneric } from '../po-input-generic/po-input-generic';
  *  <file name="sample-po-input-reactive-form/sample-po-input-reactive-form.component.html"> </file>
  *  <file name="sample-po-input-reactive-form/sample-po-input-reactive-form.component.ts"> </file>
  * </example>
+ *
+ * <example name="po-input-mask-dynamic" title="PO Input - Dynamic Mask (CPF/CNPJ)">
+ *  <file name="sample-po-input-mask-dynamic/sample-po-input-mask-dynamic.component.html"> </file>
+ *  <file name="sample-po-input-mask-dynamic/sample-po-input-mask-dynamic.component.ts"> </file>
+ *  <file name="sample-po-input-mask-dynamic/document-mask.ts"> </file>
+ * </example>
  */
 @Component({
   selector: 'po-input',

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-mask-dynamic/document-mask.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-mask-dynamic/document-mask.ts
@@ -1,0 +1,12 @@
+export const MASK_CPF = '999.999.999-99';
+export const MASK_CNPJ = '99.999.999/9999-99';
+
+const CPF_LENGTH = 11;
+
+export function onlyDigits(value: string): string {
+  return (value || '').replace(/\D/g, '');
+}
+
+export function resolveMask(digitCount: number): string {
+  return digitCount > CPF_LENGTH ? MASK_CNPJ : MASK_CPF;
+}

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-mask-dynamic/sample-po-input-mask-dynamic.component.html
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-mask-dynamic/sample-po-input-mask-dynamic.component.html
@@ -1,0 +1,36 @@
+<div class="po-row">
+  <po-container class="po-lg-6 po-md-12" p-title="CPF / CNPJ com ngModel">
+    <div class="po-row">
+      <po-input
+        class="po-md-12"
+        name="document"
+        p-clean
+        p-label="CPF / CNPJ"
+        p-placeholder="Informe o CPF ou o CNPJ"
+        [p-mask]="mask"
+        [(ngModel)]="document"
+        (p-keydown)="handleKeydown($event)"
+        (paste)="handlePaste($event)"
+        (p-change-model)="handleChangeModel($event)"
+      >
+      </po-input>
+    </div>
+  </po-container>
+
+  <po-container class="po-lg-6 po-md-12" p-title="CPF / CNPJ com Reactive Forms">
+    <div class="po-row" [formGroup]="form">
+      <po-input
+        class="po-md-12"
+        formControlName="document"
+        p-clean
+        p-label="CPF / CNPJ"
+        p-placeholder="Informe o CPF ou o CNPJ"
+        [p-mask]="formMask"
+        (p-keydown)="handleFormKeydown($event)"
+        (paste)="handleFormPaste($event)"
+        (p-change-model)="handleFormChangeModel($event)"
+      >
+      </po-input>
+    </div>
+  </po-container>
+</div>

--- a/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-mask-dynamic/sample-po-input-mask-dynamic.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/samples/sample-po-input-mask-dynamic/sample-po-input-mask-dynamic.component.ts
@@ -1,0 +1,113 @@
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { MASK_CPF, onlyDigits, resolveMask } from './document-mask';
+
+@Component({
+  selector: 'sample-po-input-mask-dynamic',
+  templateUrl: './sample-po-input-mask-dynamic.component.html',
+  standalone: false
+})
+export class SamplePoInputMaskDynamicComponent {
+  // NgModel
+  document: string = '';
+  mask: string = MASK_CPF;
+
+  // Reactive Forms
+  formMask: string = MASK_CPF;
+  form = new FormGroup({
+    document: new FormControl('')
+  });
+
+  constructor(private cd: ChangeDetectorRef) {}
+
+  // --- NgModel ---
+
+  handleKeydown(event: KeyboardEvent): void {
+    this.updateMask(this.predictMaskFromKeydown(event, this.mask));
+  }
+
+  handlePaste(event: ClipboardEvent): void {
+    this.updateMask(this.predictMaskFromPaste(event));
+  }
+
+  handleChangeModel(value: string): void {
+    this.mask = resolveMask(onlyDigits(value).length);
+  }
+
+  // --- Reactive Forms ---
+
+  handleFormKeydown(event: KeyboardEvent): void {
+    this.updateFormMask(this.predictMaskFromKeydown(event, this.formMask));
+  }
+
+  handleFormPaste(event: ClipboardEvent): void {
+    this.updateFormMask(this.predictMaskFromPaste(event));
+  }
+
+  handleFormChangeModel(value: string): void {
+    this.formMask = resolveMask(onlyDigits(value).length);
+  }
+
+  /**
+   * Calcula quantos dígitos o campo terá após a tecla ser processada e retorna a máscara
+   * correspondente. A troca precisa acontecer ANTES do po-input consumir a tecla.
+   */
+  private predictMaskFromKeydown(event: KeyboardEvent, currentMask: string): string {
+    if (event.ctrlKey || event.metaKey || event.altKey) {
+      return currentMask;
+    }
+
+    const input = event.target as HTMLInputElement;
+    const value = input.value || '';
+    const start = input.selectionStart ?? value.length;
+    const end = input.selectionEnd ?? start;
+
+    let length = onlyDigits(value).length - onlyDigits(value.slice(start, end)).length;
+
+    if (/^[0-9]$/.test(event.key)) {
+      length++;
+    } else if (event.key === 'Backspace' && start === end && start > 0) {
+      length--;
+    } else if (event.key === 'Delete' && start === end && start < value.length) {
+      length--;
+    } else {
+      return currentMask;
+    }
+
+    return resolveMask(length);
+  }
+
+  /** Calcula a quantidade de dígitos resultante de um paste e retorna a máscara correspondente. */
+  private predictMaskFromPaste(event: ClipboardEvent): string {
+    const input = event.target as HTMLInputElement;
+    const value = input.value || '';
+    const start = input.selectionStart ?? value.length;
+    const end = input.selectionEnd ?? start;
+
+    const pasted = onlyDigits(event.clipboardData?.getData('text') || '');
+    const kept = onlyDigits(value).length - onlyDigits(value.slice(start, end)).length;
+
+    return resolveMask(kept + pasted.length);
+  }
+
+  /**
+   * Atualiza `this.mask` e propaga o binding imediatamente via detectChanges.
+   * O detectChanges é necessário porque o po-input consome a máscara ainda dentro
+   * do mesmo evento de teclado, antes do próximo ciclo de detecção de mudanças.
+   */
+  private updateMask(newMask: string): void {
+    if (newMask !== this.mask) {
+      this.mask = newMask;
+      this.cd.detectChanges();
+    }
+  }
+
+  /** Mesmo que `updateMask`, mas para o campo do Reactive Forms. */
+  private updateFormMask(newMask: string): void {
+    if (newMask !== this.formMask) {
+      this.formMask = newMask;
+      this.cd.detectChanges();
+    }
+  }
+}


### PR DESCRIPTION
**po-input**

Adiciona sample de máscara dinâmica para CPF e CNPJ.

<img width="1612" height="289" alt="brave_cpOUXXb0AV" src="https://github.com/user-attachments/assets/6176c67e-9ff2-4cbe-8e1e-edd4fe53f09d" />
