### PR TITLE
feat(lookup): adiciona a propriedade initValue em p-advanced-filters

### DIFF
--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -35,6 +35,7 @@ export * from './po-search-ai/interfaces/po-search-ai-column.interface';
 export * from './po-search-ai/interfaces/po-search-ai.interface';
 export * from './po-search-ai/interfaces/po-search-ai-literals.interface';
 export * from './po-login/po-login.component';
+export * from './po-lookup/interfaces/po-lookup-advanced-filter.interface';
 export * from './po-lookup/interfaces/po-lookup-column.interface';
 export * from './po-lookup/interfaces/po-lookup-filter.interface';
 export * from './po-lookup/interfaces/po-lookup-filtered-items-params.interface';

--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-advanced-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-advanced-filter.interface.ts
@@ -4,5 +4,22 @@ import { PoDynamicFormField } from '../../../po-dynamic/po-dynamic-form/interfac
  * @docsExtends PoDynamicFormField
  *
  * @usedBy PoLookupComponent
+ *
+ * @ignoreExtendedDescription
+ *
+ * @description
+ *
+ * Interface para definição das propriedades dos campos de entrada que serão criados dinamicamente na busca avançada.
  */
-export interface PoLookupAdvancedFilter extends PoDynamicFormField {}
+export interface PoLookupAdvancedFilter extends PoDynamicFormField {
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define um valor inicial para um filtro de busca avançada.
+   *
+   * O valor será atribuído ao campo correspondente à propriedade `property` sempre que a janela de busca avançada for aberta.
+   */
+  initValue?: any;
+}

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -326,6 +326,19 @@ export abstract class PoLookupBaseComponent
    * url + ?page=1&pageSize=20&name=Tony%20Stark,Peter%20Parker,Gohan
    * ```
    *
+   * Também é possível definir um valor inicial para os campos da busca avançada através da propriedade `initValue`,
+   * que será atribuído ao campo sempre que a janela de busca avançada for aberta:
+   *
+   * ```
+   * advancedFilters: Array<PoLookupAdvancedFilter> = [
+   *   { property: 'nickname', label: 'Apelido' },
+   *   { property: 'active', label: 'Ativo', initValue: false, options: [
+   *     { label: 'Sim', value: true },
+   *     { label: 'Não', value: false }
+   *   ]}
+   * ];
+   * ```
+   *
    */
   @Input('p-advanced-filters') advancedFilters: Array<PoLookupAdvancedFilter>;
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
@@ -417,6 +417,45 @@ describe('PoLookupModalComponent', () => {
       expect(component['sort']).toEqual(expectedValue);
     });
 
+    it('getInitialValuesFromFilter: should return an object with the initValue of each filter', () => {
+      const filters = [
+        { property: 'name', initValue: 'John' },
+        { property: 'active', initValue: false },
+        { property: 'age', initValue: 0 }
+      ];
+
+      expect(component['getInitialValuesFromFilter'](filters)).toEqual({ name: 'John', active: false, age: 0 });
+    });
+
+    it('getInitialValuesFromFilter: should ignore filters without initValue', () => {
+      const filters = [{ property: 'name', initValue: 'John' }, { property: 'email' }];
+
+      expect(component['getInitialValuesFromFilter'](filters)).toEqual({ name: 'John' });
+    });
+
+    it('getInitialValuesFromFilter: should return an empty object if no filter contains initValue', () => {
+      const filters = [{ property: 'name' }, { property: 'email' }];
+
+      expect(component['getInitialValuesFromFilter'](filters)).toEqual({});
+    });
+
+    it('getInitialValuesFromFilter: should return an empty object if advancedFilters is undefined', () => {
+      expect(component['getInitialValuesFromFilter'](undefined)).toEqual({});
+    });
+
+    it('getInitialValuesFromFilter: should return an empty object if advancedFilters is null', () => {
+      expect(component['getInitialValuesFromFilter'](null)).toEqual({});
+    });
+
+    it('setupModalAdvancedFilter: should set dynamicFormValue with the initValue of the filters', () => {
+      component.advancedFilters = [{ property: 'name', initValue: 'John' }, { property: 'email' }];
+
+      component['setupModalAdvancedFilter']();
+
+      expect(component.dynamicFormValue).toEqual({ name: 'John' });
+      expect(component.isAdvancedFilter).toBe(true);
+    });
+
     it('onSelect: should concat table item in selecteds', () => {
       component.multiple = true;
       component.selectedItems = [{ value: 'Doe', label: 'Jane' }];

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
@@ -15,6 +15,7 @@ import { switchMap, tap } from 'rxjs/operators';
 import { PO_TABLE_ROW_HEIGHT_BY_SPACING, sortArrayOfObjects } from '../../../../utils/util';
 import { PoTableColumnSpacing } from '../../../po-table';
 import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
+import { PoLookupAdvancedFilter } from '../interfaces/po-lookup-advanced-filter.interface';
 import { PoLookupModalBaseComponent } from '../po-lookup-modal/po-lookup-modal-base.component';
 import { PoLanguageService } from './../../../../services/po-language/po-language.service';
 import { PoFieldSize } from './../../../../../lib/enums/po-field-size.enum';
@@ -156,8 +157,20 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
   }
 
   private setupModalAdvancedFilter() {
-    this.dynamicFormValue = {};
+    this.dynamicFormValue = this.getInitialValuesFromFilter(this.advancedFilters);
     this.isAdvancedFilter = true;
+  }
+
+  private getInitialValuesFromFilter(filters: Array<PoLookupAdvancedFilter>): Record<string, any> {
+    const initialValues: Record<string, any> = {};
+
+    filters?.forEach(filter => {
+      if (filter.initValue !== undefined) {
+        initialValues[filter.property] = filter.initValue;
+      }
+    });
+
+    return initialValues;
   }
 
   private createDynamicForm() {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -143,6 +143,12 @@ const providers = [
  *  <file name="sample-po-lookup.service.ts"> </file>
  * </example>
  *
+ * <example name="po-lookup-advanced-filter" title="PO Lookup - Advanced Filter">
+ *  <file name="sample-po-lookup-advanced-filter/sample-po-lookup-advanced-filter.component.html"> </file>
+ *  <file name="sample-po-lookup-advanced-filter/sample-po-lookup-advanced-filter.component.ts"> </file>
+ *  <file name="sample-po-lookup.service.ts"> </file>
+ * </example>
+ *
  * <example name="po-lookup-sw-films" title="PO Lookup - Star Wars films">
  *  <file name="sample-po-lookup-sw-films/sample-po-lookup-sw-films.component.html"> </file>
  *  <file name="sample-po-lookup-sw-films/sample-po-lookup-sw-films.component.ts"> </file>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-advanced-filter/sample-po-lookup-advanced-filter.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-advanced-filter/sample-po-lookup-advanced-filter.component.html
@@ -1,0 +1,32 @@
+<div class="po-row">
+  <po-info
+    class="po-lg-12"
+    p-label="Advanced filter with initial value"
+    p-value="Click on the magnifying glass, then on 'Advanced search': the Hero field is already filled with 'Hulk'. Just apply the filter to get the result."
+  >
+  </po-info>
+</div>
+
+<po-divider />
+
+<div class="po-row">
+  <po-lookup
+    class="po-md-6"
+    name="hero"
+    [(ngModel)]="hero"
+    p-field-label="name"
+    p-field-value="nickname"
+    p-help="Select a hero"
+    p-label="Hero"
+    p-clean
+    [p-columns]="columns"
+    [p-filter-service]="service"
+    [p-advanced-filters]="advancedFilters"
+    [p-literals]="{ 'modalTitle': 'Select a hero' }"
+  >
+  </po-lookup>
+</div>
+
+<div class="po-row">
+  <po-info class="po-md-6" p-label="Selected value" [p-value]="hero || '-'"> </po-info>
+</div>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-advanced-filter/sample-po-lookup-advanced-filter.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-advanced-filter/sample-po-lookup-advanced-filter.component.ts
@@ -1,0 +1,45 @@
+import { Component, inject } from '@angular/core';
+
+import { ForceOptionComponentEnum, PoLookupAdvancedFilter, PoLookupColumn } from '@po-ui/ng-components';
+
+import { SamplePoLookupService } from '../sample-po-lookup.service';
+
+@Component({
+  selector: 'sample-po-lookup-advanced-filter',
+  templateUrl: './sample-po-lookup-advanced-filter.component.html',
+  providers: [SamplePoLookupService],
+  standalone: false
+})
+export class SamplePoLookupAdvancedFilterComponent {
+  service = inject(SamplePoLookupService);
+
+  hero: string;
+
+  public readonly columns: Array<PoLookupColumn> = [
+    { property: 'nickname', label: 'Hero' },
+    { property: 'name', label: 'Name' },
+    { property: 'email', label: 'E-mail' }
+  ];
+
+  /**
+   * A propriedade `initValue` define o valor inicial de cada campo ao abrir a busca avançada.
+   * Neste exemplo a busca avançada já é aberta filtrando o herói `Hulk`.
+   */
+  public readonly advancedFilters: Array<PoLookupAdvancedFilter> = [
+    { property: 'name', label: 'Name', gridColumns: 6 },
+    { property: 'email', label: 'E-mail', gridColumns: 6 },
+    {
+      property: 'nickname',
+      label: 'Hero',
+      gridColumns: 6,
+      initValue: 'Hulk',
+      forceOptionsComponentType: ForceOptionComponentEnum.radioGroup,
+      options: [
+        { label: 'Batman', value: 'Batman' },
+        { label: 'Superman', value: 'Superman' },
+        { label: 'Hulk', value: 'Hulk' },
+        { label: 'Thor', value: 'Thor' }
+      ]
+    }
+  ];
+}


### PR DESCRIPTION
A busca avançada do po-lookup era sempre aberta com os campos vazios, sem permitir que a aplicação definisse um valor inicial para os filtros. Componentes como o po-page-dynamic-search e o po-page-dynamic-table já atendem esse cenário através da propriedade initValue, o que gerava uma inconsistência entre os componentes da suíte.

Adiciona a propriedade initValue na interface PoLookupAdvancedFilter, que até então não possuía membros próprios. O valor informado é atribuído ao campo correspondente sempre que a janela de busca avançada é aberta, seguindo o mesmo comportamento já adotado pelo po-advanced-filter. Campos sem initValue continuam sendo abertos vazios, preservando o comportamento anterior.

Exporta também a interface PoLookupAdvancedFilter no index do po-field, pois a mesma não era disponibilizada na API pública do pacote, impedindo a sua importação a partir de @po-ui/ng-components.
