### PR TITLE
feat(mcp): adiciona exemplos e boas práticas

### DIFF
--- a/projects/mcp/README.md
+++ b/projects/mcp/README.md
@@ -120,7 +120,7 @@ Em clientes compatíveis com servidores MCP locais, configure um servidor `stdio
 
 ## Ferramentas disponíveis
 
-O servidor expõe quatro ferramentas somente de leitura.
+O servidor expõe seis ferramentas somente de leitura.
 
 ### `list_components`
 
@@ -151,6 +151,40 @@ Exemplo:
 
 ```json
 { "slug": "PoButtonComponent" }
+```
+
+### `get_component_examples`
+
+Retorna exemplos oficiais de um componente, buscados diretamente do repositório `po-ui/po-angular`. Cada exemplo inclui os arquivos que o compõem (TypeScript, HTML, estilos e configuração), com o conteúdo e o link para o código-fonte.
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+| --- | --- | --- | --- |
+| `slug` | `string` | sim | Identificador do componente. Aceita slug (`po-button`), seletor (`<po-button>`) ou nome de classe (`PoButtonComponent`). |
+| `example` | `string` | não | Filtro pelo nome do exemplo, sem diferenciar maiúsculas e minúsculas. Exemplos: `basic`, `labs`. |
+| `max_examples` | número inteiro de 1 a 5 | não | Quantidade máxima de exemplos. O padrão é `3`. |
+
+Quando o componente informado não possui exemplos próprios, o servidor procura os exemplos do componente pai (por exemplo, `po-tab` retorna exemplos de `po-tabs`) e sinaliza a origem na resposta.
+
+Exemplo:
+
+```json
+{ "slug": "po-button", "example": "basic", "max_examples": 2 }
+```
+
+> Esta ferramenta consulta a API pública do GitHub. Consulte a seção [Limitação de taxa da API do GitHub](#limitação-de-taxa-da-api-do-github).
+
+### `get_best_practices`
+
+Retorna, em Markdown, um documento oficial de boas práticas do PO UI, junto com o título e o link da fonte.
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+| --- | --- | --- | --- |
+| `topic` | `"contributing" \| "development-flow" \| "getting-started" \| "theme-service"` | sim | Tema das recomendações. |
+
+Exemplo:
+
+```json
+{ "topic": "getting-started" }
 ```
 
 ### `search_docs`
@@ -193,6 +227,8 @@ Exemplo:
 - “Como usar o `PoThemeService`?”
 - “Pesquise por `p-loading` na documentação do PO UI.”
 - “Liste os guias disponíveis e traga o guia de schematics.”
+- “Mostre exemplos oficiais do `po-table`.”
+- “Quais são as boas práticas de customização de tema do PO UI?”
 
 ## Fontes de dados
 
@@ -202,8 +238,11 @@ Exemplo:
 | Documentação consolidada | `https://po-ui.io/llms-full.txt` | — |
 | Documentação por recurso | `https://po-ui.io/llms-generated/{slug}.md` | `https://raw.githubusercontent.com/po-ui/po-angular/master/projects/portal/src/llms-generated/{slug}.md` |
 | Guias | `https://raw.githubusercontent.com/po-ui/po-angular/master/docs/guides/{name}.md` | — |
+| Índice de exemplos | `https://api.github.com/repos/po-ui/po-angular/git/trees/master?recursive=1` | — |
+| Arquivos de exemplo | `https://raw.githubusercontent.com/po-ui/po-angular/master/{path}` | — |
+| Boas práticas | `https://raw.githubusercontent.com/po-ui/po-angular/master/{doc}` | — |
 
-O índice `llms.txt` é mantido em memória durante a execução do servidor. Para forçar uma nova leitura, reinicie o servidor no cliente MCP.
+O índice `llms.txt` é mantido em memória durante a execução do servidor. O índice de exemplos (árvore do repositório) também é mantido em cache durante a execução. Para forçar uma nova leitura de qualquer um deles, reinicie o servidor no cliente MCP.
 
 ## Solução de problemas
 
@@ -213,7 +252,13 @@ Confirme que o Node.js 18 ou superior está instalado e que `npx` está disponí
 
 ### Erro ao carregar o índice ou a documentação
 
-Verifique se o ambiente permite acesso HTTPS a `po-ui.io` e `raw.githubusercontent.com`. Cada requisição possui timeout de 10 segundos.
+Verifique se o ambiente permite acesso HTTPS a `po-ui.io`, `raw.githubusercontent.com` e `api.github.com`. Cada requisição possui timeout de 10 segundos.
+
+### Limitação de taxa da API do GitHub
+
+A ferramenta `get_component_examples` consulta a API pública do GitHub para localizar os exemplos no repositório. Sem autenticação, o GitHub limita as requisições a 60 por hora por endereço IP. Ao atingir esse limite, a API responde com HTTP 403 e a ferramenta retorna uma mensagem de erro correspondente.
+
+Para reduzir o consumo, o servidor mantém a árvore do repositório em cache durante a execução: apenas a primeira chamada a `get_component_examples` consulta a API do GitHub; as demais reutilizam o resultado em memória. Se você atingir o limite, aguarde a renovação da cota ou reinicie o servidor mais tarde. Ambientes com IP compartilhado (proxies corporativos, por exemplo) podem atingir o limite com mais frequência.
 
 ### Recurso não encontrado
 

--- a/projects/mcp/src/docs-client.spec.ts
+++ b/projects/mcp/src/docs-client.spec.ts
@@ -1,13 +1,21 @@
 import * as https from 'node:https';
 import * as http from 'node:http';
-import { fetchLlmsTxt, fetchLlmsFullTxt, fetchComponentDoc, fetchGuide } from './docs-client';
+import {
+  clearRepositoryTreeCache,
+  fetchBestPractices,
+  fetchComponentDoc,
+  fetchComponentExamples,
+  fetchGuide,
+  fetchLlmsFullTxt,
+  fetchLlmsTxt,
+  getLanguage
+} from './docs-client';
 
-// Mock dos modulos http/https
 jest.mock('node:https');
 jest.mock('node:http');
 
 /**
- * Helper para criar um mock de IncomingMessage (resposta HTTP).
+ * Builds a mock of IncomingMessage (the HTTP response).
  */
 function createMockResponse(statusCode: number, body: string, headers: Record<string, string> = {}): any {
   const listeners: Record<string, Function[]> = {};
@@ -30,7 +38,7 @@ function createMockResponse(statusCode: number, body: string, headers: Record<st
 }
 
 /**
- * Helper para criar mock de ClientRequest.
+ * Builds a mock of ClientRequest.
  */
 function createMockRequest(): any {
   const listeners: Record<string, Function[]> = {};
@@ -46,7 +54,7 @@ function createMockRequest(): any {
 }
 
 /**
- * Configura o mock de https.get para retornar uma resposta.
+ * Sets up the https.get mock to resolve with a single response.
  */
 function mockHttpsGet(statusCode: number, body: string, headers: Record<string, string> = {}): void {
   const mockReq = createMockRequest();
@@ -59,7 +67,7 @@ function mockHttpsGet(statusCode: number, body: string, headers: Record<string, 
 }
 
 /**
- * Configura mock sequencial para multiplas chamadas https.get.
+ * Sets up a sequential https.get mock for multiple calls.
  */
 function mockHttpsGetSequence(
   responses: Array<{ statusCode: number; body: string; headers?: Record<string, string> }>
@@ -77,47 +85,71 @@ function mockHttpsGetSequence(
   });
 }
 
+function mockHttpsRequestError(message: string): void {
+  (https.get as jest.Mock).mockImplementation(() => {
+    const mockReq = createMockRequest();
+    process.nextTick(() => mockReq._listeners.error[0](new Error(message)));
+    return mockReq;
+  });
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
+  clearRepositoryTreeCache();
 });
 
 describe('fetchLlmsTxt', () => {
-  it('deve retornar o texto quando a resposta for 200', async () => {
+  it('should return the text when the response is 200', async () => {
     mockHttpsGet(200, 'conteudo do llms.txt');
 
     const result = await fetchLlmsTxt();
     expect(result).toBe('conteudo do llms.txt');
   });
 
-  it('deve lancar erro quando a resposta nao for ok', async () => {
+  it('should throw when the response is not ok', async () => {
     mockHttpsGet(404, 'Not Found');
 
     await expect(fetchLlmsTxt()).rejects.toThrow('Falha ao buscar llms.txt (HTTP 404)');
   });
 
-  it('deve chamar a URL correta', async () => {
+  it('should call the correct URL', async () => {
     mockHttpsGet(200, 'ok');
 
     await fetchLlmsTxt();
     expect(https.get).toHaveBeenCalledWith('https://po-ui.io/llms.txt', expect.any(Object), expect.any(Function));
   });
+
+  it('should follow redirects', async () => {
+    mockHttpsGetSequence([
+      { statusCode: 302, body: '', headers: { location: 'https://po-ui.io/llms-redirected.txt' } },
+      { statusCode: 200, body: 'conteudo redirecionado' }
+    ]);
+
+    await expect(fetchLlmsTxt()).resolves.toBe('conteudo redirecionado');
+  });
+
+  it('should report a transport failure', async () => {
+    mockHttpsRequestError('connection reset');
+
+    await expect(fetchLlmsTxt()).rejects.toThrow('HTTP desconhecido');
+  });
 });
 
 describe('fetchLlmsFullTxt', () => {
-  it('deve retornar o texto quando a resposta for 200', async () => {
+  it('should return the text when the response is 200', async () => {
     mockHttpsGet(200, 'conteudo completo');
 
     const result = await fetchLlmsFullTxt();
     expect(result).toBe('conteudo completo');
   });
 
-  it('deve lancar erro quando a resposta nao for ok', async () => {
+  it('should throw when the response is not ok', async () => {
     mockHttpsGet(500, 'Internal Error');
 
     await expect(fetchLlmsFullTxt()).rejects.toThrow('Falha ao buscar llms-full.txt (HTTP 500)');
   });
 
-  it('deve chamar a URL correta', async () => {
+  it('should call the correct URL', async () => {
     mockHttpsGet(200, 'ok');
 
     await fetchLlmsFullTxt();
@@ -126,14 +158,14 @@ describe('fetchLlmsFullTxt', () => {
 });
 
 describe('fetchComponentDoc', () => {
-  it('deve retornar o doc da URL primaria quando disponivel', async () => {
+  it('should return the doc from the primary URL when available', async () => {
     mockHttpsGet(200, '# PoButton\nDocumentacao...');
 
     const result = await fetchComponentDoc('po-button');
     expect(result).toBe('# PoButton\nDocumentacao...');
   });
 
-  it('deve chamar a URL primaria correta', async () => {
+  it('should call the correct primary URL', async () => {
     mockHttpsGet(200, 'doc');
 
     await fetchComponentDoc('po-table');
@@ -144,7 +176,7 @@ describe('fetchComponentDoc', () => {
     );
   });
 
-  it('deve fazer fallback para GitHub raw quando URL primaria falha', async () => {
+  it('should fall back to GitHub raw when the primary URL fails', async () => {
     mockHttpsGetSequence([
       { statusCode: 404, body: 'Not Found' },
       { statusCode: 200, body: '# PoButton via GitHub' }
@@ -155,7 +187,7 @@ describe('fetchComponentDoc', () => {
     expect(https.get).toHaveBeenCalledTimes(2);
   });
 
-  it('deve lancar erro quando ambas URLs falham', async () => {
+  it('should throw when both URLs fail', async () => {
     mockHttpsGetSequence([
       { statusCode: 404, body: 'Not Found' },
       { statusCode: 404, body: 'Not Found' }
@@ -166,7 +198,7 @@ describe('fetchComponentDoc', () => {
     );
   });
 
-  it('deve incluir URLs tentadas na mensagem de erro', async () => {
+  it('should list the attempted URLs in the error message', async () => {
     mockHttpsGetSequence([
       { statusCode: 404, body: '' },
       { statusCode: 404, body: '' }
@@ -176,15 +208,242 @@ describe('fetchComponentDoc', () => {
   });
 });
 
+describe('fetchComponentExamples', () => {
+  function repositoryTree(paths: string[], truncated = false): string {
+    return JSON.stringify({
+      tree: paths.map(path => ({ path, type: 'blob' })),
+      truncated
+    });
+  }
+
+  const buttonTree = repositoryTree([
+    'projects/ui/src/lib/components/po-button/samples/sample-po-button-basic/sample-po-button-basic.component.html',
+    'projects/ui/src/lib/components/po-button/samples/sample-po-button-basic/sample-po-button-basic.component.ts',
+    'projects/ui/src/lib/components/po-button/samples/sample-po-button-basic/readme.txt',
+    'projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/sample-po-button-labs.component.scss',
+    'projects/ui/src/lib/components/po-button/samples/sample-po-button-labs/config.json'
+  ]);
+
+  it('should return official sample files with source URLs', async () => {
+    mockHttpsGetSequence([
+      { statusCode: 200, body: buttonTree },
+      { statusCode: 200, body: '<po-button></po-button>' },
+      { statusCode: 200, body: 'export class SamplePoButtonBasicComponent {}' }
+    ]);
+
+    const result = await fetchComponentExamples('po-button', 1);
+
+    expect(result.status).toBe('available');
+    expect(result.sourceSlug).toBe('po-button');
+    expect(result.examples).toHaveLength(1);
+    expect(result.examples[0].name).toBe('sample-po-button-basic');
+    expect(result.examples[0].files).toHaveLength(2);
+    expect(result.examples[0].files[0].language).toBe('html');
+    expect(result.examples[0].files[1].language).toBe('typescript');
+    expect(result.examples[0].files[0].url).toContain('github.com/po-ui/po-angular/blob/master');
+  });
+
+  it('should filter samples by name', async () => {
+    mockHttpsGetSequence([
+      { statusCode: 200, body: buttonTree },
+      { statusCode: 200, body: '.sample {}' },
+      { statusCode: 200, body: '{}' }
+    ]);
+
+    const result = await fetchComponentExamples('po-button', 3, 'labs');
+
+    expect(result.examples).toHaveLength(1);
+    expect(result.examples[0].name).toBe('sample-po-button-labs');
+    expect(result.examples[0].files.map(file => file.language)).toEqual(['scss', 'json']);
+  });
+
+  it.each([
+    [
+      'po-checkbox',
+      'projects/ui/src/lib/components/po-field/po-checkbox/samples/sample-po-checkbox-basic/sample-po-checkbox-basic.component.html'
+    ],
+    [
+      'po-page-login',
+      'projects/templates/src/lib/components/po-page-login/samples/sample-po-page-login-basic/sample-po-page-login-basic.component.html'
+    ],
+    [
+      'po-code-editor',
+      'projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-basic/sample-po-code-editor-basic.component.html'
+    ]
+  ])('should find %s examples in any supported package depth', async (slug, samplePath) => {
+    mockHttpsGetSequence([
+      { statusCode: 200, body: repositoryTree([samplePath]) },
+      { statusCode: 200, body: '<sample></sample>' }
+    ]);
+
+    const result = await fetchComponentExamples(slug, 1);
+
+    expect(result.status).toBe('available');
+    expect(result.sourceSlug).toBe(slug);
+    expect(result.examples[0].url).toContain(samplePath.split('/samples/')[0]);
+  });
+
+  it('should return examples from the parent component', async () => {
+    const tree = repositoryTree([
+      'projects/ui/src/lib/components/po-tabs/po-tab/po-tab.component.ts',
+      'projects/ui/src/lib/components/po-tabs/samples/sample-po-tabs-basic/sample-po-tabs-basic.component.html'
+    ]);
+    mockHttpsGetSequence([
+      { statusCode: 200, body: tree },
+      { statusCode: 200, body: '<po-tabs><po-tab></po-tab></po-tabs>' }
+    ]);
+
+    const result = await fetchComponentExamples('po-tab', 1);
+
+    expect(result.status).toBe('available');
+    expect(result.sourceSlug).toBe('po-tabs');
+    expect(result.examples[0].name).toBe('sample-po-tabs-basic');
+  });
+
+  it('should resolve every component with an official parent fallback', async () => {
+    const parentFallbacks = [
+      ['po-accordion-item', 'po-accordion', 'projects/ui/src/lib/components/po-accordion'],
+      ['po-button-base', 'po-button', 'projects/ui/src/lib/components/po-button'],
+      ['po-button-group-base', 'po-button-group', 'projects/ui/src/lib/components/po-button-group'],
+      ['po-checkbox-base', 'po-checkbox', 'projects/ui/src/lib/components/po-field/po-checkbox'],
+      ['po-helper-base', 'po-helper', 'projects/ui/src/lib/components/po-helper'],
+      ['po-modal-footer', 'po-modal', 'projects/ui/src/lib/components/po-modal'],
+      ['po-page-slide-footer', 'po-page-slide', 'projects/ui/src/lib/components/po-page/po-page-slide'],
+      ['po-popover-base', 'po-popover', 'projects/ui/src/lib/components/po-popover'],
+      ['po-step', 'po-stepper', 'projects/ui/src/lib/components/po-stepper'],
+      ['po-tab', 'po-tabs', 'projects/ui/src/lib/components/po-tabs']
+    ];
+    const paths = parentFallbacks.map(
+      ([, parentSlug, root]) => `${root}/samples/sample-${parentSlug}-basic/sample-${parentSlug}-basic.component.html`
+    );
+    mockHttpsGet(200, repositoryTree(paths));
+
+    for (const [slug, parentSlug] of parentFallbacks) {
+      const result = await fetchComponentExamples(slug, 1, 'filter-without-match');
+      expect(result.sourceSlug).toBe(parentSlug);
+      expect(result.status).toBe('no_match');
+    }
+  });
+
+  it('should return an empty list when no sample matches the filter', async () => {
+    mockHttpsGet(200, buttonTree);
+
+    await expect(fetchComponentExamples('po-button', 3, 'inexistente')).resolves.toEqual({
+      examples: [],
+      sourceSlug: 'po-button',
+      status: 'no_match'
+    });
+  });
+
+  it('should distinguish a component without official examples from an unknown component', async () => {
+    mockHttpsGet(200, repositoryTree(['projects/ui/src/lib/components/po-navbar/po-navbar.component.ts']));
+
+    await expect(fetchComponentExamples('po-navbar', 3)).resolves.toEqual({
+      examples: [],
+      sourceSlug: 'po-navbar',
+      status: 'not_available'
+    });
+  });
+
+  it('should throw when the component does not exist', async () => {
+    mockHttpsGet(200, repositoryTree(['projects/ui/src/lib/components/po-button/po-button.component.ts']));
+
+    await expect(fetchComponentExamples('po-inexistente', 3)).rejects.toThrow(
+      'Componente "po-inexistente" não encontrado'
+    );
+  });
+
+  it('should preserve the GitHub status when the repository tree cannot be loaded', async () => {
+    mockHttpsGet(403, 'rate limit exceeded');
+
+    await expect(fetchComponentExamples('po-button', 3)).rejects.toThrow('índice de exemplos (HTTP 403)');
+  });
+
+  it('should reject a truncated repository tree', async () => {
+    mockHttpsGet(200, repositoryTree([], true));
+
+    await expect(fetchComponentExamples('po-button', 3)).rejects.toThrow(
+      'índice de exemplos retornado pelo GitHub está incompleto'
+    );
+  });
+
+  it('should reject a repository response without a tree', async () => {
+    mockHttpsGet(200, JSON.stringify({ truncated: false }));
+
+    await expect(fetchComponentExamples('po-button', 3)).rejects.toThrow('campo "tree" ausente');
+  });
+
+  it('should throw when GitHub returns invalid JSON', async () => {
+    mockHttpsGet(200, 'invalid json');
+
+    await expect(fetchComponentExamples('po-button', 3)).rejects.toThrow('Resposta JSON inválida');
+  });
+
+  it('should throw when a sample file cannot be loaded', async () => {
+    mockHttpsGetSequence([
+      { statusCode: 200, body: buttonTree },
+      { statusCode: 500, body: 'Internal Error' },
+      { statusCode: 200, body: 'export class Sample {}' }
+    ]);
+
+    await expect(fetchComponentExamples('po-button', 1)).rejects.toThrow('Falha ao buscar o arquivo de exemplo');
+  });
+
+  it('should cache the repository tree for the session', async () => {
+    const tree = repositoryTree([
+      'projects/ui/src/lib/components/po-button/samples/sample-po-button-basic/sample-po-button-basic.component.html',
+      'projects/ui/src/lib/components/po-table/samples/sample-po-table-basic/sample-po-table-basic.component.html'
+    ]);
+    mockHttpsGetSequence([
+      { statusCode: 200, body: tree },
+      { statusCode: 200, body: '<po-button></po-button>' },
+      { statusCode: 200, body: '<po-table></po-table>' }
+    ]);
+
+    await fetchComponentExamples('po-button', 1);
+    await fetchComponentExamples('po-table', 1);
+
+    const treeRequests = (https.get as jest.Mock).mock.calls.filter(([url]) => url.includes('/git/trees/master'));
+    expect(treeRequests).toHaveLength(1);
+  });
+});
+
+describe('fetchBestPractices', () => {
+  it.each([
+    ['contributing', 'CONTRIBUTING.md'],
+    ['development-flow', 'docs/guides/development-flow.md'],
+    ['getting-started', 'docs/guides/getting-started.md'],
+    ['theme-service', 'docs/guides/theme-service.md']
+  ] as const)('should fetch the %s official source', async (topic, expectedPath) => {
+    mockHttpsGet(200, '# Boas práticas');
+
+    const result = await fetchBestPractices(topic);
+
+    expect(result.content).toBe('# Boas práticas');
+    expect(result.url).toContain(expectedPath);
+    expect(https.get).toHaveBeenCalledWith(
+      expect.stringContaining(`raw.githubusercontent.com/po-ui/po-angular/master/${expectedPath}`),
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
+  it('should throw when the official source cannot be loaded', async () => {
+    mockHttpsGet(503, 'Unavailable');
+
+    await expect(fetchBestPractices('contributing')).rejects.toThrow('Falha ao buscar boas práticas');
+  });
+});
+
 describe('fetchGuide', () => {
-  it('deve retornar o conteudo do guia quando disponivel', async () => {
+  it('should return the guide content when available', async () => {
     mockHttpsGet(200, '# Getting Started\nConteudo...');
 
     const result = await fetchGuide('getting-started');
     expect(result).toBe('# Getting Started\nConteudo...');
   });
 
-  it('deve chamar a URL correta no GitHub raw', async () => {
+  it('should call the correct GitHub raw URL', async () => {
     mockHttpsGet(200, 'ok');
 
     await fetchGuide('schematics');
@@ -195,7 +454,7 @@ describe('fetchGuide', () => {
     );
   });
 
-  it('deve remover extensao .md do nome antes de buscar', async () => {
+  it('should strip the .md extension from the name before fetching', async () => {
     mockHttpsGet(200, 'ok');
 
     await fetchGuide('getting-started.md');
@@ -206,21 +465,21 @@ describe('fetchGuide', () => {
     );
   });
 
-  it('deve lancar erro quando o guia nao for encontrado', async () => {
+  it('should throw when the guide is not found', async () => {
     mockHttpsGet(404, 'Not Found');
 
     await expect(fetchGuide('inexistente')).rejects.toThrow('Guia "inexistente" não encontrado');
   });
 
-  it('deve incluir URL tentada na mensagem de erro', async () => {
+  it('should include the attempted URL in the error message', async () => {
     mockHttpsGet(404, '');
 
     await expect(fetchGuide('xyz')).rejects.toThrow('URL tentada:');
   });
 });
 
-describe('fetchUrl (comportamento interno)', () => {
-  it('deve seguir redirects (301)', async () => {
+describe('fetchUrl (internal behaviour)', () => {
+  it('should follow a 301 redirect', async () => {
     let callCount = 0;
 
     (https.get as jest.Mock).mockImplementation((url: string, _opts: any, cb: Function) => {
@@ -229,7 +488,6 @@ describe('fetchUrl (comportamento interno)', () => {
       if (callCount === 0) {
         callCount++;
         const redirectRes = createMockResponse(301, '', { location: 'https://po-ui.io/redirected' });
-        // Prevent data/end events from firing for redirect
         redirectRes.on = (event: string, _cb: Function) => {
           if (event === 'data' || event === 'end') return redirectRes;
           return redirectRes;
@@ -247,10 +505,9 @@ describe('fetchUrl (comportamento interno)', () => {
     expect(result).toBe('conteudo redirecionado');
   });
 
-  it('deve resolver com ok=false em timeout', async () => {
+  it('should resolve with ok=false on timeout', async () => {
     (https.get as jest.Mock).mockImplementation((_url: string, _opts: any, _cb: Function) => {
       const mockReq = createMockRequest();
-      // Simula timeout: nao chama o callback, e dispara o evento timeout
       process.nextTick(() => {
         if (mockReq._listeners['timeout']) {
           mockReq._listeners['timeout'].forEach((fn: Function) => fn());
@@ -262,7 +519,7 @@ describe('fetchUrl (comportamento interno)', () => {
     await expect(fetchLlmsTxt()).rejects.toThrow('Falha ao buscar llms.txt');
   });
 
-  it('deve resolver com ok=false em erro de request', async () => {
+  it('should resolve with ok=false on a request error', async () => {
     (https.get as jest.Mock).mockImplementation((_url: string, _opts: any, _cb: Function) => {
       const mockReq = createMockRequest();
       process.nextTick(() => {
@@ -276,7 +533,7 @@ describe('fetchUrl (comportamento interno)', () => {
     await expect(fetchLlmsTxt()).rejects.toThrow('Falha ao buscar llms.txt');
   });
 
-  it('deve seguir redirect para URL http e usar client http', async () => {
+  it('should follow a redirect to an http URL using the http client', async () => {
     (https.get as jest.Mock).mockImplementation((_url: string, _opts: any, cb: Function) => {
       const mockReq = createMockRequest();
       const redirectRes = {
@@ -300,7 +557,7 @@ describe('fetchUrl (comportamento interno)', () => {
     expect(http.get).toHaveBeenCalled();
   });
 
-  it('deve resolver com ok=false em erro de response', async () => {
+  it('should resolve with ok=false on a response error', async () => {
     (https.get as jest.Mock).mockImplementation((_url: string, _opts: any, cb: Function) => {
       const mockReq = createMockRequest();
       const mockRes = {
@@ -339,18 +596,174 @@ describe('fetchUrl - statusCode undefined', () => {
     });
   }
 
-  it('deve incluir "desconhecido" no erro de fetchLlmsFullTxt quando statusCode e undefined', async () => {
+  it('should include "desconhecido" in the fetchLlmsFullTxt error when statusCode is undefined', async () => {
     mockUndefinedStatusCode();
     await expect(fetchLlmsFullTxt()).rejects.toThrow('desconhecido');
   });
 
-  it('deve incluir "erro" no erro de fetchComponentDoc quando statusCode e undefined', async () => {
+  it('should include "erro" in the fetchComponentDoc error when statusCode is undefined', async () => {
     mockUndefinedStatusCode();
     await expect(fetchComponentDoc('xyz')).rejects.toThrow('erro');
   });
 
-  it('deve incluir "desconhecido" no erro de fetchGuide quando statusCode e undefined', async () => {
+  it('should include "desconhecido" in the fetchGuide error when statusCode is undefined', async () => {
     mockUndefinedStatusCode();
     await expect(fetchGuide('xyz')).rejects.toThrow('desconhecido');
+  });
+
+  it('should include "desconhecido" when loading the examples index and statusCode is undefined', async () => {
+    mockUndefinedStatusCode();
+    await expect(fetchComponentExamples('po-button', 1)).rejects.toThrow(
+      'Falha ao carregar o índice de exemplos (HTTP desconhecido).'
+    );
+  });
+
+  it('should include "desconhecido" in the fetchBestPractices error when statusCode is undefined', async () => {
+    mockUndefinedStatusCode();
+    await expect(fetchBestPractices('contributing')).rejects.toThrow(
+      'Falha ao buscar boas práticas de "contributing" (HTTP desconhecido).'
+    );
+  });
+
+  it('should include "desconhecido" when downloading a sample file and statusCode is undefined', async () => {
+    const tree = JSON.stringify({
+      truncated: false,
+      tree: [
+        {
+          path: 'projects/ui/src/lib/components/po-button/samples/sample-po-button-basic/sample-po-button-basic.component.html',
+          type: 'blob'
+        }
+      ]
+    });
+    let callIndex = 0;
+
+    (https.get as jest.Mock).mockImplementation((_url: string, _opts: any, cb: Function) => {
+      const mockReq = createMockRequest();
+      const isTreeRequest = callIndex === 0;
+      callIndex++;
+      const mockRes = {
+        statusCode: isTreeRequest ? 200 : undefined,
+        headers: {},
+        on(event: string, handler: Function) {
+          if (event === 'data') process.nextTick(() => handler(Buffer.from(isTreeRequest ? tree : '')));
+          if (event === 'end') process.nextTick(() => handler());
+          return this;
+        }
+      };
+      process.nextTick(() => cb(mockRes));
+      return mockReq;
+    });
+
+    await expect(fetchComponentExamples('po-button', 1)).rejects.toThrow('(HTTP desconhecido)');
+  });
+});
+
+describe('getLanguage', () => {
+  it.each([
+    ['sample-po-button-basic.component.css', 'css'],
+    ['sample-po-button-basic.component.html', 'html'],
+    ['config.json', 'json'],
+    ['sample-po-button-labs.component.scss', 'scss'],
+    ['sample-po-button-basic.component.ts', 'typescript']
+  ])('should map %s to %s', (fileName, expected) => {
+    expect(getLanguage(fileName)).toBe(expected);
+  });
+
+  it('should return "text" for an unmapped extension', () => {
+    expect(getLanguage('readme.txt')).toBe('text');
+  });
+
+  it('should return "text" for a file without an extension', () => {
+    expect(getLanguage('Makefile')).toBe('text');
+  });
+});
+
+describe('findSamplesLocation (internal behaviour)', () => {
+  it('should ignore directories and paths outside the component packages', async () => {
+    const tree = JSON.stringify({
+      truncated: false,
+      tree: [
+        { path: 'projects/ui/src/lib/components/po-button/samples', type: 'tree' },
+        { path: 'docs/guides/getting-started.md', type: 'blob' },
+        {
+          path: 'projects/ui/src/lib/components/po-button/samples/sample-po-button-basic/sample-po-button-basic.component.html',
+          type: 'blob'
+        }
+      ]
+    });
+    mockHttpsGetSequence([
+      { statusCode: 200, body: tree },
+      { statusCode: 200, body: '<po-button></po-button>' }
+    ]);
+
+    const result = await fetchComponentExamples('po-button', 3);
+
+    expect(result.status).toBe('available');
+    expect(result.examples).toHaveLength(1);
+    expect(result.examples[0].files).toHaveLength(1);
+    expect(result.examples[0].files[0].name).toBe('sample-po-button-basic.component.html');
+  });
+
+  it('should prefer the samples directory with the shortest path', async () => {
+    const tree = JSON.stringify({
+      truncated: false,
+      tree: [
+        {
+          path: 'projects/templates/src/lib/components/po-page-dynamic-table/po-button/samples/sample-po-button-extra/sample-po-button-extra.component.html',
+          type: 'blob'
+        },
+        {
+          path: 'projects/ui/src/lib/components/po-button/samples/sample-po-button-basic/sample-po-button-basic.component.html',
+          type: 'blob'
+        }
+      ]
+    });
+    mockHttpsGetSequence([
+      { statusCode: 200, body: tree },
+      { statusCode: 200, body: '<po-button></po-button>' }
+    ]);
+
+    const result = await fetchComponentExamples('po-button', 3);
+
+    expect(result.examples).toHaveLength(1);
+    expect(result.examples[0].name).toBe('sample-po-button-basic');
+    expect(result.examples[0].url).toContain('projects/ui/src/lib/components/po-button/samples');
+  });
+});
+
+describe('fetchUrl - request headers', () => {
+  function getRequestOptions(): any {
+    const call = (https.get as jest.Mock).mock.calls[0];
+    return call[1];
+  }
+
+  it('should send the GitHub API Accept header only on api.github.com calls', async () => {
+    mockHttpsGet(200, JSON.stringify({ tree: [], truncated: false }));
+
+    await fetchComponentExamples('po-navbar', 3).catch(() => undefined);
+
+    const options = getRequestOptions();
+    expect(options.headers.Accept).toBe('application/vnd.github+json');
+    expect(options.headers['User-Agent']).toBe('po-ui-mcp');
+  });
+
+  it('should not send the GitHub API Accept header to po-ui.io', async () => {
+    mockHttpsGet(200, 'ok');
+
+    await fetchLlmsTxt();
+
+    const options = getRequestOptions();
+    expect(options.headers.Accept).toBeUndefined();
+    expect(options.headers['User-Agent']).toBe('po-ui-mcp');
+  });
+
+  it('should not send the GitHub API Accept header to raw.githubusercontent.com', async () => {
+    mockHttpsGet(200, '# Guia');
+
+    await fetchGuide('getting-started');
+
+    const options = getRequestOptions();
+    expect(options.headers.Accept).toBeUndefined();
+    expect(options.headers['User-Agent']).toBe('po-ui-mcp');
   });
 });

--- a/projects/mcp/src/docs-client.ts
+++ b/projects/mcp/src/docs-client.ts
@@ -3,7 +3,97 @@ import * as http from 'node:http';
 
 const BASE_URL = 'https://po-ui.io';
 const GITHUB_RAW = 'https://raw.githubusercontent.com/po-ui/po-angular/master';
+const GITHUB_REPOSITORY = 'https://github.com/po-ui/po-angular';
+const GITHUB_API = 'https://api.github.com/repos/po-ui/po-angular';
 const FETCH_TIMEOUT_MS = 10_000;
+
+const COMPONENT_SOURCE_ROOTS = [
+  'projects/ui/src/lib/components',
+  'projects/templates/src/lib/components',
+  'projects/code-editor/src/lib/components'
+];
+
+const COMPONENT_EXAMPLE_PARENTS: Record<string, string> = {
+  'po-accordion-item': 'po-accordion',
+  'po-button-base': 'po-button',
+  'po-button-group-base': 'po-button-group',
+  'po-checkbox-base': 'po-checkbox',
+  'po-helper-base': 'po-helper',
+  'po-modal-footer': 'po-modal',
+  'po-page-slide-footer': 'po-page-slide',
+  'po-popover-base': 'po-popover',
+  'po-step': 'po-stepper',
+  'po-tab': 'po-tabs'
+};
+
+export const BEST_PRACTICE_TOPICS = ['contributing', 'development-flow', 'getting-started', 'theme-service'] as const;
+
+export type BestPracticeTopic = (typeof BEST_PRACTICE_TOPICS)[number];
+
+export interface OfficialDocument {
+  content: string;
+  title: string;
+  url: string;
+}
+
+export interface ComponentExampleFile {
+  content: string;
+  language: string;
+  name: string;
+  url: string;
+}
+
+export interface ComponentExample {
+  files: Array<ComponentExampleFile>;
+  name: string;
+  url: string;
+}
+
+export interface ComponentExamplesResult {
+  examples: Array<ComponentExample>;
+  sourceSlug: string;
+  status: 'available' | 'no_match' | 'not_available';
+}
+
+interface GitHubTreeEntry {
+  path: string;
+  type: 'blob' | 'tree';
+}
+
+interface GitHubTreeResponse {
+  tree: Array<GitHubTreeEntry>;
+  truncated?: boolean;
+}
+
+interface SamplesLocation {
+  files: Array<GitHubTreeEntry>;
+  rootPath: string;
+}
+
+let repositoryTreePromise: Promise<Array<GitHubTreeEntry>> | undefined;
+
+const BEST_PRACTICE_SOURCES: Record<BestPracticeTopic, Omit<OfficialDocument, 'content'> & { rawUrl: string }> = {
+  contributing: {
+    title: 'Contribuindo com o PO UI',
+    url: `${GITHUB_REPOSITORY}/blob/master/CONTRIBUTING.md`,
+    rawUrl: `${GITHUB_RAW}/CONTRIBUTING.md`
+  },
+  'development-flow': {
+    title: 'Fluxo de desenvolvimento',
+    url: `${GITHUB_REPOSITORY}/blob/master/docs/guides/development-flow.md`,
+    rawUrl: `${GITHUB_RAW}/docs/guides/development-flow.md`
+  },
+  'getting-started': {
+    title: 'Primeiros passos',
+    url: `${GITHUB_REPOSITORY}/blob/master/docs/guides/getting-started.md`,
+    rawUrl: `${GITHUB_RAW}/docs/guides/getting-started.md`
+  },
+  'theme-service': {
+    title: 'Customização de temas com PoThemeService',
+    url: `${GITHUB_REPOSITORY}/blob/master/docs/guides/theme-service.md`,
+    rawUrl: `${GITHUB_RAW}/docs/guides/theme-service.md`
+  }
+};
 
 interface FetchResult {
   ok: boolean;
@@ -11,29 +101,46 @@ interface FetchResult {
   statusCode?: number;
 }
 
+function buildRequestHeaders(url: string): Record<string, string> {
+  const headers: Record<string, string> = { 'User-Agent': 'po-ui-mcp' };
+
+  if (url.startsWith(`${GITHUB_API}/`) || url === GITHUB_API) {
+    headers.Accept = 'application/vnd.github+json';
+  }
+
+  return headers;
+}
+
 function fetchUrl(url: string): Promise<FetchResult> {
   return new Promise(resolve => {
     const client = url.startsWith('https') ? https : http;
 
-    const req = (client as typeof https).get(url, { timeout: FETCH_TIMEOUT_MS }, res => {
-      // Follow redirects (301/302)
-      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        resolve(fetchUrl(res.headers.location));
-        return;
-      }
+    const req = (client as typeof https).get(
+      url,
+      {
+        headers: buildRequestHeaders(url),
+        timeout: FETCH_TIMEOUT_MS
+      },
+      res => {
+        // Follow redirects (301/302)
+        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          resolve(fetchUrl(res.headers.location));
+          return;
+        }
 
-      const chunks: Buffer[] = [];
-      res.on('data', (chunk: Buffer) => chunks.push(chunk));
-      res.on('end', () => {
-        const text = Buffer.concat(chunks).toString('utf-8');
-        resolve({
-          ok: res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 300,
-          statusCode: res.statusCode,
-          text
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf-8');
+          resolve({
+            ok: res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 300,
+            statusCode: res.statusCode,
+            text
+          });
         });
-      });
-      res.on('error', () => resolve({ ok: false, text: '' }));
-    });
+        res.on('error', () => resolve({ ok: false, text: '' }));
+      }
+    );
 
     req.on('timeout', () => {
       req.destroy();
@@ -42,6 +149,164 @@ function fetchUrl(url: string): Promise<FetchResult> {
 
     req.on('error', (err: Error) => resolve({ ok: false, text: err.message }));
   });
+}
+
+function parseJson<T>(result: FetchResult, url: string): T {
+  try {
+    return JSON.parse(result.text) as T;
+  } catch {
+    throw new Error(`Resposta JSON inválida recebida de ${url}`);
+  }
+}
+
+/** Resolve the highlight language of a sample file. Exported for direct unit testing. */
+export function getLanguage(fileName: string): string {
+  const extension = fileName.slice(fileName.lastIndexOf('.') + 1);
+  const languages: Record<string, string> = {
+    css: 'css',
+    html: 'html',
+    json: 'json',
+    scss: 'scss',
+    ts: 'typescript'
+  };
+
+  return languages[extension] ?? 'text';
+}
+
+function isWithinComponentSource(path: string): boolean {
+  return COMPONENT_SOURCE_ROOTS.some(root => path.startsWith(`${root}/`));
+}
+
+function findSamplesLocation(tree: Array<GitHubTreeEntry>, slug: string): SamplesLocation | undefined {
+  const samplesMarker = `/${slug}/samples/`;
+  const locations = new Map<string, Array<GitHubTreeEntry>>();
+
+  for (const entry of tree) {
+    if (entry.type !== 'blob' || !isWithinComponentSource(entry.path)) continue;
+
+    const markerIndex = entry.path.indexOf(samplesMarker);
+    if (markerIndex === -1 || !/\.(?:css|html|json|scss|ts)$/.test(entry.path)) continue;
+
+    const rootPath = entry.path.slice(0, markerIndex + samplesMarker.length - 1);
+    const files = locations.get(rootPath) ?? [];
+    files.push(entry);
+    locations.set(rootPath, files);
+  }
+
+  const [rootPath, files] = [...locations.entries()].sort(([pathA], [pathB]) => pathA.length - pathB.length)[0] ?? [];
+  return rootPath && files ? { files, rootPath } : undefined;
+}
+
+function componentExists(tree: Array<GitHubTreeEntry>, slug: string): boolean {
+  const componentMarker = `/${slug}/`;
+  return tree.some(entry => isWithinComponentSource(entry.path) && `/${entry.path}/`.includes(componentMarker));
+}
+
+async function loadRepositoryTree(): Promise<Array<GitHubTreeEntry>> {
+  const url = `${GITHUB_API}/git/trees/master?recursive=1`;
+  const result = await fetchUrl(url);
+
+  if (!result.ok) {
+    throw new Error(`Falha ao carregar o índice de exemplos (HTTP ${result.statusCode ?? 'desconhecido'}).`);
+  }
+
+  const response = parseJson<GitHubTreeResponse>(result, url);
+  if (!Array.isArray(response.tree)) {
+    throw new TypeError(`Resposta inválida recebida de ${url}: campo "tree" ausente.`);
+  }
+  if (response.truncated) {
+    throw new Error('O índice de exemplos retornado pelo GitHub está incompleto. Tente novamente mais tarde.');
+  }
+
+  return response.tree;
+}
+
+async function getRepositoryTree(): Promise<Array<GitHubTreeEntry>> {
+  repositoryTreePromise ??= loadRepositoryTree().catch(error => {
+    repositoryTreePromise = undefined;
+    throw error;
+  });
+
+  return repositoryTreePromise;
+}
+
+/** Clear the session cache. Intended for tests that mock the GitHub tree. */
+export function clearRepositoryTreeCache(): void {
+  repositoryTreePromise = undefined;
+}
+
+export async function fetchComponentExamples(
+  slug: string,
+  maxExamples: number,
+  exampleFilter?: string
+): Promise<ComponentExamplesResult> {
+  const repositoryTree = await getRepositoryTree();
+  const directLocation = findSamplesLocation(repositoryTree, slug);
+  const sourceSlug = directLocation ? slug : (COMPONENT_EXAMPLE_PARENTS[slug] ?? slug);
+  const location = directLocation ?? findSamplesLocation(repositoryTree, sourceSlug);
+
+  if (!location) {
+    if (componentExists(repositoryTree, slug)) {
+      return { examples: [], sourceSlug: slug, status: 'not_available' };
+    }
+    throw new Error(`Componente "${slug}" não encontrado no repositório oficial.`);
+  }
+
+  const sampleNames = [
+    ...new Set(location.files.map(entry => entry.path.slice(location.rootPath.length + 1).split('/')[0]))
+  ]
+    .filter(name => !exampleFilter || name.toLowerCase().includes(exampleFilter.toLowerCase()))
+    .sort((nameA, nameB) => nameA.localeCompare(nameB))
+    .slice(0, maxExamples);
+
+  const examples = await Promise.all(
+    sampleNames.map(async name => {
+      const entries = location.files.filter(entry => entry.path.startsWith(`${location.rootPath}/${name}/`));
+      const files = await Promise.all(
+        entries.map(async entry => {
+          const path = entry.path;
+          const rawUrl = `${GITHUB_RAW}/${path}`;
+          const result = await fetchUrl(rawUrl);
+
+          if (!result.ok) {
+            throw new Error(
+              `Falha ao buscar o arquivo de exemplo "${path}" (HTTP ${result.statusCode ?? 'desconhecido'}).`
+            );
+          }
+
+          return {
+            content: result.text,
+            language: getLanguage(entry.path),
+            name: path.slice(path.lastIndexOf('/') + 1),
+            url: `${GITHUB_REPOSITORY}/blob/master/${path}`
+          };
+        })
+      );
+
+      return {
+        files,
+        name,
+        url: `${GITHUB_REPOSITORY}/tree/master/${location.rootPath}/${name}`
+      };
+    })
+  );
+
+  return {
+    examples,
+    sourceSlug,
+    status: examples.length > 0 ? 'available' : 'no_match'
+  };
+}
+
+export async function fetchBestPractices(topic: BestPracticeTopic): Promise<OfficialDocument> {
+  const source = BEST_PRACTICE_SOURCES[topic];
+  const result = await fetchUrl(source.rawUrl);
+
+  if (!result.ok) {
+    throw new Error(`Falha ao buscar boas práticas de "${topic}" (HTTP ${result.statusCode ?? 'desconhecido'}).`);
+  }
+
+  return { content: result.text, title: source.title, url: source.url };
 }
 
 export async function fetchLlmsTxt(): Promise<string> {
@@ -61,7 +326,6 @@ export async function fetchComponentDoc(slug: string): Promise<string> {
   const primary = await fetchUrl(primaryUrl);
   if (primary.ok) return primary.text;
 
-  // Fallback: GitHub raw
   const fallbackUrl = `${GITHUB_RAW}/projects/portal/src/llms-generated/${slug}.md`;
   const fallback = await fetchUrl(fallbackUrl);
   if (fallback.ok) return fallback.text;

--- a/projects/mcp/src/llms-parser.spec.ts
+++ b/projects/mcp/src/llms-parser.spec.ts
@@ -1,16 +1,16 @@
 import { parseLlmsTxt } from './llms-parser';
 
 describe('parseLlmsTxt', () => {
-  it('deve retornar array vazio para texto vazio', () => {
+  it('should return an empty array for an empty text', () => {
     expect(parseLlmsTxt('')).toEqual([]);
   });
 
-  it('deve retornar array vazio quando nao ha entradas validas', () => {
+  it('should return an empty array when there is no valid entry', () => {
     const text = '# Titulo\n\nTexto sem entradas de lista.';
     expect(parseLlmsTxt(text)).toEqual([]);
   });
 
-  it('deve parsear entrada com descricao', () => {
+  it('should parse an entry with a description', () => {
     const text =
       '## Componentes e Diretivas\n- [PoButton](https://po-ui.io/llms-generated/po-button.md): Componente de botao';
     const result = parseLlmsTxt(text);
@@ -25,7 +25,7 @@ describe('parseLlmsTxt', () => {
     });
   });
 
-  it('deve parsear entrada sem descricao', () => {
+  it('should parse an entry without a description', () => {
     const text = '## Guias\n- [Getting Started](https://po-ui.io/guides/getting-started)';
     const result = parseLlmsTxt(text);
 
@@ -39,7 +39,7 @@ describe('parseLlmsTxt', () => {
     });
   });
 
-  it('deve mapear todas as secoes conhecidas', () => {
+  it('should map every known section', () => {
     const text = [
       '## Componentes e Diretivas',
       '- [A](https://x.io/llms-generated/a.md): desc',
@@ -53,7 +53,7 @@ describe('parseLlmsTxt', () => {
       '- [E](https://x.io/guides/e): desc'
     ].join('\n');
 
-    // "Servicos" sem acento nao esta no SECTION_MAP, entao fica como "servicos"
+    // "Servicos" without the cedilla is not in SECTION_MAP, so it stays as "servicos"
     const result = parseLlmsTxt(text);
     expect(result).toHaveLength(5);
     expect(result[0].section).toBe('components');
@@ -63,14 +63,14 @@ describe('parseLlmsTxt', () => {
     expect(result[4].section).toBe('guides');
   });
 
-  it('deve mapear secao "Servicos" com acento corretamente', () => {
+  it('should map the "Serviços" section when the cedilla is present', () => {
     const text = '## Servi\u00e7os\n- [Srv](https://x.io/llms-generated/srv.md): desc';
     const result = parseLlmsTxt(text);
 
     expect(result[0].section).toBe('services');
   });
 
-  it('deve usar "unknown" como secao padrao quando nao ha header', () => {
+  it('should use "unknown" as the default section when there is no header', () => {
     const text = '- [Orphan](https://x.io/llms-generated/orphan.md): sem secao';
     const result = parseLlmsTxt(text);
 
@@ -78,21 +78,21 @@ describe('parseLlmsTxt', () => {
     expect(result[0].section).toBe('unknown');
   });
 
-  it('deve remover extensao .md do slug', () => {
+  it('should strip the .md extension from the slug', () => {
     const text = '## Componentes e Diretivas\n- [X](https://x.io/llms-generated/po-table.md): desc';
     const result = parseLlmsTxt(text);
 
     expect(result[0].slug).toBe('po-table');
   });
 
-  it('deve manter slug sem .md intacto', () => {
+  it('should keep a slug without .md untouched', () => {
     const text = '## Guias\n- [X](https://x.io/guides/getting-started): desc';
     const result = parseLlmsTxt(text);
 
     expect(result[0].slug).toBe('getting-started');
   });
 
-  it('deve parsear multiplas entradas na mesma secao', () => {
+  it('should parse multiple entries within the same section', () => {
     const text = [
       '## Componentes e Diretivas',
       '- [PoButton](https://x.io/llms-generated/po-button.md): botao',
@@ -105,7 +105,7 @@ describe('parseLlmsTxt', () => {
     expect(result.map(e => e.slug)).toEqual(['po-button', 'po-table', 'po-modal']);
   });
 
-  it('deve ignorar linhas que nao sao entradas nem headers', () => {
+  it('should ignore lines that are neither entries nor headers', () => {
     const text = [
       '# Titulo Principal',
       '',
@@ -124,21 +124,21 @@ describe('parseLlmsTxt', () => {
     expect(result[0].name).toBe('PoButton');
   });
 
-  it('deve fazer trim na descricao', () => {
+  it('should trim the description', () => {
     const text = '## Componentes e Diretivas\n- [X](https://x.io/llms-generated/x.md):   descricao com espacos   ';
     const result = parseLlmsTxt(text);
 
     expect(result[0].description).toBe('descricao com espacos');
   });
 
-  it('deve lidar com secoes case-insensitive', () => {
+  it('should match section headers case-insensitively', () => {
     const text = '## COMPONENTES E DIRETIVAS\n- [X](https://x.io/llms-generated/x.md): desc';
     const result = parseLlmsTxt(text);
 
     expect(result[0].section).toBe('components');
   });
 
-  it('deve lidar com linhas com espacos extras (trim)', () => {
+  it('should handle lines with extra surrounding whitespace', () => {
     const text = '## Componentes e Diretivas\n   - [X](https://x.io/llms-generated/x.md): desc   ';
     const result = parseLlmsTxt(text);
 

--- a/projects/mcp/src/llms-parser.ts
+++ b/projects/mcp/src/llms-parser.ts
@@ -38,7 +38,7 @@ export function parseLlmsTxt(text: string): LlmsEntry[] {
     // Extract slug from URL path:
     // https://po-ui.io/llms-generated/po-button.md  → po-button
     // https://po-ui.io/guides/getting-started        → getting-started
-    const lastSegment = url.split('/').pop() ?? '';
+    const lastSegment = url.slice(url.lastIndexOf('/') + 1);
     const slug = lastSegment.endsWith('.md') ? lastSegment.slice(0, -3) : lastSegment;
 
     entries.push({

--- a/projects/mcp/src/server.spec.ts
+++ b/projects/mcp/src/server.spec.ts
@@ -10,47 +10,47 @@ import {
 // ── normaliseSlug ────────────────────────────────────────────────────────────
 
 describe('normaliseSlug', () => {
-  it('deve retornar slug kebab-case inalterado', () => {
+  it('should keep a kebab-case slug unchanged', () => {
     expect(normaliseSlug('po-button')).toBe('po-button');
   });
 
-  it('deve fazer trim de espacos', () => {
+  it('should trim surrounding whitespace', () => {
     expect(normaliseSlug('  po-button  ')).toBe('po-button');
   });
 
-  it('deve remover angle brackets', () => {
+  it('should strip angle brackets', () => {
     expect(normaliseSlug('<po-button>')).toBe('po-button');
   });
 
-  it('deve converter CamelCase para kebab-case', () => {
+  it('should convert CamelCase to kebab-case', () => {
     expect(normaliseSlug('PoButtonComponent')).toBe('po-button');
   });
 
-  it('deve remover sufixo -component', () => {
+  it('should drop the -component suffix', () => {
     expect(normaliseSlug('PoTableComponent')).toBe('po-table');
   });
 
-  it('deve converter class name de servico', () => {
+  it('should convert a service class name', () => {
     expect(normaliseSlug('PoDialogService')).toBe('po-dialog-service');
   });
 
-  it('deve converter siglas em CamelCase corretamente', () => {
+  it('should convert acronyms in CamelCase correctly', () => {
     expect(normaliseSlug('PoHTTPInterceptor')).toBe('po-http-interceptor');
   });
 
-  it('deve manter slug com numeros', () => {
+  it('should keep a slug containing numbers', () => {
     expect(normaliseSlug('po-chart-v2')).toBe('po-chart-v2');
   });
 
-  it('nao deve converter quando ja e lowercase', () => {
+  it('should not convert a slug that is already lowercase', () => {
     expect(normaliseSlug('po-dialog-service')).toBe('po-dialog-service');
   });
 
-  it('deve lidar com string vazia', () => {
+  it('should handle an empty string', () => {
     expect(normaliseSlug('')).toBe('');
   });
 
-  it('deve lidar com angle brackets vazios', () => {
+  it('should handle empty angle brackets', () => {
     expect(normaliseSlug('<>')).toBe('');
   });
 });
@@ -58,27 +58,27 @@ describe('normaliseSlug', () => {
 // ── extractHeading ───────────────────────────────────────────────────────────
 
 describe('extractHeading', () => {
-  it('deve extrair heading de linha com #', () => {
+  it('should extract the heading from a line starting with #', () => {
     expect(extractHeading(['# PoButton', '', 'Descricao'])).toBe('PoButton');
   });
 
-  it('deve retornar "Desconhecido" quando nao ha heading', () => {
+  it('should return "Desconhecido" when there is no heading', () => {
     expect(extractHeading(['Sem heading', 'Outra linha'])).toBe('Desconhecido');
   });
 
-  it('deve retornar "Desconhecido" para array vazio', () => {
+  it('should return "Desconhecido" for an empty array', () => {
     expect(extractHeading([])).toBe('Desconhecido');
   });
 
-  it('deve fazer trim do heading', () => {
+  it('should trim the heading', () => {
     expect(extractHeading(['# PoButton  '])).toBe('PoButton');
   });
 
-  it('deve pegar apenas o primeiro heading', () => {
+  it('should take only the first heading', () => {
     expect(extractHeading(['# Primeiro', '# Segundo'])).toBe('Primeiro');
   });
 
-  it('nao deve confundir ## com #', () => {
+  it('should not treat ## as #', () => {
     expect(extractHeading(['## SubHeading', 'texto'])).toBe('Desconhecido');
   });
 });
@@ -88,23 +88,23 @@ describe('extractHeading', () => {
 describe('findMatchingLineIndexes', () => {
   const lines = ['Linha zero', 'Linha com BUSCA aqui', 'Outra linha', 'Mais busca aqui'];
 
-  it('deve encontrar indices das linhas que contem a query', () => {
+  it('should find the indexes of the lines containing the query', () => {
     expect(findMatchingLineIndexes(lines, 'busca')).toEqual([1, 3]);
   });
 
-  it('deve ser case-insensitive (query ja vem em lowercase)', () => {
+  it('should be case-insensitive (the query already comes in lowercase)', () => {
     expect(findMatchingLineIndexes(lines, 'busca')).toEqual([1, 3]);
   });
 
-  it('deve retornar array vazio quando nao encontra', () => {
+  it('should return an empty array when there is no match', () => {
     expect(findMatchingLineIndexes(lines, 'inexistente')).toEqual([]);
   });
 
-  it('deve retornar todos os indices para match universal', () => {
+  it('should return every index for a query that matches all lines', () => {
     expect(findMatchingLineIndexes(lines, 'linha')).toEqual([0, 1, 2]);
   });
 
-  it('deve lidar com array vazio', () => {
+  it('should handle an empty array', () => {
     expect(findMatchingLineIndexes([], 'busca')).toEqual([]);
   });
 });
@@ -125,7 +125,7 @@ describe('buildContextSnippet', () => {
     'Linha 9' // 9
   ];
 
-  it('deve incluir +-2 linhas ao redor do match', () => {
+  it('should include 2 lines around the match', () => {
     const result = buildContextSnippet(lines, [5]);
     expect(result).toContain('Linha 3');
     expect(result).toContain('Linha 4');
@@ -135,7 +135,7 @@ describe('buildContextSnippet', () => {
     expect(result).toContain('...');
   });
 
-  it('deve respeitar limite inferior (indice 0)', () => {
+  it('should respect the lower bound (index 0)', () => {
     const result = buildContextSnippet(lines, [1]);
     expect(result).toContain('Linha 0');
     expect(result).toContain('Linha 1');
@@ -143,32 +143,32 @@ describe('buildContextSnippet', () => {
     expect(result).toContain('Linha 3');
   });
 
-  it('deve respeitar limite superior (ultimo indice)', () => {
+  it('should respect the upper bound (last index)', () => {
     const result = buildContextSnippet(lines, [9]);
     expect(result).toContain('Linha 7');
     expect(result).toContain('Linha 8');
     expect(result).toContain('Linha 9');
   });
 
-  it('deve limitar a 3 matches para contexto', () => {
+  it('should limit the context to 3 matches', () => {
     const result = buildContextSnippet(lines, [0, 3, 6, 9]);
     // Deve ter no maximo 3 separadores "..." (um por match usado)
     const ellipsisCount = (result.match(/\.\.\./g) || []).length;
     expect(ellipsisCount).toBeLessThanOrEqual(3);
   });
 
-  it('deve nao duplicar linhas em matches proximos', () => {
+  it('should not duplicate lines when matches are close to each other', () => {
     const result = buildContextSnippet(lines, [4, 5]);
     const resultLines = result.split('\n').filter(l => l !== '...' && l !== '');
     const uniqueLines = [...new Set(resultLines)];
     expect(resultLines.length).toBe(uniqueLines.length);
   });
 
-  it('deve retornar string vazia para array de indexes vazio', () => {
+  it('should return an empty string for an empty index array', () => {
     expect(buildContextSnippet(lines, [])).toBe('');
   });
 
-  it('deve incluir separador ... apos cada bloco de contexto', () => {
+  it('should append the ... separator after each context block', () => {
     const result = buildContextSnippet(lines, [2]);
     expect(result).toContain('...');
   });
@@ -220,54 +220,54 @@ describe('searchFullText', () => {
     '| p-required | boolean |'
   ].join('\n');
 
-  it('deve encontrar resultados em multiplas secoes', () => {
+  it('should find results across multiple sections', () => {
     const results = searchFullText(fullText, 'p-loading', 10);
     expect(results).toHaveLength(2);
     expect(results[0].componentName).toBe('PoButtonComponent');
     expect(results[1].componentName).toBe('PoInputComponent');
   });
 
-  it('deve ser case-insensitive', () => {
+  it('should be case-insensitive', () => {
     const results = searchFullText(fullText, 'P-LOADING', 10);
     expect(results).toHaveLength(2);
   });
 
-  it('deve respeitar maxResults', () => {
+  it('should respect maxResults', () => {
     const results = searchFullText(fullText, 'p-loading', 1);
     expect(results).toHaveLength(1);
     expect(results[0].componentName).toBe('PoButtonComponent');
   });
 
-  it('deve retornar array vazio quando nao encontra', () => {
+  it('should return an empty array when there is no match', () => {
     const results = searchFullText(fullText, 'xyznonexistent', 10);
     expect(results).toHaveLength(0);
   });
 
-  it('deve retornar array vazio para texto vazio', () => {
+  it('should return an empty array for an empty text', () => {
     const results = searchFullText('', 'busca', 10);
     expect(results).toHaveLength(0);
   });
 
-  it('deve retornar "Desconhecido" quando secao nao tem heading', () => {
+  it('should return "Desconhecido" when the section has no heading', () => {
     const text = 'Secao sem heading\nalgum texto com busca\noutro texto';
     const results = searchFullText(text, 'busca', 10);
     expect(results).toHaveLength(1);
     expect(results[0].componentName).toBe('Desconhecido');
   });
 
-  it('deve incluir contexto no resultado', () => {
+  it('should include the context in the result', () => {
     const results = searchFullText(fullText, 'lazy load', 10);
     expect(results).toHaveLength(1);
     expect(results[0].context).toContain('lazy load');
     expect(results[0].context).toContain('...');
   });
 
-  it('deve encontrar todas as secoes quando query e comum', () => {
+  it('should find every section when the query is common to all of them', () => {
     const results = searchFullText(fullText, 'Propriedade', 10);
     expect(results).toHaveLength(3);
   });
 
-  it('deve ter componentName e context como strings nao-vazias', () => {
+  it('should return componentName and context as non-empty strings', () => {
     const results = searchFullText(fullText, 'tabela', 10);
     expect(results).toHaveLength(1);
     expect(typeof results[0].componentName).toBe('string');
@@ -276,7 +276,7 @@ describe('searchFullText', () => {
     expect(results[0].context.length).toBeGreaterThan(0);
   });
 
-  it('deve ignorar secao quando contem query no texto completo mas nenhuma linha individual contem', () => {
+  it('should skip a section that matches the whole text but has no single matching line', () => {
     // Query que cruza quebra de linha: presente na secao mas nao em linhas individuais
     const text = 'abc\ndef';
     const results = searchFullText(text, 'abc\ndef', 10);
@@ -284,7 +284,7 @@ describe('searchFullText', () => {
   });
 });
 
-// ── createServer - tool handlers (com mock do McpServer) ────────────────────
+// ── createServer - tool handlers (with a mocked McpServer) ──────────────────
 
 describe('createServer - tool handlers', () => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -302,6 +302,8 @@ describe('createServer - tool handlers', () => {
 
   /* eslint-disable @typescript-eslint/no-var-requires */
   const docsClient = require('./docs-client') as {
+    fetchBestPractices: jest.Mock;
+    fetchComponentExamples: jest.Mock;
     fetchLlmsTxt: jest.Mock;
     fetchLlmsFullTxt: jest.Mock;
     fetchComponentDoc: jest.Mock;
@@ -345,16 +347,18 @@ describe('createServer - tool handlers', () => {
   // ── list_components ──────────────────────────────────────────────────
 
   describe('list_components', () => {
-    it('deve listar todos os componentes com section=all', async () => {
+    it('should list every component with section=all', async () => {
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('list_components')!;
       const result = await handler({ section: 'all' });
       expect(result.content[0].text).toContain('PoButton');
       expect(result.content[0].text).toContain('PoTable');
       expect(result.content[0].text).toContain('PoDialogService');
+      expect(result.structuredContent.count).toBe(4);
+      expect(result.structuredContent.items[0].url).toContain('po-ui.io');
     });
 
-    it('deve usar section=all como padrao quando nao informado', async () => {
+    it('should default to section=all when it is not provided', async () => {
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('list_components')!;
       const result = await handler({});
@@ -362,7 +366,7 @@ describe('createServer - tool handlers', () => {
       expect(result.content[0].text).toContain('PoDialogService');
     });
 
-    it('deve filtrar por section especifica', async () => {
+    it('should filter by a specific section', async () => {
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('list_components')!;
       const result = await handler({ section: 'guides' });
@@ -370,7 +374,7 @@ describe('createServer - tool handlers', () => {
       expect(result.content[0].text).not.toContain('PoButton');
     });
 
-    it('deve aplicar filtro de texto', async () => {
+    it('should apply the free text filter', async () => {
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('list_components')!;
       const result = await handler({ section: 'all', filter: 'tabela' });
@@ -378,29 +382,31 @@ describe('createServer - tool handlers', () => {
       expect(result.content[0].text).not.toContain('PoDialogService');
     });
 
-    it('deve retornar mensagem quando nenhum resultado e encontrado', async () => {
+    it('should return a message when no result is found', async () => {
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('list_components')!;
       const result = await handler({ section: 'all', filter: 'xyzinexistente' });
       expect(result.content[0].text).toContain('Nenhum resultado encontrado');
+      expect(result.structuredContent).toEqual({ count: 0, items: [], section: 'all' });
     });
 
-    it('deve retornar erro quando fetchLlmsTxt falha', async () => {
+    it('should return an error when fetchLlmsTxt fails', async () => {
       docsClient.fetchLlmsTxt.mockRejectedValue(new Error('Network error'));
       const handler = registeredTools.get('list_components')!;
       const result = await handler({ section: 'all' });
       expect(result.content[0].text).toContain('Erro ao carregar');
       expect(result.content[0].text).toContain('Network error');
+      expect(result.isError).toBe(true);
     });
 
-    it('deve agrupar resultados por secao', async () => {
+    it('should group the results by section', async () => {
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('list_components')!;
       const result = await handler({ section: 'all' });
       expect(result.content[0].text).toContain('Componentes e Diretivas');
     });
 
-    it('deve usar cache de entradas na segunda chamada', async () => {
+    it('should reuse the cached entries on the second call', async () => {
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('list_components')!;
       await handler({ section: 'all' });
@@ -408,7 +414,7 @@ describe('createServer - tool handlers', () => {
       expect(docsClient.fetchLlmsTxt).toHaveBeenCalledTimes(1);
     });
 
-    it('deve converter erro nao-Error para string quando fetchLlmsTxt rejeita com valor nao-Error', async () => {
+    it('should stringify a non-Error rejection from fetchLlmsTxt', async () => {
       docsClient.fetchLlmsTxt.mockRejectedValue('erro simples');
       const handler = registeredTools.get('list_components')!;
       const result = await handler({ section: 'all' });
@@ -416,7 +422,7 @@ describe('createServer - tool handlers', () => {
       expect(result.content[0].text).toContain('erro simples');
     });
 
-    it('deve usar nome da secao como fallback quando nao ha label em SECTION_LABELS', async () => {
+    it('should fall back to the raw section name when SECTION_LABELS has no label', async () => {
       docsClient.fetchLlmsTxt.mockResolvedValue(
         '## Secao Desconhecida\n- [Foo](https://po-ui.io/llms-generated/foo.md): descricao'
       );
@@ -429,29 +435,35 @@ describe('createServer - tool handlers', () => {
   // ── get_component_docs ───────────────────────────────────────────────
 
   describe('get_component_docs', () => {
-    it('deve retornar documentacao do componente com sucesso', async () => {
+    it('should return the component documentation successfully', async () => {
       docsClient.fetchComponentDoc.mockResolvedValue('# PoButton\nDocumentacao completa');
       const handler = registeredTools.get('get_component_docs')!;
       const result = await handler({ slug: 'po-button' });
       expect(result.content[0].text).toContain('# PoButton');
       expect(result.content[0].text).toContain('Documentacao completa');
+      expect(result.structuredContent).toEqual({
+        content: '# PoButton\nDocumentacao completa',
+        documentationUrl: 'https://po-ui.io/documentation/po-button',
+        slug: 'po-button',
+        sourceUrl: 'https://po-ui.io/llms-generated/po-button.md'
+      });
     });
 
-    it('deve normalizar slug antes de buscar', async () => {
+    it('should normalise the slug before fetching', async () => {
       docsClient.fetchComponentDoc.mockResolvedValue('# PoButton\nDoc');
       const handler = registeredTools.get('get_component_docs')!;
       await handler({ slug: 'PoButtonComponent' });
       expect(docsClient.fetchComponentDoc).toHaveBeenCalledWith('po-button');
     });
 
-    it('deve normalizar slug com angle brackets', async () => {
+    it('should normalise a slug written with angle brackets', async () => {
       docsClient.fetchComponentDoc.mockResolvedValue('# PoButton\nDoc');
       const handler = registeredTools.get('get_component_docs')!;
       await handler({ slug: '<po-button>' });
       expect(docsClient.fetchComponentDoc).toHaveBeenCalledWith('po-button');
     });
 
-    it('deve tentar slug original quando normalizado falha', async () => {
+    it('should retry with the original slug when the normalised one fails', async () => {
       docsClient.fetchComponentDoc
         .mockRejectedValueOnce(new Error('Not found'))
         .mockResolvedValueOnce('# CustomSlug\nDoc');
@@ -461,15 +473,16 @@ describe('createServer - tool handlers', () => {
       expect(result.content[0].text).toContain('# CustomSlug');
     });
 
-    it('deve retornar sugestoes quando componente nao encontrado', async () => {
+    it('should return suggestions when the component is not found', async () => {
       docsClient.fetchComponentDoc.mockRejectedValue(new Error('Not found'));
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('get_component_docs')!;
       const result = await handler({ slug: 'po-button' });
       expect(result.content[0].text).toContain('n\u00e3o encontrado');
+      expect(result.isError).toBe(true);
     });
 
-    it('deve retornar mensagem generica quando sugestoes falham', async () => {
+    it('should return a generic message when loading the suggestions fails', async () => {
       docsClient.fetchComponentDoc.mockRejectedValue(new Error('Not found'));
       docsClient.fetchLlmsTxt.mockRejectedValue(new Error('Index error'));
       const handler = registeredTools.get('get_component_docs')!;
@@ -478,63 +491,214 @@ describe('createServer - tool handlers', () => {
       expect(result.content[0].text).toContain('list_components');
     });
 
-    it('deve retornar mensagem sem sugestoes quando slug nao corresponde a nenhuma entrada', async () => {
+    it('should return a message without suggestions when the slug matches no entry', async () => {
       docsClient.fetchComponentDoc.mockRejectedValue(new Error('Not found'));
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('get_component_docs')!;
       const result = await handler({ slug: 'xyz-totally-unrelated' });
       expect(result.content[0].text).toContain('Use list_components para ver todos os slugs dispon\u00edveis.');
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // ── get_component_examples ──────────────────────────────────────────
+
+  describe('get_component_examples', () => {
+    const examples = [
+      {
+        name: 'sample-po-button-basic',
+        url: 'https://github.com/po-ui/po-angular/tree/master/sample-po-button-basic',
+        files: [
+          {
+            content: '<po-button></po-button>',
+            language: 'html',
+            name: 'sample-po-button-basic.component.html',
+            url: 'https://github.com/po-ui/po-angular/blob/master/sample-po-button-basic.component.html'
+          }
+        ]
+      }
+    ];
+
+    it('should return official component examples with structured content', async () => {
+      docsClient.fetchComponentExamples.mockResolvedValue({
+        examples,
+        sourceSlug: 'po-button',
+        status: 'available'
+      });
+      const handler = registeredTools.get('get_component_examples')!;
+
+      const result = await handler({ slug: 'PoButtonComponent', example: 'basic', max_examples: 1 });
+
+      expect(docsClient.fetchComponentExamples).toHaveBeenCalledWith('po-button', 1, 'basic');
+      expect(result.content[0].text).toContain('sample-po-button-basic');
+      expect(result.structuredContent.slug).toBe('po-button');
+      expect(result.structuredContent.examples).toEqual(examples);
+      expect(result.structuredContent.sourceSlug).toBe('po-button');
+      expect(result.structuredContent.status).toBe('available');
+    });
+
+    it('should use three examples as the default limit', async () => {
+      docsClient.fetchComponentExamples.mockResolvedValue({
+        examples,
+        sourceSlug: 'po-button',
+        status: 'available'
+      });
+      const handler = registeredTools.get('get_component_examples')!;
+
+      await handler({ slug: 'po-button' });
+
+      expect(docsClient.fetchComponentExamples).toHaveBeenCalledWith('po-button', 3, undefined);
+    });
+
+    it('should identify examples returned from the parent component', async () => {
+      docsClient.fetchComponentExamples.mockResolvedValue({
+        examples,
+        sourceSlug: 'po-tabs',
+        status: 'available'
+      });
+      const handler = registeredTools.get('get_component_examples')!;
+
+      const result = await handler({ slug: 'po-tab' });
+
+      expect(result.content[0].text).toContain('componente pai "po-tabs"');
+      expect(result.structuredContent.sourceSlug).toBe('po-tabs');
+    });
+
+    it('should return structured empty content when no example matches', async () => {
+      docsClient.fetchComponentExamples.mockResolvedValue({
+        examples: [],
+        sourceSlug: 'po-button',
+        status: 'no_match'
+      });
+      const handler = registeredTools.get('get_component_examples')!;
+
+      const result = await handler({ slug: 'po-button', example: 'inexistente' });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('corresponde ao filtro');
+      expect(result.structuredContent.examples).toEqual([]);
+      expect(result.structuredContent.status).toBe('no_match');
+    });
+
+    it('should explain when the component has no official examples', async () => {
+      docsClient.fetchComponentExamples.mockResolvedValue({
+        examples: [],
+        sourceSlug: 'po-navbar',
+        status: 'not_available'
+      });
+      const handler = registeredTools.get('get_component_examples')!;
+
+      const result = await handler({ slug: 'po-navbar' });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('não possui exemplos oficiais próprios');
+      expect(result.structuredContent.status).toBe('not_available');
+    });
+
+    it('should return a tool error when examples cannot be loaded', async () => {
+      docsClient.fetchComponentExamples.mockRejectedValue(new Error('GitHub unavailable'));
+      const handler = registeredTools.get('get_component_examples')!;
+
+      const result = await handler({ slug: 'po-button' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('GitHub unavailable');
+    });
+  });
+
+  // ── get_best_practices ──────────────────────────────────────────────
+
+  describe('get_best_practices', () => {
+    it('should return the selected official source with structured content', async () => {
+      docsClient.fetchBestPractices.mockResolvedValue({
+        content: '# Primeiros passos',
+        title: 'Primeiros passos',
+        url: 'https://github.com/po-ui/po-angular/blob/master/docs/guides/getting-started.md'
+      });
+      const handler = registeredTools.get('get_best_practices')!;
+
+      const result = await handler({ topic: 'getting-started' });
+
+      expect(docsClient.fetchBestPractices).toHaveBeenCalledWith('getting-started');
+      expect(result.content[0].text).toContain('Fonte oficial');
+      expect(result.structuredContent).toEqual({
+        content: '# Primeiros passos',
+        source: {
+          title: 'Primeiros passos',
+          url: 'https://github.com/po-ui/po-angular/blob/master/docs/guides/getting-started.md'
+        },
+        topic: 'getting-started'
+      });
+    });
+
+    it('should return a tool error when best practices cannot be loaded', async () => {
+      docsClient.fetchBestPractices.mockRejectedValue('source unavailable');
+      const handler = registeredTools.get('get_best_practices')!;
+
+      const result = await handler({ topic: 'contributing' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('source unavailable');
     });
   });
 
   // ── search_docs ──────────────────────────────────────────────────────
 
   describe('search_docs', () => {
-    it('deve retornar resultados de busca formatados', async () => {
+    it('should return formatted search results', async () => {
       docsClient.fetchLlmsFullTxt.mockResolvedValue(MOCK_LLMS_FULL_TXT);
       const handler = registeredTools.get('search_docs')!;
       const result = await handler({ query: 'p-loading' });
       expect(result.content[0].text).toContain('Encontrados');
       expect(result.content[0].text).toContain('PoButton');
+      expect(result.structuredContent.results[0]).toEqual(
+        expect.objectContaining({
+          componentName: 'PoButton',
+          slug: 'po-button',
+          url: 'https://po-ui.io/documentation/po-button'
+        })
+      );
     });
 
-    it('deve usar max_results padrao de 10', async () => {
+    it('should default max_results to 10', async () => {
       docsClient.fetchLlmsFullTxt.mockResolvedValue(MOCK_LLMS_FULL_TXT);
       const handler = registeredTools.get('search_docs')!;
       const result = await handler({ query: 'Componente' });
       expect(result.content[0].text).toContain('Encontrados');
     });
 
-    it('deve respeitar max_results personalizado', async () => {
+    it('should respect a custom max_results', async () => {
       docsClient.fetchLlmsFullTxt.mockResolvedValue(MOCK_LLMS_FULL_TXT);
       const handler = registeredTools.get('search_docs')!;
       const result = await handler({ query: 'Componente', max_results: 1 });
       expect(result.content[0].text).toContain('1 resultado(s)');
     });
 
-    it('deve retornar mensagem quando nao encontra resultados', async () => {
+    it('should return a message when there is no result', async () => {
       docsClient.fetchLlmsFullTxt.mockResolvedValue(MOCK_LLMS_FULL_TXT);
       const handler = registeredTools.get('search_docs')!;
       const result = await handler({ query: 'xyzinexistente' });
       expect(result.content[0].text).toContain('Nenhum resultado encontrado');
+      expect(result.structuredContent).toEqual({ count: 0, query: 'xyzinexistente', results: [] });
     });
 
-    it('deve retornar erro quando fetchLlmsFullTxt falha', async () => {
+    it('should return an error when fetchLlmsFullTxt fails', async () => {
       docsClient.fetchLlmsFullTxt.mockRejectedValue(new Error('Timeout'));
       const handler = registeredTools.get('search_docs')!;
       const result = await handler({ query: 'botao' });
       expect(result.content[0].text).toContain('Erro ao carregar');
       expect(result.content[0].text).toContain('Timeout');
+      expect(result.isError).toBe(true);
     });
 
-    it('deve incluir contexto nos resultados', async () => {
+    it('should include the context in the results', async () => {
       docsClient.fetchLlmsFullTxt.mockResolvedValue(MOCK_LLMS_FULL_TXT);
       const handler = registeredTools.get('search_docs')!;
       const result = await handler({ query: 'lazy load' });
       expect(result.content[0].text).toContain('PoTable');
     });
 
-    it('deve converter erro nao-Error para string no search_docs', async () => {
+    it('should stringify a non-Error rejection in search_docs', async () => {
       docsClient.fetchLlmsFullTxt.mockRejectedValue('timeout string');
       const handler = registeredTools.get('search_docs')!;
       const result = await handler({ query: 'botao' });
@@ -546,15 +710,20 @@ describe('createServer - tool handlers', () => {
   // ── get_guide ────────────────────────────────────────────────────────
 
   describe('get_guide', () => {
-    it('deve retornar conteudo do guia com sucesso', async () => {
+    it('should return the guide content successfully', async () => {
       docsClient.fetchGuide.mockResolvedValue('# Getting Started\nConteudo do guia');
       const handler = registeredTools.get('get_guide')!;
       const result = await handler({ guide: 'getting-started' });
       expect(result.content[0].text).toContain('# Getting Started');
       expect(result.content[0].text).toContain('Conteudo do guia');
+      expect(result.structuredContent).toEqual({
+        content: '# Getting Started\nConteudo do guia',
+        guide: 'getting-started',
+        url: 'https://github.com/po-ui/po-angular/blob/master/docs/guides/getting-started.md'
+      });
     });
 
-    it('deve retornar erro com lista de guias disponiveis quando falha', async () => {
+    it('should return an error listing the available guides when it fails', async () => {
       docsClient.fetchGuide.mockRejectedValue(new Error('Not found'));
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('get_guide')!;
@@ -562,9 +731,10 @@ describe('createServer - tool handlers', () => {
       expect(result.content[0].text).toContain('Erro');
       expect(result.content[0].text).toContain('Guias dispon\u00edveis');
       expect(result.content[0].text).toContain('Getting Started');
+      expect(result.isError).toBe(true);
     });
 
-    it('deve retornar apenas erro quando indice tambem falha', async () => {
+    it('should return only the error when the index also fails', async () => {
       docsClient.fetchGuide.mockRejectedValue(new Error('Not found'));
       docsClient.fetchLlmsTxt.mockRejectedValue(new Error('Index error'));
       const handler = registeredTools.get('get_guide')!;
@@ -573,7 +743,7 @@ describe('createServer - tool handlers', () => {
       expect(result.content[0].text).toContain('Not found');
     });
 
-    it('deve converter erro nao-Error para string no get_guide', async () => {
+    it('should stringify a non-Error rejection in get_guide', async () => {
       docsClient.fetchGuide.mockRejectedValue('string error');
       docsClient.fetchLlmsTxt.mockResolvedValue(MOCK_LLMS_TXT);
       const handler = registeredTools.get('get_guide')!;
@@ -582,7 +752,7 @@ describe('createServer - tool handlers', () => {
       expect(result.content[0].text).toContain('string error');
     });
 
-    it('deve exibir "Nenhum guia no indice" quando nao ha guias no indice', async () => {
+    it('should show "Nenhum guia no índice" when the index has no guide', async () => {
       docsClient.fetchGuide.mockRejectedValue(new Error('Not found'));
       docsClient.fetchLlmsTxt.mockResolvedValue(
         '## Componentes e Diretivas\n- [PoButton](https://po-ui.io/llms-generated/po-button.md): Componente'
@@ -591,19 +761,54 @@ describe('createServer - tool handlers', () => {
       const result = await handler({ guide: 'xyz' });
       expect(result.content[0].text).toContain('Nenhum guia no \u00edndice');
     });
+
+    it('should strip the .md extension from the returned guide name', async () => {
+      docsClient.fetchGuide.mockResolvedValue('# Getting Started');
+      const handler = registeredTools.get('get_guide')!;
+      const result = await handler({ guide: 'getting-started.md' });
+      expect(result.structuredContent).toEqual({
+        content: '# Getting Started',
+        guide: 'getting-started',
+        url: 'https://github.com/po-ui/po-angular/blob/master/docs/guides/getting-started.md'
+      });
+      expect(docsClient.fetchGuide).toHaveBeenCalledWith('getting-started.md');
+    });
+  });
+
+  // ── getErrorMessage (via handlers) ───────────────────────────────────
+
+  describe('getErrorMessage', () => {
+    it('should serialise with JSON.stringify an error that is neither Error nor string', async () => {
+      docsClient.fetchLlmsTxt.mockRejectedValue({ code: 500, reason: 'rate limit' });
+      const handler = registeredTools.get('list_components')!;
+      const result = await handler({ section: 'all' });
+      expect(result.content[0].text).toContain('Erro ao carregar');
+      expect(result.content[0].text).toContain('{"code":500,"reason":"rate limit"}');
+      expect(result.isError).toBe(true);
+    });
+
+    it('should return "Erro desconhecido." when the error cannot be serialised', async () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      docsClient.fetchLlmsTxt.mockRejectedValue(circular);
+      const handler = registeredTools.get('list_components')!;
+      const result = await handler({ section: 'all' });
+      expect(result.content[0].text).toContain('Erro desconhecido.');
+      expect(result.isError).toBe(true);
+    });
   });
 });
 
-// ── createServer (instancia real) ───────────────────────────────────────────
+// ── createServer (real instance) ────────────────────────────────────────────
 
 describe('createServer', () => {
-  it('deve criar uma instancia do McpServer', () => {
+  it('should create an McpServer instance', () => {
     const server = createServer();
     expect(server).toBeDefined();
     expect(typeof server).toBe('object');
   });
 
-  it('deve ter o nome "po-ui"', () => {
+  it('should be named "po-ui"', () => {
     const server = createServer();
     expect(server).toBeDefined();
   });

--- a/projects/mcp/src/server.ts
+++ b/projects/mcp/src/server.ts
@@ -1,6 +1,16 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { fetchLlmsTxt, fetchLlmsFullTxt, fetchComponentDoc, fetchGuide } from './docs-client';
+import {
+  BEST_PRACTICE_TOPICS,
+  BestPracticeTopic,
+  ComponentExample,
+  fetchBestPractices,
+  fetchComponentDoc,
+  fetchComponentExamples,
+  fetchGuide,
+  fetchLlmsFullTxt,
+  fetchLlmsTxt
+} from './docs-client';
 import { parseLlmsTxt, LlmsEntry } from './llms-parser';
 
 // Session-scoped cache for the llms.txt index
@@ -49,6 +59,62 @@ export function normaliseSlug(input: string): string {
 interface SearchResult {
   componentName: string;
   context: string;
+}
+
+type ComponentSection = 'components' | 'services' | 'interfaces' | 'enums' | 'guides' | 'all';
+
+interface ToolRegistration {
+  description: string;
+  inputSchema: Record<string, z.ZodTypeAny>;
+  outputSchema?: Record<string, z.ZodTypeAny>;
+}
+
+type RegisterToolWithoutSdkInference = (name: string, registration: ToolRegistration, handler: unknown) => void;
+
+const PO_UI_URL = 'https://po-ui.io';
+
+function getComponentDocumentationUrl(slug: string): string {
+  return `${PO_UI_URL}/documentation/${slug}`;
+}
+
+function getComponentSourceUrl(slug: string): string {
+  return `${PO_UI_URL}/llms-generated/${slug}.md`;
+}
+
+function getGuideUrl(guide: string): string {
+  return `https://github.com/po-ui/po-angular/blob/master/docs/guides/${guide}.md`;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return 'Erro desconhecido.';
+  }
+}
+
+function createToolError(message: string): { content: Array<{ type: 'text'; text: string }>; isError: true } {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+function formatExamples(examples: Array<ComponentExample>): string {
+  return examples
+    .map(example => {
+      const files = example.files
+        .map(file => `#### [${file.name}](${file.url})\n\n\`\`\`${file.language}\n${file.content}\n\`\`\``)
+        .join('\n\n');
+
+      return `### [${example.name}](${example.url})\n\n${files}`;
+    })
+    .join('\n\n');
 }
 
 /** Extract the heading text from the first `# ...` line, or fallback. */
@@ -125,10 +191,10 @@ export function createServer(): McpServer {
     name: 'po-ui',
     version: '1.0.0'
   });
+  const registerTool = server.registerTool.bind(server) as unknown as RegisterToolWithoutSdkInference;
 
   // ── list_components ─────────────────────────────────────────────────────────
-  // @ts-ignore — TS2589: limitação de inferência genérica do @modelcontextprotocol/sdk com zod
-  server.registerTool(
+  registerTool(
     'list_components',
     {
       description:
@@ -140,16 +206,28 @@ export function createServer(): McpServer {
           .optional()
           .describe('Filtrar por seção: "components", "services", "interfaces", "enums", "guides" ou "all" (padrão).'),
         filter: z.string().optional().describe('Filtro de texto livre no nome ou descrição (case-insensitive).')
+      },
+      outputSchema: {
+        count: z.number().int(),
+        items: z.array(
+          z.object({
+            description: z.string(),
+            name: z.string(),
+            section: z.string(),
+            slug: z.string(),
+            url: z.string()
+          })
+        ),
+        section: z.string()
       }
     },
-    async ({ section, filter }) => {
+    async ({ section, filter }: { section?: ComponentSection; filter?: string }) => {
       const resolvedSection = section ?? 'all';
       let entries: LlmsEntry[];
       try {
         entries = await getLlmsEntries();
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text', text: `Erro ao carregar índice: ${msg}` }] };
+        return createToolError(`Erro ao carregar índice: ${getErrorMessage(err)}`);
       }
 
       let results = resolvedSection === 'all' ? entries : entries.filter(e => e.section === resolvedSection);
@@ -160,7 +238,10 @@ export function createServer(): McpServer {
       }
 
       if (results.length === 0) {
-        return { content: [{ type: 'text', text: 'Nenhum resultado encontrado.' }] };
+        return {
+          content: [{ type: 'text' as const, text: 'Nenhum resultado encontrado.' }],
+          structuredContent: { count: 0, items: [], section: resolvedSection }
+        };
       }
 
       // Group by section
@@ -181,12 +262,25 @@ export function createServer(): McpServer {
         lines.push('');
       }
 
-      return { content: [{ type: 'text', text: lines.join('\n') }] };
+      return {
+        content: [{ type: 'text' as const, text: lines.join('\n') }],
+        structuredContent: {
+          count: results.length,
+          items: results.map(item => ({
+            description: item.description,
+            name: item.name,
+            section: item.section,
+            slug: item.slug,
+            url: item.url
+          })),
+          section: resolvedSection
+        }
+      };
     }
   );
 
   // ── get_component_docs ───────────────────────────────────────────────────────
-  server.registerTool(
+  registerTool(
     'get_component_docs',
     {
       description:
@@ -200,20 +294,42 @@ export function createServer(): McpServer {
               'Aceita também nomes de classe ("PoButtonComponent") e seletores HTML ("<po-button>"). ' +
               'Use list_components para descobrir slugs disponíveis.'
           )
+      },
+      outputSchema: {
+        content: z.string(),
+        documentationUrl: z.string(),
+        slug: z.string(),
+        sourceUrl: z.string()
       }
     },
-    async ({ slug }) => {
+    async ({ slug }: { slug: string }) => {
       const normalised = normaliseSlug(slug);
 
       try {
         const markdown = await fetchComponentDoc(normalised);
-        return { content: [{ type: 'text', text: markdown }] };
+        return {
+          content: [{ type: 'text' as const, text: markdown }],
+          structuredContent: {
+            content: markdown,
+            documentationUrl: getComponentDocumentationUrl(normalised),
+            slug: normalised,
+            sourceUrl: getComponentSourceUrl(normalised)
+          }
+        };
       } catch {
         // If normalised slug failed, try the original input as-is
         if (normalised !== slug) {
           try {
             const markdown = await fetchComponentDoc(slug);
-            return { content: [{ type: 'text', text: markdown }] };
+            return {
+              content: [{ type: 'text' as const, text: markdown }],
+              structuredContent: {
+                content: markdown,
+                documentationUrl: getComponentDocumentationUrl(slug),
+                slug,
+                sourceUrl: getComponentSourceUrl(slug)
+              }
+            };
           } catch {
             // Fall through to error with suggestions
           }
@@ -224,40 +340,152 @@ export function createServer(): McpServer {
           const entries = await getLlmsEntries();
           const q = normalised.toLowerCase();
           const suggestions = entries
-            .filter(e => e.slug.includes(q) || q.includes(e.slug.split('-')[0] ?? ''))
+            .filter(e => e.slug.includes(q) || q.includes(e.slug.split('-')[0]))
             .slice(0, 5)
             .map(e => `- ${e.name} (\`${e.slug}\`)`)
             .join('\n');
 
-          return {
-            content: [
-              {
-                type: 'text',
-                text:
-                  `Componente "${slug}" não encontrado.\n\n` +
-                  (suggestions
-                    ? `Sugestões:\n${suggestions}\n\nUse list_components para ver todos.`
-                    : 'Use list_components para ver todos os slugs disponíveis.')
-              }
-            ]
-          };
+          return createToolError(
+            `Componente "${slug}" não encontrado.\n\n` +
+              (suggestions
+                ? `Sugestões:\n${suggestions}\n\nUse list_components para ver todos.`
+                : 'Use list_components para ver todos os slugs disponíveis.')
+          );
         } catch {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Componente "${slug}" não encontrado. Use list_components para ver os slugs disponíveis.`
-              }
-            ]
-          };
+          return createToolError(
+            `Componente "${slug}" não encontrado. Use list_components para ver os slugs disponíveis.`
+          );
         }
       }
     }
   );
 
+  // ── get_component_examples ──────────────────────────────────────────────────
+  registerTool(
+    'get_component_examples',
+    {
+      description:
+        'Retorna exemplos oficiais de um componente PO UI diretamente do repositório. ' +
+        'Inclui os arquivos TypeScript, HTML e estilos necessários para compreender cada exemplo.',
+      inputSchema: {
+        slug: z.string().describe('Slug do componente. Exemplos: "po-button", "po-table" ou "PoButtonComponent".'),
+        example: z
+          .string()
+          .optional()
+          .describe('Filtro opcional pelo nome do exemplo. Exemplos: "basic", "labs" ou "airfare".'),
+        max_examples: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .optional()
+          .describe('Quantidade máxima de exemplos. Padrão: 3. Máximo: 5.')
+      },
+      outputSchema: {
+        documentationUrl: z.string(),
+        examples: z.array(
+          z.object({
+            files: z.array(z.object({ content: z.string(), language: z.string(), name: z.string(), url: z.string() })),
+            name: z.string(),
+            url: z.string()
+          })
+        ),
+        slug: z.string(),
+        sourceSlug: z.string(),
+        status: z.enum(['available', 'no_match', 'not_available'])
+      }
+    },
+    async ({ slug, example, max_examples }: { slug: string; example?: string; max_examples?: number }) => {
+      const normalised = normaliseSlug(slug);
+
+      try {
+        const result = await fetchComponentExamples(normalised, max_examples ?? 3, example);
+        const structuredContent = {
+          documentationUrl: getComponentDocumentationUrl(normalised),
+          examples: result.examples,
+          slug: normalised,
+          sourceSlug: result.sourceSlug,
+          status: result.status
+        };
+
+        if (result.status === 'not_available') {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `O componente "${normalised}" não possui exemplos oficiais próprios. Consulte ${structuredContent.documentationUrl}.`
+              }
+            ],
+            structuredContent
+          };
+        }
+
+        if (result.status === 'no_match') {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Nenhum exemplo de "${result.sourceSlug}" corresponde ao filtro "${example}".`
+              }
+            ],
+            structuredContent
+          };
+        }
+
+        const parentNotice =
+          result.sourceSlug === normalised
+            ? ''
+            : `Os exemplos abaixo pertencem ao componente pai "${result.sourceSlug}".\n\n`;
+
+        return {
+          content: [{ type: 'text' as const, text: `${parentNotice}${formatExamples(result.examples)}` }],
+          structuredContent
+        };
+      } catch (err) {
+        return createToolError(`Erro ao carregar exemplos de "${slug}": ${getErrorMessage(err)}`);
+      }
+    }
+  );
+
+  // ── get_best_practices ──────────────────────────────────────────────────────
+  registerTool(
+    'get_best_practices',
+    {
+      description:
+        'Retorna recomendações oficiais do PO UI para contribuição, fluxo de desenvolvimento, ' +
+        'configuração inicial ou customização de temas.',
+      inputSchema: {
+        topic: z
+          .enum(BEST_PRACTICE_TOPICS)
+          .describe('Tema das recomendações: contributing, development-flow, getting-started ou theme-service.')
+      },
+      outputSchema: {
+        content: z.string(),
+        source: z.object({ title: z.string(), url: z.string() }),
+        topic: z.string()
+      }
+    },
+    async ({ topic }: { topic: BestPracticeTopic }) => {
+      try {
+        const document = await fetchBestPractices(topic);
+        const text = `Fonte oficial: ${document.url}\n\n${document.content}`;
+
+        return {
+          content: [{ type: 'text' as const, text }],
+          structuredContent: {
+            content: document.content,
+            source: { title: document.title, url: document.url },
+            topic
+          }
+        };
+      } catch (err) {
+        return createToolError(`Erro ao carregar boas práticas de "${topic}": ${getErrorMessage(err)}`);
+      }
+    }
+  );
+
   // ── search_docs ──────────────────────────────────────────────────────────────
-  // @ts-ignore — TS2589: limitação de inferência genérica do @modelcontextprotocol/sdk com zod
-  server.registerTool(
+  registerTool(
     'search_docs',
     {
       description:
@@ -275,23 +503,44 @@ export function createServer(): McpServer {
           .max(50)
           .optional()
           .describe('Número máximo de resultados (padrão: 10, máximo: 50).')
+      },
+      outputSchema: {
+        count: z.number().int(),
+        query: z.string(),
+        results: z.array(
+          z.object({
+            componentName: z.string(),
+            context: z.string(),
+            slug: z.string(),
+            url: z.string()
+          })
+        )
       }
     },
-    async ({ query, max_results }) => {
+    async ({ query, max_results }: { query: string; max_results?: number }) => {
       const limit = max_results ?? 10;
       let fullText: string;
       try {
         fullText = await fetchLlmsFullTxt();
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text', text: `Erro ao carregar documentação completa: ${msg}` }] };
+        return createToolError(`Erro ao carregar documentação completa: ${getErrorMessage(err)}`);
       }
 
       const results = searchFullText(fullText, query, limit);
+      const structuredResults = results.map(result => {
+        const slug = normaliseSlug(result.componentName);
+        return {
+          componentName: result.componentName,
+          context: result.context,
+          slug,
+          url: getComponentDocumentationUrl(slug)
+        };
+      });
 
       if (results.length === 0) {
         return {
-          content: [{ type: 'text', text: `Nenhum resultado encontrado para "${query}".` }]
+          content: [{ type: 'text' as const, text: `Nenhum resultado encontrado para "${query}".` }],
+          structuredContent: { count: 0, query, results: [] }
         };
       }
 
@@ -300,12 +549,15 @@ export function createServer(): McpServer {
         ...results.map((r, i) => `### Resultado ${i + 1}: ${r.componentName}\n\`\`\`\n${r.context}\n\`\`\``)
       ].join('\n\n');
 
-      return { content: [{ type: 'text', text: output }] };
+      return {
+        content: [{ type: 'text' as const, text: output }],
+        structuredContent: { count: structuredResults.length, query, results: structuredResults }
+      };
     }
   );
 
   // ── get_guide ────────────────────────────────────────────────────────────────
-  server.registerTool(
+  registerTool(
     'get_guide',
     {
       description:
@@ -318,14 +570,23 @@ export function createServer(): McpServer {
             'Nome do guia sem extensão. Exemplos: "getting-started", "schematics", "browser-support", "llms". ' +
               'Aceita também com extensão: "getting-started.md".'
           )
+      },
+      outputSchema: {
+        content: z.string(),
+        guide: z.string(),
+        url: z.string()
       }
     },
-    async ({ guide }) => {
+    async ({ guide }: { guide: string }) => {
+      const guideName = guide.endsWith('.md') ? guide.slice(0, -3) : guide;
       try {
         const content = await fetchGuide(guide);
-        return { content: [{ type: 'text', text: content }] };
+        return {
+          content: [{ type: 'text' as const, text: content }],
+          structuredContent: { content, guide: guideName, url: getGuideUrl(guideName) }
+        };
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
+        const msg = getErrorMessage(err);
 
         // Build helpful error with guide list from the index
         try {
@@ -335,16 +596,9 @@ export function createServer(): McpServer {
             .map(e => `- ${e.name} (\`${e.slug}\`)`)
             .join('\n');
 
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Erro: ${msg}\n\nGuias disponíveis:\n${guideList || 'Nenhum guia no índice.'}`
-              }
-            ]
-          };
+          return createToolError(`Erro: ${msg}\n\nGuias disponíveis:\n${guideList || 'Nenhum guia no índice.'}`);
         } catch {
-          return { content: [{ type: 'text', text: `Erro: ${msg}` }] };
+          return createToolError(`Erro: ${msg}`);
         }
       }
     }

--- a/projects/mcp/tsconfig.spec.json
+++ b/projects/mcp/tsconfig.spec.json
@@ -5,7 +5,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "declaration": false,
-    "sourceMap": false,
+    "sourceMap": true,
     "outDir": null
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
Amplia o servidor MCP @po-ui/mcp com duas novas ferramentas e enriquece as existentes com respostas estruturadas, mantendo total retrocompatibilidade.

**O que muda?**
Novas ferramentas!

**get_component_examples**: retorna exemplos oficiais de um componente buscados direto do repositório po-ui/po-angular. Inclui o conteúdo de cada arquivo (TS, HTML, estilos, config) e o link do código-fonte. Aceita filtro por nome do exemplo (example) e limite de resultados (max_examples, padrão 3, máx 5). Quando o componente não tem exemplos próprios, resolve automaticamente para o componente pai (ex.: po-tab → po-tabs) e sinaliza a origem.

**get_best_practices**: retorna, em Markdown, documentos oficiais de boas práticas (contributing, development-flow, getting-started, theme-service) com título e link da fonte.

**Melhorias nas ferramentas existentes**
**list_components**, **get_component_docs**, **search_docs** e **get_guide** agora retornam **structuredContent** + **outputSchema**, além do content em texto (aditivo, sem breaking change).

**Erros passam a retornar isError: true, conforme o protocolo MCP.**

Substituição dos @ts-ignore (TS2589) por um cast tipado, sem suprimir checagem no restante do arquivo.

**Segurança / higiene HTTP**
O header Accept: application/vnd.github+json passa a ser enviado apenas nas chamadas a api.github.com, deixando de ser incluído (incorretamente) nas requisições a po-ui.io e raw.githubusercontent.com. 
O User-Agent: po-ui-mcp é mantido em todas as requisições (obrigatório para a API do GitHub).

**Documentação**
README atualizado: "quatro" → "seis" ferramentas, novas seções das ferramentas, tabela de fontes de dados ampliada e nova seção sobre a limitação de taxa da API do GitHub (60 req/h sem autenticação, com mitigação via cache da árvore do repositório por sessão).

**Compatibilidade**
Sem breaking changes. 
As ferramentas existentes preservam nome, inputSchema e o campo content; todas as adições são aditivas. Clientes que consomem apenas o texto continuam funcionando sem alteração.

**Notas de implementação**
A árvore do repositório do GitHub é carregada uma vez e mantida em cache por sessão; apenas a primeira chamada a get_component_examples consulta a API, as demais reutilizam o resultado em memória.
Requisições possuem timeout de 10s e seguem redirects.
