### PR TITLE
fix(combo): corrige largura do po-listbox em diferentes navegadores

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -22,7 +22,7 @@
           class="po-field-container-content po-combo-container-content"
           [attr.p-size]="size"
         >
-          <div class="po-combo-container-wrapper">
+          <div #fieldContainerInput class="po-combo-container-wrapper">
             @if (icon) {
               <div class="po-field-icon-container-left">
                 <po-icon

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -1302,7 +1302,7 @@ describe('PoComboComponent:', () => {
       expect(spySetElements).toHaveBeenCalledWith(
         component.containerElement.nativeElement,
         containerOffset,
-        component.inputEl,
+        component.fieldContainerInput,
         customPositions,
         isSetElementWidth
       );

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -114,6 +114,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   @ViewChild('outerContainer ', { read: ElementRef }) outerContainer: ElementRef;
   @ViewChild('containerElement', { read: ElementRef }) containerElement: ElementRef;
   @ViewChild('contentElement', { read: ElementRef }) contentElement: ElementRef;
+  @ViewChild('fieldContainerInput', { read: ElementRef }) fieldContainerInput: ElementRef;
   @ViewChild('iconArrow', { read: ElementRef, static: true }) iconElement: ElementRef;
   @ViewChild('inp', { read: ElementRef, static: true }) inputEl: ElementRef;
   @ViewChild('poListbox') poListbox: PoListBoxComponent;
@@ -811,7 +812,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
     this.controlPosition?.setElements(
       this.containerElement?.nativeElement,
       poComboContainerOffset,
-      this.inputEl,
+      this.fieldContainerInput,
       ['top', 'bottom'],
       true
     );


### PR DESCRIPTION
Corrige largura do po-listbox em diferentes navegadores.

Fixes: DTHFUI-13451

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
