### PR TITLE
fix(calendar): corrige exibição de anos nos modos month-year/year

### DIFF
--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.spec.ts
@@ -65,6 +65,28 @@ describe('PoCalendarBaseComponent:', () => {
       expect(component.poDate.getDateForDateRange).toHaveBeenCalledWith(minDate, true);
       expect(component.minDate).toEqual(dateExpected);
     });
+
+    it('p-year-range-limit: should accept a valid number', () => {
+      component.yearRangeLimit = 50;
+
+      expect(component.yearRangeLimit).toBe(50);
+    });
+
+    it('p-year-range-limit: should fallback to 150 when value is null', () => {
+      component.yearRangeLimit = null;
+
+      expect(component.yearRangeLimit).toBe(150);
+    });
+
+    it('p-year-range-limit: should fallback to 150 when value is undefined', () => {
+      component.yearRangeLimit = undefined;
+
+      expect(component.yearRangeLimit).toBe(150);
+    });
+
+    it('p-year-range-limit: should have default value of 150', () => {
+      expect(component.yearRangeLimit).toBe(150);
+    });
   });
 
   describe('Methods:', () => {

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
@@ -342,7 +342,15 @@ export class PoCalendarBaseComponent {
   //
   //  O valor informado determina o intervalo de anos anterior e posterior
   //  à data corrente que será disponibilizado para seleção.
-  @Input('p-year-range-limit') yearRangeLimit?: number = 150;
+  @Input('p-year-range-limit') set yearRangeLimit(value: number) {
+    this._yearRangeLimit = value ?? 150;
+  }
+
+  get yearRangeLimit(): number {
+    return this._yearRangeLimit;
+  }
+
+  private _yearRangeLimit: number = 150;
 
   // --- Outputs ---
 

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
@@ -2071,6 +2071,51 @@ describe('PoCalendarComponent:', () => {
 
         expect(component.displayYears.length).toBe(0);
       });
+
+      it('should initialize displayYears with 301 items when yearRangeLimit is undefined', () => {
+        component.mode = PoCalendarMode.MonthYear;
+        component.yearRangeLimit = undefined;
+
+        component.ngOnInit();
+
+        expect(component.displayYears.length).toBe(301);
+      });
+
+      it('should initialize displayYears with 301 items when yearRangeLimit is null', () => {
+        component.mode = PoCalendarMode.Year;
+        component.yearRangeLimit = null;
+
+        component.ngOnInit();
+
+        expect(component.displayYears.length).toBe(301);
+      });
+
+      it('should fallback to 150 when internal _yearRangeLimit is bypassed as undefined', () => {
+        component.mode = PoCalendarMode.MonthYear;
+        component['_yearRangeLimit'] = undefined;
+
+        component.ngOnInit();
+
+        expect(component.displayYears.length).toBe(301);
+      });
+
+      it('should fallback to 150 when internal _yearRangeLimit is bypassed as null', () => {
+        component.mode = PoCalendarMode.Year;
+        component['_yearRangeLimit'] = null;
+
+        component.ngOnInit();
+
+        expect(component.displayYears.length).toBe(301);
+      });
+
+      it('should initialize displayYears respecting custom yearRangeLimit', () => {
+        component.mode = PoCalendarMode.Year;
+        component.yearRangeLimit = 10;
+
+        component.ngOnInit();
+
+        expect(component.displayYears.length).toBe(21);
+      });
     });
   });
 

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.ts
@@ -339,11 +339,9 @@ export class PoCalendarComponent extends PoCalendarBaseComponent implements OnIn
     this.displayMonths = this.poCalendarLangService.getMonthsArray();
 
     const currentYear = new Date().getFullYear();
+    const rangeLimit = this.yearRangeLimit ?? 150;
 
-    this.displayYears = Array.from(
-      { length: this.yearRangeLimit * 2 + 1 },
-      (_, i) => currentYear - this.yearRangeLimit + i
-    );
+    this.displayYears = Array.from({ length: rangeLimit * 2 + 1 }, (_, i) => currentYear - rangeLimit + i);
   }
 
   getActivateDate(partType) {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -914,6 +914,28 @@ describe('PoDatepickerBaseComponent:', () => {
         expect((component as any).applySizeBasedOnA11y).toHaveBeenCalled();
       });
     });
+
+    it('p-year-range-limit: should accept a valid number', () => {
+      component.yearRangeLimit = 50;
+
+      expect(component.yearRangeLimit).toBe(50);
+    });
+
+    it('p-year-range-limit: should fallback to 150 when value is null', () => {
+      component.yearRangeLimit = null;
+
+      expect(component.yearRangeLimit).toBe(150);
+    });
+
+    it('p-year-range-limit: should fallback to 150 when value is undefined', () => {
+      component.yearRangeLimit = undefined;
+
+      expect(component.yearRangeLimit).toBe(150);
+    });
+
+    it('p-year-range-limit: should have default value of 150', () => {
+      expect(component.yearRangeLimit).toBe(150);
+    });
   });
 
   describe('Getters:', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -136,7 +136,15 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
    *
    * @default 150
    */
-  @Input('p-year-range-limit') yearRangeLimit?: number = 150;
+  @Input('p-year-range-limit') set yearRangeLimit(value: number) {
+    this._yearRangeLimit = value ?? 150;
+  }
+
+  get yearRangeLimit(): number {
+    return this._yearRangeLimit;
+  }
+
+  private _yearRangeLimit: number = 150;
 
   /**
    *


### PR DESCRIPTION
Corrige a não exibição da lista de anos nos modos month-year e year do po-datepicker/po-calendar quando renderizado via po-dynamic-form. Quando o p-year-range-limit recebia undefined por binding sem valor definido, o cálculo resultava em NaN, gerando um array de anos vazio.

Fixes DTHFUI-13697

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [ ] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [ ] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [ ] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [ ] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [ ] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [ ] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
[app-year-dynamic-form.zip](https://github.com/user-attachments/files/31566691/app-year-dynamic-form.zip)
