### PR TITLE
docs(lookup): indica importar PoDynamicModule com p-advanced-filters

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -308,6 +308,11 @@ export abstract class PoLookupBaseComponent
    *
    * > Caso não seja passado um objeto ou então ele esteja em branco o link de busca avançada ficará escondido.
    *
+   * > A busca avançada é construída a partir do `po-dynamic-form`. Em aplicações que não importam o `PoModule`,
+   * como projetos *standalone* ou que utilizam módulos específicos, é necessário importar o `PoDynamicModule`
+   * no componente ou módulo onde o `po-lookup` é utilizado, caso contrário será lançado o erro
+   * `NG0201: No provider found for _TitleCasePipe` ao abrir a busca avançada.
+   *
    * Exemplo de URL com busca avançada:
    *
    * ```

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -71,6 +71,21 @@ const providers = [
  *   </po-lookup>
  *   ```
  *
+ * - Ao utilizar a propriedade `p-advanced-filters`, a janela de busca avançada é construída
+ * a partir do `po-dynamic-form`. Em aplicações que não importam o `PoModule`, como projetos
+ * *standalone* ou que utilizam módulos específicos, é necessário importar o `PoDynamicModule`
+ * no componente ou módulo onde o `po-lookup` é utilizado, caso contrário será lançado o erro
+ * `NG0201: No provider found for _TitleCasePipe` ao abrir a busca avançada.
+ *   ```
+ *   import { PoDynamicModule, PoFieldModule } from '@po-ui/ng-components';
+ *
+ *   @Component({
+ *     standalone: true,
+ *     imports: [PoFieldModule, PoDynamicModule]
+ *   })
+ *   export class MyComponent {}
+ *   ```
+ *
  * #### Tokens customizáveis
  *
  * É possível alterar o estilo do componente usando os seguintes tokens (CSS):


### PR DESCRIPTION
A busca avançada do po-lookup é construída a partir do po-dynamic-form, que depende do TitleCasePipe fornecido pelo PoDynamicModule. Em aplicações standalone ou que não importam o PoModule, abrir a busca avançada lança o erro NG0201: No provider found for _TitleCasePipe.

Documenta na descrição do componente a necessidade de importar o PoDynamicModule quando a propriedade p-advanced-filters é utilizada.