### PR TITLE
feat(drag-drop): nova diretiva

### DIFF
--- a/projects/ui/src/lib/directives/directives.module.ts
+++ b/projects/ui/src/lib/directives/directives.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 
+import { PoDragDropModule } from './po-drag-drop/po-drag-drop.module';
 import { PoTooltipModule } from './po-tooltip/po-tooltip.module';
 
 @NgModule({
   declarations: [],
-  imports: [PoTooltipModule],
-  exports: [PoTooltipModule],
+  imports: [PoDragDropModule, PoTooltipModule],
+  exports: [PoDragDropModule, PoTooltipModule],
   providers: [],
   bootstrap: []
 })

--- a/projects/ui/src/lib/directives/index.ts
+++ b/projects/ui/src/lib/directives/index.ts
@@ -1,3 +1,4 @@
 export * from './directives.module';
 
+export * from './po-drag-drop/index';
 export * from './po-tooltip/index';

--- a/projects/ui/src/lib/directives/po-drag-drop/index.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/index.ts
@@ -1,0 +1,6 @@
+export * from './interfaces/po-draggable-item.interface';
+export * from './po-drag-base.directive';
+export * from './po-drag.directive';
+export * from './po-drop-list-base.directive';
+export * from './po-drop-list.directive';
+export * from './po-drag-drop.module';

--- a/projects/ui/src/lib/directives/po-drag-drop/interfaces/po-draggable-item.interface.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/interfaces/po-draggable-item.interface.ts
@@ -1,0 +1,88 @@
+/**
+ * @usedBy PoDropListDirective, PoDragDirective
+ *
+ * @description
+ *
+ * Define a estrutura de um item arrastável genérico utilizado pelas diretivas
+ * `PoDropListDirective` e `PoDragDirective`.
+ *
+ * A interface é intencionalmente leve — contém apenas os campos essenciais para
+ * qualquer componente arrastável.
+ */
+export interface PoDraggableItem {
+  /** Identificador único do item. */
+  id: string;
+
+  /**
+   * @optional
+   * @description
+   *
+   * Dados arbitrários do consumidor. Útil para associar informações extras
+   * ao item sem estender a interface.
+   */
+  data?: any;
+}
+
+/**
+ * @usedBy PoDropListDirective
+ *
+ * @description
+ *
+ * Evento emitido quando um item é solto em um container (`p-drop-list`), contendo os índices,
+ * o item movido e os identificadores dos containers envolvidos.
+ */
+export interface PoDropEvent {
+  /** Índice original do item antes do drop. */
+  previousIndex: number;
+
+  /** Índice final do item após o drop. */
+  currentIndex: number;
+
+  /** O item que foi movido. */
+  item: PoDraggableItem;
+
+  /**
+   * @description
+   * Array resultante após o drop, já com a nova ordem aplicada.
+   * Use este valor para atualizar o signal ou array do consumidor.
+   */
+  items: Array<PoDraggableItem>;
+
+  /** Identificador do container de destino. */
+  container: string;
+
+  /**
+   * @optional
+   * @description
+   * Identificador do container de origem. Preenchido apenas quando o item
+   * foi transferido entre containers distintos.
+   */
+  previousContainer?: string;
+
+  dropPoint?: any;
+}
+
+/**
+ * @usedBy PoDropListDirective
+ *
+ * @description
+ *
+ * Evento emitido quando um item entra em um container `p-drop-list`.
+ */
+export interface PoDragEnterEvent<T = any> {
+  /** O item que entrou no container. */
+  item: T;
+
+  /** Identificador do container que recebeu o item. */
+  container: string;
+}
+
+/**
+ * @usedBy PoDragDirective
+ *
+ * @description
+ *
+ * Evento emitido continuamente enquanto o item está sendo arrastado.
+ * Contém a posição do ponteiro e a distância percorrida desde o início do arraste.
+ */
+export { CdkDragMove as PoDragMovedEvent } from '@angular/cdk/drag-drop';

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drag-base.directive.spec.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drag-base.directive.spec.ts
@@ -1,0 +1,166 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { PoDragDirective } from './po-drag.directive';
+import { PoDragDropModule } from './po-drag-drop.module';
+import { PoWidgetModule } from '../../components/po-widget/po-widget.module';
+
+interface TestItem {
+  id: string;
+  name: string;
+}
+
+@Component({
+  template: `
+    <po-widget
+      [p-drag]="item"
+      [p-drag-disabled]="disabled"
+      (p-drag-started)="onStarted($event)"
+      (p-drag-ended)="onEnded($event)"
+      (p-drag-moved)="onMoved($event)"
+    ></po-widget>
+  `,
+  standalone: false
+})
+class TestHostComponent {
+  item: TestItem = { id: '1', name: 'test' };
+  disabled = false;
+  startedItem: TestItem | null = null;
+  endedItem: TestItem | null = null;
+  movedEvent: any = null;
+
+  onStarted(item: TestItem) {
+    this.startedItem = item;
+  }
+
+  onEnded(item: TestItem) {
+    this.endedItem = item;
+  }
+
+  onMoved(event: any) {
+    this.movedEvent = event;
+  }
+}
+
+@Component({
+  template: `<po-widget [p-drag]="item" [p-drag-disabled]="'true'"></po-widget>`,
+  standalone: false
+})
+class TestStringBooleanHostComponent {
+  item: TestItem = { id: '2', name: 'string boolean' };
+}
+
+describe('PoDragBaseDirective (via PoDragDirective)', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let directive: PoDragDirective;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PoDragDropModule, PoWidgetModule],
+      declarations: [TestHostComponent, TestStringBooleanHostComponent]
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    directive = fixture.debugElement.query(By.directive(PoDragDirective)).injector.get(PoDragDirective);
+  });
+
+  it('should create the host component', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should render a po-widget with poDrag applied', () => {
+    const el = fixture.nativeElement.querySelector('po-widget');
+    expect(el).toBeTruthy();
+  });
+
+  describe('data input (p-drag)', () => {
+    it('should read `data` signal with the bound item', () => {
+      expect(directive.data()).toEqual(jasmine.objectContaining({ id: '1', name: 'test' }));
+    });
+
+    it('should reflect changes when input item is updated', () => {
+      component.item = { id: '99', name: 'changed' };
+      fixture.detectChanges();
+      expect(directive.data()).toEqual(jasmine.objectContaining({ id: '99', name: 'changed' }));
+    });
+
+    it('should accept undefined as data value', () => {
+      component.item = undefined;
+      fixture.detectChanges();
+      expect(directive.data()).toBeUndefined();
+    });
+
+    it('should accept null as data value', () => {
+      component.item = null;
+      fixture.detectChanges();
+      expect(directive.data()).toBeNull();
+    });
+  });
+
+  describe('dragDisabled input (p-drag-disabled)', () => {
+    it('should read `dragDisabled` signal as false by default', () => {
+      expect(directive.dragDisabled()).toBeFalse();
+    });
+
+    it('should read `dragDisabled` signal as true when bound to true', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      expect(directive.dragDisabled()).toBeTrue();
+    });
+
+    it('should toggle dragDisabled back to false', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      component.disabled = false;
+      fixture.detectChanges();
+      expect(directive.dragDisabled()).toBeFalse();
+    });
+
+    it('should accept string "true" via convertToBoolean transform', () => {
+      const strFixture = TestBed.createComponent(TestStringBooleanHostComponent);
+      strFixture.detectChanges();
+      const strDirective = strFixture.debugElement.query(By.directive(PoDragDirective)).injector.get(PoDragDirective);
+      expect(strDirective.dragDisabled()).toBeTrue();
+    });
+  });
+
+  describe('dragStarted output (p-drag-started)', () => {
+    it('should emit the item data when dragStarted fires', () => {
+      directive.dragStarted.emit(component.item);
+      expect(component.startedItem).toEqual(component.item);
+    });
+
+    it('should emit updated item data after input change', () => {
+      const newItem: TestItem = { id: '5', name: 'new item' };
+      component.item = newItem;
+      fixture.detectChanges();
+      directive.dragStarted.emit(directive.data());
+      expect(component.startedItem).toEqual(newItem);
+    });
+  });
+
+  describe('dragEnded output (p-drag-ended)', () => {
+    it('should emit the item data when dragEnded fires', () => {
+      directive.dragEnded.emit(component.item);
+      expect(component.endedItem).toEqual(component.item);
+    });
+  });
+
+  describe('dragMoved output (p-drag-moved)', () => {
+    it('should emit CdkDragMove event when dragMoved fires', () => {
+      const fakeEvent = {
+        source: {},
+        pointerPosition: { x: 100, y: 200 },
+        distance: { x: 10, y: 20 },
+        delta: { x: 1, y: 0 }
+      } as any;
+      directive.dragMoved.emit(fakeEvent);
+      expect(component.movedEvent).toEqual(fakeEvent);
+    });
+  });
+});

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drag-base.directive.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drag-base.directive.ts
@@ -1,0 +1,61 @@
+import { Directive, output, input } from '@angular/core';
+
+import { convertToBoolean } from '../../utils/util';
+import { PoDraggableItem, PoDragMovedEvent } from './interfaces/po-draggable-item.interface';
+
+@Directive()
+export abstract class PoDragBaseDirective {
+  /**
+   * @description
+   *
+   * Dado associado ao item arrastável. O valor é emitido nos eventos
+   * `p-drag-started` e `p-drag-ended`.
+   */
+  data = input<PoDraggableItem>(undefined, { alias: 'p-drag' });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Desabilita o arraste do item. Quando `true`, o usuário não pode iniciar
+   * um gesto de arrastar neste elemento, mas o item continua participando do
+   * cálculo de posições dos vizinhos dentro do `p-drop-list`.
+   *
+   * @default false
+   */
+  dragDisabled = input<boolean, unknown>(false, { alias: 'p-drag-disabled', transform: convertToBoolean });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento emitido quando o arraste do item é iniciado.
+   * O valor emitido é o dado associado ao item (propriedade `p-drag`).
+   */
+  dragStarted = output<PoDraggableItem>({ alias: 'p-drag-started' });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento emitido quando o arraste do item é encerrado.
+   * O valor emitido é o dado associado ao item (propriedade `p-drag`).
+   */
+  dragEnded = output<PoDraggableItem>({ alias: 'p-drag-ended' });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento emitido continuamente enquanto o item está sendo arrastado.
+   * Contém a posição do ponteiro, a distância percorrida e a direção do movimento.
+   *
+   * > **Atenção:** Este evento é disparado em alta frequência (a cada frame de movimento).
+   * > Evite operações custosas no handler ou aplique técnicas de throttle/debounce.
+   */
+  dragMoved = output<PoDragMovedEvent>({ alias: 'p-drag-moved' });
+}

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drag-drop.module.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drag-drop.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+
+import { PoDragDirective } from './po-drag.directive';
+import { PoDropListDirective } from './po-drop-list.directive';
+
+/**
+ * @description
+ *
+ * Módulo que exporta as diretivas de drag & drop do PO UI:
+ * - `PoDropListDirective` (`p-drop-list`) — define um container de drop.
+ * - `PoDragDirective` (`p-drag`) — torna um elemento arrastável.
+ */
+@NgModule({
+  imports: [PoDragDirective, PoDropListDirective],
+  exports: [PoDragDirective, PoDropListDirective]
+})
+export class PoDragDropModule {}

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drag-handle-button/po-drag-handle-button.component.spec.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drag-handle-button/po-drag-handle-button.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PoDragHandleButtonComponent } from './po-drag-handle-button.component';
+
+describe('PoDragHandleButtonComponent', () => {
+  let fixture: ComponentFixture<PoDragHandleButtonComponent>;
+  let component: PoDragHandleButtonComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PoDragHandleButtonComponent]
+    });
+
+    fixture = TestBed.createComponent(PoDragHandleButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should resolve default size when sizeInput is empty', () => {
+    expect(component.resolvedSize()).toBeTruthy();
+  });
+
+  it('should resolve size based on sizeInput when provided', () => {
+    fixture.componentRef.setInput('p-size', 'medium');
+    fixture.detectChanges();
+    expect(component.resolvedSize()).toBe('medium');
+  });
+
+  it('should update resolvedSize when onThemeChange is called', () => {
+    const initialSize = component.resolvedSize();
+    (component as any).onThemeChange();
+    fixture.detectChanges();
+
+    expect(component.resolvedSize()).toBeTruthy();
+    expect(component.resolvedSize()).toBe(initialSize);
+  });
+
+  it('should render a button with cdkDragHandle', () => {
+    const button = fixture.nativeElement.querySelector('button.po-drag-drop-handle');
+    expect(button).toBeTruthy();
+  });
+
+  it('should have aria-label for accessibility', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('aria-label')).toBe(component.literals.dragToReorder);
+  });
+
+  it('should stop click propagation', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    const event = new MouseEvent('click', { bubbles: true });
+    spyOn(event, 'stopPropagation');
+    button.dispatchEvent(event);
+    expect(button).toBeTruthy();
+  });
+});

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drag-handle-button/po-drag-handle-button.component.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drag-handle-button/po-drag-handle-button.component.ts
@@ -1,0 +1,69 @@
+import { CdkDragHandle } from '@angular/cdk/drag-drop';
+import { Component, computed, HostListener, inject, input, signal, ViewEncapsulation } from '@angular/core';
+
+import { PoTooltipModule } from '../../po-tooltip';
+import { getDefaultSizeFn, validateSizeFn } from '../../../utils/util';
+import { PoIconModule } from '../../../components/po-icon/po-icon.module';
+import { PoButtonSize } from '../../../components/po-button/enums/po-button-size.enum';
+import { PoLanguageService } from '../../../services/po-language/po-language.service';
+import { poLocaleDefault } from '../../../services/po-language/po-language.constant';
+
+export const poDragHandleButtonLiteralsDefault = {
+  en: { dragToReorder: 'Drag to reorder' },
+  es: { dragToReorder: 'Arrastre para reordenar' },
+  pt: { dragToReorder: 'Arraste para reordenar' },
+  ru: { dragToReorder: 'Перетащите для изменения порядка' }
+};
+
+/**
+ * @docsPrivate
+ *
+ * Componente interno criado programaticamente pela diretiva `poDrag`.
+ * Renderiza o botão de handle de arraste posicionado absolutamente sobre o
+ * elemento arrastável. Visível apenas no hover, via CSS da diretiva.
+ *
+ * Não deve ser instanciado diretamente pelo consumidor.
+ */
+@Component({
+  selector: 'po-drag-handle-button',
+  standalone: true,
+  imports: [CdkDragHandle, PoTooltipModule, PoIconModule],
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <button
+      cdkDragHandle
+      class="po-drag-drop-handle"
+      [class.size-small]="resolvedSize() === 'small'"
+      type="button"
+      tabindex="-1"
+      [attr.aria-label]="literals.dragToReorder"
+      [p-tooltip]="literals.dragToReorder"
+      p-tooltip-position="top"
+      [p-append-in-body]="true"
+      (click)="$event.stopPropagation()"
+    >
+      <po-icon p-icon="ICON_DRAG"></po-icon>
+    </button>
+  `
+})
+export class PoDragHandleButtonComponent {
+  readonly sizeInput = input<string>('', { alias: 'p-size' });
+
+  readonly literals = {
+    ...poDragHandleButtonLiteralsDefault[poLocaleDefault],
+    ...poDragHandleButtonLiteralsDefault[inject(PoLanguageService).getShortLanguage()]
+  };
+
+  private readonly themeChangeSignal = signal(0);
+
+  readonly resolvedSize = computed(() => {
+    this.themeChangeSignal();
+    const value = this.sizeInput();
+    return value ? validateSizeFn(value, PoButtonSize) : getDefaultSizeFn(PoButtonSize);
+  });
+
+  @HostListener('window:PoUiThemeChange')
+  protected onThemeChange(): void {
+    this.themeChangeSignal.update(v => v + 1);
+  }
+}

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drag.directive.spec.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drag.directive.spec.ts
@@ -1,0 +1,392 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CdkDrag } from '@angular/cdk/drag-drop';
+
+import { PoDragDirective } from './po-drag.directive';
+import { PoDragDropModule } from './po-drag-drop.module';
+import { PoWidgetModule } from '../../components/po-widget/po-widget.module';
+
+interface TestItem {
+  id: string;
+  name: string;
+}
+
+@Component({
+  template: `
+    <po-widget
+      [p-drag]="item"
+      [p-drag-disabled]="disabled"
+      (p-drag-started)="onStarted($event)"
+      (p-drag-ended)="onEnded($event)"
+      (p-drag-moved)="onMoved($event)"
+    ></po-widget>
+  `,
+  standalone: false
+})
+class TestHostComponent {
+  item: TestItem = { id: '1', name: 'test' };
+  disabled = false;
+  startedItem: TestItem | null = null;
+  endedItem: TestItem | null = null;
+  movedEvent: any = null;
+
+  onStarted(item: TestItem) {
+    this.startedItem = item;
+  }
+
+  onEnded(item: TestItem) {
+    this.endedItem = item;
+  }
+
+  onMoved(event: any) {
+    this.movedEvent = event;
+  }
+}
+
+@Component({
+  template: `<po-widget [p-drag]="item" [p-drag-disabled]="true"></po-widget>`,
+  standalone: false
+})
+class TestDisabledHostComponent {
+  item: TestItem = { id: '1', name: 'disabled item' };
+}
+
+@Component({
+  template: `
+    <div [p-drop-list]="items" [p-drop-list-disabled]="dropListDisabled">
+      <po-widget [p-drag]="item"></po-widget>
+    </div>
+  `,
+  standalone: false
+})
+class TestDropListHostComponent {
+  item: TestItem = { id: '1', name: 'test' };
+  items: Array<TestItem> = [{ id: '1', name: 'test' }];
+  dropListDisabled = false;
+}
+
+describe('PoDragDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let directive: PoDragDirective;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PoDragDropModule, PoWidgetModule],
+      declarations: [TestHostComponent, TestDisabledHostComponent, TestDropListHostComponent]
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    directive = fixture.debugElement.query(By.directive(PoDragDirective)).injector.get(PoDragDirective);
+  });
+
+  it('should be created', () => {
+    expect(directive).toBeTruthy();
+  });
+
+  describe('inputs', () => {
+    it('should read `data` signal matching the bound item', () => {
+      expect(directive.data()).toEqual(component.item);
+    });
+
+    it('should update `data` signal when input changes', () => {
+      const newItem: TestItem = { id: '2', name: 'updated' };
+      component.item = newItem;
+      fixture.detectChanges();
+      expect(directive.data()).toEqual(newItem);
+    });
+
+    it('should read `dragDisabled` signal as false by default', () => {
+      expect(directive.dragDisabled()).toBeFalse();
+    });
+
+    it('should read `dragDisabled` signal as true when disabled is set', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      expect(directive.dragDisabled()).toBeTrue();
+    });
+  });
+
+  describe('outputs', () => {
+    it('should emit `p-drag-started` with the item data', () => {
+      directive.dragStarted.emit(component.item);
+      expect(component.startedItem).toEqual(component.item);
+    });
+
+    it('should emit `p-drag-ended` with the item data', () => {
+      directive.dragEnded.emit(component.item);
+      expect(component.endedItem).toEqual(component.item);
+    });
+
+    it('should emit `p-drag-moved` when dragMoved fires', () => {
+      const fakeEvent = { source: {}, pointerPosition: { x: 10, y: 20 } } as any;
+      directive.dragMoved.emit(fakeEvent);
+      expect(component.movedEvent).toEqual(fakeEvent);
+    });
+  });
+
+  describe('ngOnInit', () => {
+    it('should set previewClass on cdkDrag', () => {
+      const cdkDrag = fixture.debugElement.query(By.directive(CdkDrag)).injector.get(CdkDrag);
+      expect(cdkDrag.previewClass).toBe('po-drag-drop-item-preview');
+    });
+
+    it('should add po-drag-drop-item class when not disabled', () => {
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.classList.contains('po-drag-drop-item')).toBeTrue();
+    });
+
+    it('should remove po-drag-drop-item class when disabled', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.classList.contains('po-drag-drop-item')).toBeFalse();
+    });
+
+    it('should add po-drag-drop-item class back when re-enabled', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      component.disabled = false;
+      fixture.detectChanges();
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.classList.contains('po-drag-drop-item')).toBeTrue();
+    });
+  });
+
+  describe('handle button', () => {
+    it('should append a po-drag-handle-button element', () => {
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      const handle = hostEl.querySelector('po-drag-handle-button');
+      expect(handle).toBeTruthy();
+    });
+
+    it('should not duplicate handle on multiple AfterViewChecked cycles', () => {
+      // Force multiple view checks
+      fixture.detectChanges();
+      fixture.detectChanges();
+      fixture.detectChanges();
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      const handles = hostEl.querySelectorAll('po-drag-handle-button');
+      expect(handles.length).toBe(1);
+    });
+
+    it('should remove handle when drag is disabled', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      const handle = hostEl.querySelector('po-drag-handle-button');
+      expect(handle).toBeNull();
+    });
+
+    it('should re-append handle when drag is re-enabled', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      component.disabled = false;
+      fixture.detectChanges();
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      const handle = hostEl.querySelector('po-drag-handle-button');
+      expect(handle).toBeTruthy();
+    });
+  });
+
+  describe('CdkDrag integration', () => {
+    it('should sync data to cdkDrag.data via effect', () => {
+      const cdkDrag = fixture.debugElement.query(By.directive(CdkDrag)).injector.get(CdkDrag);
+      expect(cdkDrag.data).toEqual(component.item);
+    });
+
+    it('should update cdkDrag.data when input changes', () => {
+      const newItem: TestItem = { id: '3', name: 'new' };
+      component.item = newItem;
+      fixture.detectChanges();
+      const cdkDrag = fixture.debugElement.query(By.directive(CdkDrag)).injector.get(CdkDrag);
+      expect(cdkDrag.data).toEqual(newItem);
+    });
+  });
+
+  describe('CdkDrag event subscriptions', () => {
+    it('should emit dragStarted with data and add placeholder class when cdkDrag.started fires', () => {
+      const cdkDrag = fixture.debugElement.query(By.directive(CdkDrag)).injector.get(CdkDrag);
+
+      spyOn(directive.dragStarted, 'emit');
+      cdkDrag.started.emit({ source: cdkDrag } as any);
+
+      expect(directive.dragStarted.emit).toHaveBeenCalledWith(component.item);
+    });
+
+    it('should emit dragEnded with data and re-append handle when cdkDrag.ended fires', () => {
+      const cdkDrag = fixture.debugElement.query(By.directive(CdkDrag)).injector.get(CdkDrag);
+
+      spyOn(directive.dragEnded, 'emit');
+      cdkDrag.ended.emit({ source: cdkDrag } as any);
+
+      expect(directive.dragEnded.emit).toHaveBeenCalledWith(component.item);
+    });
+
+    it('should subscribe to cdkDrag.moved and relay events to dragMoved output', () => {
+      // Access the internal _dragRef.moved Subject to simulate a move event
+      const cdkDrag = fixture.debugElement.query(By.directive(CdkDrag)).injector.get(CdkDrag);
+      const dragRef = (cdkDrag as any)._dragRef;
+
+      spyOn(directive.dragMoved, 'emit');
+
+      if (dragRef && dragRef.moved) {
+        const fakeEvent = {
+          pointerPosition: { x: 50, y: 60 },
+          distance: { x: 5, y: 6 },
+          delta: { x: 1, y: 1 },
+          event: new MouseEvent('mousemove')
+        };
+        dragRef.moved.next(fakeEvent);
+
+        expect(directive.dragMoved.emit).toHaveBeenCalled();
+      } else {
+        expect(directive.dragMoved).toBeDefined();
+      }
+    });
+
+    it('should remove only the tooltips inside the dragged element on drag start', () => {
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement as HTMLElement;
+
+      const innerTooltip = document.createElement('div');
+      innerTooltip.className = 'po-tooltip';
+      hostEl.appendChild(innerTooltip);
+
+      const outerTooltip = document.createElement('div');
+      outerTooltip.className = 'po-tooltip';
+      document.body.appendChild(outerTooltip);
+
+      const cdkDrag = fixture.debugElement.query(By.directive(CdkDrag)).injector.get(CdkDrag);
+      cdkDrag.started.emit({ source: cdkDrag } as any);
+
+      expect(hostEl.querySelectorAll('.po-tooltip')).toHaveSize(0);
+      expect(document.body.contains(outerTooltip)).toBeTrue();
+
+      outerTooltip.remove();
+    });
+  });
+
+  describe('cdkDrag.started subscription', () => {
+    it('should add placeholder class when getPlaceholderElement returns an element', () => {
+      const cdkDrag = fixture.debugElement.query(By.directive(CdkDrag)).injector.get(CdkDrag);
+      const fakePlaceholder = document.createElement('div');
+      spyOn(cdkDrag, 'getPlaceholderElement').and.returnValue(fakePlaceholder);
+
+      cdkDrag.started.emit({ source: cdkDrag } as any);
+
+      expect(fakePlaceholder.classList.contains('po-drag-drop-item-placeholder')).toBeTrue();
+    });
+  });
+
+  describe('removeTooltipOnDragStart', () => {
+    it('should remove only the tooltip elements inside the dragged element', () => {
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement as HTMLElement;
+
+      const innerTooltip = document.createElement('div');
+      innerTooltip.className = 'po-tooltip';
+      hostEl.appendChild(innerTooltip);
+
+      const outerTooltip = document.createElement('div');
+      outerTooltip.className = 'po-tooltip';
+      document.body.appendChild(outerTooltip);
+
+      (directive as any).removeTooltipOnDragStart();
+
+      expect(hostEl.querySelectorAll('.po-tooltip')).toHaveSize(0);
+      expect(document.body.contains(outerTooltip)).toBeTrue();
+
+      outerTooltip.remove();
+    });
+  });
+
+  describe('disabled component', () => {
+    it('should not append handle when dragDisabled is true', () => {
+      const disabledFixture = TestBed.createComponent(TestDisabledHostComponent);
+      disabledFixture.detectChanges();
+      const hostEl = disabledFixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      const handle = hostEl.querySelector('po-drag-handle-button');
+
+      expect(handle).toBeNull();
+    });
+  });
+
+  describe('parent drop list disabled', () => {
+    it('should not append handle when parent drop list is disabled', () => {
+      const dropListFixture = TestBed.createComponent(TestDropListHostComponent);
+      dropListFixture.componentInstance.dropListDisabled = true;
+      dropListFixture.detectChanges();
+
+      const hostEl = dropListFixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.querySelector('po-drag-handle-button')).toBeNull();
+    });
+
+    it('should append handle when parent drop list is enabled', () => {
+      const dropListFixture = TestBed.createComponent(TestDropListHostComponent);
+      dropListFixture.detectChanges();
+
+      const hostEl = dropListFixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.querySelector('po-drag-handle-button')).toBeTruthy();
+    });
+
+    it('should remove po-drag-drop-item class when parent drop list is disabled', () => {
+      const dropListFixture = TestBed.createComponent(TestDropListHostComponent);
+      dropListFixture.componentInstance.dropListDisabled = true;
+      dropListFixture.detectChanges();
+
+      const hostEl = dropListFixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.classList.contains('po-drag-drop-item')).toBeFalse();
+    });
+
+    it('should add po-drag-drop-item class when parent drop list is enabled', () => {
+      const dropListFixture = TestBed.createComponent(TestDropListHostComponent);
+      dropListFixture.detectChanges();
+
+      const hostEl = dropListFixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.classList.contains('po-drag-drop-item')).toBeTrue();
+    });
+
+    it('should destroy and re-append handle when toggling parent drop list disabled', () => {
+      const dropListFixture = TestBed.createComponent(TestDropListHostComponent);
+      dropListFixture.detectChanges();
+      const hostEl = dropListFixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.querySelector('po-drag-handle-button')).toBeTruthy();
+
+      dropListFixture.componentInstance.dropListDisabled = true;
+      dropListFixture.detectChanges();
+      expect(hostEl.querySelector('po-drag-handle-button')).toBeNull();
+
+      dropListFixture.componentInstance.dropListDisabled = false;
+      dropListFixture.detectChanges();
+      expect(hostEl.querySelector('po-drag-handle-button')).toBeTruthy();
+    });
+  });
+
+  describe('handle lifecycle', () => {
+    it('should re-append a fresh handle when toggling dragDisabled off and on', () => {
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.querySelector('po-drag-handle-button')).toBeTruthy();
+
+      // Disabling destroys the handle
+      component.disabled = true;
+      fixture.detectChanges();
+      expect(hostEl.querySelector('po-drag-handle-button')).toBeNull();
+
+      // Re-enabling appends the handle again
+      component.disabled = false;
+      fixture.detectChanges();
+      expect(hostEl.querySelector('po-drag-handle-button')).toBeTruthy();
+    });
+
+    it('should not append handle while dragDisabled is true', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+
+      const hostEl = fixture.debugElement.query(By.directive(PoDragDirective)).nativeElement;
+      expect(hostEl.querySelector('po-drag-handle-button')).toBeNull();
+    });
+  });
+});

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drag.directive.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drag.directive.ts
@@ -1,0 +1,166 @@
+import {
+  effect,
+  inject,
+  OnInit,
+  Injector,
+  Renderer2,
+  Directive,
+  OnDestroy,
+  ElementRef,
+  ComponentRef,
+  ApplicationRef,
+  createComponent,
+  EnvironmentInjector
+} from '@angular/core';
+import { CdkDrag } from '@angular/cdk/drag-drop';
+
+import { PoDragBaseDirective } from './po-drag-base.directive';
+import { PoDropListDirective } from './po-drop-list.directive';
+import { PoDragMovedEvent } from './interfaces/po-draggable-item.interface';
+import { PoDragHandleButtonComponent } from './po-drag-handle-button/po-drag-handle-button.component';
+
+/**
+ * @docsExtends PoDragBaseDirective
+ *
+ * @description
+ *
+ * A diretiva `p-drag` torna um elemento arrastável, encapsulando o `CdkDrag` do Angular CDK.
+ *
+ * Ela pode ser usada em conjunto com a diretiva `p-drop-list`. O valor atribuído ao seletor (`p-drag`)
+ * corresponde ao dado do item, que é emitido nos eventos de drag.
+ *
+ * > Atualmente validada com o componente `po-widget`. O suporte a outros componentes
+ * > PO UI será avaliado em versões futuras.
+ *
+ * @example
+ *
+ * <example name="po-drag-basic" title="PO Drag Basic" >
+ *  <file name="sample-po-drag-basic/sample-po-drag-basic.component.html"> </file>
+ *  <file name="sample-po-drag-basic/sample-po-drag-basic.component.ts"> </file>
+ * </example>
+ *
+ * <example name="po-drop-list-vertical" title="PO Drop List - Vertical (Kanban)" >
+ *  <file name="sample-po-drop-list-vertical/sample-po-drop-list-vertical.component.html"> </file>
+ *  <file name="sample-po-drop-list-vertical/sample-po-drop-list-vertical.component.ts"> </file>
+ * </example>
+ *
+ * <example name="po-drop-list-horizontal" title="PO Drop List - Horizontal (Pipeline)" >
+ *  <file name="sample-po-drop-list-horizontal/sample-po-drop-list-horizontal.component.html"> </file>
+ *  <file name="sample-po-drop-list-horizontal/sample-po-drop-list-horizontal.component.ts"> </file>
+ * </example>
+ *
+ * <example name="po-drop-list-mixed" title="PO Drop List - Mixed (Dashboard)" >
+ *  <file name="sample-po-drop-list-mixed/sample-po-drop-list-mixed.component.html"> </file>
+ *  <file name="sample-po-drop-list-mixed/sample-po-drop-list-mixed.component.ts"> </file>
+ * </example>
+ *
+ */
+@Directive({
+  selector: '[p-drag]',
+  standalone: true,
+  hostDirectives: [
+    {
+      directive: CdkDrag,
+      inputs: ['cdkDragDisabled: p-drag-disabled', 'cdkDragData: p-drag']
+    }
+  ]
+})
+export class PoDragDirective extends PoDragBaseDirective implements OnInit, OnDestroy {
+  private readonly cdkDrag = inject(CdkDrag);
+  private readonly el = inject(ElementRef);
+  private readonly renderer = inject(Renderer2);
+  private readonly injector = inject(Injector);
+  private readonly envInjector = inject(EnvironmentInjector);
+  private readonly appRef = inject(ApplicationRef);
+  private readonly parentDropList = inject(PoDropListDirective, { optional: true });
+  private handleRef: ComponentRef<PoDragHandleButtonComponent> | null = null;
+
+  constructor() {
+    super();
+
+    effect(() => {
+      this.cdkDrag.data = this.data() as any;
+    });
+
+    effect(
+      () => {
+        if (this.dragDisabled() || this.parentDropList?.dropListDisabled()) {
+          this.destroyHandle();
+        } else {
+          this.appendHandle();
+        }
+      },
+      { injector: this.injector }
+    );
+  }
+
+  ngOnInit(): void {
+    this.cdkDrag.previewClass = 'po-drag-drop-item-preview';
+
+    this.appendItemHover();
+
+    this.cdkDrag.started.subscribe(() => {
+      this.removeTooltipOnDragStart();
+
+      const placeholder = this.cdkDrag.getPlaceholderElement();
+      if (placeholder) {
+        this.renderer.addClass(placeholder, 'po-drag-drop-item-placeholder');
+      }
+
+      this.dragStarted.emit(this.data());
+    });
+
+    this.cdkDrag.ended.subscribe(() => {
+      this.dragEnded.emit(this.data());
+    });
+
+    this.cdkDrag.moved.subscribe((event: PoDragMovedEvent) => {
+      this.dragMoved.emit(event);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroyHandle();
+  }
+
+  private appendHandle(): void {
+    this.destroyHandle();
+
+    const handleRef = createComponent(PoDragHandleButtonComponent, {
+      environmentInjector: this.envInjector,
+      elementInjector: this.injector
+    });
+
+    this.appRef.attachView(handleRef.hostView);
+    handleRef.changeDetectorRef.detectChanges();
+    this.renderer.appendChild(this.el.nativeElement, handleRef.location.nativeElement);
+    this.handleRef = handleRef;
+  }
+
+  private destroyHandle(): void {
+    if (this.handleRef) {
+      this.appRef.detachView(this.handleRef.hostView);
+      this.renderer.removeChild(this.el.nativeElement, this.handleRef.location.nativeElement);
+      this.handleRef.destroy();
+      this.handleRef = null;
+    }
+  }
+
+  private removeTooltipOnDragStart(): void {
+    const tooltips = this.el.nativeElement.querySelectorAll('.po-tooltip');
+    tooltips.forEach(tooltip => tooltip.remove());
+  }
+
+  private appendItemHover(): void {
+    effect(
+      () => {
+        if (this.dragDisabled() || this.parentDropList?.dropListDisabled()) {
+          this.renderer.removeClass(this.el.nativeElement, 'po-drag-drop-item');
+        } else {
+          this.renderer.addClass(this.el.nativeElement, 'po-drag-drop-item');
+        }
+      },
+      { injector: this.injector }
+    );
+  }
+}

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drop-list-base.directive.spec.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drop-list-base.directive.spec.ts
@@ -1,0 +1,258 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { PoDropListDirective } from './po-drop-list.directive';
+import { PoDropEvent, PoDragEnterEvent } from './interfaces/po-draggable-item.interface';
+import { PoDragDropModule } from './po-drag-drop.module';
+
+interface TestItem {
+  id: string;
+  value: number;
+}
+
+@Component({
+  template: `
+    <div
+      [p-drop-list]="items"
+      [p-drop-list-id]="listId"
+      [p-drop-list-disabled]="disabled"
+      [p-drop-list-orientation]="orientation"
+      [p-drop-list-connected-to]="connectedTo"
+      [p-drop-sorting-disabled]="sortingDisabled"
+      (p-dropped)="onDropped($event)"
+      (p-drag-entered)="onEntered($event)"
+    ></div>
+  `,
+  standalone: false
+})
+class TestHostComponent {
+  items: Array<TestItem> = [
+    { id: '1', value: 10 },
+    { id: '2', value: 20 }
+  ];
+  listId = 'test-list';
+  disabled = false;
+  orientation: 'horizontal' | 'vertical' | 'mixed' = 'vertical';
+  connectedTo: Array<string> = [];
+  sortingDisabled = false;
+  droppedEvent: PoDropEvent | null = null;
+  enteredEvent: PoDragEnterEvent<TestItem> | null = null;
+
+  onDropped(event: PoDropEvent) {
+    this.droppedEvent = event;
+  }
+
+  onEntered(event: PoDragEnterEvent<TestItem>) {
+    this.enteredEvent = event;
+  }
+}
+
+@Component({
+  template: `<div [p-drop-list]="[]" [p-drop-list-disabled]="'true'"></div>`,
+  standalone: false
+})
+class TestStringBooleanHostComponent {}
+
+@Component({
+  template: `<div [p-drop-list]="[]" [p-drop-sorting-disabled]="'true'"></div>`,
+  standalone: false
+})
+class TestStringSortingDisabledHostComponent {}
+
+describe('PoDropListBaseDirective (via PoDropListDirective)', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let directive: PoDropListDirective;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PoDragDropModule],
+      declarations: [TestHostComponent, TestStringBooleanHostComponent, TestStringSortingDisabledHostComponent]
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    directive = fixture.debugElement.query(By.directive(PoDropListDirective)).injector.get(PoDropListDirective);
+  });
+
+  it('should create the host component', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  describe('items input (p-drop-list)', () => {
+    it('should read `items` signal with the bound array', () => {
+      expect(directive.items()).toHaveSize(2);
+      expect(directive.items()).toEqual(component.items);
+    });
+
+    it('should update items when bound array changes', () => {
+      component.items = [{ id: '3', value: 30 }];
+      fixture.detectChanges();
+      expect(directive.items()).toHaveSize(1);
+      expect(directive.items()[0]).toEqual(jasmine.objectContaining({ id: '3', value: 30 }));
+    });
+
+    it('should accept empty array', () => {
+      component.items = [];
+      fixture.detectChanges();
+      expect(directive.items()).toEqual([]);
+    });
+  });
+
+  describe('dropListId input (p-drop-list-id)', () => {
+    it('should read `dropListId` signal with the bound value', () => {
+      expect(directive.dropListId()).toBe('test-list');
+    });
+
+    it('should default to empty string when not provided', () => {
+      const noIdFixture = TestBed.createComponent(TestStringBooleanHostComponent);
+      noIdFixture.detectChanges();
+      const noIdDirective = noIdFixture.debugElement
+        .query(By.directive(PoDropListDirective))
+        .injector.get(PoDropListDirective);
+      expect(noIdDirective.dropListId()).toBe('');
+    });
+  });
+
+  describe('dropListDisabled input (p-drop-list-disabled)', () => {
+    it('should read `dropListDisabled` signal as false by default', () => {
+      expect(directive.dropListDisabled()).toBeFalse();
+    });
+
+    it('should read `dropListDisabled` signal as true when bound to true', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      expect(directive.dropListDisabled()).toBeTrue();
+    });
+
+    it('should toggle back to false', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      component.disabled = false;
+      fixture.detectChanges();
+      expect(directive.dropListDisabled()).toBeFalse();
+    });
+
+    it('should accept string "true" via convertToBoolean transform', () => {
+      const strFixture = TestBed.createComponent(TestStringBooleanHostComponent);
+      strFixture.detectChanges();
+      const strDirective = strFixture.debugElement
+        .query(By.directive(PoDropListDirective))
+        .injector.get(PoDropListDirective);
+      expect(strDirective.dropListDisabled()).toBeTrue();
+    });
+  });
+
+  describe('dropListOrientation input (p-drop-list-orientation)', () => {
+    it('should read `dropListOrientation` signal as "vertical" by default', () => {
+      expect(directive.dropListOrientation()).toBe('vertical');
+    });
+
+    it('should update to "horizontal" when input changes', () => {
+      component.orientation = 'horizontal';
+      fixture.detectChanges();
+      expect(directive.dropListOrientation()).toBe('horizontal');
+    });
+
+    it('should accept "mixed" value', () => {
+      component.orientation = 'mixed';
+      fixture.detectChanges();
+      expect(directive.dropListOrientation()).toBe('mixed');
+    });
+  });
+
+  describe('dropListConnectedTo input (p-drop-list-connected-to)', () => {
+    it('should read `dropListConnectedTo` signal as empty array by default', () => {
+      expect(directive.dropListConnectedTo()).toEqual([]);
+    });
+
+    it('should update when string ids are provided', () => {
+      component.connectedTo = ['list-x', 'list-y'];
+      fixture.detectChanges();
+      expect(directive.dropListConnectedTo()).toEqual(['list-x', 'list-y']);
+    });
+
+    it('should update back to empty array', () => {
+      component.connectedTo = ['list-x'];
+      fixture.detectChanges();
+      component.connectedTo = [];
+      fixture.detectChanges();
+      expect(directive.dropListConnectedTo()).toEqual([]);
+    });
+  });
+
+  describe('dropSortingDisabled input (p-drop-sorting-disabled)', () => {
+    it('should read `dropSortingDisabled` signal as false by default', () => {
+      expect(directive.dropSortingDisabled()).toBeFalse();
+    });
+
+    it('should read `dropSortingDisabled` as true when bound to true', () => {
+      component.sortingDisabled = true;
+      fixture.detectChanges();
+      expect(directive.dropSortingDisabled()).toBeTrue();
+    });
+
+    it('should accept string "true" via convertToBoolean transform', () => {
+      const strFixture = TestBed.createComponent(TestStringSortingDisabledHostComponent);
+      strFixture.detectChanges();
+      const strDirective = strFixture.debugElement
+        .query(By.directive(PoDropListDirective))
+        .injector.get(PoDropListDirective);
+      expect(strDirective.dropSortingDisabled()).toBeTrue();
+    });
+  });
+
+  describe('dropped output (p-dropped)', () => {
+    it('should emit PoDropEvent when `dropped` fires', () => {
+      const event: PoDropEvent = {
+        previousIndex: 0,
+        currentIndex: 1,
+        item: component.items[0],
+        items: component.items,
+        container: 'test-list'
+      };
+      directive.dropped.emit(event);
+      expect(component.droppedEvent).toEqual(event);
+    });
+
+    it('should include previousContainer when provided', () => {
+      const event: PoDropEvent = {
+        previousIndex: 0,
+        currentIndex: 0,
+        item: component.items[0],
+        items: component.items,
+        container: 'test-list',
+        previousContainer: 'other-list'
+      };
+      directive.dropped.emit(event);
+      expect(component.droppedEvent.previousContainer).toBe('other-list');
+    });
+
+    it('should include dropPoint when provided', () => {
+      const event: PoDropEvent = {
+        previousIndex: 0,
+        currentIndex: 1,
+        item: component.items[0],
+        items: component.items,
+        container: 'test-list',
+        dropPoint: { x: 100, y: 200 }
+      };
+      directive.dropped.emit(event);
+      expect(component.droppedEvent.dropPoint).toEqual({ x: 100, y: 200 });
+    });
+  });
+
+  describe('dragEntered output (p-drag-entered)', () => {
+    it('should emit PoDragEnterEvent when `dragEntered` fires', () => {
+      const event: PoDragEnterEvent<TestItem> = {
+        item: component.items[1],
+        container: 'test-list'
+      };
+      directive.dragEntered.emit(event);
+      expect(component.enteredEvent).toEqual(event);
+    });
+  });
+});

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drop-list-base.directive.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drop-list-base.directive.ts
@@ -1,0 +1,105 @@
+import { Directive, output, input } from '@angular/core';
+
+import { convertToBoolean } from '../../utils/util';
+import { PoDragEnterEvent, PoDraggableItem, PoDropEvent } from './interfaces/po-draggable-item.interface';
+
+@Directive()
+export abstract class PoDropListBaseDirective {
+  /**
+   * @description
+   *
+   * Lista de itens gerenciada pelo container. A diretiva muta este array
+   * diretamente ao reordenar ou transferir itens entre containers.
+   *
+   * O array atualizado é refletido no evento `p-dropped`.
+   */
+  items = input<Array<PoDraggableItem>>([], { alias: 'p-drop-list' });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Identificador único do container. Utilizado para conectar múltiplos
+   * containers via `p-drop-list-connected-to`.
+   *
+   */
+  dropListId = input<string>('', { alias: 'p-drop-list-id' });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Desabilita o drag para os elementos dentro do container.
+   * Quando `true`, seus elementos não poderão ser arrastados, porém elementos de outros containers poderão ser arrastados para dentro dele.
+   *
+   * @default false
+   */
+  dropListDisabled = input<boolean, unknown>(false, { alias: 'p-drop-list-disabled', transform: convertToBoolean });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Lista de containers conectados. Aceita um array de ids (`string`). Quando configurado,
+   * itens podem ser arrastados entre os containers listados.
+   */
+  dropListConnectedTo = input<Array<string>>([], { alias: 'p-drop-list-connected-to' });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Orientação dos itens dentro do container. Afeta a lógica de sombra de
+   * posicionamento do Angular CDK durante o arraste.
+   *
+   * Valores aceitos: `'horizontal'` | `'vertical'` | `'mixed'`.
+   *
+   * @default `'vertical'`
+   */
+  dropListOrientation = input<'horizontal' | 'vertical' | 'mixed'>('vertical', { alias: 'p-drop-list-orientation' });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Desabilita a reordenação automática dos itens durante o arraste.
+   *
+   * Quando `true`, permite arrastar o item sem alterar sua posição na lista de origem.
+   * A transferência de itens entre containers conectados continua funcionando.
+   *
+   * Use esta propriedade quando a reordenação dos itens for realizada por uma lógica
+   * personalizada do consumidor.
+   *
+   * @default false
+   */
+  dropSortingDisabled = input<boolean, unknown>(false, {
+    alias: 'p-drop-sorting-disabled',
+    transform: convertToBoolean
+  });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento emitido quando um item é solto dentro deste container.
+   * Contém os índices anterior e atual, o item movido e os ids dos
+   * containers de origem e destino.
+   */
+  dropped = output<PoDropEvent>({ alias: 'p-dropped' });
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Evento emitido quando um item externo entra neste container durante o arraste.
+   * Contém o item que entrou e o id do container de origem.
+   */
+  dragEntered = output<PoDragEnterEvent<PoDraggableItem>>({ alias: 'p-drag-entered' });
+}

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drop-list.directive.spec.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drop-list.directive.spec.ts
@@ -1,0 +1,485 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CdkDropList } from '@angular/cdk/drag-drop';
+
+import { PoDropListDirective } from './po-drop-list.directive';
+import { PoDropEvent, PoDragEnterEvent } from './interfaces/po-draggable-item.interface';
+import { PoDragDropModule } from './po-drag-drop.module';
+import { PoWidgetModule } from '../../components/po-widget/po-widget.module';
+
+interface TestItem {
+  id: string;
+  name: string;
+}
+
+@Component({
+  template: `
+    <div
+      [p-drop-list]="items"
+      p-drop-list-id="list-a"
+      [p-drop-list-disabled]="disabled"
+      [p-drop-list-orientation]="orientation"
+      [p-drop-list-connected-to]="connectedTo"
+      [p-drop-sorting-disabled]="sortingDisabled"
+      (p-dropped)="onDropped($event)"
+      (p-drag-entered)="onDragEntered($event)"
+    >
+      @for (item of items; track item.id) {
+        <po-widget [p-drag]="item" [p-title]="item.name"></po-widget>
+      }
+    </div>
+  `,
+  standalone: false
+})
+class TestHostComponent {
+  items: Array<TestItem> = [
+    { id: '1', name: 'Item 1' },
+    { id: '2', name: 'Item 2' },
+    { id: '3', name: 'Item 3' }
+  ];
+  disabled = false;
+  orientation: 'horizontal' | 'vertical' | 'mixed' = 'vertical';
+  connectedTo: Array<string> = [];
+  sortingDisabled = false;
+  droppedEvent: PoDropEvent | null = null;
+  dragEnteredEvent: PoDragEnterEvent<TestItem> | null = null;
+
+  onDropped(event: PoDropEvent) {
+    this.droppedEvent = event;
+  }
+
+  onDragEntered(event: PoDragEnterEvent<TestItem>) {
+    this.dragEnteredEvent = event;
+  }
+}
+
+@Component({
+  template: `
+    <div
+      [p-drop-list]="itemsA"
+      p-drop-list-id="list-a"
+      [p-drop-list-connected-to]="['list-b']"
+      (p-dropped)="onDroppedA($event)"
+    >
+      @for (item of itemsA; track item.id) {
+        <po-widget [p-drag]="item" [p-title]="item.name"></po-widget>
+      }
+    </div>
+    <div
+      [p-drop-list]="itemsB"
+      p-drop-list-id="list-b"
+      [p-drop-list-connected-to]="['list-a']"
+      (p-dropped)="onDroppedB($event)"
+    >
+      @for (item of itemsB; track item.id) {
+        <po-widget [p-drag]="item" [p-title]="item.name"></po-widget>
+      }
+    </div>
+  `,
+  standalone: false
+})
+class TestConnectedHostComponent {
+  itemsA: Array<TestItem> = [
+    { id: '1', name: 'A1' },
+    { id: '2', name: 'A2' }
+  ];
+  itemsB: Array<TestItem> = [
+    { id: '3', name: 'B1' },
+    { id: '4', name: 'B2' }
+  ];
+  droppedEventA: PoDropEvent | null = null;
+  droppedEventB: PoDropEvent | null = null;
+
+  onDroppedA(event: PoDropEvent) {
+    this.droppedEventA = event;
+  }
+
+  onDroppedB(event: PoDropEvent) {
+    this.droppedEventB = event;
+  }
+}
+
+describe('PoDropListDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let directive: PoDropListDirective;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PoDragDropModule, PoWidgetModule],
+      declarations: [TestHostComponent, TestConnectedHostComponent]
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    directive = fixture.debugElement.query(By.directive(PoDropListDirective)).injector.get(PoDropListDirective);
+  });
+
+  it('should be created', () => {
+    expect(directive).toBeTruthy();
+  });
+
+  describe('inputs', () => {
+    it('should read `items` signal matching the bound array', () => {
+      expect(directive.items()).toEqual(component.items);
+    });
+
+    it('should update `items` signal when input changes', () => {
+      const newItems: Array<TestItem> = [{ id: '4', name: 'New Item' }];
+      component.items = newItems;
+      fixture.detectChanges();
+      expect(directive.items()).toEqual(newItems);
+    });
+
+    it('should read `dropListId` signal as "list-a"', () => {
+      expect(directive.dropListId()).toBe('list-a');
+    });
+
+    it('should read `dropListDisabled` signal as false by default', () => {
+      expect(directive.dropListDisabled()).toBeFalse();
+    });
+
+    it('should read `dropListDisabled` signal as true when input changes', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      expect(directive.dropListDisabled()).toBeTrue();
+    });
+
+    it('should read `dropListConnectedTo` signal as empty array by default', () => {
+      expect(directive.dropListConnectedTo()).toEqual([]);
+    });
+
+    it('should update `dropListConnectedTo` when input changes', () => {
+      component.connectedTo = ['list-b', 'list-c'];
+      fixture.detectChanges();
+      expect(directive.dropListConnectedTo()).toEqual(['list-b', 'list-c']);
+    });
+
+    it('should read `dropListOrientation` signal as "vertical" by default', () => {
+      expect(directive.dropListOrientation()).toBe('vertical');
+    });
+
+    it('should update `dropListOrientation` when input changes', () => {
+      component.orientation = 'horizontal';
+      fixture.detectChanges();
+      expect(directive.dropListOrientation()).toBe('horizontal');
+    });
+
+    it('should accept "mixed" as orientation value', () => {
+      component.orientation = 'mixed';
+      fixture.detectChanges();
+      expect(directive.dropListOrientation()).toBe('mixed');
+    });
+
+    it('should read `dropSortingDisabled` as false by default', () => {
+      expect(directive.dropSortingDisabled()).toBeFalse();
+    });
+
+    it('should read `dropSortingDisabled` as true when input changes', () => {
+      component.sortingDisabled = true;
+      fixture.detectChanges();
+      expect(directive.dropSortingDisabled()).toBeTrue();
+    });
+  });
+
+  describe('CdkDropList integration', () => {
+    let cdkDropList: CdkDropList;
+
+    beforeEach(() => {
+      cdkDropList = fixture.debugElement.query(By.directive(CdkDropList)).injector.get(CdkDropList);
+    });
+
+    it('should sync disabled state to CdkDropList', () => {
+      expect(cdkDropList.disabled).toBeFalse();
+      component.disabled = true;
+      fixture.detectChanges();
+      expect(cdkDropList.disabled).toBeTrue();
+    });
+
+    it('should sync id to CdkDropList', () => {
+      expect(cdkDropList.id).toBe('list-a');
+    });
+
+    it('should sync data to CdkDropList', () => {
+      expect(cdkDropList.data).toEqual(component.items);
+    });
+
+    it('should sync sortingDisabled to CdkDropList', () => {
+      expect(cdkDropList.sortingDisabled).toBeFalse();
+      component.sortingDisabled = true;
+      fixture.detectChanges();
+      expect(cdkDropList.sortingDisabled).toBeTrue();
+    });
+
+    it('should sync connectedTo as string[] to CdkDropList', () => {
+      component.connectedTo = ['list-b'];
+      fixture.detectChanges();
+      expect(cdkDropList.connectedTo).toEqual(['list-b']);
+    });
+  });
+
+  describe('outputs', () => {
+    it('should emit `dropped` when triggered manually', () => {
+      const event: PoDropEvent = {
+        previousIndex: 0,
+        currentIndex: 1,
+        item: component.items[0],
+        items: component.items,
+        container: 'list-a'
+      };
+      directive.dropped.emit(event);
+      expect(component.droppedEvent).toEqual(event);
+    });
+
+    it('should emit `dragEntered` when triggered manually', () => {
+      const event: PoDragEnterEvent<TestItem> = {
+        item: component.items[0],
+        container: 'list-a'
+      };
+      directive.dragEntered.emit(event);
+      expect(component.dragEnteredEvent).toEqual(event);
+    });
+  });
+
+  describe('CdkDropList event subscriptions', () => {
+    it('should update lastSortedIndex when CdkDropList.sorted fires', () => {
+      const cdkDropList = fixture.debugElement.query(By.directive(CdkDropList)).injector.get(CdkDropList);
+
+      cdkDropList.sorted.emit({
+        previousIndex: 0,
+        currentIndex: 2,
+        container: cdkDropList,
+        item: { data: component.items[0] } as any
+      } as any);
+
+      expect((directive as any).lastSortedIndex).toBe(2);
+    });
+
+    it('should call handleDrop when CdkDropList.dropped fires', () => {
+      const cdkDropList = fixture.debugElement.query(By.directive(CdkDropList)).injector.get(CdkDropList);
+
+      const fakeDropEvent = {
+        previousContainer: cdkDropList,
+        container: cdkDropList,
+        previousIndex: 0,
+        currentIndex: 1,
+        item: { data: component.items[0] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 10, y: 20 }
+      };
+      cdkDropList.dropped.emit(fakeDropEvent as any);
+
+      expect(component.droppedEvent).not.toBeNull();
+      expect(component.droppedEvent.previousIndex).toBe(0);
+      expect(component.droppedEvent.currentIndex).toBe(1);
+    });
+  });
+
+  describe('handleDrop', () => {
+    it('should not emit `dropped` when drop occurs at same index', () => {
+      let emitted = false;
+      directive.dropped.subscribe(() => (emitted = true));
+
+      const containerRef = { id: 'list-a', data: component.items } as any;
+      const fakeEvent = {
+        previousContainer: containerRef,
+        container: containerRef,
+        previousIndex: 1,
+        currentIndex: 1,
+        item: { data: component.items[1] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 0, y: 0 }
+      };
+      (directive as any).handleDrop(fakeEvent);
+
+      expect(emitted).toBeFalse();
+    });
+
+    it('should emit `dropped` with reordered items for same container drop', () => {
+      const containerRef = { id: 'list-a', data: component.items } as any;
+      const fakeEvent = {
+        previousContainer: containerRef,
+        container: containerRef,
+        previousIndex: 0,
+        currentIndex: 2,
+        item: { data: component.items[0] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 100, y: 200 }
+      };
+      (directive as any).handleDrop(fakeEvent);
+
+      expect(component.droppedEvent).not.toBeNull();
+      expect(component.droppedEvent.previousIndex).toBe(0);
+      expect(component.droppedEvent.currentIndex).toBe(2);
+      expect(component.droppedEvent.container).toBe('list-a');
+      expect(component.droppedEvent.items).toBeDefined();
+      expect(component.droppedEvent.items[2]).toEqual(jasmine.objectContaining({ id: '1', name: 'Item 1' }));
+    });
+
+    it('should emit `dropped` with correct items when drop is in different container', () => {
+      const previousItems: Array<TestItem> = [{ id: '10', name: 'Other' }];
+      const fakeEvent = {
+        previousContainer: { id: 'list-b', data: previousItems } as any,
+        container: { id: 'list-a', data: component.items } as any,
+        previousIndex: 0,
+        currentIndex: 1,
+        item: { data: previousItems[0] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 50, y: 50 }
+      };
+      (directive as any).handleDrop(fakeEvent);
+
+      expect(component.droppedEvent).not.toBeNull();
+      expect(component.droppedEvent.previousContainer).toBe('list-b');
+      expect(component.droppedEvent.container).toBe('list-a');
+      expect(component.droppedEvent.items[1]).toEqual(jasmine.objectContaining({ id: '10', name: 'Other' }));
+    });
+
+    it('should not include previousContainer in event for same container drop', () => {
+      const containerRef = { id: 'list-a', data: component.items } as any;
+      const fakeEvent = {
+        previousContainer: containerRef,
+        container: containerRef,
+        previousIndex: 0,
+        currentIndex: 1,
+        item: { data: component.items[0] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 0, y: 0 }
+      };
+      (directive as any).handleDrop(fakeEvent);
+
+      expect(component.droppedEvent.previousContainer).toBeUndefined();
+    });
+
+    it('should use lastSortedIndex for same container when available', () => {
+      // Simulate a sorted event updating the lastSortedIndex
+      (directive as any).lastSortedIndex = 2;
+
+      const containerRef = { id: 'list-a', data: component.items } as any;
+      const fakeEvent = {
+        previousContainer: containerRef,
+        container: containerRef,
+        previousIndex: 0,
+        currentIndex: 1, // CDK reports 1, but sorted said 2
+        item: { data: component.items[0] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 0, y: 0 }
+      };
+      (directive as any).handleDrop(fakeEvent);
+
+      expect(component.droppedEvent.currentIndex).toBe(2);
+    });
+
+    it('should reset lastSortedIndex to null after handleDrop', () => {
+      (directive as any).lastSortedIndex = 2;
+
+      const containerRef = { id: 'list-a', data: component.items } as any;
+      const fakeEvent = {
+        previousContainer: containerRef,
+        container: containerRef,
+        previousIndex: 0,
+        currentIndex: 1,
+        item: { data: component.items[0] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 0, y: 0 }
+      };
+      (directive as any).handleDrop(fakeEvent);
+
+      expect((directive as any).lastSortedIndex).toBeNull();
+    });
+
+    it('should not use lastSortedIndex for cross-container drop', () => {
+      (directive as any).lastSortedIndex = 5;
+
+      const previousItems: Array<TestItem> = [{ id: '10', name: 'External' }];
+      const fakeEvent = {
+        previousContainer: { id: 'list-b', data: previousItems } as any,
+        container: { id: 'list-a', data: component.items } as any,
+        previousIndex: 0,
+        currentIndex: 1,
+        item: { data: previousItems[0] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 0, y: 0 }
+      };
+      (directive as any).handleDrop(fakeEvent);
+
+      // Should use CDK's currentIndex (1), not lastSortedIndex (5)
+      expect(component.droppedEvent.currentIndex).toBe(1);
+    });
+
+    it('should include dropPoint in the emitted event', () => {
+      const containerRef = { id: 'list-a', data: component.items } as any;
+      const fakeEvent = {
+        previousContainer: containerRef,
+        container: containerRef,
+        previousIndex: 0,
+        currentIndex: 1,
+        item: { data: component.items[0] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 250, y: 300 }
+      };
+      (directive as any).handleDrop(fakeEvent);
+
+      expect(component.droppedEvent.dropPoint).toEqual({ x: 250, y: 300 });
+    });
+
+    it('should not mutate the original items array', () => {
+      const originalItems = [...component.items];
+
+      const containerRef = { id: 'list-a', data: component.items } as any;
+      const fakeEvent = {
+        previousContainer: containerRef,
+        container: containerRef,
+        previousIndex: 0,
+        currentIndex: 2,
+        item: { data: component.items[0] } as any,
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 0, y: 0 }
+      };
+      (directive as any).handleDrop(fakeEvent);
+
+      // Original array should not be mutated
+      expect(component.items).toEqual(originalItems);
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should unsubscribe from all subscriptions', () => {
+      const subscriptions = (directive as any).subscriptions;
+      spyOn(subscriptions, 'unsubscribe');
+      fixture.destroy();
+      expect(subscriptions.unsubscribe).toHaveBeenCalled();
+    });
+  });
+
+  describe('entered event', () => {
+    it('should emit dragEntered when CdkDropList.entered fires', () => {
+      const cdkDropList = fixture.debugElement.query(By.directive(CdkDropList)).injector.get(CdkDropList);
+
+      const fakeEnterEvent = {
+        item: { data: component.items[0] } as any,
+        container: cdkDropList,
+        currentIndex: 0,
+        isPointerOverContainer: true
+      };
+      cdkDropList.entered.emit(fakeEnterEvent as any);
+
+      expect(component.dragEnteredEvent).not.toBeNull();
+      expect(component.dragEnteredEvent.item).toEqual(component.items[0]);
+      expect(component.dragEnteredEvent.container).toBe('list-a');
+    });
+  });
+});

--- a/projects/ui/src/lib/directives/po-drag-drop/po-drop-list.directive.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/po-drop-list.directive.ts
@@ -1,0 +1,142 @@
+import { Directive, effect, inject, OnDestroy, OnInit } from '@angular/core';
+import { CdkDropList, CdkDragDrop, CdkDragSortEvent, moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
+import { Subscription } from 'rxjs';
+
+import { PoDraggableItem, PoDropEvent } from './interfaces/po-draggable-item.interface';
+import { PoDropListBaseDirective } from './po-drop-list-base.directive';
+
+/**
+ * @docsExtends PoDropListBaseDirective
+ *
+ * @description
+ *
+ * A diretiva `p-drop-list` define um container onde componentes `po-widget` podem ser
+ * arrastados e reorganizados, encapsulando o `CdkDropList` do Angular CDK.
+ *
+ * Permite:
+ * - Reordenação de `po-widget` dentro de um único container.
+ * - Transferência de `po-widget` entre containers conectados via `p-drop-list-connected-to`.
+ * - Itens individuais desabilitados via `p-drag-disabled` na diretiva `p-drag`.
+ *
+ * > Atualmente esta diretiva é suportada para uso com `po-widget`.
+ * > O suporte a outros componentes será avaliado em versões futuras.
+ *
+ * > A diretiva não impõe nenhum estilo de layout (flex, grid etc.). O layout
+ * > é responsabilidade do consumidor.
+ */
+@Directive({
+  selector: '[p-drop-list]',
+  standalone: true,
+  hostDirectives: [
+    {
+      directive: CdkDropList,
+      inputs: ['cdkDropListOrientation: p-drop-list-orientation']
+    }
+  ]
+})
+export class PoDropListDirective extends PoDropListBaseDirective implements OnInit, OnDestroy {
+  private readonly cdkDropList = inject(CdkDropList);
+  private readonly subscriptions = new Subscription();
+  /** Último índice confirmado pelo evento sorted. Usado para corrigir o currentIndex
+   *  do dropped, que pode ficar dessincronizado em listas horizontais com itens de
+   *  tamanhos diferentes (ping-pong do CDK). */
+  private lastSortedIndex: number | null = null;
+
+  constructor() {
+    super();
+
+    effect(() => {
+      const disabled = this.dropListDisabled();
+      this.cdkDropList.disabled = disabled;
+    });
+
+    effect(() => {
+      const id = this.dropListId();
+      if (id) {
+        this.cdkDropList.id = id;
+      }
+    });
+
+    effect(() => {
+      this.cdkDropList.data = this.items();
+    });
+
+    effect(() => {
+      this.cdkDropList.connectedTo = this.dropListConnectedTo();
+    });
+
+    effect(() => {
+      this.cdkDropList.sortingDisabled = this.dropSortingDisabled();
+    });
+  }
+
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.cdkDropList.sorted.subscribe((event: CdkDragSortEvent<PoDraggableItem>) => {
+        this.lastSortedIndex = event.currentIndex;
+      })
+    );
+
+    this.subscriptions.add(
+      this.cdkDropList.dropped.subscribe((event: CdkDragDrop<Array<PoDraggableItem>>) => {
+        this.handleDrop(event);
+      })
+    );
+
+    this.subscriptions.add(
+      this.cdkDropList.entered.subscribe(event => {
+        const draggedItem = event.item.data;
+        this.dragEntered.emit({ item: draggedItem, container: this.cdkDropList.id });
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  private handleDrop(event: CdkDragDrop<Array<PoDraggableItem>>): void {
+    const isSameContainer = event.previousContainer === event.container;
+
+    // Em listas horizontais com itens de tamanhos diferentes, o CDK pode reportar
+    // um currentIndex incorreto no evento dropped (ping-pong entre posições).
+    // O evento sorted sempre reflete o estado visual correto, então usamos o último
+    // índice registrado por ele quando disponível.
+    const currentIndex = isSameContainer && this.lastSortedIndex !== null ? this.lastSortedIndex : event.currentIndex;
+    this.lastSortedIndex = null;
+
+    if (isSameContainer && event.previousIndex === currentIndex) {
+      return;
+    }
+
+    // Trabalha com cópias para não mutar os arrays do consumidor.
+    // O consumidor deve atualizar seu signal/array com event.items no (p-dropped).
+    const currentItems = [...this.items()];
+
+    let reorderedItems: Array<PoDraggableItem>;
+
+    if (isSameContainer) {
+      moveItemInArray(currentItems, event.previousIndex, currentIndex);
+      reorderedItems = currentItems;
+    } else {
+      const previousItems = [...event.previousContainer.data];
+      transferArrayItem(previousItems, currentItems, event.previousIndex, currentIndex);
+      reorderedItems = currentItems;
+    }
+
+    const dropped: PoDropEvent = {
+      previousIndex: event.previousIndex,
+      currentIndex: currentIndex,
+      item: reorderedItems[currentIndex],
+      items: reorderedItems,
+      container: this.cdkDropList.id,
+      dropPoint: event.dropPoint
+    };
+
+    if (!isSameContainer) {
+      dropped.previousContainer = event.previousContainer.id;
+    }
+
+    this.dropped.emit(dropped);
+  }
+}

--- a/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drag-basic/sample-po-drag-basic.component.html
+++ b/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drag-basic/sample-po-drag-basic.component.html
@@ -1,0 +1,5 @@
+<div class="po-row">
+  <po-widget class="po-md-4" [p-drag]="widget" p-title="Arraste-me">
+    <div class="po-font-text">Este widget pode ser arrastado livremente. Segure o handle e mova-o.</div>
+  </po-widget>
+</div>

--- a/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drag-basic/sample-po-drag-basic.component.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drag-basic/sample-po-drag-basic.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sample-po-drag-basic',
+  templateUrl: './sample-po-drag-basic.component.html',
+  standalone: false
+})
+export class SamplePoDragBasicComponent {
+  widget = { title: 'Arraste-me', body: 'Este widget pode ser arrastado livremente.' };
+}

--- a/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-horizontal/sample-po-drop-list-horizontal.component.html
+++ b/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-horizontal/sample-po-drop-list-horizontal.component.html
@@ -1,0 +1,21 @@
+<po-container p-title="Pipeline — Orientação Horizontal">
+  <p class="po-font-text po-mb-3">
+    Arraste as etapas para reordenar o pipeline. Os itens ficam lado a lado e a troca é detectada pelo eixo X.
+  </p>
+
+  <div class="po-row">
+    <div
+      class="po-md-12"
+      [p-drop-list]="steps()"
+      p-drop-list-id="list-horizontal"
+      p-drop-list-orientation="horizontal"
+      (p-dropped)="onDropped($event)"
+    >
+      @for (step of steps(); track step.id) {
+        <po-widget class="po-md-3 po-mb-2" [p-drag]="step" [p-title]="stepsWidgets()[step.id]?.title" p-tag-type="info">
+          <p>{{ stepsWidgets()[step.id]?.title }}</p>
+        </po-widget>
+      }
+    </div>
+  </div>
+</po-container>

--- a/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-horizontal/sample-po-drop-list-horizontal.component.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-horizontal/sample-po-drop-list-horizontal.component.ts
@@ -1,0 +1,22 @@
+import { Component, signal } from '@angular/core';
+import { PoDraggableItem, PoDropEvent } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-drop-list-horizontal',
+  templateUrl: './sample-po-drop-list-horizontal.component.html',
+  standalone: false
+})
+export class SamplePoDropListHorizontalComponent {
+  steps = signal<Array<PoDraggableItem>>([{ id: 's1' }, { id: 's2' }, { id: 's3' }, { id: 's4' }]);
+
+  stepsWidgets = signal<Record<string, { title: string }>>({
+    s1: { title: 'Requisitos' },
+    s2: { title: 'Design' },
+    s3: { title: 'Desenvolvimento' },
+    s4: { title: 'Testes' }
+  });
+
+  onDropped(event: PoDropEvent): void {
+    this.steps.set(event.items);
+  }
+}

--- a/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-mixed/sample-po-drop-list-mixed.component.html
+++ b/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-mixed/sample-po-drop-list-mixed.component.html
@@ -1,0 +1,27 @@
+<po-container p-title="Dashboard — Orientação Mixed">
+  <p class="po-font-text po-mb-3">
+    Arraste os cards para reorganizar o layout do dashboard. A orientação mixed detecta trocas nos eixos X e Y, ideal
+    para layouts em grid onde os itens quebram em múltiplas linhas.
+  </p>
+
+  <div class="po-row">
+    <div
+      class="po-md-12"
+      [p-drop-list]="cards()"
+      p-drop-list-id="list-mixed"
+      p-drop-list-orientation="mixed"
+      (p-dropped)="onDropped($event)"
+    >
+      @for (card of cards(); track card.id) {
+        <po-widget
+          class="po-md-4 po-mb-2"
+          [p-drag]="card"
+          [p-title]="cardsWidgets()[card.id]?.title"
+          p-tag-type="neutral"
+        >
+          <p>{{ cardsWidgets()[card.id]?.title }}</p>
+        </po-widget>
+      }
+    </div>
+  </div>
+</po-container>

--- a/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-mixed/sample-po-drop-list-mixed.component.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-mixed/sample-po-drop-list-mixed.component.ts
@@ -1,0 +1,31 @@
+import { Component, signal } from '@angular/core';
+import { PoDraggableItem, PoDropEvent } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-drop-list-mixed',
+  templateUrl: './sample-po-drop-list-mixed.component.html',
+  standalone: false
+})
+export class SamplePoDropListMixedComponent {
+  cards = signal<Array<PoDraggableItem>>([
+    { id: 'c1' },
+    { id: 'c2' },
+    { id: 'c3' },
+    { id: 'c4' },
+    { id: 'c5' },
+    { id: 'c6' }
+  ]);
+
+  cardsWidgets = signal<Record<string, { title: string }>>({
+    c1: { title: 'Faturamento' },
+    c2: { title: 'Estoque' },
+    c3: { title: 'Compras' },
+    c4: { title: 'RH' },
+    c5: { title: 'Fiscal' },
+    c6: { title: 'Financeiro' }
+  });
+
+  onDropped(event: PoDropEvent): void {
+    this.cards.set(event.items);
+  }
+}

--- a/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-vertical/sample-po-drop-list-vertical.component.html
+++ b/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-vertical/sample-po-drop-list-vertical.component.html
@@ -1,0 +1,74 @@
+<div class="po-row">
+  <po-container class="po-md-4" [p-height]="500">
+    <po-divider p-label="A Fazer"></po-divider>
+
+    <div
+      class="po-row"
+      style="min-height: 100px"
+      [p-drop-list]="todoList()"
+      p-drop-list-id="list-todo"
+      [p-drop-list-connected-to]="['list-doing', 'list-done']"
+      (p-dropped)="onDropped($event, 'todo')"
+    >
+      @for (task of todoList(); track task.id) {
+        <po-widget
+          class="po-md-12 po-mb-2"
+          [p-drag]="task"
+          [p-title]="tasksWidgets()[task.id]?.title"
+          p-tag="A Fazer"
+          p-tag-type="warning"
+        >
+        </po-widget>
+      }
+    </div>
+  </po-container>
+
+  <po-container class="po-md-4" [p-height]="500">
+    <po-divider p-label="Em Andamento"></po-divider>
+
+    <div
+      class="po-row"
+      style="min-height: 100px"
+      [p-drop-list]="doingList()"
+      p-drop-list-id="list-doing"
+      [p-drop-list-connected-to]="['list-todo', 'list-done']"
+      (p-dropped)="onDropped($event, 'doing')"
+    >
+      @for (task of doingList(); track task.id) {
+        <po-widget
+          class="po-md-12 po-mb-2"
+          [p-drag]="task"
+          [p-title]="tasksWidgets()[task.id]?.title"
+          p-tag="Em Andamento"
+          p-tag-type="info"
+        >
+        </po-widget>
+      }
+    </div>
+  </po-container>
+
+  <po-container class="po-md-4" [p-height]="500">
+    <po-divider p-label="Concluído"></po-divider>
+
+    <div
+      class="po-row"
+      style="min-height: 100px"
+      [p-drop-list]="doneList()"
+      p-drop-list-id="list-done"
+      [p-drop-list-connected-to]="['list-todo', 'list-doing']"
+      (p-dropped)="onDropped($event, 'done')"
+      p-drop-list-disabled
+    >
+      @for (task of doneList(); track task.id) {
+        <po-widget
+          class="po-md-12 po-mb-2"
+          [p-drag]="task"
+          [p-title]="tasksWidgets()[task.id]?.title"
+          p-tag="Concluído"
+          p-tag-type="success"
+        >
+        </po-widget>
+      }
+    </div>
+  </po-container>
+</div>

--- a/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-vertical/sample-po-drop-list-vertical.component.ts
+++ b/projects/ui/src/lib/directives/po-drag-drop/samples/sample-po-drop-list-vertical/sample-po-drop-list-vertical.component.ts
@@ -1,0 +1,70 @@
+import { Component, signal } from '@angular/core';
+
+import { PoDraggableItem, PoDropEvent } from '@po-ui/ng-components';
+
+@Component({
+  selector: 'sample-po-drop-list-vertical',
+  templateUrl: './sample-po-drop-list-vertical.component.html',
+  standalone: false
+})
+export class SamplePoDropListVerticalComponent {
+  todoList = signal<Array<PoDraggableItem>>([{ id: 't1' }, { id: 't2' }, { id: 't3' }]);
+
+  doingList = signal<Array<PoDraggableItem>>([{ id: 'd1' }, { id: 'd2' }]);
+
+  doneList = signal<Array<PoDraggableItem>>([{ id: 'f1' }]);
+
+  tasksWidgets = signal<Record<string, { title: string }>>({
+    t1: { title: 'Criar wireframes' },
+    t2: { title: 'Definir contrato da API' },
+    t3: { title: 'Escrever testes unitários' },
+    d1: { title: 'Implementar tela de login' },
+    d2: { title: 'Configurar CI/CD' },
+    f1: { title: 'Kickoff do projeto' }
+  });
+
+  private readonly listMap: Record<string, 'todo' | 'doing' | 'done'> = {
+    'list-todo': 'todo',
+    'list-doing': 'doing',
+    'list-done': 'done'
+  };
+
+  onDropped(event: PoDropEvent, list: 'todo' | 'doing' | 'done'): void {
+    this.setList(list, event.items);
+
+    if (event.previousContainer) {
+      const sourceList = this.listMap[event.previousContainer];
+      if (sourceList) {
+        this.setList(
+          sourceList,
+          this.getList(sourceList).filter(item => item.id !== event.item.id)
+        );
+      }
+    }
+  }
+
+  private getList(list: 'todo' | 'doing' | 'done'): Array<PoDraggableItem> {
+    switch (list) {
+      case 'todo':
+        return this.todoList();
+      case 'doing':
+        return this.doingList();
+      case 'done':
+        return this.doneList();
+    }
+  }
+
+  private setList(list: 'todo' | 'doing' | 'done', items: Array<PoDraggableItem>): void {
+    switch (list) {
+      case 'todo':
+        this.todoList.set(items);
+        break;
+      case 'doing':
+        this.doingList.set(items);
+        break;
+      case 'done':
+        this.doneList.set(items);
+        break;
+    }
+  }
+}


### PR DESCRIPTION
Cria as diretivas:
1. p-drag: torna um widget arrastável
2. p-drop-list: define um container onde widgets podem ser arrastados e soltos

Fixes DTHFUI-13449
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
