### PR TITLE
feat(fields): adiciona p-change-model nos componentes de formulário

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -48,6 +48,7 @@
         [p-show-required]="field.showRequired"
         [p-year-range-limit]="field.yearRangeLimit"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         [p-placeholder]="field.placeholder"
         (p-additional-help)="field.additionalHelp?.($event)"
         (p-keydown)="field.keydown?.($event)"
@@ -89,6 +90,7 @@
         [p-show-required]="field.showRequired"
         [p-size]="field.size || componentsSize"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         (p-keydown)="field.keydown?.($event)"
       >
       </po-datetimepicker>
@@ -126,6 +128,7 @@
         [p-range-presets-order]="field.rangePresetsOrder"
         (p-additional-help)="field.additionalHelp?.($event)"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         (p-keydown)="field.keydown?.($event)"
       >
       </po-datepicker-range>
@@ -163,6 +166,7 @@
         [p-show-seconds]="field.showSeconds"
         [p-size]="field.size || componentsSize"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         (p-keydown)="field.keydown?.($event)"
       >
       </po-timepicker>
@@ -317,6 +321,7 @@
         [p-size]="field.size || componentsSize"
         (p-additional-help)="field.additionalHelp?.($event)"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         (p-keydown)="field.keydown?.($event)"
         [p-placeholder]="field.placeholder"
         [p-readonly]="field.readonly"
@@ -347,6 +352,7 @@
         [p-size]="field.size || componentsSize"
         (p-additional-help)="field.additionalHelp?.($event)"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         (p-keydown)="field.keydown?.($event)"
       >
       </po-radio-group>
@@ -376,6 +382,7 @@
         [p-size]="field.size || componentsSize"
         (p-additional-help)="field.additionalHelp?.($event)"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         (p-keydown)="field.keydown?.($event)"
       >
       </po-switch>
@@ -397,6 +404,7 @@
         [p-size]="field.size || componentsSize"
         (p-additional-help)="field.additionalHelp?.($event)"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         (p-keydown)="field.keydown?.($event)"
       >
       </po-checkbox>
@@ -433,6 +441,7 @@
         [p-error-limit]="field.errorLimit"
         [p-show-required]="field.showRequired"
         (p-change)="onChangeField(field, $event)"
+        (p-change-model)="onChangeFieldModel(field)"
         [p-icon]="field.icon"
         [p-placeholder]="field.placeholder"
         [p-filter-minlength]="field.filterMinlength"
@@ -485,6 +494,7 @@
         [p-show-required]="field.showRequired"
         [p-size]="field.size || componentsSize"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         [p-placeholder]="field.placeholder"
         [p-advanced-filters]="field.advancedFilters"
         (p-additional-help)="field.additionalHelp?.($event)"
@@ -518,6 +528,7 @@
         [p-size]="field.size || componentsSize"
         (p-additional-help)="field.additionalHelp?.($event)"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         (p-keydown)="field.keydown?.($event)"
       >
       </po-checkbox-group>
@@ -546,6 +557,7 @@
         [p-error-limit]="field.errorLimit"
         [p-show-required]="field.showRequired"
         (p-change)="onChangeField(field)"
+        (p-change-model)="onChangeFieldModel(field)"
         [p-placeholder]="field.placeholder"
         [p-field-label]="field.fieldLabel"
         [p-field-value]="field.fieldValue"

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -86,7 +86,11 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
         await this.validateField(changedField, changedFieldIndex, visibleField);
       }
 
-      this.triggerValidationOnForm(changedFieldIndex);
+      // Quando validateOnInput está ativo, o onChangeFieldModel já disparou o triggerValidationOnForm.
+      // Evita disparo duplicado para componentes onde p-change e p-change-model ocorrem no mesmo ciclo.
+      if (!this.validateOnInput) {
+        this.triggerValidationOnForm(changedFieldIndex);
+      }
     }
 
     this.updatePreviousValue();

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.spec.ts
@@ -530,4 +530,60 @@ describe('PoCheckboxGroupBaseComponent: ', () => {
       });
     });
   });
+
+  describe('p-change-model:', () => {
+    // Feature: p-change-model-fields, Property 1: Emission on new value
+    it('should emit changeModel when writeValue receives a new array value (Property 1)', () => {
+      component.options = [].concat(options);
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(['1']);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(['1']);
+      expect(component.modelLastUpdate).toEqual(['1']);
+    });
+
+    // Feature: p-change-model-fields, Property 4: Deep equality for complex values
+    it('should NOT emit changeModel when writeValue receives same array content with different reference (Property 4)', () => {
+      component.options = [].concat(options);
+      component.modelLastUpdate = ['1'];
+      component.checkedOptionsList = ['1'];
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(['1']);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+    });
+
+    // Feature: p-change-model-fields, Property 5: User interaction triggers emission
+    it('should emit changeModel on user checkbox toggle via checkOption (Property 5)', () => {
+      component.options = [].concat(options);
+      component.checkedOptionsList = [];
+      component.indeterminate = false;
+      component.modelLastUpdate = [];
+      component.propagateChange = () => {};
+
+      spyOn(component.changeModel, 'emit');
+
+      component.checkOption(options[0]);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(['1']);
+      expect(component.modelLastUpdate).toEqual(['1']);
+    });
+
+    // Feature: p-change-model-fields, Property 6: WriteValue does not emit p-change
+    it('should NOT emit change event on writeValue (Property 6)', () => {
+      component.options = [].concat(options);
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.change, 'emit');
+
+      component.writeValue(['1']);
+
+      expect(component.change.emit).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
@@ -243,6 +243,21 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
    * @optional
    *
    * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
    * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
    * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
    */
@@ -253,6 +268,7 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
   checkedOptionsList: any = [];
   displayAdditionalHelp: boolean = false;
   mdColumns: number = poCheckboxGroupColumnsDefaultLength;
+  modelLastUpdate: any;
   propagateChange: any;
   validatorChange: any;
 
@@ -415,6 +431,7 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
     }
 
     this.change.emit(value);
+    this.controlChangeModelEmitter(value);
   }
 
   checkIndeterminate() {
@@ -446,6 +463,19 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
     } else {
       this.checkedOptionsList = [];
       this.checkedOptions = {};
+    }
+
+    if (optionsModel != null) {
+      this.controlChangeModelEmitter(this.checkIndeterminate());
+    }
+  }
+
+  controlChangeModelEmitter(value: any) {
+    const current = JSON.stringify(this.modelLastUpdate);
+    const incoming = JSON.stringify(value);
+    if (current !== incoming) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = Array.isArray(value) ? [...value] : value;
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/samples/sample-po-checkbox-group-labs/sample-po-checkbox-group-labs.component.html
@@ -17,6 +17,7 @@
   [p-compact-label]="properties?.includes('compactLabel')"
   [p-size]="size"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-keydown)="changeEvent('p-keydown')"
 >
 </po-checkbox-group>

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox-base.component.ts
@@ -195,6 +195,21 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
    * @optional
    *
    * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
    * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
    * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
    */
@@ -211,6 +226,7 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
 
   displayAdditionalHelp: boolean = false;
   id = uuid();
+  modelLastUpdate: any;
   propagateChange: any;
   onTouched;
 
@@ -300,6 +316,7 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
     }
 
     this.change.emit(this.checkboxValue);
+    this.controlChangeModelEmitter(this.checkboxValue);
   }
 
   checkOption(event: any, value: boolean | null | string) {
@@ -333,6 +350,17 @@ export abstract class PoCheckboxBaseComponent implements ControlValueAccessor {
   writeValue(value: any) {
     if (value !== this.checkboxValue) {
       this.changeModelValue(value);
+    }
+
+    if (value != null) {
+      this.controlChangeModelEmitter(this.checkboxValue);
+    }
+  }
+
+  controlChangeModelEmitter(value: any) {
+    if (this.modelLastUpdate !== value) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value;
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/po-checkbox.component.spec.ts
@@ -481,6 +481,60 @@ describe('PoCheckboxComponent:', () => {
     });
   });
 
+  describe('p-change-model:', () => {
+    it('should emit changeModel when writeValue receives true and modelLastUpdate is undefined', () => {
+      component.modelLastUpdate = undefined;
+      component.checkboxValue = false;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(true);
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith(true);
+      expect(component.modelLastUpdate).toBe(true);
+    });
+
+    it('should NOT emit changeModel when writeValue receives the same value as modelLastUpdate', () => {
+      component.checkboxValue = true;
+      component.modelLastUpdate = true;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(true);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+      expect(component.modelLastUpdate).toBe(true);
+    });
+
+    it('should emit changeModel when user clicks to toggle checkbox via checkOption', () => {
+      component.checkboxValue = false;
+      component.modelLastUpdate = false;
+      component.disabled = false;
+      component.propagateChange = (v: any) => {};
+
+      spyOn(component.changeModel, 'emit');
+
+      const fakeEvent = { target: { closest: () => null } };
+      component.checkOption(fakeEvent, false);
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith(true);
+      expect(component.modelLastUpdate).toBe(true);
+    });
+
+    it('should NOT emit change event when writeValue is called (only changeModel should emit)', () => {
+      component.modelLastUpdate = undefined;
+      component.checkboxValue = false;
+
+      spyOn(component.change, 'emit');
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(true);
+
+      expect(component.change.emit).not.toHaveBeenCalled();
+      expect(component.changeModel.emit).toHaveBeenCalledWith(true);
+    });
+  });
+
   describe('Templates:', () => {
     it('should have label.', () => {
       const newLabel = 'PO';

--- a/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-labs/sample-po-checkbox-labs.component.html
@@ -7,6 +7,7 @@
   [p-label]="label"
   [p-size]="size"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-keydown)="changeEvent('p-keydown')"
   [p-label-text-wrap]="labelTextWrap"
   [p-compact-label]="compactLabel"

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -930,7 +930,7 @@ describe('PoComboBaseComponent:', () => {
       expect(component.selectedValue).toBe(value);
     });
 
-    it('updateModel: shouldn`t call `callModelChange` and should call `change.emit` if `fromWriteValue` is true', () => {
+    it('updateModel: shouldn`t call `callModelChange` and shouldn`t call `change.emit` if `fromWriteValue` is true', () => {
       const value = 1;
 
       component.selectedValue = undefined;
@@ -942,7 +942,7 @@ describe('PoComboBaseComponent:', () => {
       component['updateModel'](value);
 
       expect(spyCallModelChange).not.toHaveBeenCalled();
-      expect(spyChangeEmit).toHaveBeenCalled();
+      expect(spyChangeEmit).not.toHaveBeenCalled();
 
       expect(component.selectedValue).toBe(value);
     });
@@ -1833,6 +1833,110 @@ describe('PoComboBaseComponent:', () => {
       const expectLabel = component['checkIfService']('value');
 
       expect(expectLabel).toEqual('valueTest');
+    });
+  });
+
+  describe('p-change-model:', () => {
+    // Feature: p-change-model-fields, Property 1: Emission on new value
+    it('should emit changeModel when writeValue receives a new value (Property 1)', () => {
+      const newValue = 'newValue';
+      const option = { label: 'New', value: newValue };
+
+      component['comboOptionsList'] = [option];
+      component.options = [option];
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(newValue);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(newValue);
+      expect(component.modelLastUpdate).toBe(newValue);
+    });
+
+    // Feature: p-change-model-fields, Property 2: Deduplication
+    it('should NOT emit changeModel when writeValue receives the same value (Property 2)', () => {
+      const sameValue = 'sameValue';
+      const option = { label: 'Same', value: sameValue };
+
+      component['comboOptionsList'] = [option];
+      component.options = [option];
+      component.modelLastUpdate = sameValue;
+      component.selectedValue = sameValue;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(sameValue);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+    });
+
+    // Feature: p-change-model-fields, Property 5: User interaction triggers emission
+    it('should emit changeModel on user selection with new value (Property 5)', () => {
+      const newValue = 2;
+      component.selectedValue = 1;
+      component.modelLastUpdate = 1;
+
+      spyOn(component.changeModel, 'emit');
+      spyOn(component, 'callModelChange');
+
+      component['fromWriteValue'] = false;
+      component['updateModel'](newValue);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(newValue);
+      expect(component.modelLastUpdate).toBe(newValue);
+    });
+
+    // Feature: p-change-model-fields, Property 6: WriteValue does not emit p-change
+    it('should NOT emit change event on writeValue (Property 6)', () => {
+      const newValue = 'testValue';
+      const option = { label: 'Test', value: newValue };
+
+      component['comboOptionsList'] = [option];
+      component.options = [option];
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.change, 'emit');
+
+      component.writeValue(newValue);
+
+      expect(component.change.emit).not.toHaveBeenCalled();
+    });
+
+    // Feature: p-change-model-fields, Property 1 edge: writeValue(null) with non-null modelLastUpdate
+    it('should emit changeModel when writeValue(null) and modelLastUpdate is non-null (Property 1 edge)', () => {
+      component.modelLastUpdate = 'previousValue';
+      component.selectedValue = 'previousValue';
+      component['comboOptionsList'] = [];
+      component.options = [];
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(null);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(undefined);
+      expect(component.modelLastUpdate).toBe(undefined);
+    });
+
+    // Feature: p-change-model-fields, Property 1: Async scenario with service
+    it('should emit changeModel after async service resolution (Property 1 async)', () => {
+      const value = 'asyncValue';
+
+      component.modelLastUpdate = undefined;
+      component.selectedValue = undefined;
+      component['fromWriteValue'] = true;
+
+      spyOn(component.changeModel, 'emit');
+      spyOn(component, 'callModelChange');
+
+      // Simulate what happens after getObjectByValue resolves:
+      // updateModel is called with the resolved value
+      component['updateModel'](value);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(value);
+      expect(component.modelLastUpdate).toBe(value);
+      // change should NOT emit because fromWriteValue was true
+      expect(component['fromWriteValue']).toBe(false);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -388,6 +388,21 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
    * @optional
    *
    * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @optional
+   *
+   * @description
    * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
    * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
    */
@@ -472,6 +487,7 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   isFirstFilter: boolean = true;
   isFiltering: boolean = false;
   keyupSubscribe: any;
+  modelLastUpdate: any;
   onModelChange: any;
   previousSearchValue: string = '';
   selectedOption: any;
@@ -1017,6 +1033,13 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     return this.onModelChange ? this.onModelChange(value) : this.ngModelChange.emit(value);
   }
 
+  controlChangeModelEmitter(value: any) {
+    if (this.modelLastUpdate !== value) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value;
+    }
+  }
+
   isEqual(value: any, inputValue: any): boolean {
     if ((value || value === 0) && inputValue) {
       return value.toString() === inputValue.toString();
@@ -1424,16 +1447,14 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   }
 
   private updateModel(value: any): void {
-    if (value !== this.selectedValue) {
-      if (!this.fromWriteValue) {
-        this.callModelChange(this.getValueUpdate(value, this.selectedOption));
-      }
-
+    if (value !== this.selectedValue && !this.fromWriteValue) {
+      this.callModelChange(this.getValueUpdate(value, this.selectedOption));
       this.change.emit(this.emitObjectValue ? this.selectedOption : value);
     }
 
     this.selectedValue = value;
     this.fromWriteValue = false;
+    this.controlChangeModelEmitter(value);
   }
 
   private updateSelectedValueWithOldOption() {

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -32,6 +32,7 @@
   [p-compact-label]="properties?.includes('compactLabel')"
   [p-listbox-control-position]="listboxPosition"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-keydown)="changeEvent('p-keydown')"
 >
 </po-combo>

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.spec.ts
@@ -944,7 +944,8 @@ describe('PoDatepickerRangeBaseComponent:', () => {
 
     it('updateModel: should call `onChangeModel` with `value` if `onChangeModel` is valid.', () => {
       const fakeThis = {
-        onChangeModel: arg => {}
+        onChangeModel: arg => {},
+        controlChangeModelEmitter: arg => {}
       };
       const value: any = 'value';
 
@@ -957,7 +958,8 @@ describe('PoDatepickerRangeBaseComponent:', () => {
 
     it('updateModel: should call `onChangeModel` with `value` object if `onChangeModel` is valid.', () => {
       const fakeThis = {
-        onChangeModel: arg => {}
+        onChangeModel: arg => {},
+        controlChangeModelEmitter: arg => {}
       };
       const value: any = { key: 'value' };
 
@@ -1102,6 +1104,84 @@ describe('PoDatepickerRangeBaseComponent:', () => {
       component.maxDate = new Date(2021, 11, 14);
 
       expect(component['validateDateInRange'](date)).toBeTruthy();
+    });
+  });
+
+  describe('p-change-model:', () => {
+    // Feature: p-change-model-fields, Property 1: Emission on new value
+    it('should emit changeModel when writeValue receives a new range value (Property 1)', () => {
+      const newRange = { start: '2023-01-10', end: '2023-01-20' };
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(newRange);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith({ start: '2023-01-10', end: '2023-01-20' });
+      expect(component.modelLastUpdate).toEqual({ start: '2023-01-10', end: '2023-01-20' });
+    });
+
+    // Feature: p-change-model-fields, Property 4: Deep equality for complex values
+    it('should NOT emit changeModel when writeValue receives same range content with different reference (Property 4)', () => {
+      component.modelLastUpdate = { start: '2023-01-10', end: '2023-01-20' };
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue({ start: '2023-01-10', end: '2023-01-20' });
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+    });
+
+    // Feature: p-change-model-fields, Property 5: User interaction triggers emission
+    it('should emit changeModel on user interaction via updateModel (Property 5)', () => {
+      component.modelLastUpdate = { start: '', end: '' };
+      component.registerOnChange(() => {});
+
+      spyOn(component.changeModel, 'emit');
+
+      const newRange = { start: '2023-03-01', end: '2023-03-15' };
+      component['updateModel'](newRange);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith({ start: '2023-03-01', end: '2023-03-15' });
+      expect(component.modelLastUpdate).toEqual({ start: '2023-03-01', end: '2023-03-15' });
+    });
+
+    // Feature: p-change-model-fields, Property 6: WriteValue does not emit p-change
+    it('should NOT emit change event on writeValue (Property 6)', () => {
+      const newRange = { start: '2023-02-01', end: '2023-02-28' };
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.onChange, 'emit');
+
+      component.writeValue(newRange);
+
+      expect(component.onChange.emit).not.toHaveBeenCalled();
+    });
+
+    it('should store modelLastUpdate as object copy when value is an object', () => {
+      component.modelLastUpdate = undefined;
+
+      const range = { start: '2023-05-01', end: '2023-05-31' };
+      component.controlChangeModelEmitter(range);
+
+      expect(component.modelLastUpdate).toEqual(range);
+      expect(component.modelLastUpdate).not.toBe(range);
+    });
+
+    it('should store modelLastUpdate as primitive when value is not an object', () => {
+      component.modelLastUpdate = undefined;
+
+      component.controlChangeModelEmitter(null);
+
+      expect(component.modelLastUpdate).toBeNull();
+    });
+
+    it('should store modelLastUpdate as primitive when value is undefined', () => {
+      component.modelLastUpdate = { start: '2023-01-01', end: '2023-01-31' };
+
+      component.controlChangeModelEmitter(undefined);
+
+      expect(component.modelLastUpdate).toBeUndefined();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range-base.component.ts
@@ -367,6 +367,21 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
    * @optional
    *
    * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
    * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
    * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
    */
@@ -375,6 +390,7 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
   errorMessage: string = '';
   dateRange: PoDatepickerRange = { start: '', end: '' };
   displayAdditionalHelp: boolean = false;
+  modelLastUpdate: any;
 
   protected format: any = 'dd/mm/yyyy';
   protected isDateRangeInputFormatValid: boolean = true;
@@ -889,6 +905,16 @@ export abstract class PoDatepickerRangeBaseComponent implements ControlValueAcce
     // Quando o input não possui um formulário, então esta função não é registrada
     if (this.onChangeModel) {
       this.onChangeModel(model);
+    }
+    this.controlChangeModelEmitter(model);
+  }
+
+  controlChangeModelEmitter(value: any) {
+    const current = JSON.stringify(this.modelLastUpdate);
+    const incoming = JSON.stringify(value);
+    if (current !== incoming) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value && typeof value === 'object' ? { ...value } : value;
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/samples/sample-po-datepicker-range-labs/sample-po-datepicker-range-labs.component.html
@@ -25,6 +25,7 @@
   [p-label-text-wrap]="properties?.includes('labelTextWrap')"
   [p-compact-label]="properties?.includes('compactLabel')"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
   [p-range-presets]="rangePresets"

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -1144,4 +1144,67 @@ describe('PoDatepickerBaseComponent:', () => {
       expect(component['validateYearRange'](date, minDate, maxDate)).toBeTrue();
     });
   });
+
+  describe('p-change-model:', () => {
+    // Feature: p-change-model-fields, Property 1: Emission on new value
+    it('should emit changeModel when writeValue triggers callOnChange with a new date value (Property 1)', () => {
+      const newValue = '2023-05-15';
+      component.modelLastUpdate = undefined;
+      component['onChangeModel'] = (v: any) => {};
+      component['previousValue'] = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.callOnChange(newValue);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(newValue);
+      expect(component.modelLastUpdate).toBe(newValue);
+    });
+
+    // Feature: p-change-model-fields, Property 2: Deduplication
+    it('should NOT emit changeModel when callOnChange receives same value as modelLastUpdate (Property 2)', () => {
+      const sameValue = '2023-05-15';
+      component.modelLastUpdate = sameValue;
+      component['onChangeModel'] = (v: any) => {};
+      component['previousValue'] = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.callOnChange(sameValue);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+      expect(component.modelLastUpdate).toBe(sameValue);
+    });
+
+    // Feature: p-change-model-fields, Property 5: User interaction triggers emission (calendar selection)
+    it('should emit changeModel when calendar selection triggers callOnChange with new value (Property 5)', () => {
+      const newDateValue = '2023-08-20';
+      component.modelLastUpdate = '2023-05-15';
+      component['onChangeModel'] = (v: any) => {};
+      component['previousValue'] = '2023-05-15';
+
+      spyOn(component.changeModel, 'emit');
+
+      component.callOnChange(newDateValue);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(newDateValue);
+      expect(component.modelLastUpdate).toBe(newDateValue);
+    });
+
+    // Feature: p-change-model-fields, Property 6: WriteValue does not emit p-change
+    it('should NOT emit onchange (p-change) when callOnChange is invoked via writeValue flow (Property 6)', () => {
+      const newValue = '2023-05-15';
+      component.modelLastUpdate = undefined;
+      component['onChangeModel'] = (v: any) => {};
+      component['previousValue'] = undefined;
+
+      spyOn(component.onchange, 'emit');
+      spyOn(component.changeModel, 'emit');
+
+      component.callOnChange(newValue);
+
+      expect(component.onchange.emit).not.toHaveBeenCalled();
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(newValue);
+    });
+  });
 });

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -289,6 +289,21 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    *
    * @description
    *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Evento disparado ao sair do campo.
    */
   @Output('p-blur') onblur: EventEmitter<any> = new EventEmitter<any>();
@@ -336,6 +351,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    */
   labelTextWrap = input<boolean>(false, { alias: 'p-label-text-wrap' });
 
+  modelLastUpdate: any;
   offset: number;
   protected firstStart = true;
   protected hour: string = 'T00:00:00-00:00';
@@ -738,8 +754,16 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
     if (this.onChangeModel && value !== this.previousValue) {
       this.onChangeModel(value);
       this.previousValue = value;
+      this.controlChangeModelEmitter(value);
     } else if (retry) {
       setTimeout(() => this.callOnChange(value, false));
+    }
+  }
+
+  controlChangeModelEmitter(value: any) {
+    if (this.modelLastUpdate !== value) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value;
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
@@ -26,6 +26,7 @@
   [p-size]="size"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
 >

--- a/projects/ui/src/lib/components/po-field/po-datetimepicker/po-datetimepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datetimepicker/po-datetimepicker-base.component.spec.ts
@@ -620,6 +620,69 @@ describe('PoDatetimepickerBaseComponent:', () => {
       expect(component['extractTimeFromDate'](date)).toBe('14:30');
     });
   });
+
+  describe('p-change-model:', () => {
+    it('should emit changeModel when writeValue receives a new datetime value different from modelLastUpdate', () => {
+      component.modelLastUpdate = undefined;
+      spyOn(component, 'refreshValue');
+      spyOn(component.changeModel, 'emit');
+      component.registerOnChange(() => {});
+
+      const dateValue = new Date(2026, 4, 12, 14, 30);
+      component.writeValue(dateValue);
+
+      expect(component.changeModel.emit).toHaveBeenCalledTimes(1);
+      const emittedValue = (component.changeModel.emit as jasmine.Spy).calls.mostRecent().args[0];
+      expect(emittedValue).toContain('2026-05-12T14:30');
+      expect(component.modelLastUpdate).toBe(emittedValue);
+    });
+
+    it('should NOT emit changeModel when writeValue receives the same datetime value as modelLastUpdate', () => {
+      spyOn(component, 'refreshValue');
+      component.registerOnChange(() => {});
+
+      const dateValue = new Date(2026, 4, 12, 14, 30);
+      component.writeValue(dateValue);
+
+      const firstEmittedValue = component.modelLastUpdate;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(new Date(2026, 4, 12, 14, 30));
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+      expect(component.modelLastUpdate).toBe(firstEmittedValue);
+    });
+
+    it('should emit changeModel when user triggers controlModel with a new datetime value', () => {
+      component.registerOnChange(() => {});
+      component.modelLastUpdate = undefined;
+      component['date'] = new Date(2026, 4, 12);
+      component['timeValue'] = '14:30';
+
+      spyOn(component.changeModel, 'emit');
+
+      component.controlModel();
+
+      expect(component.changeModel.emit).toHaveBeenCalledTimes(1);
+      const emittedValue = (component.changeModel.emit as jasmine.Spy).calls.mostRecent().args[0];
+      expect(emittedValue).toContain('2026-05-12T14:30');
+    });
+
+    it('should NOT emit change event (p-change) when writeValue is called', () => {
+      component.modelLastUpdate = undefined;
+      spyOn(component, 'refreshValue');
+      spyOn(component.onchange, 'emit');
+      spyOn(component.changeModel, 'emit');
+      component.registerOnChange(() => {});
+
+      const dateValue = new Date(2026, 4, 12, 14, 30);
+      component.writeValue(dateValue);
+
+      expect(component.onchange.emit).not.toHaveBeenCalled();
+      expect(component.changeModel.emit).toHaveBeenCalled();
+    });
+  });
 });
 
 describe('PoDatetimepickerBaseComponent - Effects (with fixture):', () => {

--- a/projects/ui/src/lib/components/po-field/po-datetimepicker/po-datetimepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datetimepicker/po-datetimepicker-base.component.ts
@@ -530,6 +530,23 @@ export abstract class PoDatetimepickerBaseComponent implements ControlValueAcces
    */
   @Output('p-keydown') keydown = new EventEmitter<KeyboardEvent>();
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter<any>();
+
+  modelLastUpdate: any;
+
   constructor(protected languageService: PoLanguageService) {
     // p-clean
     effect(() => {
@@ -812,8 +829,16 @@ export abstract class PoDatetimepickerBaseComponent implements ControlValueAcces
   callOnChange(value: any, retry: boolean = true): void {
     if (this.onChangeModel) {
       this.onChangeModel(value);
+      this.controlChangeModelEmitter(value);
     } else if (retry) {
       setTimeout(() => this.callOnChange(value, false));
+    }
+  }
+
+  controlChangeModelEmitter(value: any) {
+    if (this.modelLastUpdate !== value) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value;
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-datetimepicker/samples/sample-po-datetimepicker-labs/sample-po-datetimepicker-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datetimepicker/samples/sample-po-datetimepicker-labs/sample-po-datetimepicker-labs.component.html
@@ -32,6 +32,7 @@
   [p-size]="size"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-keydown)="changeEvent('p-keydown')"
 >
 </po-datetimepicker>

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -359,7 +359,13 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
    *
    * @description
    *
-   * Evento disparado ao alterar valor do model.
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
    */
   @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -260,7 +260,8 @@ describe('PoLookupBaseComponent:', () => {
       onChangePropagate: '',
       change: {
         emit: () => {}
-      }
+      },
+      controlChangeModelEmitter: () => {}
     };
 
     spyOn<any>(component, 'onChangePropagate');
@@ -1231,6 +1232,104 @@ describe('PoLookupBaseComponent:', () => {
 
         expect(component.spacing).toBe(defaultSpacing);
       });
+    });
+  });
+
+  describe('p-change-model:', () => {
+    // Feature: p-change-model-fields, Property 1: Emission on new value via async resolution
+    it('should emit changeModel when writeValue receives a new value after async resolution (Property 1)', fakeAsync(
+      inject([LookupFilterService], (lookupFilterService: LookupFilterService) => {
+        const searchValue = '123';
+        const resolvedObject = { value: 123, label: 'teste' };
+
+        component.fieldValue = 'value';
+        component.fieldLabel = 'label';
+        component.service = lookupFilterService;
+        component.modelLastUpdate = undefined;
+
+        spyOn(component.changeModel, 'emit');
+        spyOn(component.service, 'getObjectByValue').and.returnValue(of(resolvedObject));
+
+        component.writeValue(searchValue);
+
+        tick();
+
+        expect(component.changeModel.emit).toHaveBeenCalledOnceWith(123);
+        expect(component.modelLastUpdate).toBe(123);
+      })
+    ));
+
+    // Feature: p-change-model-fields, Property 2: Deduplication — suppression on same value
+    it('should NOT emit changeModel when writeValue receives the same value (Property 2)', fakeAsync(
+      inject([LookupFilterService], (lookupFilterService: LookupFilterService) => {
+        const searchValue = '123';
+        const resolvedObject = { value: 123, label: 'teste' };
+
+        component.fieldValue = 'value';
+        component.fieldLabel = 'label';
+        component.service = lookupFilterService;
+        component.modelLastUpdate = 123;
+
+        spyOn(component.changeModel, 'emit');
+        spyOn(component.service, 'getObjectByValue').and.returnValue(of(resolvedObject));
+
+        component.writeValue(searchValue);
+
+        tick();
+
+        expect(component.changeModel.emit).not.toHaveBeenCalled();
+      })
+    ));
+
+    // Feature: p-change-model-fields, Property 5: User interaction triggers emission (modal selection)
+    it('should emit changeModel on user selection in modal with new value (Property 5)', () => {
+      const valueSelected = { value: 456, label: 'Selected Item' };
+
+      component.fieldValue = 'value';
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.selectValue(valueSelected);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(456);
+      expect(component.modelLastUpdate).toBe(456);
+    });
+
+    // Feature: p-change-model-fields, Property 6: WriteValue does not emit p-change
+    // Note: In po-lookup, writeValue calls searchById → selectModel → selectValue → callOnChange.
+    // The change event suppression relies on oldValueToModel === valueToModel check.
+    // When writing the same value (re-entry scenario), change should NOT emit.
+    it('should NOT emit change event on writeValue when oldValueToModel matches valueToModel (Property 6)', () => {
+      const valueSelected = { value: 123, label: 'teste' };
+
+      component.fieldValue = 'value';
+      component['valueToModel'] = valueSelected;
+      component['oldValueToModel'] = valueSelected;
+      component.modelLastUpdate = 123;
+
+      spyOn(component.change, 'emit');
+      spyOn(component.changeModel, 'emit');
+
+      // Directly call callOnChange simulating the writeValue completion
+      // with same valueToModel already set
+      component.callOnChange(123);
+
+      expect(component.change.emit).not.toHaveBeenCalled();
+    });
+
+    // Feature: p-change-model-fields, Property 1 edge: writeValue(undefined) cleans and emits changeModel(undefined)
+    it('should emit changeModel(undefined) when writeValue(undefined) and modelLastUpdate is non-null (Property 1 edge)', () => {
+      component.modelLastUpdate = 'previousValue';
+
+      spyOn(component.changeModel, 'emit');
+      spyOn(component, <any>'cleanViewValue');
+
+      component.writeValue(undefined);
+
+      expect(component['cleanViewValue']).toHaveBeenCalled();
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith(undefined);
+      expect(component.modelLastUpdate).toBeUndefined();
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -607,6 +607,21 @@ export abstract class PoLookupBaseComponent
    * @optional
    *
    * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @optional
+   *
+   * @description
    * Evento disparado ao fechar o popover do gerenciador de colunas após alterar as colunas visíveis.
    *
    * O componente envia como parâmetro um array de string com as colunas visíveis atualizadas.
@@ -627,6 +642,7 @@ export abstract class PoLookupBaseComponent
 
   displayAdditionalHelp: boolean = false;
   service: any;
+  modelLastUpdate: any;
 
   protected selectedOptions = [];
   protected getSubscription: Subscription;
@@ -905,6 +921,15 @@ export abstract class PoLookupBaseComponent
         this.updateLookupInputHeight();
       }
     });
+
+    this.controlChangeModelEmitter(value);
+  }
+
+  controlChangeModelEmitter(value: any) {
+    if (this.modelLastUpdate !== value) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value;
+    }
   }
 
   //Transforma o tamanho do input para o tamanho do ícone de loading correspondente
@@ -980,6 +1005,7 @@ export abstract class PoLookupBaseComponent
       this.searchById(value);
     } else {
       this.cleanViewValue();
+      this.controlChangeModelEmitter(undefined);
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.html
@@ -30,6 +30,7 @@
   [p-label-text-wrap]="properties?.includes('labelTextWrap')"
   [p-virtual-scroll]="properties.includes('virtualScroll')"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-error)="changeEvent('p-error')"
   (p-keydown)="changeEvent('p-keydown')"
   (p-selected)="changeEvent('p-selected')"

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -282,14 +282,17 @@ describe('PoMultiselectBaseComponent:', () => {
       onModelChange: v => {},
       eventChange: v => {},
       getValuesFromOptions: v => [],
-      getValueUpdate: v => []
+      getValueUpdate: v => [],
+      controlChangeModelEmitter: v => {}
     };
 
     spyOn(fakeThis, 'onModelChange');
     spyOn(fakeThis, 'eventChange');
+    spyOn(fakeThis, 'controlChangeModelEmitter');
     component.callOnChange.call(fakeThis, []);
     expect(fakeThis.onModelChange).toHaveBeenCalledWith([]);
     expect(fakeThis.eventChange).toHaveBeenCalledWith([]);
+    expect(fakeThis.controlChangeModelEmitter).toHaveBeenCalledWith([]);
   });
 
   it('shouldn`t call eventChange', () => {
@@ -991,6 +994,142 @@ describe('PoMultiselectBaseComponent:', () => {
       component.loading = false;
 
       expect(component.isDisabled).toBeTrue();
+    });
+  });
+
+  describe('p-change-model:', () => {
+    // Feature: p-change-model-fields, Property 1: Emission on new value
+    it('should emit changeModel when writeValue receives a new array value (Property 1)', () => {
+      const options = [
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' }
+      ];
+      component.options = options;
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue([1, 2]);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith([1, 2]);
+      expect(component.modelLastUpdate).toEqual([1, 2]);
+    });
+
+    // Feature: p-change-model-fields, Property 4: Deep equality for complex values
+    it('should NOT emit changeModel when writeValue receives same array content with different reference (Property 4)', () => {
+      const options = [
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' }
+      ];
+      component.options = options;
+      component.modelLastUpdate = [1, 2];
+      component.selectedOptions = [
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' }
+      ];
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue([1, 2]);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+    });
+
+    // Feature: p-change-model-fields, Property 5: User interaction triggers emission
+    it('should emit changeModel on user selection via callOnChange (Property 5)', () => {
+      component.modelLastUpdate = [];
+      component.registerOnChange(() => {});
+
+      const selectedOptions = [{ value: 1, label: 'One' }];
+
+      spyOn(component.changeModel, 'emit');
+
+      component.callOnChange(selectedOptions);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith([1]);
+      expect(component.modelLastUpdate).toEqual([1]);
+    });
+
+    // Feature: p-change-model-fields, Property 5: User deselection triggers emission
+    it('should emit changeModel on user deselection via callOnChange (Property 5)', () => {
+      component.modelLastUpdate = [1, 2];
+      component.registerOnChange(() => {});
+
+      const selectedOptions = [{ value: 1, label: 'One' }];
+
+      spyOn(component.changeModel, 'emit');
+
+      component.callOnChange(selectedOptions);
+
+      expect(component.changeModel.emit).toHaveBeenCalledOnceWith([1]);
+      expect(component.modelLastUpdate).toEqual([1]);
+    });
+
+    // Feature: p-change-model-fields, Property 6: WriteValue does not emit p-change
+    it('should NOT emit change event on writeValue (Property 6)', () => {
+      const options = [
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' }
+      ];
+      component.options = options;
+      component.modelLastUpdate = undefined;
+      component.selectedOptions = [];
+
+      spyOn(component.change, 'emit');
+
+      component.writeValue([1]);
+
+      expect(component.change.emit).not.toHaveBeenCalled();
+    });
+
+    it('should NOT emit changeModel when writeValue receives null', () => {
+      component.options = [
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' }
+      ];
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(null);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+    });
+
+    it('should NOT emit changeModel when writeValue receives empty array', () => {
+      component.options = [
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' }
+      ];
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue([]);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+    });
+
+    it('should store modelLastUpdate as array copy when value is an array', () => {
+      component.options = [
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' }
+      ];
+      component.modelLastUpdate = undefined;
+      component.selectedOptions = [];
+
+      component.writeValue([1, 2]);
+
+      expect(component.modelLastUpdate).toEqual([1, 2]);
+      expect(component.modelLastUpdate).not.toBe([1, 2]);
+    });
+
+    it('should store modelLastUpdate as primitive when value is not an array', () => {
+      component.modelLastUpdate = undefined;
+
+      component.controlChangeModelEmitter('single');
+
+      expect(component.modelLastUpdate).toBe('single');
     });
   });
 });

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -308,6 +308,21 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    * @optional
    *
    * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @optional
+   *
+   * @description
    * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
    * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
    */
@@ -383,6 +398,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   service: PoMultiselectFilterService;
   defaultService: PoMultiselectFilterService;
   displayAdditionalHelp: boolean = false;
+  modelLastUpdate: any;
 
   // eslint-disable-next-line
   protected onModelTouched: any = null;
@@ -864,8 +880,10 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
 
   callOnChange(selectedOptions: Array<PoMultiselectOption | any>) {
     if (this.onModelChange) {
-      this.onModelChange(this.getValueUpdate(selectedOptions));
+      const value = this.getValueUpdate(selectedOptions);
+      this.onModelChange(value);
       this.eventChange(selectedOptions);
+      this.controlChangeModelEmitter(value);
     }
     setTimeout(() => {
       if (this.autoHeight) {
@@ -879,6 +897,15 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
       this.change.emit(selectedOptions);
     }
     this.lastLengthModel = selectedOptions ? selectedOptions.length : null;
+  }
+
+  controlChangeModelEmitter(value: any) {
+    const current = JSON.stringify(this.modelLastUpdate);
+    const incoming = JSON.stringify(value);
+    if (current !== incoming) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = Array.isArray(value) ? [...value] : value;
+    }
   }
 
   getValuesFromOptions(selectedOptions: Array<PoMultiselectOption | any>) {
@@ -968,6 +995,7 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   }
 
   writeValue(values: any): void {
+    const originalValues = values;
     values = this.getValueWrite(values);
 
     if (values !== null && values !== undefined && !Array.isArray(values)) {
@@ -987,6 +1015,8 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
 
       if (this.selectedOptions && this.selectedOptions.length < values.length) {
         this.callOnChange(this.selectedOptions);
+      } else if (originalValues != null && (!Array.isArray(originalValues) || originalValues.length > 0)) {
+        this.controlChangeModelEmitter(this.getValuesFromOptions(this.selectedOptions));
       }
     }
   }

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.html
@@ -27,6 +27,7 @@
     [p-sort]="properties.includes('sort')"
     [p-listbox-control-position]="listboxPosition"
     (p-change)="changeEvent('p-change')"
+    (p-change-model)="changeEvent('p-change-model')"
     (p-keydown)="changeEvent('p-keydown')"
     [p-error-limit]="properties?.includes('errorLimit')"
     [p-label-text-wrap]="properties?.includes('labelTextWrap')"

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.spec.ts
@@ -215,6 +215,74 @@ describe('PoRadioGroupBase: ', () => {
     });
   });
 
+  describe('p-change-model:', () => {
+    it('should emit changeModel when writeValue receives a new value different from modelLastUpdate', () => {
+      const newValue = 'option1';
+      component.modelLastUpdate = undefined;
+      component.options = [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2' }
+      ];
+
+      spyOn(component, 'getElementByValue').and.returnValue(true);
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(newValue);
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith(newValue);
+      expect(component.modelLastUpdate).toBe(newValue);
+    });
+
+    it('should NOT emit changeModel when writeValue receives the same value as modelLastUpdate', () => {
+      const sameValue = 'option1';
+      component.modelLastUpdate = sameValue;
+      component.options = [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2' }
+      ];
+
+      spyOn(component, 'getElementByValue').and.returnValue(true);
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(sameValue);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+      expect(component.modelLastUpdate).toBe(sameValue);
+    });
+
+    it('should emit changeModel when user selects a different radio option via changeValue', () => {
+      const newValue = 'option2';
+      component.value = 'option1';
+      component.modelLastUpdate = 'option1';
+      component['onChangePropagate'] = (v: any) => {};
+
+      spyOn(component.changeModel, 'emit');
+
+      component.changeValue(newValue);
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith(newValue);
+      expect(component.modelLastUpdate).toBe(newValue);
+    });
+
+    it('should NOT emit change event when writeValue is called (only changeModel should emit)', () => {
+      const newValue = 'option1';
+      component.modelLastUpdate = undefined;
+      component.options = [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2' }
+      ];
+
+      spyOn(component, 'getElementByValue').and.returnValue(true);
+      spyOn(component.change, 'emit');
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(newValue);
+
+      expect(component.change.emit).not.toHaveBeenCalled();
+      expect(component.changeModel.emit).toHaveBeenCalledWith(newValue);
+    });
+  });
+
   describe('Properties:', () => {
     const validateModel: any = 'validateModel';
 

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
@@ -259,6 +259,21 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
    * @optional
    *
    * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * @optional
+   *
+   * @description
    * Evento disparado quando uma tecla é pressionada enquanto o foco está no componente.
    * Retorna um objeto `KeyboardEvent` com informações sobre a tecla.
    */
@@ -266,6 +281,7 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
 
   displayAdditionalHelp: boolean = false;
   mdColumns: number = poRadioGroupColumnsDefaultLength;
+  modelLastUpdate: any;
   value: any;
 
   protected readonly cd = inject(ChangeDetectorRef);
@@ -395,6 +411,13 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
     this.applySizeBasedOnA11y();
   }
 
+  controlChangeModelEmitter(value: any) {
+    if (this.modelLastUpdate !== value) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value;
+    }
+  }
+
   // Função que controla quando deve ser emitido onChange e atualiza o Model
   changeValue(changedValue: any) {
     if (this.onChangePropagate) {
@@ -406,6 +429,7 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
     }
 
     this.value = changedValue;
+    this.controlChangeModelEmitter(changedValue);
   }
 
   // Função implementada do ControlValueAccessor
@@ -444,6 +468,10 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
     if (!element && this.onChangePropagate) {
       this.value = undefined;
       this.onChangePropagate(this.value);
+    }
+
+    if (this.value != null) {
+      this.controlChangeModelEmitter(this.value);
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/samples/sample-po-radio-group-labs/sample-po-radio-group-labs.component.html
@@ -13,6 +13,7 @@
   [p-show-required]="properties.includes('showRequired')"
   [p-size]="size"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-keydown)="changeEvent('p-keydown')"
   [p-error-limit]="properties?.includes('errorLimit')"
   [p-label-text-wrap]="properties?.includes('labelTextWrap')"

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -332,7 +332,8 @@ describe('PoSelectComponent:', () => {
         displayValue: label => {},
         updateModel: value => {},
         emitChange: value => {},
-        getValueUpdate: value => {}
+        getValueUpdate: value => {},
+        controlChangeModelEmitter: value => {}
       };
 
       spyOn(fakeThis, 'emitChange');
@@ -676,6 +677,74 @@ describe('PoSelectComponent:', () => {
       const defaultLabel = 'label';
       expectSettersMethod(component, 'fieldLabel', '', 'fieldLabel', defaultLabel);
       expect(component.fieldLabel).toEqual(defaultLabel);
+    });
+  });
+
+  describe('p-change-model:', () => {
+    it('should emit changeModel when writeValue receives a new value different from modelLastUpdate', () => {
+      const newValue = 1;
+      component.modelLastUpdate = undefined;
+      component.options = [
+        { value: 1, label: 'Option 1' },
+        { value: 2, label: 'Option 2' }
+      ];
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(newValue);
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith(newValue);
+      expect(component.modelLastUpdate).toBe(newValue);
+    });
+
+    it('should NOT emit changeModel when writeValue receives the same value as modelLastUpdate', () => {
+      const sameValue = 1;
+      component.modelLastUpdate = sameValue;
+      component.selectedValue = sameValue;
+      component.options = [
+        { value: 1, label: 'Option 1' },
+        { value: 2, label: 'Option 2' }
+      ];
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(sameValue);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+    });
+
+    it('should emit changeModel when user selects a different option via onSelectChange', () => {
+      component.options = [
+        { value: 1, label: 'Option 1' },
+        { value: 2, label: 'Option 2' }
+      ];
+      component.selectedValue = 1;
+      component.modelLastUpdate = 1;
+      component['onModelTouched'] = () => {};
+
+      spyOn(component.changeModel, 'emit');
+
+      component.onSelectChange(2);
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith(2);
+      expect(component.modelLastUpdate).toBe(2);
+    });
+
+    it('should NOT emit change event when writeValue is called (only changeModel should emit)', () => {
+      const newValue = 1;
+      component.modelLastUpdate = undefined;
+      component.options = [
+        { value: 1, label: 'Option 1' },
+        { value: 2, label: 'Option 2' }
+      ];
+
+      spyOn(component.change, 'emit');
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(newValue);
+
+      expect(component.change.emit).not.toHaveBeenCalled();
+      expect(component.changeModel.emit).toHaveBeenCalledWith(newValue);
     });
   });
 

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -149,6 +149,21 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
    *
    * @description
    *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Função para atualizar o ngModel do componente, necessário quando não for utilizado dentro da tag form.
    *
    * Na versão 12.2.0 do Angular a verificação `strictTemplates` vem true como default. Portanto, para utilizar
@@ -215,6 +230,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
   displayValue;
   id = `po-select[${uuid()}]`;
   modelValue: any;
+  modelLastUpdate: any;
   selectedValue: any;
   optionsDefault = [];
   listGroupOptions = [];
@@ -511,6 +527,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
       this.updateModel(this.getValueUpdate(option));
       this.displayValue = option[this.fieldLabel];
       this.emitChange(option[this.fieldValue]);
+      this.controlChangeModelEmitter(option[this.fieldValue]);
     }
   }
 
@@ -532,6 +549,7 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
 
     this.modelValue = value;
     this.changeDetector.detectChanges();
+    this.controlChangeModelEmitter(this.selectedValue);
   }
 
   extraValidation(c: AbstractControl): { [key: string]: any } {
@@ -593,6 +611,13 @@ export class PoSelectComponent extends PoFieldValidateModel<any> implements OnCh
       this.size,
       this.isAdditionalHelpEventTriggered() ? this.additionalHelp : undefined
     );
+  }
+
+  controlChangeModelEmitter(value: any) {
+    if (this.modelLastUpdate !== value) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value;
+    }
   }
 
   private isEqual(value: any, inputValue: any): boolean {

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
@@ -665,6 +665,57 @@ describe('PoSwitchComponent', () => {
     });
   });
 
+  describe('p-change-model:', () => {
+    it('should emit changeModel when writeValue receives a new value different from modelLastUpdate', () => {
+      component.modelLastUpdate = undefined;
+      component.value = false;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(true);
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith(true);
+      expect(component.modelLastUpdate).toBe(true);
+    });
+
+    it('should NOT emit changeModel when writeValue receives the same value as modelLastUpdate', () => {
+      component.value = true;
+      component.modelLastUpdate = true;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(true);
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+    });
+
+    it('should emit changeModel when user clicks to toggle value via eventClick', () => {
+      component.value = false;
+      component.disabled = false;
+      component.modelLastUpdate = false;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.eventClick();
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith(true);
+      expect(component.modelLastUpdate).toBe(true);
+    });
+
+    it('should NOT emit change event when writeValue is called (only changeModel should emit)', () => {
+      component.modelLastUpdate = undefined;
+      component.value = false;
+
+      spyOn(component.change, 'emit');
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue(true);
+
+      expect(component.change.emit).not.toHaveBeenCalled();
+      expect(component.changeModel.emit).toHaveBeenCalledWith(true);
+    });
+  });
+
   describe('Template:', () => {
     it('should set tabindex to -1 when switch is disabled', () => {
       component.disabled = true;

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
@@ -4,11 +4,13 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   forwardRef,
   inject,
   InjectOptions,
   Injector,
   Input,
+  Output,
   ViewChild,
   OnDestroy,
   HostListener,
@@ -383,6 +385,23 @@ export class PoSwitchComponent extends PoFieldModel<any> implements Validator, A
    */
   labelTextWrap = input<boolean>(false, { alias: 'p-label-text-wrap' });
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
+
+  modelLastUpdate: any;
+
   private readonly el: ElementRef = inject(ElementRef);
   private readonly injectOptions: InjectOptions = {
     self: true
@@ -467,6 +486,7 @@ export class PoSwitchComponent extends PoFieldModel<any> implements Validator, A
         this.updateModel(value);
       }
       this.emitChange(this.value);
+      this.controlChangeModelEmitter(this.value);
     }
   }
 
@@ -484,6 +504,9 @@ export class PoSwitchComponent extends PoFieldModel<any> implements Validator, A
         this.value = !!value;
       }
       this.changeDetector.markForCheck();
+    }
+    if (value != null) {
+      this.controlChangeModelEmitter(this.value);
     }
   }
 
@@ -573,6 +596,13 @@ export class PoSwitchComponent extends PoFieldModel<any> implements Validator, A
    */
   override showAdditionalHelp(): boolean {
     return super.showAdditionalHelp(this.helperEl, this.poHelperComponent());
+  }
+
+  controlChangeModelEmitter(value: any) {
+    if (this.modelLastUpdate !== value) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value;
+    }
   }
 
   private applySizeBasedOnA11y(): void {

--- a/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-switch/samples/sample-po-switch-labs/sample-po-switch-labs.component.html
@@ -18,6 +18,7 @@
   [p-compact-label]="properties?.includes('compactLabel')"
   [p-size]="size"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-keydown)="changeEvent('p-keydown')"
 >
 </po-switch>

--- a/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker-base.component.ts
@@ -153,6 +153,21 @@ export abstract class PoTimepickerBaseComponent implements ControlValueAccessor,
   /** Evento disparado ao alterar valor do campo. */
   @Output('p-change') onchange: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento disparado sempre que o valor do model é alterado, seja por interação do usuário
+   * ou por atualização programática (ex: `setValue`, `patchValue`, carregamento assíncrono).
+   *
+   * Diferentemente do `p-change`, que é disparado apenas por interação do usuário,
+   * o `p-change-model` cobre todos os cenários de alteração de valor.
+   *
+   * Não emite quando o novo valor é idêntico ao anterior (deduplicação automática).
+   */
+  @Output('p-change-model') changeModel: EventEmitter<any> = new EventEmitter();
+
   /** Evento disparado quando uma tecla é pressionada enquanto o foco está no componente. */
   @Output('p-keydown') keydown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
 
@@ -199,6 +214,8 @@ export abstract class PoTimepickerBaseComponent implements ControlValueAccessor,
 
   /** Habilita ação para limpar o campo. */
   clean?: boolean = false;
+
+  modelLastUpdate: any;
 
   protected onChangeModel: any = null;
   protected validatorChange: any;
@@ -666,6 +683,15 @@ export abstract class PoTimepickerBaseComponent implements ControlValueAccessor,
       this.pendingChangeValue = null;
     } else {
       this.pendingChangeValue = { value: formatted };
+    }
+
+    this.controlChangeModelEmitter(formatted);
+  }
+
+  controlChangeModelEmitter(value: any) {
+    if (this.modelLastUpdate !== value) {
+      this.changeModel.emit(value);
+      this.modelLastUpdate = value;
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker.component.spec.ts
@@ -4580,4 +4580,61 @@ describe('PoTimepickerComponent:', () => {
       expect(component['periodDisplay']).toBe('AM');
     });
   });
+
+  describe('p-change-model:', () => {
+    // Feature: p-change-model-fields, Property 1: Emission on new value
+    it('should emit changeModel when writeValue receives a new valid time (Property 1)', () => {
+      fixture.detectChanges();
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue('10:30');
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith('10:30');
+      expect(component.modelLastUpdate).toBe('10:30');
+    });
+
+    // Feature: p-change-model-fields, Property 2: Deduplication
+    it('should NOT emit changeModel when writeValue receives the same time value as modelLastUpdate (Property 2)', () => {
+      fixture.detectChanges();
+      component.modelLastUpdate = '10:30';
+
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue('10:30');
+
+      expect(component.changeModel.emit).not.toHaveBeenCalled();
+    });
+
+    // Feature: p-change-model-fields, Property 5: User interaction triggers emission
+    it('should emit changeModel when user selects time via timer panel (Property 5)', () => {
+      fixture.detectChanges();
+      component.modelLastUpdate = undefined;
+      component['onChangeModel'] = jasmine.createSpy('onChangeModel');
+      component['previousValue'] = '';
+
+      spyOn(component.changeModel, 'emit');
+
+      component.timerSelected('14:30');
+
+      expect(component.changeModel.emit).toHaveBeenCalledWith('14:30');
+      expect(component.modelLastUpdate).toBe('14:30');
+    });
+
+    // Feature: p-change-model-fields, Property 6: WriteValue does not emit p-change
+    it('should NOT emit onchange (p-change) when writeValue is called (Property 6)', fakeAsync(() => {
+      fixture.detectChanges();
+      component.modelLastUpdate = undefined;
+
+      spyOn(component.onchange, 'emit');
+      spyOn(component.changeModel, 'emit');
+
+      component.writeValue('10:30');
+      tick(300);
+
+      expect(component.onchange.emit).not.toHaveBeenCalled();
+      expect(component.changeModel.emit).toHaveBeenCalledWith('10:30');
+    }));
+  });
 });

--- a/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-timepicker/po-timepicker.component.ts
@@ -709,6 +709,9 @@ export class PoTimepickerComponent extends PoTimepickerBaseComponent implements 
     }
 
     this.valueBeforeChange = this.timeValue;
+    if (value != null) {
+      this.controlChangeModelEmitter(this.formatOutput(this.timeValue) || this.timeValue);
+    }
   }
 
   verifyMobile() {

--- a/projects/ui/src/lib/components/po-field/po-timepicker/samples/sample-po-timepicker-labs/sample-po-timepicker-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-timepicker/samples/sample-po-timepicker-labs/sample-po-timepicker-labs.component.html
@@ -31,6 +31,7 @@
   [p-size]="size"
   (p-blur)="changeEvent('p-blur')"
   (p-change)="changeEvent('p-change')"
+  (p-change-model)="changeEvent('p-change-model')"
   (p-keydown)="changeEvent('p-keydown')"
 >
 </po-timepicker>


### PR DESCRIPTION
Adiciona evento p-change-model nos componentes: po-combo, po-select, po-multiselect, po-lookup, po-radio-group, po-datepicker, po-datepicker-range, po-datetimepicker, po-timepicker, po-checkbox, po-switch, po-checkbox-group.

fixes DTHFUI-13565

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**
Componentes mencionados passam a ter o output p-change-model.

**Simulação**
[app-p-change-model-po-ui.zip](https://github.com/user-attachments/files/31192571/app-p-change-model-po-ui.zip)