### PR TITLE
[POC] feat(chart): adiciona padrões em gráficos de barra

### DIFF
--- a/projects/ui/src/lib/components/po-chart/index.ts
+++ b/projects/ui/src/lib/components/po-chart/index.ts
@@ -9,5 +9,7 @@ export * from './interfaces/po-chart-literals.interface';
 export * from './interfaces/po-chart-options.interface';
 export * from './interfaces/po-chart-serie.interface';
 
+export * from './services/po-chart-pattern.service';
+
 export * from './po-chart.component';
 export * from './po-chart.module';

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-options.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-options.interface.ts
@@ -287,4 +287,28 @@ export interface PoChartOptions {
    * @default `false`
    */
   showContainerGauge?: boolean;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Habilita o preenchimento das séries por cor combinada com padrão/textura,
+   * melhorando a acessibilidade ao não transmitir a informação apenas por cor
+   * (atende à diretriz de não depender exclusivamente de cor).
+   *
+   * Cada série suportada recebe automaticamente um dos 8 padrões disponíveis, podendo o padrão
+   * ser customizado por série através da propriedade `patternIndex` da interface `PoChartSerie`.
+   *
+   * > Aplica-se aos gráficos dos tipos `Pie`, `Donut`, `Bar` e `Column` quando o renderizador
+   * for `canvas` (propriedade `rendererOption`). Nos demais tipos e no renderizador `svg`,
+   * as séries são exibidas com cor sólida.
+   *
+   * > Quando esta propriedade não for informada, o modo de padrões é habilitado automaticamente
+   * caso o nível de acessibilidade do tema ativo seja `AAA`. Ao informar `true` ou `false`
+   * explicitamente, o valor definido pelo desenvolvedor é respeitado independentemente do tema.
+   *
+   * @default `false` (ou `true` automaticamente quando o tema ativo estiver no nível `AAA`)
+   */
+  usePatterns?: boolean;
 }

--- a/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie.interface.ts
+++ b/projects/ui/src/lib/components/po-chart/interfaces/po-chart-serie.interface.ts
@@ -156,4 +156,23 @@ export interface PoChartSerie {
    * > Essa propriedade habilita a propriedade `p-data-label` por padrão, podendo ser desabilitada passando `[p-data-label]={ fixed: false }`.
    */
   stackGroupName?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define explicitamente o padrão/textura aplicado à série, no intervalo de `0` a `7`,
+   * correspondendo respectivamente a: `0` linhas diagonais, `1` grid/xadrez, `2` pontos/círculos,
+   * `3` onda senoidal, `4` triângulos, `5` linhas horizontais, `6` linhas verticais e `7` zigue-zague.
+   *
+   * > Só tem efeito quando a propriedade `usePatterns` da interface `PoChartOptions` estiver como `true`
+   * e a série for de um tipo suportado (`Pie`, `Donut`, `Bar` ou `Column`) no renderizador `canvas`.
+   *
+   * > Quando não informado, o padrão é atribuído automaticamente conforme a ordem da série entre as séries de tipo suportado.
+   *
+   * Valores fora do intervalo `0` a `7` são normalizados por módulo 8 (por exemplo, `8` → `0`, `9` → `1`, `-1` → `7`).
+   * Valores nulos ou não inteiros são ignorados, aplicando-se a atribuição automática do padrão.
+   */
+  patternIndex?: number;
 }

--- a/projects/ui/src/lib/components/po-chart/po-chart-grid-utils.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart-grid-utils.ts
@@ -3,6 +3,13 @@ import { PoChartSerie } from '../po-chart/interfaces/po-chart-serie.interface';
 import { PoChartType } from '../po-chart/enums/po-chart-type.enum';
 import { PoChartRadarOptions } from './interfaces/po-chart-radar-options.interface';
 
+/**
+ * Preenchimento de série aceito pelo ECharts em `itemStyle.color`.
+ * Pode ser uma cor sólida (`string`) ou um padrão gerado a partir de um canvas
+ * (`{ image, repeat: 'repeat' }`) quando o modo de padrões está habilitado.
+ */
+export type PoChartSerieFill = string | { image: HTMLCanvasElement; repeat: 'repeat' };
+
 const gridPaddingValues = {
   paddingBottomWithTopLegend: 48,
   paddingBottomWithBottomLegend: 72,
@@ -166,11 +173,11 @@ export class PoChartGridUtils {
     }
   }
 
-  setSerieTypeBarColumn(serie: any, color: string) {
+  setSerieTypeBarColumn(serie: any, color: string, fill: PoChartSerieFill = color) {
     if (serie.type === 'bar') {
       serie.itemStyle = {
         borderRadius: this.resolvePx('--border-radius-bar', '.po-chart'),
-        color: color
+        color: fill
       };
       serie.emphasis = { focus: 'series' };
       serie.blur = {
@@ -188,7 +195,7 @@ export class PoChartGridUtils {
     }
   }
 
-  setSerieTypeDonutPie(serie: any, color: string) {
+  setSerieTypeDonutPie(serie: any, color: string, fill: PoChartSerieFill = color) {
     if (this.component.listTypePieDonut?.length) {
       const borderWidth = this.resolvePx('--border-width-sm');
       const borderColor = this.component.getCSSVariable('--border-color', '.po-chart');
@@ -198,7 +205,7 @@ export class PoChartGridUtils {
         itemStyle: {
           borderWidth: borderWidth,
           borderColor: borderColor,
-          color: color,
+          color: fill,
           borderRadius: this.component.options?.borderRadius
         }
       };

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.spec.ts
@@ -2156,6 +2156,47 @@ describe('PoChartComponent', () => {
       });
       expect(component['configureImageCanvas']).toHaveBeenCalledWith('jpeg', mockImage);
     });
+
+    it('should signal error and not propagate exception when getDataURL fails (Requirement 8.5)', () => {
+      const mockChartInstance = {
+        getDataURL: jasmine.createSpy('getDataURL').and.throwError('boom')
+      };
+      (component as any).chartInstance = mockChartInstance;
+      component['currentRenderer'] = 'canvas';
+
+      const notifySpy = spyOn<any>(component, 'notifyExportImageError');
+      const configureSpy = spyOn<any>(component, 'configureImageCanvas');
+
+      expect(() => (component as any).exportImage('png')).not.toThrow();
+      expect(notifySpy).toHaveBeenCalledWith('png');
+      expect(configureSpy).not.toHaveBeenCalled();
+    });
+
+    it('should signal error and not propagate exception when svg export fails (Requirement 8.5)', () => {
+      (component as any).chartInstance = { getDataURL: jasmine.createSpy('getDataURL') };
+      component['currentRenderer'] = 'svg';
+
+      spyOn<any>(component, 'exportSvgAsImage').and.throwError('boom');
+      const notifySpy = spyOn<any>(component, 'notifyExportImageError');
+
+      expect(() => (component as any).exportImage('jpeg')).not.toThrow();
+      expect(notifySpy).toHaveBeenCalledWith('jpeg');
+    });
+  });
+
+  describe('notifyExportImageError:', () => {
+    it('should log an error indication without mutating the chart instance (Requirement 8.5)', () => {
+      const consoleSpy = spyOn(console, 'error');
+      const chartInstance = { getDataURL: jasmine.createSpy('getDataURL') };
+      (component as any).chartInstance = chartInstance;
+
+      (component as any).notifyExportImageError('png');
+
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      expect(consoleSpy.calls.mostRecent().args[0]).toContain('PNG');
+      // O gráfico exibido permanece inalterado: a instância não é recriada nem descartada.
+      expect((component as any).chartInstance).toBe(chartInstance);
+    });
   });
 
   it('exportSvgAsImage: should serialize svg, create blob, url and call configureImageCanvas', () => {
@@ -2212,6 +2253,60 @@ describe('PoChartComponent', () => {
       mockImage.onload?.(new Event('load'));
 
       expect(component['setHeaderProperties']).not.toHaveBeenCalled();
+    });
+
+    it('should signal error when the canvas context is null (Requirement 8.5)', () => {
+      const mockImage = new Image();
+      const canvas = document.createElement('canvas');
+      spyOn(canvas, 'getContext').and.returnValue(null);
+
+      spyOn(document, 'createElement').and.callFake((tag: string) => {
+        if (tag === 'canvas') return canvas;
+        return document.createElement(tag);
+      });
+
+      const notifySpy = spyOn<any>(component, 'notifyExportImageError');
+
+      component['configureImageCanvas']('png', mockImage);
+      mockImage.onload?.(new Event('load'));
+
+      expect(notifySpy).toHaveBeenCalledWith('png');
+    });
+
+    it('should signal error via onerror handler when the source image fails to load (Requirement 8.5)', () => {
+      const mockImage = new Image();
+      const notifySpy = spyOn<any>(component, 'notifyExportImageError');
+
+      component['configureImageCanvas']('jpeg', mockImage);
+      mockImage.onerror?.(new Event('error'));
+
+      expect(notifySpy).toHaveBeenCalledWith('jpeg');
+    });
+
+    it('should signal error without propagating exception when toDataURL fails (Requirement 8.5)', () => {
+      const chartElement = document.createElement('div');
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+      spyOn(canvas, 'getContext').and.returnValue(ctx);
+      spyOn(canvas, 'toDataURL').and.throwError('boom');
+
+      const originalCreateElement = document.createElement;
+      spyOn(document, 'createElement').and.callFake((tag: string) => {
+        if (tag === 'canvas') return canvas;
+        return originalCreateElement.call(document, tag);
+      });
+
+      spyOn<any>(component, 'setHeaderProperties');
+      const notifySpy = spyOn<any>(component, 'notifyExportImageError');
+
+      const mockImage = document.createElement('img');
+      Object.defineProperty(mockImage, 'width', { value: 800 });
+      Object.defineProperty(mockImage, 'height', { value: 600 });
+
+      component['configureImageCanvas']('png', mockImage);
+
+      expect(() => mockImage.onload?.(new Event('load'))).not.toThrow();
+      expect(notifySpy).toHaveBeenCalledWith('png');
     });
 
     it('should create and download a PNG image correctly', done => {
@@ -2387,6 +2482,272 @@ describe('PoChartComponent', () => {
       component['setPopupActions']();
 
       expect(component['popupActions']).toEqual([...initialPopupActions, ...newActions]);
+    });
+  });
+
+  describe('setSeries - usePatterns (acessibilidade cor + padrão):', () => {
+    function mockGetPropertyValue(prop: string): string {
+      const values: { [key: string]: string } = {
+        '--color-01': '#0000ff',
+        '--color-02': '#00ff00',
+        '--color-neutral-light-00': '#ffffff',
+        '--border-width-md': '2px'
+      };
+      return values[prop] || '';
+    }
+
+    function mockGetComputedStyle(): CSSStyleDeclaration {
+      return {
+        getPropertyValue: mockGetPropertyValue
+      } as CSSStyleDeclaration;
+    }
+
+    function isPatternFill(color: any): boolean {
+      return !!color && typeof color === 'object' && 'image' in color && color.repeat === 'repeat';
+    }
+
+    beforeEach(() => {
+      spyOn(colorService, 'getColors').and.callFake((series: Array<any>) => series);
+      window.getComputedStyle = mockGetComputedStyle;
+      component['currentRenderer'] = 'canvas';
+    });
+
+    it('should keep solid color (never image fill) when usePatterns is undefined (Property 1)', () => {
+      component.series = [
+        { label: 'Serie 1', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01' },
+        { label: 'Serie 2', data: [4, 5, 6], type: PoChartType.Column, color: 'po-color-02' }
+      ];
+      component.options = {};
+
+      const result = component['setSeries']();
+
+      result.forEach(serie => {
+        expect(isPatternFill(serie.itemStyle?.color)).toBeFalse();
+      });
+    });
+
+    it('should keep solid color (never image fill) when usePatterns is false (Property 1)', () => {
+      component.series = [
+        { label: 'Serie 1', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01' },
+        { label: 'Serie 2', data: [4, 5, 6], type: PoChartType.Column, color: 'po-color-02' }
+      ];
+      component.options = { usePatterns: false };
+
+      const result = component['setSeries']();
+
+      result.forEach(serie => {
+        expect(isPatternFill(serie.itemStyle?.color)).toBeFalse();
+      });
+      expect(result[0].itemStyle.color).toBe('#0000ff');
+    });
+
+    it('should ignore patternIndex when usePatterns is disabled (Requirement 10.3)', () => {
+      const getPatternFillSpy = spyOn(component['patternService'], 'getPatternFill').and.callThrough();
+      component.series = [{ label: 'Serie 1', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01', patternIndex: 3 }];
+      component.options = { usePatterns: false };
+
+      const result = component['setSeries']();
+
+      expect(getPatternFillSpy).not.toHaveBeenCalled();
+      expect(isPatternFill(result[0].itemStyle.color)).toBeFalse();
+    });
+
+    it('should apply image fill to supported types and solid color to unsupported types on canvas (Property 8)', () => {
+      component.series = [
+        { label: 'Column', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01' },
+        { label: 'Bar', data: [4, 5, 6], type: PoChartType.Bar, color: 'po-color-02' },
+        { label: 'Line', data: [7, 8, 9], type: PoChartType.Line, color: 'po-color-01' }
+      ];
+      component.options = { usePatterns: true };
+
+      const result = component['setSeries']();
+
+      expect(isPatternFill(result[0].itemStyle.color)).toBeTrue();
+      expect(isPatternFill(result[1].itemStyle.color)).toBeTrue();
+      expect(isPatternFill(result[2].itemStyle?.color)).toBeFalse();
+    });
+
+    it('should cycle pattern indices 0..7,0,1 for 10 supported column series (Property 4)', () => {
+      const capturedIndices: Array<number> = [];
+      spyOn(component['patternService'], 'getPatternFill').and.callFake((color: string, patternIndex: number) => {
+        capturedIndices.push(patternIndex);
+        return { image: document.createElement('canvas'), repeat: 'repeat' };
+      });
+
+      component.series = Array.from({ length: 10 }, (_, i) => ({
+        label: `Serie ${i + 1}`,
+        data: [i, i + 1, i + 2],
+        type: PoChartType.Column,
+        color: 'po-color-01'
+      }));
+      component.options = { usePatterns: true };
+
+      component['setSeries']();
+
+      expect(capturedIndices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 0, 1]);
+    });
+
+    it('should count only supported series when mixing column and line (Property 5)', () => {
+      const capturedIndices: Array<number> = [];
+      spyOn(component['patternService'], 'getPatternFill').and.callFake((color: string, patternIndex: number) => {
+        capturedIndices.push(patternIndex);
+        return { image: document.createElement('canvas'), repeat: 'repeat' };
+      });
+
+      component.series = [
+        { label: 'Column 1', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01' },
+        { label: 'Line 1', data: [4, 5, 6], type: PoChartType.Line, color: 'po-color-02' },
+        { label: 'Column 2', data: [7, 8, 9], type: PoChartType.Column, color: 'po-color-01' },
+        { label: 'Line 2', data: [1, 1, 1], type: PoChartType.Line, color: 'po-color-02' },
+        { label: 'Column 3', data: [2, 2, 2], type: PoChartType.Column, color: 'po-color-01' }
+      ];
+      component.options = { usePatterns: true };
+
+      component['setSeries']();
+
+      // Apenas as 3 séries suportadas (column) recebem índices, contadas de forma independente das line.
+      expect(capturedIndices).toEqual([0, 1, 2]);
+    });
+
+    it('should respect an explicit in-range patternIndex (Requirements 5.2)', () => {
+      const capturedIndices: Array<number> = [];
+      spyOn(component['patternService'], 'getPatternFill').and.callFake((color: string, patternIndex: number) => {
+        capturedIndices.push(patternIndex);
+        return { image: document.createElement('canvas'), repeat: 'repeat' };
+      });
+
+      component.series = [{ label: 'Serie 1', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01', patternIndex: 5 }];
+      component.options = { usePatterns: true };
+
+      component['setSeries']();
+
+      expect(capturedIndices).toEqual([5]);
+    });
+
+    it('should normalize an out-of-range explicit patternIndex by modulo 8 (Requirements 5.4)', () => {
+      const capturedIndices: Array<number> = [];
+      spyOn(component['patternService'], 'getPatternFill').and.callFake((color: string, patternIndex: number) => {
+        capturedIndices.push(patternIndex);
+        return { image: document.createElement('canvas'), repeat: 'repeat' };
+      });
+
+      component.series = [
+        { label: 'A', data: [1], type: PoChartType.Column, color: 'po-color-01', patternIndex: 9 },
+        { label: 'B', data: [2], type: PoChartType.Column, color: 'po-color-01', patternIndex: -1 }
+      ];
+      component.options = { usePatterns: true };
+
+      component['setSeries']();
+
+      expect(capturedIndices).toEqual([1, 7]);
+    });
+
+    it('should fall back to automatic index when patternIndex is null or non-integer (Requirements 5.5)', () => {
+      const capturedIndices: Array<number> = [];
+      spyOn(component['patternService'], 'getPatternFill').and.callFake((color: string, patternIndex: number) => {
+        capturedIndices.push(patternIndex);
+        return { image: document.createElement('canvas'), repeat: 'repeat' };
+      });
+
+      component.series = [
+        { label: 'A', data: [1], type: PoChartType.Column, color: 'po-color-01', patternIndex: null as any },
+        { label: 'B', data: [2], type: PoChartType.Column, color: 'po-color-01', patternIndex: 2.5 as any }
+      ];
+      component.options = { usePatterns: true };
+
+      component['setSeries']();
+
+      // null e não inteiro são ignorados → automático por posição (0, 1).
+      expect(capturedIndices).toEqual([0, 1]);
+    });
+
+    it('should use solid color and emit exactly one console.warn per instance on svg renderer (Property 9)', () => {
+      const warnSpy = spyOn(console, 'warn');
+      component['currentRenderer'] = 'svg';
+      component['patternSvgWarningEmitted'] = false;
+
+      component.series = [
+        { label: 'Column 1', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01' },
+        { label: 'Column 2', data: [4, 5, 6], type: PoChartType.Column, color: 'po-color-02' },
+        { label: 'Column 3', data: [7, 8, 9], type: PoChartType.Column, color: 'po-color-01' }
+      ];
+      component.options = { usePatterns: true };
+
+      const result = component['setSeries']();
+
+      result.forEach(serie => {
+        expect(isPatternFill(serie.itemStyle?.color)).toBeFalse();
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall back to solid color without throwing when getPatternFill fails (Property 10)', () => {
+      spyOn(component['patternService'], 'getPatternFill').and.throwError('canvas indisponível');
+
+      component.series = [{ label: 'Serie 1', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01' }];
+      component.options = { usePatterns: true };
+
+      let result: Array<any>;
+      expect(() => (result = component['setSeries']())).not.toThrow();
+      expect(isPatternFill(result[0].itemStyle.color)).toBeFalse();
+      expect(result[0].itemStyle.color).toBe('#0000ff');
+    });
+
+    it('should produce the same itemStyle.color per serie across two setSeries runs with the same data (Property 7)', () => {
+      const buildSeries = (): Array<PoChartSerie> => [
+        { label: 'Serie 1', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01' },
+        { label: 'Serie 2', data: [4, 5, 6], type: PoChartType.Column, color: 'po-color-02' }
+      ];
+
+      component.options = { usePatterns: true };
+
+      component.series = buildSeries();
+      const firstRun = component['setSeries']().map(serie => serie.itemStyle?.color);
+
+      component.series = buildSeries();
+      const secondRun = component['setSeries']().map(serie => serie.itemStyle?.color);
+
+      firstRun.forEach((color, index) => {
+        expect(isPatternFill(color)).toBeTrue();
+        expect(isPatternFill(secondRun[index])).toBeTrue();
+      });
+      // Mesmos dados/ordem/configuração → mesmo índice de padrão por série.
+      const firstIndices = [0, 1];
+      const capturedIndices: Array<number> = [];
+      spyOn(component['patternService'], 'getPatternFill').and.callFake((color: string, patternIndex: number) => {
+        capturedIndices.push(patternIndex);
+        return { image: document.createElement('canvas'), repeat: 'repeat' };
+      });
+      component.series = buildSeries();
+      component['setSeries']();
+      expect(capturedIndices).toEqual(firstIndices);
+    });
+
+    it('should regenerate fill with active theme color and preserve pattern index after PoUiThemeChange (Requirements 9.1, 9.2)', () => {
+      const capturedIndices: Array<number> = [];
+      spyOn(component['patternService'], 'getPatternFill').and.callFake((color: string, patternIndex: number) => {
+        capturedIndices.push(patternIndex);
+        return { image: document.createElement('canvas'), repeat: 'repeat' };
+      });
+
+      component.series = [
+        { label: 'Serie 1', data: [1, 2, 3], type: PoChartType.Column, color: 'po-color-01' },
+        { label: 'Serie 2', data: [4, 5, 6], type: PoChartType.Column, color: 'po-color-02' }
+      ];
+      component.options = { usePatterns: true };
+
+      // Primeira renderização.
+      component['setSeries']();
+      const indicesBefore = [...capturedIndices];
+      capturedIndices.length = 0;
+
+      // Simula recriação da instância após troca de tema (dispose + initECharts reexecuta setSeries).
+      component['patternSvgWarningEmitted'] = false;
+      component['setSeries']();
+      const indicesAfter = [...capturedIndices];
+
+      expect(indicesBefore).toEqual([0, 1]);
+      expect(indicesAfter).toEqual(indicesBefore);
     });
   });
 });

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.ts
@@ -19,6 +19,8 @@ import { CurrencyPipe, DecimalPipe } from '@angular/common';
 import { PoTooltipDirective } from '../../directives';
 import { PoColorService } from '../../services/po-color';
 import { PoLanguageService } from '../../services/po-language/po-language.service';
+import { PoThemeA11yEnum } from '../../services/po-theme/enum/po-theme-a11y.enum';
+import { getA11yLevel } from '../../utils/util';
 import { PoChartLabelFormat } from '../po-chart/enums/po-chart-label-format.enum';
 import { PoChartSerie } from '../po-chart/interfaces/po-chart-serie.interface';
 import { PoModalAction } from '../po-modal';
@@ -27,7 +29,8 @@ import { PoTableColumn } from '../po-table';
 import { PoChartBaseComponent } from './po-chart-base.component';
 
 import { PoChartType } from '../po-chart/enums/po-chart-type.enum';
-import { PoChartGridUtils } from './po-chart-grid-utils';
+import { PoChartGridUtils, PoChartSerieFill } from './po-chart-grid-utils';
+import { PoChartPatternService } from './services/po-chart-pattern.service';
 
 import { BarChart, CustomChart, GaugeChart, LineChart, PieChart, RadarChart } from 'echarts/charts';
 import {
@@ -107,7 +110,8 @@ use([
 @Component({
   selector: 'po-chart',
   templateUrl: './po-chart.component.html',
-  standalone: false
+  standalone: false,
+  providers: [PoChartPatternService]
 })
 export class PoChartComponent extends PoChartBaseComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
   el = inject(ElementRef);
@@ -115,6 +119,7 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
   private readonly decimalPipe = inject(DecimalPipe);
   private readonly colorService = inject(PoColorService);
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly patternService = inject(PoChartPatternService);
 
   @ViewChildren(PoTooltipDirective) poTooltip: QueryList<PoTooltipDirective>;
   @ViewChild('targetPopup', { read: ElementRef, static: false }) targetRef: ElementRef;
@@ -153,6 +158,7 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
   protected popupActions: Array<PoPopupAction> = [];
   private chartInstance!: echarts.ECharts;
   private currentRenderer: 'svg' | 'canvas';
+  private patternSvgWarningEmitted = false;
   private resizeObserver: ResizeObserver;
   private intersectionObserver: IntersectionObserver;
   private hideDomEchartsDiv = false;
@@ -172,6 +178,7 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
   changeTheme = (event: any) => {
     this.chartInstance?.dispose();
     this.chartInstance = undefined;
+    this.patternSvgWarningEmitted = false;
     this.initECharts();
     this.checkShowCEcharts();
   };
@@ -402,6 +409,7 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
       return;
     }
     this.currentRenderer = this.options?.rendererOption || 'canvas';
+    this.patternSvgWarningEmitted = false;
     this.chartInstance = echarts.init(echartsDiv, null, { renderer: this.currentRenderer });
     this.observeContainerResize();
     this.setChartsProperties();
@@ -625,8 +633,12 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
       this.chartGridUtils.setListTypeRadar();
     }
 
+    let supportedPositionCounter = 0;
+    const usePatterns = this.isPatternModeEnabled();
+
     const seriesUpdated = newSeries.map((serie, index) => {
       serie.name = serie.name || (serie.label && typeof serie.label === 'string') ? (serie.name ?? serie.label) : ' ';
+      const resolvedType: PoChartType = serie.type || this.type || typeDefault;
       !serie.type ? this.setTypeSerie(serie, this.type || typeDefault) : this.setTypeSerie(serie, serie.type);
 
       let colorVariable: string;
@@ -641,12 +653,46 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
         colorVariable = serie.color;
       }
 
-      this.chartGridUtils.setSerieTypeDonutPie(serie, colorVariable);
+      let fill: PoChartSerieFill = colorVariable;
+
+      if (
+        usePatterns &&
+        this.currentRenderer === 'canvas' &&
+        this.patternService.isPatternSupportedType(resolvedType)
+      ) {
+        if (colorVariable === undefined || colorVariable === null || colorVariable === '') {
+          // Cor do tema ativo indisponível/indefinida: mantém cor sólida (fill já é colorVariable)
+          // e registra indicação de erro sinalizando cor de tema indisponível (Requirement 9.3).
+          console.error(
+            'po-chart: cor do tema ativo indisponível para a série; o padrão (usePatterns) não será aplicado e a série será renderizada com cor sólida.'
+          );
+        } else {
+          const patternIndex = this.resolvePatternIndex(serie, supportedPositionCounter);
+
+          try {
+            fill = this.patternService.getPatternFill(colorVariable, patternIndex);
+          } catch {
+            fill = colorVariable;
+          }
+        }
+
+        supportedPositionCounter++;
+      } else if (
+        usePatterns &&
+        this.currentRenderer === 'svg' &&
+        this.patternService.isPatternSupportedType(resolvedType)
+      ) {
+        // Renderer SVG não suporta os padrões: mantém a Effective_Color em cor sólida
+        // (fill já é colorVariable) e emite exatamente um aviso por instância (Requirements 7.2, 7.3).
+        this.emitPatternSvgWarning();
+      }
+
+      this.chartGridUtils.setSerieTypeDonutPie(serie, colorVariable, fill);
       this.chartGaugeUtils.setSerieTypeGauge(serie, colorVariable);
       this.setSerieEmphasis(serie, colorVariable, tokenBorderWidthMd);
       this.chartGridUtils.setSerieTypeLine(serie, tokenBorderWidthMd, colorVariable);
       this.chartGridUtils.setSerieTypeArea(serie, index);
-      this.chartGridUtils.setSerieTypeBarColumn(serie, colorVariable);
+      this.chartGridUtils.setSerieTypeBarColumn(serie, colorVariable, fill);
       this.chartGridUtils.setSerieTypeRadar(serie, tokenBorderWidthMd, colorVariable);
 
       return serie;
@@ -661,6 +707,63 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
     }
 
     return seriesUpdated;
+  }
+
+  /**
+   * Resolve o `Pattern_Index` de uma série de tipo suportado de forma determinística.
+   *
+   * - Quando `serie.patternIndex` for um inteiro, ele é respeitado e normalizado
+   *   para o intervalo `0..7` (Requirements 5.2 e 5.4).
+   * - Caso contrário (ausente, nulo ou não inteiro), aplica-se a atribuição
+   *   automática cíclica com base na posição da série entre as séries de tipo
+   *   suportado: `position % PATTERN_COUNT` (Requirements 4.1, 4.3 e 5.5).
+   *
+   * @param serie Série a ter o padrão resolvido.
+   * @param position Índice base-zero da série entre as séries de tipo suportado.
+   * @returns Índice de padrão no intervalo `0..7`.
+   */
+  private resolvePatternIndex(serie: PoChartSerie, position: number): number {
+    if (Number.isInteger(serie?.patternIndex)) {
+      return this.patternService.normalizePatternIndex(serie.patternIndex);
+    }
+
+    return position % PoChartPatternService.PATTERN_COUNT;
+  }
+
+  /**
+   * Resolve se o modo de padrões (cor + textura) deve ser aplicado.
+   *
+   * - Quando `options.usePatterns` é informado explicitamente (`true` ou `false`),
+   *   o valor do consumidor é respeitado.
+   * - Quando `options.usePatterns` não é informado, o modo é habilitado
+   *   automaticamente se o nível de acessibilidade do tema ativo for `AAA`,
+   *   reforçando a diretriz de não depender apenas de cor nesse nível.
+   *
+   * @returns `true` se os padrões devem ser aplicados às séries suportadas.
+   */
+  private isPatternModeEnabled(): boolean {
+    if (typeof this.options?.usePatterns === 'boolean') {
+      return this.options.usePatterns;
+    }
+
+    return getA11yLevel() === PoThemeA11yEnum.AAA;
+  }
+
+  /**
+   * Emite exatamente um aviso por instância de gráfico informando que os padrões
+   * não são aplicados no renderer `svg`, mantendo o fallback de cor sólida
+   * (Requirements 7.2 e 7.3). O controle é feito pela flag `patternSvgWarningEmitted`,
+   * resetada sempre que a instância do ECharts é recriada (`initECharts`/`changeTheme`).
+   */
+  private emitPatternSvgWarning(): void {
+    if (this.patternSvgWarningEmitted) {
+      return;
+    }
+
+    this.patternSvgWarningEmitted = true;
+    console.warn(
+      'po-chart: os padrões (usePatterns) não são aplicados no renderer "svg". As séries suportadas serão renderizadas com cor sólida.'
+    );
   }
 
   private setSerieEmphasis(serie, color: string, tokenBorder: number) {
@@ -866,16 +969,22 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
       return;
     }
 
-    if (this.currentRenderer === 'svg') {
-      this.exportSvgAsImage(type);
-    } else {
-      const chartImage = new Image();
-      chartImage.src = this.chartInstance.getDataURL({
-        type: type,
-        pixelRatio: 2,
-        backgroundColor: this.getCSSVariable('--color-neutral-light-00')
-      });
-      this.configureImageCanvas(type, chartImage);
+    // Requirement 8.5: qualquer falha na exportação PNG/JPG deve sinalizar erro ao usuário
+    // sem propagar exceção e sem mutar o estado atual do gráfico exibido na tela.
+    try {
+      if (this.currentRenderer === 'svg') {
+        this.exportSvgAsImage(type);
+      } else {
+        const chartImage = new Image();
+        chartImage.src = this.chartInstance.getDataURL({
+          type: type,
+          pixelRatio: 2,
+          backgroundColor: this.getCSSVariable('--color-neutral-light-00')
+        });
+        this.configureImageCanvas(type, chartImage);
+      }
+    } catch {
+      this.notifyExportImageError(type);
     }
   }
 
@@ -897,35 +1006,57 @@ export class PoChartComponent extends PoChartBaseComponent implements OnInit, Af
   }
 
   private configureImageCanvas(type: 'png' | 'jpeg', chartImage: HTMLImageElement) {
-    chartImage.onload = () => {
-      const canvas = document.createElement('canvas');
-      const ctx = canvas.getContext('2d');
-
-      if (!ctx) return;
-
-      const chartElement = this.el.nativeElement.querySelector('#chart-id') as HTMLDivElement;
-      const headerElement = this.el.nativeElement.querySelector('.po-chart-header') as HTMLDivElement;
-
-      const chartWidth = chartElement.clientWidth;
-      const chartHeight = chartElement.clientHeight;
-
-      const headerHeight = headerElement?.clientHeight || 40;
-
-      canvas.width = chartWidth;
-      canvas.height = headerHeight + chartHeight + 40;
-      ctx.fillStyle = this.getCSSVariable('--color-neutral-light-00');
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-      this.setHeaderProperties(ctx, headerElement, chartWidth, headerHeight);
-      ctx.drawImage(chartImage, 0, headerHeight, chartWidth, chartHeight);
-
-      const link = document.createElement('a');
-      link.href = canvas.toDataURL(`image/${type}`);
-      link.download = `grafico-exportado.${type}`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+    // Requirement 8.5: falha no carregamento da imagem-fonte sinaliza erro sem alterar o gráfico.
+    chartImage.onerror = () => {
+      this.notifyExportImageError(type);
     };
+
+    chartImage.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+
+        if (!ctx) {
+          this.notifyExportImageError(type);
+          return;
+        }
+
+        const chartElement = this.el.nativeElement.querySelector('#chart-id') as HTMLDivElement;
+        const headerElement = this.el.nativeElement.querySelector('.po-chart-header') as HTMLDivElement;
+
+        const chartWidth = chartElement.clientWidth;
+        const chartHeight = chartElement.clientHeight;
+
+        const headerHeight = headerElement?.clientHeight || 40;
+
+        canvas.width = chartWidth;
+        canvas.height = headerHeight + chartHeight + 40;
+        ctx.fillStyle = this.getCSSVariable('--color-neutral-light-00');
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        this.setHeaderProperties(ctx, headerElement, chartWidth, headerHeight);
+        ctx.drawImage(chartImage, 0, headerHeight, chartWidth, chartHeight);
+
+        const link = document.createElement('a');
+        link.href = canvas.toDataURL(`image/${type}`);
+        link.download = `grafico-exportado.${type}`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      } catch {
+        // Requirement 8.5: falha ao gerar o data URL/canvas não propaga e preserva o gráfico atual.
+        this.notifyExportImageError(type);
+      }
+    };
+  }
+
+  private notifyExportImageError(type: 'png' | 'jpeg') {
+    // Requirement 8.5: indica ao usuário que a exportação falhou. O fluxo de exportação apenas
+    // lê o gráfico (getDataURL) e opera sobre um canvas/âncora fora da tela, portanto o estado
+    // atual do gráfico exibido permanece inalterado.
+    console.error(
+      `po-chart: falha ao exportar o gráfico como imagem ${type.toUpperCase()}. O gráfico exibido permanece inalterado.`
+    );
   }
 
   private setHeaderProperties(ctx, headerElement, chartWidth, headerHeight) {

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-pattern.service.spec.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-pattern.service.spec.ts
@@ -1,0 +1,175 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PoChartType } from '../enums/po-chart-type.enum';
+import { PoChartPatternService } from './po-chart-pattern.service';
+
+describe('PoChartPatternService', () => {
+  let service: PoChartPatternService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PoChartPatternService]
+    });
+
+    service = TestBed.inject(PoChartPatternService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should expose PATTERN_COUNT equal to 8', () => {
+    expect(PoChartPatternService.PATTERN_COUNT).toBe(8);
+  });
+
+  describe('normalizePatternIndex:', () => {
+    it('should keep values already in range 0..7 unchanged', () => {
+      for (let i = 0; i <= 7; i++) {
+        expect(service.normalizePatternIndex(i)).toBe(i);
+      }
+    });
+
+    it('should normalize 8 to 0', () => {
+      expect(service.normalizePatternIndex(8)).toBe(0);
+    });
+
+    it('should normalize 9 to 1', () => {
+      expect(service.normalizePatternIndex(9)).toBe(1);
+    });
+
+    it('should normalize -1 to 7 using non-negative modulo', () => {
+      expect(service.normalizePatternIndex(-1)).toBe(7);
+    });
+
+    it('should normalize 13 to 5', () => {
+      expect(service.normalizePatternIndex(13)).toBe(5);
+    });
+
+    it('should follow the formula ((v % 8) + 8) % 8 for a range of integers', () => {
+      for (let v = -20; v <= 20; v++) {
+        expect(service.normalizePatternIndex(v)).toBe(((v % 8) + 8) % 8);
+      }
+    });
+
+    it('should be periodic with period 8 (v and v + 8 map to the same index)', () => {
+      for (let v = -10; v <= 10; v++) {
+        expect(service.normalizePatternIndex(v)).toBe(service.normalizePatternIndex(v + 8));
+      }
+    });
+  });
+
+  describe('isPatternSupportedType:', () => {
+    it('should return true for supported types (pie, donut, bar, column)', () => {
+      expect(service.isPatternSupportedType(PoChartType.Pie)).toBeTrue();
+      expect(service.isPatternSupportedType(PoChartType.Donut)).toBeTrue();
+      expect(service.isPatternSupportedType(PoChartType.Bar)).toBeTrue();
+      expect(service.isPatternSupportedType(PoChartType.Column)).toBeTrue();
+    });
+
+    it('should return false for unsupported types (line, area, radar, gauge)', () => {
+      expect(service.isPatternSupportedType(PoChartType.Line)).toBeFalse();
+      expect(service.isPatternSupportedType(PoChartType.Area)).toBeFalse();
+      expect(service.isPatternSupportedType(PoChartType.Radar)).toBeFalse();
+      expect(service.isPatternSupportedType(PoChartType.Gauge)).toBeFalse();
+    });
+
+    it('should return false for an unknown type', () => {
+      expect(service.isPatternSupportedType('unknown' as PoChartType)).toBeFalse();
+    });
+  });
+
+  describe('getPatternFill:', () => {
+    it('should return an object in the format { image, repeat: "repeat" }', () => {
+      const fill = service.getPatternFill('#c9357d', 0);
+
+      expect(fill.repeat).toBe('repeat');
+      expect(fill.image instanceof HTMLCanvasElement).toBeTrue();
+    });
+
+    it('should create a canvas with the expected tile dimensions', () => {
+      const fill = service.getPatternFill('#c9357d', 0);
+
+      expect(fill.image.width).toBe(12);
+      expect(fill.image.height).toBe(12);
+    });
+
+    it('should paint the background with the Effective_Color', () => {
+      const backgroundHex = '#204080'; // r=32, g=64, b=128
+      const fill = service.getPatternFill(backgroundHex, 6); // vertical line: corner pixel stays background
+
+      const ctx = fill.image.getContext('2d')!;
+      // Sample a corner pixel unlikely to be covered by the (centered) stroke.
+      const { data } = ctx.getImageData(0, 0, 1, 1);
+
+      expect(data[0]).toBe(32);
+      expect(data[1]).toBe(64);
+      expect(data[2]).toBe(128);
+      expect(data[3]).toBe(255);
+    });
+
+    it('should normalize an out-of-range index before drawing (8 behaves like 0)', () => {
+      const color = '#808080';
+      const fillZero = service.getPatternFill(color, 0);
+      const fillEight = service.getPatternFill(color, 8);
+
+      expect(getSignature(fillZero.image)).toEqual(getSignature(fillEight.image));
+    });
+
+    it('should draw a distinct stroke for each index 0..7 (pixel sampling)', () => {
+      const color = '#808080'; // neutral background so the stroke is well contrasted
+      const signatures = [];
+
+      for (let index = 0; index <= 7; index++) {
+        const fill = service.getPatternFill(color, index);
+        signatures.push(getSignature(fill.image).join(','));
+      }
+
+      const uniqueSignatures = new Set(signatures);
+
+      expect(uniqueSignatures.size).toBe(8);
+    });
+
+    it('should throw when the 2D context is unavailable', () => {
+      const originalGetContext = HTMLCanvasElement.prototype.getContext;
+      spyOn(HTMLCanvasElement.prototype, 'getContext').and.returnValue(null);
+
+      expect(() => service.getPatternFill('#000000', 0)).toThrow();
+
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+    });
+  });
+});
+
+/**
+ * Builds a coarse signature of a canvas by counting, for each pixel, whether it
+ * differs from the solid background. Patterns that draw different strokes produce
+ * different signatures, allowing distinctness verification without depending on
+ * exact anti-aliased pixel values.
+ */
+function getSignature(canvas: HTMLCanvasElement): Array<number> {
+  const ctx = canvas.getContext('2d')!;
+  const { data, width, height } = ctx.getImageData(0, 0, canvas.width, canvas.height) as ImageData;
+
+  // Assume the top-left pixel is the untouched background color.
+  const bgR = data[0];
+  const bgG = data[1];
+  const bgB = data[2];
+
+  const signature: Array<number> = [];
+  for (let y = 0; y < height; y++) {
+    let rowMask = 0;
+    for (let x = 0; x < width; x++) {
+      const offset = (y * width + x) * 4;
+      const differs =
+        Math.abs(data[offset] - bgR) > 8 ||
+        Math.abs(data[offset + 1] - bgG) > 8 ||
+        Math.abs(data[offset + 2] - bgB) > 8;
+      if (differs) {
+        rowMask |= 1 << x;
+      }
+    }
+    signature.push(rowMask);
+  }
+
+  return signature;
+}

--- a/projects/ui/src/lib/components/po-chart/services/po-chart-pattern.service.ts
+++ b/projects/ui/src/lib/components/po-chart/services/po-chart-pattern.service.ts
@@ -1,0 +1,258 @@
+import { Injectable } from '@angular/core';
+
+import { PoChartType } from '../enums/po-chart-type.enum';
+
+/**
+ * @docsPrivate
+ *
+ * @description
+ *
+ * Serviço responsável por gerar o preenchimento de séries com cor combinada com
+ * padrão/textura, melhorando a acessibilidade do `po-chart` (não depender apenas
+ * de cor). O desenho dos padrões é puro e desacoplado do ECharts.
+ *
+ * São suportados exatamente 8 padrões (índices 0 a 7), quantidade correspondente
+ * ao número de cores categóricas da paleta (`--categorical-01`..`--categorical-08`).
+ */
+@Injectable()
+export class PoChartPatternService {
+  /** Quantidade de padrões suportados (igual ao número de cores categóricas). */
+  static readonly PATTERN_COUNT = 8;
+
+  private static readonly SUPPORTED_TYPES = new Set<PoChartType>([
+    PoChartType.Pie,
+    PoChartType.Donut,
+    PoChartType.Bar,
+    PoChartType.Column
+  ]);
+
+  /**
+   * Indica se o tipo de gráfico informado suporta a aplicação de padrões.
+   *
+   * Tipos suportados: `pie`, `donut`, `bar` e `column`.
+   *
+   * @param type Tipo do gráfico da série.
+   * @returns `true` para tipos suportados; `false` para os demais ou desconhecidos.
+   */
+  isPatternSupportedType(type: PoChartType): boolean {
+    return PoChartPatternService.SUPPORTED_TYPES.has(type);
+  }
+
+  /**
+   * Normaliza qualquer inteiro para o intervalo `0..7` usando o resto não negativo
+   * da divisão por `8` (`((v % 8) + 8) % 8`).
+   *
+   * Exemplos: `8` → `0`, `9` → `1`, `-1` → `7`.
+   *
+   * @param value Valor inteiro a ser normalizado.
+   * @returns Índice de padrão no intervalo `0..7`.
+   */
+  normalizePatternIndex(value: number): number {
+    const count = PoChartPatternService.PATTERN_COUNT;
+    return ((value % count) + count) % count;
+  }
+
+  /**
+   * Gera o preenchimento de uma série no formato aceito pelo ECharts em
+   * `itemStyle.color`: um elemento `<canvas>` com a cor de fundo sólida (a
+   * `Effective_Color` preservada) e uma textura sobreposta correspondente ao
+   * padrão informado, repetida em ambos os eixos (`repeat: 'repeat'`).
+   *
+   * O índice é normalizado para `0..7` antes do desenho. A cor do traço da
+   * textura é calculada a partir da luminância relativa da cor de fundo, de modo
+   * que o traço seja claro sobre fundos escuros e escuro sobre fundos claros,
+   * mantendo o padrão perceptível independentemente do tema.
+   *
+   * @param color Cor de fundo (Effective_Color) resolvida pelo `PoColorService`.
+   * @param patternIndex Índice do padrão desejado (normalizado para `0..7`).
+   * @returns Objeto `{ image, repeat: 'repeat' }` para uso em `itemStyle.color`.
+   * @throws Erro quando o contexto 2D do canvas não estiver disponível; o
+   * chamador é responsável por tratar o fallback para cor sólida.
+   */
+  getPatternFill(color: string, patternIndex: number): { image: HTMLCanvasElement; repeat: 'repeat' } {
+    const size = 12;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('PoChartPatternService: contexto 2D do canvas indisponível.');
+    }
+
+    // Fundo sólido preservando a Effective_Color.
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, size, size);
+
+    // Cor do traço com contraste em relação ao fundo.
+    const strokeColor = this.getContrastStroke(color);
+    ctx.strokeStyle = strokeColor;
+    ctx.fillStyle = strokeColor;
+    ctx.lineWidth = 1.5;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    this.drawPattern(ctx, this.normalizePatternIndex(patternIndex), size);
+
+    return { image: canvas, repeat: 'repeat' };
+  }
+
+  /**
+   * Desenha a textura correspondente ao índice de padrão sobre o contexto do
+   * canvas de *tile*. O índice recebido é normalizado antes do desenho.
+   *
+   * Catálogo: `0` diagonais, `1` grid/xadrez, `2` pontos/círculos, `3` senoidal,
+   * `4` triângulos, `5` horizontais, `6` verticais, `7` zigue-zague.
+   *
+   * @param ctx Contexto 2D do canvas de *tile*.
+   * @param index Índice do padrão (será normalizado para `0..7`).
+   * @param size Dimensão (largura e altura) do *tile* em pixels.
+   */
+  private drawPattern(ctx: CanvasRenderingContext2D, index: number, size: number): void {
+    const normalized = this.normalizePatternIndex(index);
+
+    switch (normalized) {
+      case 0: // Linhas diagonais (45°)
+        ctx.beginPath();
+        ctx.moveTo(0, size);
+        ctx.lineTo(size, 0);
+        ctx.moveTo(-size / 2, size / 2);
+        ctx.lineTo(size / 2, -size / 2);
+        ctx.moveTo(size / 2, size + size / 2);
+        ctx.lineTo(size + size / 2, size / 2);
+        ctx.stroke();
+        break;
+
+      case 1: // Grid / xadrez (horizontais + verticais)
+        ctx.beginPath();
+        ctx.moveTo(0, size / 2);
+        ctx.lineTo(size, size / 2);
+        ctx.moveTo(size / 2, 0);
+        ctx.lineTo(size / 2, size);
+        ctx.stroke();
+        break;
+
+      case 2: // Pontos / círculos em grade
+        ctx.beginPath();
+        ctx.arc(size / 2, size / 2, size / 4, 0, Math.PI * 2);
+        ctx.fill();
+        break;
+
+      case 3: // Onda senoidal
+        ctx.beginPath();
+        for (let x = 0; x <= size; x++) {
+          const y = size / 2 + (size / 4) * Math.sin((x / size) * Math.PI * 2);
+          if (x === 0) {
+            ctx.moveTo(x, y);
+          } else {
+            ctx.lineTo(x, y);
+          }
+        }
+        ctx.stroke();
+        break;
+
+      case 4: // Triângulos preenchidos
+        ctx.beginPath();
+        ctx.moveTo(size / 2, size / 4);
+        ctx.lineTo(size / 4, (size * 3) / 4);
+        ctx.lineTo((size * 3) / 4, (size * 3) / 4);
+        ctx.closePath();
+        ctx.fill();
+        break;
+
+      case 5: // Linhas horizontais
+        ctx.beginPath();
+        ctx.moveTo(0, size / 2);
+        ctx.lineTo(size, size / 2);
+        ctx.stroke();
+        break;
+
+      case 6: // Linhas verticais
+        ctx.beginPath();
+        ctx.moveTo(size / 2, 0);
+        ctx.lineTo(size / 2, size);
+        ctx.stroke();
+        break;
+
+      case 7: // Zigue-zague (chevron)
+        ctx.beginPath();
+        ctx.moveTo(0, (size * 3) / 4);
+        ctx.lineTo(size / 4, size / 4);
+        ctx.lineTo(size / 2, (size * 3) / 4);
+        ctx.lineTo((size * 3) / 4, size / 4);
+        ctx.lineTo(size, (size * 3) / 4);
+        ctx.stroke();
+        break;
+    }
+  }
+
+  /**
+   * Calcula a cor de traço (textura) com contraste adequado em relação à cor de
+   * fundo, a partir da luminância relativa: fundos escuros recebem traço claro
+   * (branco translúcido) e fundos claros recebem traço escuro (preto translúcido).
+   *
+   * @param background Cor de fundo (Effective_Color).
+   * @returns Cor de traço com transparência para manter a textura sutil.
+   */
+  private getContrastStroke(background: string): string {
+    const rgb = this.parseColor(background);
+    if (!rgb) {
+      return 'rgba(0, 0, 0, 0.55)';
+    }
+
+    const luminance = this.relativeLuminance(rgb);
+    return luminance < 0.5 ? 'rgba(255, 255, 255, 0.65)' : 'rgba(0, 0, 0, 0.55)';
+  }
+
+  /**
+   * Converte uma cor CSS (hex de 3/6 dígitos, `rgb()`/`rgba()`) em componentes
+   * RGB. Cores não reconhecidas retornam `null`.
+   */
+  private parseColor(color: string): { r: number; g: number; b: number } | null {
+    if (!color) {
+      return null;
+    }
+
+    const value = color.trim();
+
+    const hexMatch = value.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+    if (hexMatch) {
+      let hex = hexMatch[1];
+      if (hex.length === 3) {
+        hex = hex
+          .split('')
+          .map(c => c + c)
+          .join('');
+      }
+      return {
+        r: parseInt(hex.substring(0, 2), 16),
+        g: parseInt(hex.substring(2, 4), 16),
+        b: parseInt(hex.substring(4, 6), 16)
+      };
+    }
+
+    const rgbMatch = value.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
+    if (rgbMatch) {
+      return {
+        r: parseInt(rgbMatch[1], 10),
+        g: parseInt(rgbMatch[2], 10),
+        b: parseInt(rgbMatch[3], 10)
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Calcula a luminância relativa (0..1) de uma cor RGB conforme a fórmula do
+   * WCAG, usada para decidir o contraste do traço.
+   */
+  private relativeLuminance({ r, g, b }: { r: number; g: number; b: number }): number {
+    const toLinear = (channel: number): number => {
+      const c = channel / 255;
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    };
+
+    return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+  }
+}


### PR DESCRIPTION
> ⚠️ **Esta é uma Prova de Conceito (POC).** O objetivo é validar a abordagem técnica antes de uma implementação definitiva. Não deve ser mergeada diretamente na branch principal.

## Objetivo

Permitir que o `po-chart` distinga séries por **cor combinada com padrão/textura**, e não apenas por cor sólida, atendendo à diretriz de acessibilidade de não transmitir informação exclusivamente por cor.

## Exemplos

Portal com a POC implementada: https://luiz-s-vasconcellos.github.io/po-ui-portal-chart-pattern-poc/documentation/po-chart?view=web

<img width="1531" height="423" alt="image" src="https://github.com/user-attachments/assets/6e092c70-15a1-4167-82f9-a680bf176218" />
<img width="1532" height="830" alt="image" src="https://github.com/user-attachments/assets/2e0e6df0-e613-4fd5-93c6-d6b4cb8a61bd" />


## O que foi feito

- Nova propriedade opcional `usePatterns` em `PoChartOptions` que habilita o modo de padrões.
- Nova propriedade opcional `patternIndex` em `PoChartSerie` para customizar o padrão de uma série específica (0 a 7).
- `PoChartPatternService` isolado que gera 8 texturas matemáticas em canvas (diagonais, grid, pontos, senoidal, triângulos, horizontais, verticais, zigue-zague).
- Integração em `setSeries` e `po-chart-grid-utils` para aplicar o fill via `itemStyle.color = { image: canvas, repeat: 'repeat' }`.
- Habilitação automática dos padrões quando o nível de acessibilidade do tema for AAA (`usePatterns` não informado).
- Tratamento de erro na exportação de imagem (PNG/JPG).
- Testes unitários do service e testes de integração no componente.

## Tipos de gráfico suportados

| Tipo | Recebe padrão |
|------|--------------|
| Pie, Donut, Bar, Column | Sim | 
| Line, Area, Radar, Gauge | Não (cor sólida) | 

<img width="1578" height="807" alt="image" src="https://github.com/user-attachments/assets/579ffbcc-dba3-4d9d-bafd-83b85f3fa384" />
<img width="1578" height="489" alt="image" src="https://github.com/user-attachments/assets/a1fcf8a5-e4b9-4dd4-9c56-18b2953b2deb" />

Os tipos suportados possuem áreas preenchidas e bem delimitadas (fatias e barras), onde a textura repetida ajuda a distinguir as séries. Já `line`, `area`, `radar` e `gauge` não têm esse tipo de área sólida por série: a linha é apenas um traço, `area`/`radar` sobrepõem regiões translúcidas e o `gauge` representa um único valor em arco — nesses casos a textura não melhora a distinção e pode poluir a leitura, por isso mantêm cor sólida.

## Retrocompatibilidade

Com `usePatterns` ausente ou `false` (e fora do nível AAA), a saída é idêntica ao comportamento atual. Nenhuma assinatura pública existente foi alterada — apenas propriedades opcionais foram adicionadas.

## Pontos em aberto / feedback desejado

- Validação visual dos 8 padrões em diferentes temas (claro/escuro).
- Contraste do traço da textura: a abordagem por luminância relativa está adequada?
- Uso com SVG (atualmente funciona apenas com canvas)
- Quando são usados números em conjunto com o padrão, a visibilidade do número fica prejudicada: <img width="1543" height="600" alt="image" src="https://github.com/user-attachments/assets/11d78bdf-db25-45d4-a9fd-802fe99644e7" />

